### PR TITLE
docs: Vision & Roadmap — langres as the composable ER seam

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -84,6 +84,7 @@ The `.agent/` folder contains external expert analyses of the langres project:
 
 ## Reference Documentation (`docs/`)
 
+- **`docs/ROADMAP.md`** ⭐ **DIRECTION** — the post-POC vision: langres as the composable ER seam; the feature-bag architecture; the use-case compass; verifiable milestones M0–M6. Read alongside `POC.md` before planning new work.
 - **`docs/POC.md`** ⭐ **START HERE** — current development stage and priorities; the three approaches; success criteria; what's in scope NOW vs. later. Read before any implementation work.
 - **`docs/PROJECT_OVERVIEW.md`** — architecture and philosophy; the "why" behind design decisions; component relationships; the two-layer API.
 - **`docs/TECHNICAL_OVERVIEW.md`** — API reference and data contracts (`PairwiseJudgement`, `Candidate`, method signatures, expected inputs/outputs).

--- a/docs/POC.md
+++ b/docs/POC.md
@@ -1,4 +1,9 @@
 # langres: Proof of Concept
+
+> **See [ROADMAP.md](ROADMAP.md) for the post-POC direction** (vision, the
+> feature-bag architecture, the use-case compass, and milestones M0–M6). This
+> document remains the record of the original POC validation plan.
+
 ## TODO Add as well the idea of training a classifier (classical) after the blocker to decide whether is a match or not.
 
 ## Purpose

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -158,7 +158,7 @@ flagship loop (§2.4) as a named use case in `USE_CASES.md` and promote UC4 ther
 | GLiNER / GLiNER2 | Extractor | feature extraction → blocking keys + comparison features |
 | LLM judge (litellm) | Module | strong judge / teacher |
 | **DSPy-distilled judge** | Module | cheap student compiled from the teacher (the differentiator) |
-| **GLinker** (`gliner-linker`, pg_trgm retrieval) | Blocker + Module | proven external linking tool, benchmarked as one option |
+| **GLinker** (`gliner-linker`, pg_trgm retrieval) | Blocker + Module | candidate — fit for record↔record is **unverified** (trained on mention↔description; see §8), benchmarked as one option in M3 |
 | Fellegi-Sunter / logistic | Module | learned weighted comparison |
 
 **Benchmark on two axes:** (a) brainsquad's own Person/Program gold sets
@@ -223,7 +223,9 @@ Person: feature bag → block → baseline judge (embedding cascade or
 ### M3 — The seam: multi-method benchmark
 Wrap ≥3 methods (rapidfuzz, embedding cascade, LLM judge, **GLinker**) behind the
 interfaces; benchmark harness emits BCubed / recall / cost / latency table on the
-Person gold set (+ ≥1 standard benchmark dataset).
+Person gold set (+ ≥1 standard benchmark dataset). These method families *are* the
+three `POC.md` approaches — 1 (classical/rapidfuzz), 2 (embedding ANN), 3 (hybrid
+LLM) — now raced head-to-head behind one interface instead of run in sequence.
 - **Exit:** a reproducible **method-comparison table**; a winner selected with
   evidence.
 
@@ -231,7 +233,9 @@ Person gold set (+ ≥1 standard benchmark dataset).
 Compile a teacher→student judge (MIPROv2) against the gold set; the cheap student
 becomes part of the artifact.
 - **Exit:** distilled student within a stated margin of teacher **BCubed at ≥N×
-  lower cost/latency** (the Overture 60→82% analogue, measured on our data).
+  lower cost/latency** (analogue of the Overture Maps DSPy distillation case
+  study — a small model went 60.7% → 82% accuracy after MIPRO prompt
+  compilation — measured on our data).
 
 ### M5 — Generalise + incremental + golden-record loop
 Program/Project via **config-only** change; Geography via external authority

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -1,0 +1,274 @@
+# langres — Vision & Roadmap
+
+> **Status:** Direction-setting document (2026-06-25). Supersedes the pure-POC
+> framing in `POC.md` for *where we are going*; `POC.md` remains the record of
+> the original validation plan. This doc defines the vision, the architectural
+> spine, and **verifiable milestones** so progress is measurable at each step.
+
+---
+
+## 1. Vision — the PyTorch of Entity Resolution
+
+langres is the **composable seam** for entity resolution: a framework where you
+**compose, benchmark, and tune** different ER methods behind common interfaces,
+**bootstrap** the labels you don't have, and **ship a versioned model artifact**
+that runs at inference elsewhere.
+
+Three stacked definitions of "usable", all true at once:
+
+1. **Seam** — every method (rapidfuzz, embeddings, LLM judge, DSPy-distilled
+   judge, GLinker, GLiNER extraction) is wrapped behind one `Blocker`/`Module`
+   interface, so you can swap and **benchmark them head-to-head on your data**.
+2. **Training framework** — you `fit` / `optimize` / `distill` a pipeline and it
+   produces a **versioned artifact** (extractors + blocking funnel + judge +
+   thresholds + compiled prompt).
+3. **Inference** — a consumer (brainsquad) `load`s that artifact and runs it on
+   its own infra. *Engine intelligence in langres; data, persistence, visibility
+   in the consumer.*
+
+**General by design, proven by one real use case.** brainsquad
+([raisesquad/brainsquad#1051](https://github.com/raisesquad/brainsquad/issues/1051))
+is our first and only real consumer — Person (hard, multilingual), Program/Project
+(easy), Geography (external authority), Grant (later). We prove the framework on
+it, while keeping every abstraction entity-agnostic.
+
+---
+
+## 2. The architectural spine
+
+### 2.1 Entity = a typed **feature bag** (the core model)
+
+An entity is a set of typed, possibly multi-valued, possibly missing features
+(name, aliases, role, org, location, dates, identifiers…). Matching compares
+feature bags that may be **lopsided** — one side rich, one side sparse. This is
+the Fellegi-Sunter model, modernised.
+
+**Design rules that make asymmetric matching work:**
+
+- **Comparison vector, not a single string compare.** Each candidate pair yields
+  a per-feature comparison *level*: `exact / fuzzy-high / fuzzy-low / mismatch /
+  missing`.
+- **`missing` is a neutral level — it never penalises.** Score on shared
+  features; stay silent on the rest. This is what lets "many features vs. one
+  feature" resolve correctly.
+- **The judge weights features by discriminativeness** — learned from the gold
+  set, or reasoned by the LLM (which degrades gracefully under partial info).
+- **Anchors decide alone.** A shared unique identifier (UID, domain, ORCID) →
+  deterministic match, no judge.
+
+**Features unify blocking and matching:** each feature is both a *blocking key*
+(union of per-feature keys → high recall; a one-feature entity is still
+blockable) and a *comparison signal*. Extraction (incl. GLiNER) populates the bag.
+
+```
+raw → [enrich: extractors / GLiNER / (later) web-search] → feature bag
+    → [union of per-feature blockers]            → candidate pairs   (HIGH RECALL)
+    → [per-feature comparison vector, missing-aware]
+    → [judge: heuristic | embedding | LLM | DSPy-distilled | GLinker] → PairwiseJudgement
+    → [Clusterer: pos + neg judgements → connected components]        → clusters / golden labels
+```
+
+### 2.2 Components (interfaces — the seam)
+
+| Component | Role | Today |
+|---|---|---|
+| **Enricher / feature source** (extractors incl. `GLiNERExtractor`; later web-search/Exa, registries) | populate & **augment** the feature bag from text or external sources | new (extraction); web-search **deferred, slotted** |
+| **Blocker** | feature bag → candidate pairs (high recall) | exists (Vector/AllPairs); add funnel + per-feature union |
+| **Comparator** | pair → per-feature comparison vector (missing-aware) | seed in `RapidfuzzModule.field_extractors`; generalise |
+| **Module (judge)** | comparison/raw → `PairwiseJudgement` | exists (rapidfuzz/LLM/cascade); add DSPy + GLinker adapters |
+| **Clusterer** | judgements (pos+neg) → clusters | exists (connected components); add cannot-link |
+| **Bootstrapper** | entities → gold set (sample→label→mine→report) | new — **critical path** |
+| **Benchmark** | race methods on gold set → metric table | ~70% (eval exists); add harness |
+| **Resolver** | the composed, fitted, **serializable** pipeline | new — **the artifact** |
+
+### 2.3 Two operating modes of a Resolver
+
+- **Dedup / batch** — resolve a dataset against itself → clusters. (Have the parts.)
+- **Incremental / linking** — probe a *new* record against an existing entity
+  store → matched entity id or "new". (`stream_against`; brainsquad's runtime op.)
+
+### 2.4 The flagship loop — build a golden label, then grow it over time
+
+The core brainsquad pattern (and the most common real ER loop): we first *see* a
+sparse mention (often just a name — a person extracted from a document, an org
+name), optionally **enrich** it (e.g. add a LinkedIn URL, a registry id, web-search
+content), and mint it as a **golden label**. Then every future appearance of that
+entity must **link** back to the golden label — and each link **enriches** the
+golden record with whatever new features that mention carried.
+
+```
+new mention (sparse: maybe just a name)
+   → [enrich?]  (extraction now; web-search/Exa later — optional)
+   → link against existing golden labels  (incremental, asymmetric: sparse ↔ rich)
+        ├─ match  → merge features into the golden record (it grows)  → canonicalize
+        └─ no match → mint a new golden label
+```
+
+Two properties make this work and must be designed in:
+
+- **Asymmetric matching (sparse ↔ rich).** A new one-feature mention links against
+  a feature-rich golden record. The missing-aware Comparator (§2.1) scores on the
+  shared feature; the golden record's accumulated **aliases + popularity prior**
+  (à la GLinker) *help* rather than hurt. We do **not** require symmetric features.
+- **Progressive enrichment = canonicalization in a loop.** The golden record is the
+  survivorship-merge of all its linked mentions' features. Each link feeds back. So
+  the entity store is **growing and self-enriching**, not a fixed target.
+
+This is **UC2 (Entity Linking) ⊕ UC4 (Master Data Creation), run incrementally** —
+see §2.5. langres provides the *brain* (the linker + the canonicalization rules,
+as a versioned artifact); brainsquad provides the *body* (the persistent golden
+store, the event log, reversibility — exactly its #1051 design).
+
+### 2.5 Use-case coverage — the compass
+
+We track direction against the documented taxonomy in `USE_CASES.md`. Each use
+case must end up either **filled by a milestone** or **deliberately delegated to
+the consumer** (brainsquad owns the stateful "body"; langres owns the "brain").
+
+| Use case (`USE_CASES.md`) | Where it lands | Status |
+|---|---|---|
+| **UC1 Deduplication** (batch → clusters) | M2 | on path |
+| **UC2 Entity Linking** (link to a target store) | M5 (incremental `stream_against`) | on path |
+| **UC10 Fuzzy FK** (special case of UC2) | via M5 | on path |
+| **UC4 Master Data Creation** (golden records / survivorship) | M5 — **promoted** (brainsquad needs golden labels *now*, not V1.1) | on path |
+| ⭐ **Flagship: incremental linking + progressive golden-record enrichment** (§2.4) | M5 (= UC2 ⊕ UC4 + Enricher loop) | **explicitly captured** — was only implicit across UC2/UC4/UC5 in `USE_CASES.md` |
+| **UC9 Negative constraints** (cannot-link) | M6 (constrained clustering) | on path |
+| **Human-in-the-loop** labeling | M1 (bootstrapper labeler — human option) | on path |
+| **Optimization** (Optuna + DSPy) | M3 / M4 / M6 | on path |
+| **Data generation / cold-start** | M1 (bootstrapper) | on path |
+| **UC3 Record Linkage** (multi-source) | post-M5, config | deferred (V1.1) |
+| **Enrichment via web-search / Exa** | Enricher plug-in (§2.2) | **deferred, slotted** — out of scope now |
+| **UC8 PPRL** (privacy-preserving) | consumer strips private features *before* langres sees them (§5) | delegated |
+| **UC7 Collective / graph** | langres = pairwise brain; brainsquad builds the graph/network layer on resolved nodes | delegated |
+| **UC5 Streaming** | langres compiles the artifact (brain); brainsquad runs it real-time (body) — matches #1051 | delegated |
+| **UC6 Temporal evolution** | langres emits reversible judgements; brainsquad owns the temporal store + event log (#1051) | delegated |
+
+The "delegated" rows are not gaps — they are the **clean brain/body seam** the
+#1051 design already assumes. *Follow-up: once direction is locked, formalize the
+flagship loop (§2.4) as a named use case in `USE_CASES.md` and promote UC4 there.*
+
+---
+
+## 3. The seam in practice — methods we compose & compare
+
+| Method | Wrapped as | Use |
+|---|---|---|
+| rapidfuzz | Comparator + Module | cheap baseline |
+| embedding ANN (FAISS/Qdrant) | Blocker | high-recall candidate gen |
+| GLiNER / GLiNER2 | Extractor | feature extraction → blocking keys + comparison features |
+| LLM judge (litellm) | Module | strong judge / teacher |
+| **DSPy-distilled judge** | Module | cheap student compiled from the teacher (the differentiator) |
+| **GLinker** (`gliner-linker`, pg_trgm retrieval) | Blocker + Module | proven external linking tool, benchmarked as one option |
+| Fellegi-Sunter / logistic | Module | learned weighted comparison |
+
+**Benchmark on two axes:** (a) brainsquad's own Person/Program gold sets
+(dogfood + real validity), and (b) standard ER benchmarks (DBLP-ACM, Abt-Buy,
+etc.) for external validity and method sanity-checks.
+
+---
+
+## 4. Cold-start labelling (LLM-teacher first)
+
+We have no gold labels and they gate everything (DSPy, benchmark, optimisation).
+The bootstrapper is the unlock.
+
+- **Sampler:** uncertainty + hard-negative mining (embedding-kNN near-misses),
+  small random tail for the easy-negative class. *Not* random pairs.
+- **Labeler (chosen): LLM-teacher** — GPT-class model labels the ambiguous band
+  with rationales; validate against a ~100–200 pair human spot-check; calibrate;
+  route low-confidence to a human. (Pluggable with human active-learning / weak
+  supervision later.)
+- **Output:** `GoldPair` set + **coverage report** (blocking Pair-Completeness,
+  label-count-vs-F1 curve, teacher calibration/ECE).
+- **Reusable strategy interface:** swappable `sampler` / `labeler` /
+  `hard_negative_source` behind one `Bootstrapper.build(entities)`.
+
+---
+
+## 5. The artifact (brainsquad integration contract)
+
+A `Resolver` serialises to a **versioned artifact**: feature extractors +
+blocking funnel config + judge (incl. compiled DSPy prompt / model ref) +
+thresholds + metric provenance. brainsquad `Resolver.load("person_v1")` and calls
+`.resolve(records)` (batch) or `.link(record)` (incremental). langres owns engine
+intelligence; brainsquad owns persistence, visibility (public/private feature
+stripping happens consumer-side before features reach langres), and the cluster
+store.
+
+---
+
+## 6. Milestones (verifiable)
+
+Each milestone has a **measurable exit criterion**. Targets inherit the POC bars:
+**blocking recall ≥ 0.95**, **BCubed F1 ≥ 0.85** for the hybrid judge.
+
+### M0 — Contract & spine
+Build the `Resolver` container (compose Blocker+Comparator+Module+Clusterer;
+`save`/`load`) and the entity feature-bag + missing-aware Comparator abstraction.
+- **Exit:** existing example runs through `Resolver.save/load` round-trip and
+  produces identical clusters before/after; one external adapter stub compiles.
+
+### M1 — Person gold set (cold-start, LLM-teacher)
+Bootstrapper: hard-negative mining from the Blocker + LLM-teacher labeler +
+coverage report. Produce the brainsquad **People (board-members) gold set**.
+- **Exit:** a Person gold set exists with measured teacher-vs-human agreement on
+  a spot-check sample; blocking **Pair-Completeness reported** (target ≥ 0.95).
+
+### M2 — Walking skeleton end-to-end + baseline
+Person: feature bag → block → baseline judge (embedding cascade or
+`gliner-linker`) → cluster → eval → **artifact**. brainsquad loads & runs it.
+- **Exit:** **BCubed F1 baseline reported** on held-out gold; artifact runs a
+  brainsquad-style `.link()` / `.resolve()` call end-to-end.
+
+### M3 — The seam: multi-method benchmark
+Wrap ≥3 methods (rapidfuzz, embedding cascade, LLM judge, **GLinker**) behind the
+interfaces; benchmark harness emits BCubed / recall / cost / latency table on the
+Person gold set (+ ≥1 standard benchmark dataset).
+- **Exit:** a reproducible **method-comparison table**; a winner selected with
+  evidence.
+
+### M4 — DSPy-distilled cheap judge (the differentiator)
+Compile a teacher→student judge (MIPROv2) against the gold set; the cheap student
+becomes part of the artifact.
+- **Exit:** distilled student within a stated margin of teacher **BCubed at ≥N×
+  lower cost/latency** (the Overture 60→82% analogue, measured on our data).
+
+### M5 — Generalise + incremental + golden-record loop
+Program/Project via **config-only** change; Geography via external authority
+(GeoNames) adapter; `stream_against` incremental linking against an entity store;
+**Canonicalizer** survivorship so a matched link **merges its features into the
+golden record** (§2.4 flagship loop).
+- **Exit:** a second entity type resolved with no new core code (config only);
+  incremental `.link(new_record)` returns the correct existing entity or "new";
+  **a sparse new mention correctly links to a feature-rich golden record, and the
+  golden record gains the mention's new features** (enrichment verified).
+
+### M6 — Hardening (post-proof)
+Blocking-funnel optimisation (recall-first Optuna objective), score calibration,
+model/version registry, production/operability guidance, cannot-link clustering.
+- **Exit:** Person resolver meets **BCubed F1 ≥ 0.85**; documented deploy/rollback
+  path; reproducible artifact versioning.
+
+---
+
+## 7. Mapping to brainsquad (#1051)
+
+| brainsquad task (#1051) | langres milestone |
+|---|---|
+| Build People gold set (teacher set) | **M1** |
+| Walking skeleton: features → blocking → judge → clusters → persist | **M2** (langres half) |
+| Iterate: multi-filter blocking + DSPy distillation | **M3 + M4 + M6** |
+| Generalise to Program/Project + Geography | **M5** |
+| Versioned model artifact consumed at inference | **M2 artifact, hardened in M6** |
+
+---
+
+## 8. Open questions / things to learn
+
+- **Comparator design for heterogeneous features** — how rich to make the
+  comparison-level taxonomy; learned vs. LLM-reasoned combiner; how anchors
+  short-circuit. (We have the conceptual model; validate empirically in M2–M3.)
+- **GLinker fit** — is `gliner-linker` competitive on *record↔record* (it was
+  trained on mention↔description)? Answer empirically in M3, don't assume.
+- **DSPy distillation cost/quality** on our messy multilingual Person data vs.
+  the clean POI case in the Overture talk. Validate in M4.

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -234,8 +234,8 @@ Compile a teacher→student judge (MIPROv2) against the gold set; the cheap stud
 becomes part of the artifact.
 - **Exit:** distilled student within a stated margin of teacher **BCubed at ≥N×
   lower cost/latency** (analogue of the Overture Maps DSPy distillation case
-  study — a small model went 60.7% → 82% accuracy after MIPRO prompt
-  compilation — measured on our data).
+  study — Drew Breunig, Databricks Data+AI Summit 2025: a small model went
+  60.7% → 82% accuracy after MIPRO prompt compilation — measured on our data).
 
 ### M5 — Generalise + incremental + golden-record loop
 Program/Project via **config-only** change; Geography via external authority

--- a/docs/USE_CASES.md
+++ b/docs/USE_CASES.md
@@ -1,5 +1,14 @@
 # langres: Use Case Taxonomy & Development Roadmap
 
+> **Note (2026-06-25):** Several components named below — `tasks.*`
+> (`DeduplicationTask`, `EntityLinkingTask`, `RecordLinkageTask`),
+> `core.Canonicalizer`, `data.ReviewQueue`, `data.SyntheticGenerator`, and
+> `Blocker.stream_against` — are **not yet implemented**; they describe the
+> intended API. See **[ROADMAP.md](ROADMAP.md)** for the delivery timeline
+> (the golden-record / canonicalization loop lands in M5; the cold-start
+> data generator in M1). The "Status" column below predates the roadmap; the
+> roadmap's use-case compass (§2.5) is the current source of truth.
+
 ## 1. Introduction
 
 Entity Resolution (ER) is not a single problem but a wide spectrum of use cases. A core design principle of langres is to provide a robust, flexible, and lightweight framework for the most common and critical ER tasks.


### PR DESCRIPTION
## What

Adds `docs/ROADMAP.md` — the vision + verifiable milestone roadmap for taking langres out of POC state into a usable, composable ER framework, proven on the brainsquad use case.

## Why

langres has solid `langres.core` parts (Blocker/Module/Clusterer, ANN blocking, Optuna optimizer, eval/inspection) but **no ER *model object*** — nothing that bootstraps labels, benchmarks methods, distills a cheap judge, or serializes a deployable artifact. This doc sets the direction to close that gap.

## Highlights

- **Vision** — langres = the *seam* for ER: compose & benchmark methods behind common interfaces → bootstrap the labels you don't have → DSPy-distill a cheap judge → ship a versioned artifact. (PyTorch/sklearn-style.)
- **Architectural spine** — entity = typed **feature bag**; **missing-aware comparison** so asymmetric (sparse ↔ rich) matching works; features unify blocking + matching; GLiNER as an upstream extractor.
- **Flagship loop (§2.4)** — build a golden label, link future mentions, **enrich the golden record over time** (UC2 × UC4 run incrementally).
- **Use-case coverage compass (§2.5)** — maps `USE_CASES.md` UC1–10 to milestones or to the brain/body delegation that brainsquad#1051 already assumes (streaming/temporal/graph = consumer's "body").
- **Milestones M0–M6** — each with a measurable exit criterion (blocking recall ≥ 0.95, BCubed F1 ≥ 0.85 for the hybrid judge).
- **Enricher** as a pluggable feature source (extraction now; web-search/Exa deferred but slotted).

## Notes

- `USE_CASES.md` still describes some components as if they exist (`tasks.*`, `Canonicalizer`, `stream_against`); left untouched here — a follow-up will reconcile it once direction is locked.
- Tracking epic: see companion issue (langres) + consumer umbrella raisesquad/brainsquad#1051.
