### PR TITLE
chore(deps): migrate langfuse 2.59.7 → 4.x (OTel integration)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,7 @@ dependencies = [
     "dspy-ai>=3.0.3",
     "faiss-cpu>=1.12.0",
     "fastembed>=0.7.3",
-    "langfuse==2.59.7",
+    "langfuse>=4,<5",
     "litellm>=1.79.0",
     "networkx>=3.5",
     "onnxruntime>=1.23.2",

--- a/src/langres/clients/llm.py
+++ b/src/langres/clients/llm.py
@@ -1,11 +1,10 @@
 """LiteLLM client factory with Langfuse tracing."""
 
 import logging
-import os
 from typing import Any
 
 import litellm
-from langfuse import Langfuse  # type: ignore[import-untyped]
+from langfuse import Langfuse
 
 from langres.clients.settings import Settings
 
@@ -15,8 +14,11 @@ logger = logging.getLogger(__name__)
 def create_llm_client(settings: Settings | None = None, enable_langfuse: bool = True) -> Any:
     """Create LiteLLM client with optional Langfuse tracing.
 
-    This function configures LiteLLM with optional Langfuse callbacks for tracing.
-    LiteLLM and Langfuse read credentials directly from environment variables.
+    This function configures LiteLLM with the Langfuse OpenTelemetry callback
+    (``langfuse_otel``) for tracing. langfuse 4.x is the OpenTelemetry-based SDK,
+    so LiteLLM emits traces via its ``langfuse_otel`` integration rather than the
+    legacy v2 ``langfuse`` callback. LiteLLM's callback reads ``LANGFUSE_*``
+    credentials directly from environment variables.
 
     Args:
         settings: Optional Settings object. If None, loads from environment.
@@ -85,25 +87,27 @@ def create_llm_client(settings: Settings | None = None, enable_langfuse: bool = 
             settings.langfuse_public_key[:10] if settings.langfuse_public_key else "None",
         )
 
-        # Explicitly initialize Langfuse client
-        # This ensures proper SDK setup before LiteLLM uses it
+        # Explicitly initialize the Langfuse client (v4 / OpenTelemetry SDK)
+        # to validate credentials before LiteLLM starts emitting traces.
         try:
             langfuse_client = Langfuse(
                 public_key=settings.langfuse_public_key,
                 secret_key=settings.langfuse_secret_key,
                 host=settings.langfuse_host,
             )
-            # Verify connection by flushing any pending events
-            langfuse_client.flush()
+            # Verify credentials and connectivity (returns False on failure).
+            if not langfuse_client.auth_check():
+                raise ValueError("Langfuse auth_check failed (invalid credentials or host)")
             logger.info("Langfuse client initialized successfully")
         except Exception as e:
             logger.error("Failed to initialize Langfuse client: %s", e)
             raise ValueError(f"Langfuse initialization failed: {e}") from e
 
-        # Configure LiteLLM to use Langfuse callbacks
-        # LiteLLM will read LANGFUSE_* env vars for its own Langfuse client
-        litellm.success_callback = ["langfuse"]
-        litellm.failure_callback = ["langfuse"]
+        # Configure LiteLLM to use the Langfuse OpenTelemetry callback.
+        # langfuse 4.x is OTel-based, so LiteLLM's "langfuse_otel" integration
+        # (not the legacy v2 "langfuse" callback) is the correct one. It reads
+        # LANGFUSE_* env vars for its own exporter.
+        litellm.callbacks = ["langfuse_otel"]
 
         # Suppress verbose LiteLLM logging (prevents "Langfuse Layer Logging - logging success" spam)
         # LiteLLM logs every single API call at INFO level, which pollutes logs with thousands of messages

--- a/tests/clients/test_llm.py
+++ b/tests/clients/test_llm.py
@@ -38,6 +38,7 @@ class TestCreateLLMClient:
             patch("langres.clients.llm.Langfuse") as mock_langfuse_class,
         ):
             mock_langfuse_instance = MagicMock()
+            mock_langfuse_instance.auth_check.return_value = True
             mock_langfuse_class.return_value = mock_langfuse_instance
 
             client = create_llm_client(settings)
@@ -48,11 +49,10 @@ class TestCreateLLMClient:
                 secret_key="sk-lf-test",
                 host="https://custom.langfuse.com",
             )
-            mock_langfuse_instance.flush.assert_called_once()
+            mock_langfuse_instance.auth_check.assert_called_once()
 
-            # Verify litellm callbacks are configured
-            assert "langfuse" in mock_litellm.success_callback
-            assert "langfuse" in mock_litellm.failure_callback
+            # Verify litellm Langfuse OpenTelemetry callback is configured
+            assert mock_litellm.callbacks == ["langfuse_otel"]
 
             # Verify litellm module is returned
             assert client is mock_litellm
@@ -76,17 +76,17 @@ class TestCreateLLMClient:
                 patch("langres.clients.llm.Langfuse") as mock_langfuse_class,
             ):
                 mock_langfuse_instance = MagicMock()
+                mock_langfuse_instance.auth_check.return_value = True
                 mock_langfuse_class.return_value = mock_langfuse_instance
 
                 client = create_llm_client()
 
                 # Verify Langfuse initialized with env vars
                 mock_langfuse_class.assert_called_once()
-                mock_langfuse_instance.flush.assert_called_once()
+                mock_langfuse_instance.auth_check.assert_called_once()
 
-                # Verify callbacks configured
-                assert "langfuse" in mock_litellm.success_callback
-                assert "langfuse" in mock_litellm.failure_callback
+                # Verify callback configured
+                assert mock_litellm.callbacks == ["langfuse_otel"]
 
     def test_create_llm_client_uses_default_host(self):
         """Test create_llm_client with Settings using default Langfuse host."""
@@ -105,6 +105,7 @@ class TestCreateLLMClient:
             patch("langres.clients.llm.Langfuse") as mock_langfuse_class,
         ):
             mock_langfuse_instance = MagicMock()
+            mock_langfuse_instance.auth_check.return_value = True
             mock_langfuse_class.return_value = mock_langfuse_instance
 
             client = create_llm_client(settings)
@@ -115,11 +116,10 @@ class TestCreateLLMClient:
                 secret_key="sk-lf-test",
                 host="https://cloud.langfuse.com",
             )
-            mock_langfuse_instance.flush.assert_called_once()
+            mock_langfuse_instance.auth_check.assert_called_once()
 
-            # Verify callbacks configured
-            assert "langfuse" in mock_litellm.success_callback
-            assert "langfuse" in mock_litellm.failure_callback
+            # Verify callback configured
+            assert mock_litellm.callbacks == ["langfuse_otel"]
 
             # Verify Settings has default host
             assert settings.langfuse_host == "https://cloud.langfuse.com"
@@ -144,17 +144,17 @@ class TestCreateLLMClient:
             patch("langres.clients.llm.Langfuse") as mock_langfuse_class,
         ):
             mock_langfuse_instance = MagicMock()
+            mock_langfuse_instance.auth_check.return_value = True
             mock_langfuse_class.return_value = mock_langfuse_instance
 
             client = create_llm_client(settings)
 
             # Verify Langfuse initialized
             mock_langfuse_class.assert_called_once()
-            mock_langfuse_instance.flush.assert_called_once()
+            mock_langfuse_instance.auth_check.assert_called_once()
 
-            # Verify callbacks configured
-            assert "langfuse" in mock_litellm.success_callback
-            assert "langfuse" in mock_litellm.failure_callback
+            # Verify callback configured
+            assert mock_litellm.callbacks == ["langfuse_otel"]
 
             # Verify Settings has Azure configuration
             assert settings.azure_api_key == "azure-key-123"
@@ -169,9 +169,8 @@ class TestCreateLLMClient:
         with patch("langres.clients.llm.litellm") as mock_litellm:
             client = create_llm_client(enable_langfuse=False)
 
-            # Verify callbacks NOT configured
-            assert mock_litellm.success_callback != ["langfuse"]
-            assert mock_litellm.failure_callback != ["langfuse"]
+            # Verify the Langfuse OTel callback is NOT configured
+            assert mock_litellm.callbacks != ["langfuse_otel"]
 
             # Verify litellm module is returned
             assert client is mock_litellm
@@ -212,17 +211,17 @@ class TestCreateLLMClient:
             patch("langres.clients.llm.Langfuse") as mock_langfuse_class,
         ):
             mock_langfuse_instance = MagicMock()
+            mock_langfuse_instance.auth_check.return_value = True
             mock_langfuse_class.return_value = mock_langfuse_instance
 
             client = create_llm_client(settings)
 
             # Verify Langfuse initialized
             mock_langfuse_class.assert_called_once()
-            mock_langfuse_instance.flush.assert_called_once()
+            mock_langfuse_instance.auth_check.assert_called_once()
 
-            # Verify callbacks configured
-            assert "langfuse" in mock_litellm.success_callback
-            assert "langfuse" in mock_litellm.failure_callback
+            # Verify callback configured
+            assert mock_litellm.callbacks == ["langfuse_otel"]
 
             # Verify litellm module is returned
             assert client is mock_litellm
@@ -237,6 +236,22 @@ class TestCreateLLMClient:
         with patch("langres.clients.llm.Langfuse") as mock_langfuse_class:
             # Simulate Langfuse initialization failure
             mock_langfuse_class.side_effect = Exception("Connection failed")
+
+            with pytest.raises(ValueError, match="Langfuse initialization failed"):
+                create_llm_client(settings, enable_langfuse=True)
+
+    def test_create_llm_client_raises_error_on_failed_auth_check(self):
+        """Test create_llm_client raises ValueError if Langfuse auth_check fails."""
+        settings = Settings(
+            langfuse_public_key="pk-lf-test",
+            langfuse_secret_key="sk-lf-test",
+        )
+
+        with patch("langres.clients.llm.Langfuse") as mock_langfuse_class:
+            mock_langfuse_instance = MagicMock()
+            # auth_check returns False -> invalid credentials/host
+            mock_langfuse_instance.auth_check.return_value = False
+            mock_langfuse_class.return_value = mock_langfuse_instance
 
             with pytest.raises(ValueError, match="Langfuse initialization failed"):
                 create_llm_client(settings, enable_langfuse=True)


### PR DESCRIPTION
## What

Migrates `langfuse` from the pinned `2.59.7` to the current v4 line (resolved **4.9.0** under the `exclude-newer` quarantine), fixing the LLM-tracing integration for the v3/v4 OpenTelemetry rewrite. langfuse is lightly used here (only `src/langres/clients/llm.py`), so moving off the old pin is low-risk and removes a stale dependency.

## The key change

langfuse v3+ is OpenTelemetry-based. The LiteLLM integration moves from the legacy v2 callback (`success_callback = ["langfuse"]`) to **`litellm.callbacks = ["langfuse_otel"]`** — verified against the [LiteLLM Langfuse-OTel docs](https://docs.litellm.ai/docs/observability/langfuse_otel_integration) and cross-checked against installed litellm 1.89.2 (resolves to a real `LangfuseOtelLogger`). Same `LANGFUSE_*` env vars as before.

## Changes
- `pyproject.toml`: `langfuse==2.59.7` → `langfuse>=4,<5`.
- `src/langres/clients/llm.py`: `langfuse_otel` callback; credential validation via `Langfuse.auth_check()` (raises `ValueError` if it fails / creds missing) instead of `.flush()`; docstrings updated; dropped a now-unneeded `# type: ignore` (v4 ships type stubs). `enable_langfuse=False` path unchanged; public signature preserved.
- `tests/clients/test_llm.py`: mock `auth_check`; assert the `langfuse_otel` callback; added an `auth_check()=False → ValueError` test. Enable/disable + missing-creds paths still covered.
- `settings.py`: unchanged (v4 uses the same env var names).

## Verification
729 tests pass, 97.5% coverage (llm.py 100%); ruff + mypy clean.

**Not validated here (no live creds):** a real end-to-end trace landing in the Langfuse UI. To verify: set real `LANGFUSE_PUBLIC_KEY`/`SECRET_KEY`/`HOST` (+ an LLM provider key), run one `create_llm_client(enable_langfuse=True)` completion, and confirm it appears in the Langfuse dashboard.
