### PR TITLE
ci: Blacksmith runners + Python 3.13-only tests

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -18,7 +18,7 @@ jobs:
     #   github.event.pull_request.user.login == 'new-developer' ||
     #   github.event.pull_request.author_association == 'FIRST_TIME_CONTRIBUTOR'
 
-    runs-on: ubuntu-latest
+    runs-on: blacksmith-4vcpu-ubuntu-2404
     permissions:
       contents: read
       pull-requests: read

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -17,7 +17,7 @@ jobs:
       (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude')) ||
       (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude')) ||
       (github.event_name == 'issues' && (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')))
-    runs-on: ubuntu-latest
+    runs-on: blacksmith-4vcpu-ubuntu-2404
     permissions:
       contents: read
       pull-requests: read

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   lint:
-    runs-on: ubuntu-latest
+    runs-on: blacksmith-4vcpu-ubuntu-2404
     steps:
       - name: Checkout code
         uses: actions/checkout@v7

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   publish:
-    runs-on: ubuntu-latest
+    runs-on: blacksmith-4vcpu-ubuntu-2404
     environment: pypi  # Optional: matches what you set in PyPI
     permissions:
       id-token: write  # REQUIRED for trusted publishing

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -12,7 +12,7 @@ on:
 
 jobs:
   security:
-    runs-on: ubuntu-latest
+    runs-on: blacksmith-4vcpu-ubuntu-2404
     permissions:
       contents: read
     steps:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,10 +8,10 @@ on:
 
 jobs:
   test:
-    runs-on: ubuntu-latest
+    runs-on: blacksmith-4vcpu-ubuntu-2404
     strategy:
       matrix:
-        python-version: ["3.12", "3.13"]
+        python-version: ["3.13"]
     steps:
       - name: Checkout
         uses: actions/checkout@v7


### PR DESCRIPTION
## Move CI to Blacksmith runners + test on Python 3.13 only

Aligns langres CI with the org convention (brainsquad's `test_cov.yml` uses `blacksmith-4vcpu-ubuntu-2404`).

### Changes
- **All 6 workflows** (`test`, `lint`, `security`, `publish`, `claude`, `claude-code-review`): `runs-on: ubuntu-latest` → `runs-on: blacksmith-4vcpu-ubuntu-2404`.
- **`test.yml`**: drop Python `3.12` from the matrix — test on **3.13 only**.
- `publish.yml` still *builds* on 3.12 (the project's `>=3.12` floor; building on the minimum supported version is intentional) — only its runner changed.

### Why now
GitHub-hosted runners are currently halted account-wide (Actions billing), so no checks start. Blacksmith runners are billed through Blacksmith, not GitHub Actions minutes — so this both matches how the other repos run and unblocks CI. Because `pull_request` checks run from the **head** workflow files, this PR's own checks should execute on Blacksmith even while GitHub-hosted runners are blocked.

### Verification
- All 6 workflow files parse as valid YAML.
- Diff is workflow-only (7 lines), no code touched.

Independent of #29 (M0). Recommend merging this first; #29's checks (re-run) will then pick up Blacksmith from `main` and can go green.

https://claude.ai/code/session_01KUj19Gwj4x3pvXywysezPp
