### PR TITLE
M0.5: Seam consolidation — unified judge contract, vector-similarity fix, serializable LLMJudge, Person strong-path proof

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -2,3 +2,13 @@
 # Copy to .env (gitignored) before running pytest or pre-commit hooks.
 OMP_NUM_THREADS=1
 KMP_DUPLICATE_LIB_OK=1
+
+# --- LLM teacher / judge (OpenRouter via litellm) -----------------------------
+# OpenRouter is a unified gateway; litellm routes models prefixed "openrouter/".
+# Pull the value from brainsquad's .env (it already has OpenRouter creds):
+#   grep -i openrouter ../brainsquad/.env >> .env
+# Not needed for M0.5 (the example uses a fake/recorded LLM); required for the
+# M1 teacher run and the optional live smoke test.
+OPENROUTER_API_KEY=
+# litellm model id for the judge/teacher, e.g. openrouter/openai/gpt-4o-mini
+LANGRES_LLM_MODEL=openrouter/openai/gpt-4o-mini

--- a/docs/DX_RESOLVER.md
+++ b/docs/DX_RESOLVER.md
@@ -119,10 +119,11 @@ The four-slot constructor is unchanged for advanced use — swap in a
 scorer:
 
 ```python
+comparator = Comparator.from_schema(CompanySchema, weights={...})
 Resolver(
     blocker=AllPairsBlocker(schema=CompanySchema),
-    comparator=Comparator.from_schema(CompanySchema, weights={...}),
-    module=WeightedAverageJudge(),
+    comparator=comparator,
+    module=WeightedAverageJudge(feature_specs=comparator.feature_specs),
     clusterer=Clusterer(threshold=0.7),
 )
 ```

--- a/examples/blocking_evaluation_comprehensive_comparison.py
+++ b/examples/blocking_evaluation_comprehensive_comparison.py
@@ -53,10 +53,10 @@ from langres.core.embeddings import (
     FastEmbedSparseEmbedder,
     SentenceTransformerEmbedder,
 )
-from langres.core.hybrid_vector_index import QdrantHybridIndex
+from langres.core.indexes.hybrid_vector_index import QdrantHybridIndex
 from langres.core.metrics import evaluate_blocking_with_ranking, pairs_from_clusters
-from langres.core.reranking_vector_index import QdrantHybridRerankingIndex
-from langres.core.vector_index import FAISSIndex
+from langres.core.indexes.reranking_vector_index import QdrantHybridRerankingIndex
+from langres.core.indexes.vector_index import FAISSIndex
 from langres.data import load_labeled_dedup_data
 
 # Configure logging

--- a/examples/blocking_evaluation_faiss_vs_qdrant.py
+++ b/examples/blocking_evaluation_faiss_vs_qdrant.py
@@ -31,9 +31,9 @@ from qdrant_client import QdrantClient
 from langres.clients.settings import Settings
 from langres.core.blockers.vector import VectorBlocker
 from langres.core.embeddings import FastEmbedSparseEmbedder, SentenceTransformerEmbedder
-from langres.core.hybrid_vector_index import QdrantHybridIndex
+from langres.core.indexes.hybrid_vector_index import QdrantHybridIndex
 from langres.core.metrics import pairs_from_clusters
-from langres.core.vector_index import FAISSIndex
+from langres.core.indexes.vector_index import FAISSIndex
 from langres.data import load_labeled_dedup_data
 
 # Configure logging

--- a/examples/blocking_evaluation_with_instructions.py
+++ b/examples/blocking_evaluation_with_instructions.py
@@ -60,9 +60,9 @@ from langres.core.embeddings import (
     FastEmbedSparseEmbedder,
     SentenceTransformerEmbedder,
 )
-from langres.core.hybrid_vector_index import QdrantHybridIndex
+from langres.core.indexes.hybrid_vector_index import QdrantHybridIndex
 from langres.core.metrics import evaluate_blocking_with_ranking, pairs_from_clusters
-from langres.core.vector_index import FAISSIndex
+from langres.core.indexes.vector_index import FAISSIndex
 from langres.data import load_labeled_dedup_data
 
 # Configure logging

--- a/examples/blocking_evaluation_with_reranking.py
+++ b/examples/blocking_evaluation_with_reranking.py
@@ -51,10 +51,10 @@ from langres.core.embeddings import (
     FastEmbedSparseEmbedder,
     SentenceTransformerEmbedder,
 )
-from langres.core.hybrid_vector_index import QdrantHybridIndex
+from langres.core.indexes.hybrid_vector_index import QdrantHybridIndex
 from langres.core.metrics import evaluate_blocking_with_ranking, pairs_from_clusters
-from langres.core.reranking_vector_index import QdrantHybridRerankingIndex
-from langres.core.vector_index import FAISSIndex
+from langres.core.indexes.reranking_vector_index import QdrantHybridRerankingIndex
+from langres.core.indexes.vector_index import FAISSIndex
 from langres.data import load_labeled_dedup_data
 
 # Configure logging

--- a/examples/deduplication_cached_faiss_simple.py
+++ b/examples/deduplication_cached_faiss_simple.py
@@ -30,7 +30,7 @@ from pydantic import BaseModel, Field
 from langres.core.blockers.vector import VectorBlocker
 from langres.core.embeddings import DiskCachedEmbedder, SentenceTransformerEmbedder
 from langres.core.metrics import pairs_from_clusters
-from langres.core.vector_index import FAISSIndex
+from langres.core.indexes.vector_index import FAISSIndex
 from langres.data import load_labeled_dedup_data
 
 # Configure logging

--- a/examples/deduplication_example.py
+++ b/examples/deduplication_example.py
@@ -49,7 +49,7 @@ from langres.core.metrics import (
 )
 from langres.core.modules.llm_judge import LLMJudgeModule
 from langres.core.optimizers.blocker_optimizer import BlockerOptimizer
-from langres.core.vector_index import FAISSIndex
+from langres.core.indexes.vector_index import FAISSIndex
 from langres.data import load_labeled_dedup_data, stratified_dedup_split
 
 # Configure logging
@@ -99,8 +99,8 @@ def run_deduplication_pipeline(
     # Initialize embedding provider
     embedding_provider = SentenceTransformerEmbedder(model_name=embedding_model)
 
-    # Initialize vector index
-    vector_index = FAISSIndex(metric="L2")
+    # Initialize vector index (the index owns the embedder in the current API)
+    vector_index = FAISSIndex(embedder=embedding_provider, metric="L2")
 
     # Schema factory: dict → OrganizationSchema
     def org_factory(record: dict[str, Any]) -> OrganizationSchema:
@@ -114,11 +114,10 @@ def run_deduplication_pipeline(
         """Extract text for embedding."""
         return org.name
 
-    # Create VectorBlocker
+    # Create VectorBlocker (the index owns the embedder; no embedding_provider= arg)
     blocker = VectorBlocker(
         schema_factory=org_factory,
         text_field_extractor=org_text_extractor,
-        embedding_provider=embedding_provider,
         vector_index=vector_index,
         k_neighbors=k_neighbors,
     )

--- a/examples/deduplication_with_blocker_optimization.py
+++ b/examples/deduplication_with_blocker_optimization.py
@@ -57,7 +57,7 @@ from langres.core.embeddings import SentenceTransformerEmbedder
 from langres.core.metrics import calculate_bcubed_metrics, calculate_pairwise_metrics
 from langres.core.modules.llm_judge import LLMJudgeModule
 from langres.core.optimizers.blocker_optimizer import BlockerOptimizer
-from langres.core.vector_index import FAISSIndex
+from langres.core.indexes.vector_index import FAISSIndex
 
 # Configure logging
 logging.basicConfig(

--- a/examples/instruction_embeddings_demo.py
+++ b/examples/instruction_embeddings_demo.py
@@ -30,7 +30,7 @@ from typing import Any
 import numpy as np
 
 from langres.core.embeddings import DiskCachedEmbedder, SentenceTransformerEmbedder
-from langres.core.vector_index import FAISSIndex
+from langres.core.indexes.vector_index import FAISSIndex
 from langres.data import load_labeled_dedup_data
 
 # Configure logging

--- a/examples/person_resolution.py
+++ b/examples/person_resolution.py
@@ -1,0 +1,399 @@
+"""Person resolution: the embeddings + LLM "strong path", end-to-end and deterministic.
+
+This is the runnable proof that langres's target architecture — semantic
+blocking (real sentence-transformer embeddings + FAISS ANN) feeding an LLM judge,
+clustered into entities, and round-tripped through ``save``/``load`` — actually
+runs on Person-shaped records. It is wired **manually** from ``langres.core``
+primitives via ``Resolver(...)`` (the declarative ``from_schema(blocker=, judge=)``
+builder is intentionally out of scope for M0.5).
+
+It stays deterministic and free by injecting a tiny **fake** LLM client whose
+``completion(...)`` returns canned ``MATCH/NO_MATCH`` text derived from a
+name-normalization rule that mirrors how an LLM would judge these records
+(accent-stripped, lower-cased, order-insensitive, initial-aware). Swap that fake
+for ``LLMJudge.from_env(...)`` and the exact same pipeline calls a real model.
+
+Run it::
+
+    OMP_NUM_THREADS=1 KMP_DUPLICATE_LIB_OK=1 uv run python examples/person_resolution.py
+
+What it shows:
+
+1. Build the strong-path ``Resolver`` manually: ``VectorBlocker`` (declarative
+   ``schema=`` + ``text_field=``, cosine FAISS) -> ``comparator=None`` (the judge
+   reads raw entities) -> ``LLMJudge`` -> ``Clusterer``.
+2. Resolve a small Person fixture with known duplicates into entity clusters.
+3. Report **blocking Pair-Completeness** (the M1-critical "is blocking even
+   catching the duplicates" signal) and **honest cost** (0.0 with the fake).
+4. ``save`` the pipeline to a human-readable, pickle-free ``resolver.json``,
+   reload it, re-attach the fake client, and prove the clustering is identical.
+5. Optionally run one real pair through ``LLMJudge.from_env`` when
+   ``OPENROUTER_API_KEY`` is set (skipped cleanly otherwise).
+
+``print`` is allowed in examples (this is demonstration, not library code).
+"""
+
+from __future__ import annotations
+
+import re
+import tempfile
+import unicodedata
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+from pydantic import BaseModel, Field
+
+from langres.core import Resolver
+from langres.core.blockers.vector import VectorBlocker
+from langres.core.clusterer import Clusterer
+from langres.core.embeddings import SentenceTransformerEmbedder
+from langres.core.indexes.vector_index import FAISSIndex
+from langres.core.metrics import (
+    calculate_bcubed_metrics,
+    calculate_pairwise_metrics,
+    evaluate_blocking,
+)
+from langres.core.models import PairwiseJudgement
+from langres.core.modules.llm_judge import LLMJudge
+
+# ----------------------------------------------------------------------------
+# Schema + fixture: a handful of people with KNOWN duplicates.
+# ----------------------------------------------------------------------------
+
+
+class PersonSchema(BaseModel):
+    """A minimal Person entity: an id, a name, and a few optional attributes."""
+
+    id: str = Field(description="Unique entity identifier")
+    name: str = Field(description="Person's full name (the field we embed)")
+    role: str | None = Field(default=None, description="Job title / role")
+    org: str | None = Field(default=None, description="Organization / employer")
+    linkedin_url: str | None = Field(default=None, description="LinkedIn profile URL")
+
+
+# 10 records. Two true duplicate clusters with realistic name variation
+# (accents vs stripped, abbreviated initial, name-order swap) plus look-alike
+# non-duplicates that must stay separate (shared first name; near-name).
+PERSON_RECORDS: list[dict[str, Any]] = [
+    # Cluster A — Joséphine Goube (4 surface forms of the same person).
+    {"id": "p1", "name": "Joséphine Goube", "role": "CEO", "org": "Tech4Good"},
+    {"id": "p2", "name": "Josephine Goube", "role": "Chief Executive", "org": "Tech4Good"},
+    {"id": "p3", "name": "J. Goube", "org": "Tech4Good"},
+    {"id": "p4", "name": "Goube, Josephine", "linkedin_url": "https://linkedin.com/in/jgoube"},
+    # Cluster B — Liang Wei (name-order variation, common for Chinese names).
+    {"id": "p5", "name": "Liang Wei", "role": "Researcher", "org": "DeepMind"},
+    {"id": "p6", "name": "Wei Liang", "role": "Research Scientist", "org": "DeepMind"},
+    # Non-duplicates (must NOT merge).
+    {"id": "p7", "name": "Maria Garcia", "role": "Designer"},
+    {"id": "p8", "name": "Maria Silva", "role": "Designer"},
+    {"id": "p9", "name": "John Smith", "org": "Acme"},
+    {"id": "p10", "name": "Jonathan Smith", "org": "Acme"},
+]
+
+# Ground-truth entity clusters (multi-record only) and the duplicate pairs they
+# imply — the blocking Pair-Completeness target.
+KNOWN_DUPLICATE_GROUPS: list[set[str]] = [
+    {"p1", "p2", "p3", "p4"},
+    {"p5", "p6"},
+]
+KNOWN_DUPLICATE_PAIRS: set[frozenset[str]] = {
+    frozenset({a, b}) for group in KNOWN_DUPLICATE_GROUPS for a in group for b in group if a < b
+}
+
+
+# ----------------------------------------------------------------------------
+# Deterministic fake LLM client.
+# ----------------------------------------------------------------------------
+
+
+def _normalize_tokens(name: str) -> list[str]:
+    """Lower-case, strip accents, drop punctuation -> sorted alnum tokens.
+
+    ``"Joséphine Goube"`` and ``"Goube, Josephine"`` both normalize to
+    ``["goube", "josephine"]`` — accent- and order-insensitive.
+    """
+    folded = unicodedata.normalize("NFKD", name)
+    ascii_only = folded.encode("ascii", "ignore").decode("ascii").lower()
+    tokens = [t for t in re.split(r"[^a-z0-9]+", ascii_only) if t]
+    return sorted(tokens)
+
+
+def _names_match(a: str, b: str) -> bool:
+    """True iff two names plausibly denote the same person.
+
+    Mirrors an LLM's judgement on these records with a transparent rule: same
+    number of normalized tokens, each aligned pair either equal or one being a
+    single-letter initial of the other (so ``"J. Goube"`` matches
+    ``"Josephine Goube"`` but ``"John Smith"`` does not match ``"Jonathan Smith"``).
+    """
+    ta, tb = _normalize_tokens(a), _normalize_tokens(b)
+    if len(ta) != len(tb):
+        return False
+    for x, y in zip(ta, tb, strict=True):
+        if x == y:
+            continue
+        if len(x) == 1 and y.startswith(x):
+            continue
+        if len(y) == 1 and x.startswith(y):
+            continue
+        return False
+    return True
+
+
+@dataclass
+class _FakeUsage:
+    prompt_tokens: int
+    completion_tokens: int
+
+
+@dataclass
+class _FakeMessage:
+    content: str
+
+
+@dataclass
+class _FakeChoice:
+    message: _FakeMessage
+
+
+@dataclass
+class _FakeResponse:
+    choices: list[_FakeChoice]
+    usage: _FakeUsage
+
+
+class FakeLLMClient:
+    """A canned, deterministic stand-in for a real LLM client.
+
+    Implements only the ``.completion(...)`` surface ``LLMJudge.forward`` calls.
+    It extracts the two record names from the rendered prompt and answers
+    ``MATCH``/``NO_MATCH`` via :func:`_names_match`, so the whole pipeline runs
+    offline, for free, and identically on every invocation.
+    """
+
+    # The judge dumps each entity as JSON, so the prompt contains exactly two
+    # ``"name": "..."`` fields — Record A then Record B.
+    _NAME_RE = re.compile(r'"name":\s*"([^"]*)"')
+
+    def completion(
+        self,
+        *,
+        model: str,
+        messages: list[dict[str, str]],
+        temperature: float,
+        **kwargs: Any,
+    ) -> _FakeResponse:
+        prompt = messages[0]["content"]
+        names = self._NAME_RE.findall(prompt)
+        if len(names) != 2:  # pragma: no cover - prompt shape is fixed
+            raise ValueError(f"Expected two names in prompt, found {len(names)}: {names!r}")
+
+        is_match = _names_match(names[0], names[1])
+        verdict = "MATCH" if is_match else "NO_MATCH"
+        score = 0.95 if is_match else 0.05
+        reasoning = (
+            f"Names '{names[0]}' and '{names[1]}' normalize to the same person."
+            if is_match
+            else f"Names '{names[0]}' and '{names[1]}' denote different people."
+        )
+        content = f"{verdict}\nScore: {score}\nReasoning: {reasoning}"
+        return _FakeResponse(
+            choices=[_FakeChoice(message=_FakeMessage(content=content))],
+            usage=_FakeUsage(prompt_tokens=len(prompt) // 4, completion_tokens=16),
+        )
+
+
+# ----------------------------------------------------------------------------
+# Pipeline construction + run.
+# ----------------------------------------------------------------------------
+
+
+def build_resolver(client: Any, *, k_neighbors: int = 5, threshold: float = 0.5) -> Resolver:
+    """Wire the embeddings + LLM strong path manually into a Resolver.
+
+    Args:
+        client: The LLM client injected into the ``LLMJudge`` (the deterministic
+            :class:`FakeLLMClient` here; ``LLMJudge.from_env`` in production).
+        k_neighbors: Nearest neighbours per record for the vector blocker.
+        threshold: Clusterer match threshold over judge scores.
+
+    Returns:
+        A runnable, serializable Resolver (declarative blocker -> ``None``
+        comparator -> LLM judge -> clusterer).
+    """
+    blocker: VectorBlocker[PersonSchema] = VectorBlocker(
+        vector_index=FAISSIndex(
+            embedder=SentenceTransformerEmbedder("all-MiniLM-L6-v2"),
+            metric="cosine",
+        ),
+        schema=PersonSchema,
+        text_field="name",
+        k_neighbors=k_neighbors,
+    )
+    judge: LLMJudge[PersonSchema] = LLMJudge(
+        client=client,
+        model="openrouter/openai/gpt-4o-mini",
+        temperature=0.0,
+        entity_noun="person",
+    )
+    return Resolver(
+        blocker=blocker,
+        comparator=None,  # the LLM judge reads raw entities; no comparison vector
+        module=judge,
+        clusterer=Clusterer(threshold=threshold),
+    )
+
+
+def _canonical(clusters: list[set[str]]) -> frozenset[frozenset[str]]:
+    """Order-independent cluster identity for equality checks."""
+    return frozenset(frozenset(c) for c in clusters)
+
+
+def run_demo() -> dict[str, Any]:
+    """Run the deterministic strong path end-to-end and return its key results.
+
+    Returns a dict with the predicted clusters, blocking recall, total cost,
+    BCubed/pairwise F1, and whether a save/reload round-trip reproduced the
+    clustering identically — everything the test asserts on.
+    """
+    client = FakeLLMClient()
+    resolver = build_resolver(client)
+
+    # Build the blocker's index explicitly so we can measure blocking quality
+    # on the candidates before the LLM ever runs. The Resolver reuses this same
+    # built index (it never re-embeds an identical corpus).
+    blocker = resolver.blocker
+    assert isinstance(blocker, VectorBlocker)  # narrows Blocker[Any] -> VectorBlocker
+    texts = [str(r["name"]) for r in PERSON_RECORDS]
+    blocker.vector_index.create_index(texts)
+    candidates = list(blocker.stream(PERSON_RECORDS))
+    blocking_stats = evaluate_blocking(candidates, KNOWN_DUPLICATE_GROUPS)
+
+    # Score (LLM judge) then cluster. predict() returns the judgements so we can
+    # sum honest cost without paying for a second pass.
+    judgements: list[PairwiseJudgement] = resolver.predict(PERSON_RECORDS)
+    clusters = resolver.clusterer.cluster(judgements)
+    total_cost = sum(float(j.provenance["cost_usd"]) for j in judgements)
+
+    bcubed = calculate_bcubed_metrics(clusters, KNOWN_DUPLICATE_GROUPS)
+    pairwise = calculate_pairwise_metrics(clusters, KNOWN_DUPLICATE_GROUPS)
+
+    # save -> load -> re-attach the fake client -> re-resolve identically.
+    with tempfile.TemporaryDirectory() as tmp:
+        artifact_dir = Path(tmp) / "person_v0"
+        resolver.save(artifact_dir)
+        manifest = (artifact_dir / "resolver.json").read_text()
+        reloaded = Resolver.load(artifact_dir)
+        # from_config rebuilds the judge with a lazy env client; re-inject the
+        # SAME fake so the reloaded run is deterministic and free.
+        reloaded.module.client = client  # type: ignore[attr-defined]
+        reloaded_clusters = reloaded.clusterer.cluster(reloaded.predict(PERSON_RECORDS))
+
+    identical = _canonical(clusters) == _canonical(reloaded_clusters)
+
+    return {
+        "clusters": clusters,
+        "candidates": candidates,
+        "blocking_recall": blocking_stats.candidate_recall,
+        "blocking_stats": blocking_stats,
+        "num_judgements": len(judgements),
+        "total_cost": total_cost,
+        "bcubed": bcubed,
+        "pairwise": pairwise,
+        "identical": identical,
+        "reloaded_clusters": reloaded_clusters,
+        "manifest": manifest,
+    }
+
+
+def maybe_live_smoke() -> None:
+    """Run ONE real pair through ``LLMJudge.from_env`` if a key is present.
+
+    Gated on ``OPENROUTER_API_KEY`` so the default run is offline and free.
+    Cost is trivial (a single pair). Prints the real ``completion_cost``.
+    """
+    import os
+
+    if not os.getenv("OPENROUTER_API_KEY"):
+        print("\n[live smoke] OPENROUTER_API_KEY not set — skipping real LLM call.")
+        return
+
+    from langres.core.models import ERCandidate
+
+    judge: LLMJudge[PersonSchema] = LLMJudge.from_env(
+        model="openrouter/openai/gpt-4o-mini", temperature=0.0, entity_noun="person"
+    )
+    pair: ERCandidate[PersonSchema] = ERCandidate(
+        left=PersonSchema(**PERSON_RECORDS[0]),
+        right=PersonSchema(**PERSON_RECORDS[1]),
+        blocker_name="manual",
+    )
+    judgement = next(iter(judge.forward(iter([pair]))))
+    print("\n[live smoke] real LLM judgement on (p1, p2):")
+    print(f"  score={judgement.score:.3f}  cost=${judgement.provenance['cost_usd']:.6f}")
+    print(f"  reasoning: {judgement.reasoning}")
+
+
+def _print_clusters(title: str, clusters: list[set[str]]) -> None:
+    print(f"\n{title}")
+    for cluster in sorted(sorted(c) for c in clusters):
+        print(f"  {cluster}")
+
+
+def main() -> None:
+    # Quiet langres' info/warning chatter (e.g. the honest "completion_cost
+    # unavailable -> 0.0" note the fake response triggers) for a clean demo.
+    import logging
+
+    logging.getLogger("langres").setLevel(logging.ERROR)
+
+    print("=" * 78)
+    print("Person resolution — embeddings + LLM strong path (deterministic)")
+    print("=" * 78)
+
+    results = run_demo()
+
+    _print_clusters("Predicted clusters:", results["clusters"])
+
+    recall = results["blocking_recall"]
+    print(
+        f"\nBlocking Pair-Completeness (recall over known duplicate pairs): {recall:.3f}"
+        f"  [target >= 0.95]  {'PASS' if recall >= 0.95 else 'LOW'}"
+    )
+    stats = results["blocking_stats"]
+    print(
+        f"  candidates={stats.total_candidates}  "
+        f"missed={stats.missed_matches_count}  "
+        f"avg_per_entity={stats.avg_candidates_per_entity:.1f}"
+    )
+
+    print(
+        f"\nEnd-to-end accuracy vs known duplicates: "
+        f"BCubed F1={results['bcubed']['f1']:.3f}  "
+        f"Pairwise F1={results['pairwise']['f1']:.3f}"
+    )
+
+    print(
+        f"\nHonest cost: ${results['total_cost']:.6f} over "
+        f"{results['num_judgements']} LLM judgements (0.0 with the fake client)."
+    )
+
+    print("\nresolver.json is human-readable, pickle-free, and carries NO client/secret.")
+    print("Manifest head (note the judge's model ref but no API key):")
+    for line in results["manifest"].splitlines()[:14]:
+        print(f"  {line}")
+
+    _print_clusters("Clusters after save -> load -> re-resolve:", results["reloaded_clusters"])
+    assert results["identical"], "Reloaded clustering differs from the original!"
+    print("\nSave/reload round-trip: clustering is IDENTICAL ✓")
+
+    maybe_live_smoke()
+
+    print("\n" + "=" * 78)
+    print("Strong path ran end-to-end. ✓")
+    print("=" * 78)
+
+
+if __name__ == "__main__":
+    main()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -142,3 +142,14 @@ mypy_path = "src"
 # Silencing the missing-import check here is stable across both.
 module = ["faiss.*"]
 ignore_missing_imports = true
+
+[[tool.mypy.overrides]]
+# litellm ships type info in some installs but not others, and under strict
+# `no_implicit_reexport` an attribute like `litellm.completion_cost` flips
+# between typed (needs an inline `# type: ignore[attr-defined]`) and untyped
+# (the ignore is unused — which fails `warn_unused_ignores`). Treat litellm as
+# untyped uniformly so neither side flips. `create_llm_client` already returns
+# `Any`, so this introduces no `warn_return_any` regressions.
+module = ["litellm.*"]
+ignore_missing_imports = true
+follow_imports = "skip"

--- a/src/langres/core/__init__.py
+++ b/src/langres/core/__init__.py
@@ -43,6 +43,12 @@ from langres.core.models import (
     PairwiseJudgement,
 )
 from langres.core.module import Module
+
+# Importing LLMJudge here ensures its ``@register("llm_judge")`` runs on plain
+# ``import langres.core`` — so a fresh process doing ``Resolver.load(path)`` on
+# an LLMJudge artifact finds the type in the registry (mirrors WeightedAverageJudge
+# above). It also makes ``from langres.core import LLMJudge`` work.
+from langres.core.modules.llm_judge import LLMJudge
 from langres.core.registry import (
     SchemaNotRegistered,
     UnknownComponentType,
@@ -86,6 +92,7 @@ __all__ = [
     "get_component",
     "get_schema",
     "GLinkerAdapter",
+    "LLMJudge",
     "metrics",
     "Module",
     "optimizers",

--- a/src/langres/core/blockers/vector.py
+++ b/src/langres/core/blockers/vector.py
@@ -104,7 +104,7 @@ class VectorBlocker(Blocker[SchemaT]):
 
     Example (production with FAISS):
         from langres.core.embeddings import SentenceTransformerEmbedder
-        from langres.core.vector_index import FAISSIndex
+        from langres.core.indexes.vector_index import FAISSIndex
 
         def company_factory(record: dict) -> CompanySchema:
             return CompanySchema(
@@ -141,7 +141,7 @@ class VectorBlocker(Blocker[SchemaT]):
     Example (production with Qdrant hybrid search):
         from qdrant_client import QdrantClient
         from langres.core.embeddings import SentenceTransformerEmbedder, FastEmbedSparseEmbedder
-        from langres.core.hybrid_vector_index import QdrantHybridIndex
+        from langres.core.indexes.hybrid_vector_index import QdrantHybridIndex
 
         client = QdrantClient(url="http://localhost:6333")
         dense_embedder = SentenceTransformerEmbedder("all-MiniLM-L6-v2")
@@ -168,7 +168,7 @@ class VectorBlocker(Blocker[SchemaT]):
         candidates = list(blocker.stream(entities))
 
     Example (testing with fakes):
-        from langres.core.vector_index import FakeVectorIndex
+        from langres.core.indexes.vector_index import FakeVectorIndex
 
         index = FakeVectorIndex()
 

--- a/src/langres/core/blockers/vector.py
+++ b/src/langres/core/blockers/vector.py
@@ -16,8 +16,6 @@ from collections.abc import Callable, Iterator
 from pathlib import Path
 from typing import Any, ClassVar
 
-import numpy as np
-
 from langres.core.blocker import Blocker, SchemaT
 from langres.core.blockers.all_pairs import (
     register_schema_idempotent,
@@ -457,14 +455,11 @@ class VectorBlocker(Blocker[SchemaT]):
         k = min(self.k_neighbors + 1, len(entities))
         distances, indices = self.vector_index.search_all(k, query_prompt=self.query_prompt)
 
-        # 5. Convert distances to similarity scores
-        # The conversion depends on the vector index metric:
-        # - For cosine metric (IndexFlatIP): distances ARE similarities [0, 1]
-        # - For L2 metric: need to convert distance to similarity
-        # Since we don't know the metric here, we use a heuristic:
-        # - If distances are in [0, 1], assume they're already similarities
-        # - Otherwise, convert using exponential decay: sim = exp(-distance)
-        similarities = self._distances_to_similarities(distances)
+        # 5. Convert distances to similarity scores in [0, 1] (1.0 = most similar).
+        # The vector index owns this conversion because only it knows its metric
+        # (e.g. FAISS L2 squared distances vs. cosine inner products vs. Qdrant
+        # fusion scores). Delegating here avoids guessing the metric blocker-side.
+        similarities = self.vector_index.to_similarities(distances)
 
         # 6. Generate pairs from nearest neighbors
         # Use a set to track seen pairs and avoid duplicates
@@ -504,58 +499,6 @@ class VectorBlocker(Blocker[SchemaT]):
                         blocker_name="vector_blocker",
                         similarity_score=float(similarity),
                     )
-
-    def _distances_to_similarities(
-        self, distances: np.ndarray
-    ) -> np.ndarray:  # TODO verify if this is doing what you think it does.
-        """Convert distance matrix to similarity scores in [0, 1].
-
-        Args:
-            distances: Distance matrix from vector index (shape: N x k)
-
-        Returns:
-            Similarity matrix in [0, 1] where 1.0 = most similar
-
-        Note:
-            Handles different distance metrics:
-            - Cosine (IndexFlatIP): distances are already similarities (higher = more similar)
-            - L2/Fake: distances need conversion (lower = more similar)
-
-            We use a heuristic to detect the metric:
-            - If max distance <= 2.0 AND distances increase monotonically for each row,
-              treat as L2-style distances (convert with exp(-distance))
-            - Otherwise, assume cosine similarities (clip to [0, 1])
-
-            NaN values are replaced with 0.0 (lowest similarity).
-        """
-        # Replace NaN values with 0.0 (lowest similarity)
-        # This can happen with some vector index implementations
-        distances = np.nan_to_num(distances, nan=0.0)  # TODO: verify.
-
-        # Check if distances look like L2-style (lower = better)
-        # FakeVectorIndex produces [0.0, 0.1, 0.2, ...] (monotonic increasing)
-        # Real L2 distances also increase with rank
-        max_dist = np.max(distances)
-
-        # Check if each row is monotonically increasing (L2 pattern)
-        is_monotonic_increasing = True
-        for row in distances:
-            if len(row) > 1:
-                diffs = np.diff(row)
-                if not np.all(diffs >= -1e-6):  # Allow small numerical errors
-                    is_monotonic_increasing = False
-                    break
-
-        if is_monotonic_increasing and max_dist <= 2.0:
-            # L2-style distances - convert using exponential decay
-            # sim = exp(-distance) maps: distance=0 -> sim=1, distance=inf -> sim=0
-            similarities: np.ndarray = np.exp(-distances)
-            return similarities
-        else:
-            # Cosine-style similarities - already in correct form (higher = better)
-            # Just clip to [0, 1] to handle any numerical errors
-            clipped: np.ndarray = np.clip(distances, 0.0, 1.0)
-            return clipped
 
     def inspect_candidates(
         self,

--- a/src/langres/core/indexes/hybrid_vector_index.py
+++ b/src/langres/core/indexes/hybrid_vector_index.py
@@ -354,12 +354,16 @@ class QdrantHybridIndex:
         )
 
     def to_similarities(self, distances: np.ndarray) -> np.ndarray:
-        """Convert Qdrant fusion scores to similarities in ``[0, 1]``.
+        """Map Qdrant fusion scores into ``[0, 1]`` — bounded but lossy, observability only.
 
         ``search``/``search_all`` return RRF/DBSF fusion scores (higher = more
-        similar), already similarity-like, plus ``NaN`` padding when a query
-        returns fewer than ``k`` results. Delegates to
-        :func:`clip_scores_to_similarities` (clip to ``[0, 1]``, ``NaN`` → 0.0).
+        similar) plus ``NaN`` padding when a query returns fewer than ``k``
+        results. These fusion scores are **not** in ``[0, 1]`` — they are tiny
+        (~0.01–0.03) — so :func:`clip_scores_to_similarities` (clip to ``[0, 1]``,
+        ``NaN`` → 0.0) is a lossy mapping that collapses most of them toward 0.0.
+        The resulting ``similarity_score`` is therefore for observability only and
+        is degenerate for ranking; candidate membership is unaffected (it comes
+        from the index's neighbour ranking, which the monotonic clip preserves).
         """
         return clip_scores_to_similarities(distances)
 

--- a/src/langres/core/indexes/hybrid_vector_index.py
+++ b/src/langres/core/indexes/hybrid_vector_index.py
@@ -28,6 +28,10 @@ from qdrant_client.models import (
 )
 
 from langres.core.embeddings import EmbeddingProvider, SparseEmbeddingProvider
+from langres.core.indexes.vector_index import (
+    clip_scores_to_similarities,
+    inverse_distances_to_similarities,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -349,6 +353,16 @@ class QdrantHybridIndex:
             _dense_embeddings=self._cached_dense_embeddings,
         )
 
+    def to_similarities(self, distances: np.ndarray) -> np.ndarray:
+        """Convert Qdrant fusion scores to similarities in ``[0, 1]``.
+
+        ``search``/``search_all`` return RRF/DBSF fusion scores (higher = more
+        similar), already similarity-like, plus ``NaN`` padding when a query
+        returns fewer than ``k`` results. Delegates to
+        :func:`clip_scores_to_similarities` (clip to ``[0, 1]``, ``NaN`` → 0.0).
+        """
+        return clip_scores_to_similarities(distances)
+
 
 class FakeHybridVectorIndex:
     """Test double for hybrid vector index.
@@ -450,3 +464,12 @@ class FakeHybridVectorIndex:
                 distances[i, j] = j * 0.1
 
         return distances, indices
+
+    def to_similarities(self, distances: np.ndarray) -> np.ndarray:
+        """Convert the fake's synthetic distances (lower = closer) to ``[0, 1]``.
+
+        Uses :func:`inverse_distances_to_similarities` to match the rank-ordered
+        ``j * 0.1`` distances this double emits (nearest neighbor scores highest),
+        keeping its similarity ordering meaningful. ``NaN`` maps to 0.0.
+        """
+        return inverse_distances_to_similarities(distances)

--- a/src/langres/core/indexes/reranking_vector_index.py
+++ b/src/langres/core/indexes/reranking_vector_index.py
@@ -34,6 +34,10 @@ from langres.core.embeddings import (
     LateInteractionEmbeddingProvider,
     SparseEmbeddingProvider,
 )
+from langres.core.indexes.vector_index import (
+    clip_scores_to_similarities,
+    inverse_distances_to_similarities,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -389,6 +393,16 @@ class QdrantHybridRerankingIndex:
             _dense_embeddings=self._cached_dense_embeddings,
         )
 
+    def to_similarities(self, distances: np.ndarray) -> np.ndarray:
+        """Convert late-interaction MaxSim scores to similarities in ``[0, 1]``.
+
+        ``search``/``search_all`` return reranking (ColBERT/ColPali MaxSim) scores
+        (higher = more similar), already similarity-like, plus ``NaN`` padding when
+        a query returns fewer than ``k`` results. Delegates to
+        :func:`clip_scores_to_similarities` (clip to ``[0, 1]``, ``NaN`` → 0.0).
+        """
+        return clip_scores_to_similarities(distances)
+
 
 class FakeHybridRerankingVectorIndex:
     """Test double for hybrid reranking vector index.
@@ -486,3 +500,12 @@ class FakeHybridRerankingVectorIndex:
                 distances[i, j] = j * 0.1
 
         return distances, indices
+
+    def to_similarities(self, distances: np.ndarray) -> np.ndarray:
+        """Convert the fake's synthetic distances (lower = closer) to ``[0, 1]``.
+
+        Uses :func:`inverse_distances_to_similarities` to match the rank-ordered
+        ``j * 0.1`` distances this double emits (nearest neighbor scores highest),
+        keeping its similarity ordering meaningful. ``NaN`` maps to 0.0.
+        """
+        return inverse_distances_to_similarities(distances)

--- a/src/langres/core/indexes/reranking_vector_index.py
+++ b/src/langres/core/indexes/reranking_vector_index.py
@@ -394,12 +394,16 @@ class QdrantHybridRerankingIndex:
         )
 
     def to_similarities(self, distances: np.ndarray) -> np.ndarray:
-        """Convert late-interaction MaxSim scores to similarities in ``[0, 1]``.
+        """Map MaxSim scores into ``[0, 1]`` — bounded but lossy, observability only.
 
-        ``search``/``search_all`` return reranking (ColBERT/ColPali MaxSim) scores
-        (higher = more similar), already similarity-like, plus ``NaN`` padding when
-        a query returns fewer than ``k`` results. Delegates to
-        :func:`clip_scores_to_similarities` (clip to ``[0, 1]``, ``NaN`` → 0.0).
+        ``search``/``search_all`` return late-interaction (ColBERT/ColPali) MaxSim
+        scores (higher = more similar) plus ``NaN`` padding when a query returns
+        fewer than ``k`` results. MaxSim scores are **not** in ``[0, 1]`` — they
+        routinely exceed 1.0 — so :func:`clip_scores_to_similarities` (clip to
+        ``[0, 1]``, ``NaN`` → 0.0) is a lossy mapping that saturates them at 1.0.
+        The resulting ``similarity_score`` is therefore for observability only and
+        is degenerate for ranking; candidate membership is unaffected (it comes
+        from the index's neighbour ranking, which the monotonic clip preserves).
         """
         return clip_scores_to_similarities(distances)
 
@@ -444,12 +448,16 @@ class FakeHybridRerankingVectorIndex:
         self._texts = texts
         logger.debug("FakeHybridRerankingVectorIndex: recorded %d samples", self._n_samples)
 
-    def search(self, query_texts: str | list[str], k: int) -> tuple[np.ndarray, np.ndarray]:
+    def search(
+        self, query_texts: str | list[str], k: int, query_prompt: str | None = None
+    ) -> tuple[np.ndarray, np.ndarray]:
         """Generate fake search results (deterministic).
 
         Args:
             query_texts: Single text or list of texts.
             k: Number of neighbors per query.
+            query_prompt: Optional instruction prompt (accepted for protocol
+                parity with the real index and VectorBlocker; fake ignores it).
 
         Returns:
             - If single query: distances=(k,), indices=(k,)
@@ -477,11 +485,13 @@ class FakeHybridRerankingVectorIndex:
         else:
             return distances, indices
 
-    def search_all(self, k: int) -> tuple[np.ndarray, np.ndarray]:
+    def search_all(self, k: int, query_prompt: str | None = None) -> tuple[np.ndarray, np.ndarray]:
         """Generate fake deduplication results (deterministic).
 
         Args:
             k: Number of neighbors per corpus item.
+            query_prompt: Optional instruction prompt (accepted for protocol
+                parity with the real index and VectorBlocker; fake ignores it).
 
         Returns:
             distances: shape (N, k) where N = corpus size

--- a/src/langres/core/indexes/vector_index.py
+++ b/src/langres/core/indexes/vector_index.py
@@ -50,18 +50,28 @@ def inverse_distances_to_similarities(distances: np.ndarray) -> np.ndarray:
 
 
 def clip_scores_to_similarities(scores: np.ndarray) -> np.ndarray:
-    """Clip already-similarity-like scores (higher = more similar) to ``[0, 1]``.
+    """Clip "higher = more similar" scores into ``[0, 1]`` — bounded, but lossy.
 
-    Use when an index returns scores that are *already* monotonic in true
-    similarity (higher = better) and roughly in ``[0, 1]`` — e.g. Qdrant fusion
-    (RRF/DBSF) or late-interaction MaxSim scores. ``NaN`` scores (such as the
-    padding emitted when a query returns fewer than ``k`` results) map to 0.0.
+    Use when an index returns scores that are monotonic in true similarity
+    (higher = better) but **not** already on a ``[0, 1]`` scale — e.g. Qdrant
+    fusion (RRF/DBSF) or late-interaction (ColBERT/ColPali) MaxSim scores.
+    Despite their name these are NOT probabilities and do not sit in ``[0, 1]``:
+    RRF/DBSF fusion scores are typically tiny (~0.01–0.03) and MaxSim scores
+    routinely exceed 1.0. Clipping to ``[0, 1]`` is therefore a **lossy** mapping
+    — most fusion scores collapse toward 0.0 and MaxSim scores saturate at 1.0 —
+    so the resulting per-pair ``similarity_score`` is degenerate and should be
+    treated as **observability only**, never as a calibrated similarity. It does
+    not affect candidate membership: the blocker's candidate set comes from the
+    index's neighbour ranking, which this clip preserves (it is monotonic). For a
+    real score, run a downstream scorer (e.g. a Comparator + judge). ``NaN``
+    scores (such as the padding emitted when a query returns fewer than ``k``
+    results) map to 0.0.
 
     Args:
         scores: Score matrix (any shape), higher = more similar.
 
     Returns:
-        Similarity array of the same shape, values in ``[0, 1]``.
+        Similarity array of the same shape, values clipped into ``[0, 1]``.
     """
     s = np.asarray(scores, dtype=np.float64)
     return np.nan_to_num(np.clip(s, 0.0, 1.0), nan=0.0)

--- a/src/langres/core/indexes/vector_index.py
+++ b/src/langres/core/indexes/vector_index.py
@@ -510,7 +510,8 @@ class FAISSIndex:
             sim = 1.0 / (1.0 + np.sqrt(np.maximum(d, 0.0)))
         else:  # cosine: inner products of normalized vectors, in [-1, 1]
             sim = np.clip((d + 1.0) / 2.0, 0.0, 1.0)
-        return np.nan_to_num(sim, nan=0.0)
+        result: np.ndarray = np.nan_to_num(sim, nan=0.0)
+        return result
 
     # ============ OLD API (for backward compatibility during transition) ============
     def build(self, embeddings: np.ndarray) -> None:

--- a/src/langres/core/indexes/vector_index.py
+++ b/src/langres/core/indexes/vector_index.py
@@ -27,6 +27,46 @@ from langres.core.serialization import ComponentSpec
 logger = logging.getLogger(__name__)
 
 
+def inverse_distances_to_similarities(distances: np.ndarray) -> np.ndarray:
+    """Map non-negative distances (lower = closer) to similarities in ``(0, 1]``.
+
+    Uses ``1 / (1 + d)``, monotonically decreasing in the distance: a distance
+    of 0 maps to 1.0 (most similar) and decays toward 0.0 as the distance grows.
+    ``NaN`` distances map to 0.0 (least similar).
+
+    Shared by the in-memory fake indexes, whose synthetic distances are
+    rank-ordered (lower = closer), so their ``to_similarities`` stays meaningful.
+
+    Args:
+        distances: Distance matrix (any shape), values ``>= 0`` (negatives are
+            clamped to 0 before conversion).
+
+    Returns:
+        Similarity array of the same shape, values in ``[0, 1]``.
+    """
+    d = np.asarray(distances, dtype=np.float64)
+    sim = 1.0 / (1.0 + np.maximum(d, 0.0))
+    return np.nan_to_num(sim, nan=0.0)
+
+
+def clip_scores_to_similarities(scores: np.ndarray) -> np.ndarray:
+    """Clip already-similarity-like scores (higher = more similar) to ``[0, 1]``.
+
+    Use when an index returns scores that are *already* monotonic in true
+    similarity (higher = better) and roughly in ``[0, 1]`` — e.g. Qdrant fusion
+    (RRF/DBSF) or late-interaction MaxSim scores. ``NaN`` scores (such as the
+    padding emitted when a query returns fewer than ``k`` results) map to 0.0.
+
+    Args:
+        scores: Score matrix (any shape), higher = more similar.
+
+    Returns:
+        Similarity array of the same shape, values in ``[0, 1]``.
+    """
+    s = np.asarray(scores, dtype=np.float64)
+    return np.nan_to_num(np.clip(s, 0.0, 1.0), nan=0.0)
+
+
 class SerializableEmbedder(EmbeddingProvider, Protocol):
     """An :class:`EmbeddingProvider` that can round-trip through a ``ComponentSpec``.
 
@@ -185,6 +225,25 @@ class VectorIndex(Protocol):
             For deduplication pattern where you want neighbors for all items.
             More efficient than calling search(all_texts, k) because it reuses
             cached embeddings without re-encoding.
+        """
+        ...  # pragma: no cover
+
+    def to_similarities(self, distances: np.ndarray) -> np.ndarray:
+        """Convert this index's raw distance/score matrix to similarities in [0, 1].
+
+        Each concrete index knows its own metric and converts so that 1.0 = most
+        similar and the result is monotonic in true similarity. ``NaN`` entries
+        map to 0.0 (least similar). This keeps the distance→similarity conversion
+        with the index that produced the distances, rather than having callers
+        guess the metric.
+
+        Args:
+            distances: The distance/score matrix returned by :meth:`search_all`
+                (or :meth:`search`), typically shape ``(N, k)``.
+
+        Returns:
+            Similarity array of the same shape, values in ``[0, 1]`` where 1.0 =
+            most similar.
         """
         ...  # pragma: no cover
 
@@ -427,6 +486,32 @@ class FAISSIndex:
         # query_prompt parameter is passed through but ignored for pre-computed embeddings
         return self.search(self._corpus_embeddings, k, query_prompt=query_prompt)
 
+    def to_similarities(self, distances: np.ndarray) -> np.ndarray:
+        """Convert FAISS distances to similarities in [0, 1] using the index metric.
+
+        - ``metric="L2"`` (``IndexFlatL2``): ``distances`` are *squared* L2
+          distances (``d >= 0``, lower = closer, routinely ``> 2.0``). Converted
+          with ``1 / (1 + sqrt(d))``, monotonically decreasing in distance and in
+          ``(0, 1]``.
+        - ``metric="cosine"`` (``IndexFlatIP`` over normalized vectors):
+          ``distances`` are inner products in ``[-1, 1]`` (higher = more similar).
+          Mapped to ``[0, 1]`` with ``(ip + 1) / 2``.
+
+        ``NaN`` entries map to 0.0 (least similar).
+
+        Args:
+            distances: Distance/score matrix from :meth:`search_all` / :meth:`search`.
+
+        Returns:
+            Similarity array of the same shape, values in ``[0, 1]``.
+        """
+        d = np.asarray(distances, dtype=np.float64)
+        if self.metric == "L2":
+            sim = 1.0 / (1.0 + np.sqrt(np.maximum(d, 0.0)))
+        else:  # cosine: inner products of normalized vectors, in [-1, 1]
+            sim = np.clip((d + 1.0) / 2.0, 0.0, 1.0)
+        return np.nan_to_num(sim, nan=0.0)
+
     # ============ OLD API (for backward compatibility during transition) ============
     def build(self, embeddings: np.ndarray) -> None:
         """DEPRECATED: Use create_index() instead.
@@ -569,6 +654,16 @@ class FakeVectorIndex:
                 distances[i, j] = j * 0.1
 
         return distances, indices
+
+    def to_similarities(self, distances: np.ndarray) -> np.ndarray:
+        """Convert the fake's synthetic distances (lower = closer) to ``[0, 1]``.
+
+        Uses :func:`inverse_distances_to_similarities` (``1 / (1 + d)``), matching
+        the rank-ordered ``j * 0.1`` distances this double emits so its similarity
+        ordering stays meaningful (nearest neighbor scores highest). ``NaN`` maps
+        to 0.0.
+        """
+        return inverse_distances_to_similarities(distances)
 
     # ============ OLD API (for backward compatibility) ============
     def build(self, embeddings: np.ndarray) -> None:

--- a/src/langres/core/judges/weighted_average.py
+++ b/src/langres/core/judges/weighted_average.py
@@ -1,17 +1,22 @@
 """WeightedAverageJudge: the M0 heuristic scorer Module.
 
-The judge is the scorer slot of the Resolver. It is **arg-free** to construct
-(``WeightedAverageJudge()``); it owns the scoring *rule* but not the features.
-The Resolver drives the pipeline:
+The judge is the scorer slot of the Resolver. It **owns its FeatureSpecs** (the
+weights) and reads each candidate's attached
+:class:`~langres.core.feature.ComparisonVector`. The Resolver drives the
+pipeline: a Comparator attaches a ``comparison`` to each candidate, then the
+judge scores it::
 
     comparator = Comparator.from_schema(CompanySchema)
-    judge = WeightedAverageJudge()
-    for judgement in judge.forward(candidates, comparator=comparator):
+    judge = WeightedAverageJudge(feature_specs=comparator.feature_specs)
+    candidates = (
+        c.model_copy(update={"comparison": comparator.compare(c.left, c.right)})
+        for c in raw_candidates
+    )
+    for judgement in judge.forward(candidates):
         ...
 
-For each candidate the judge asks the ``comparator`` for a
-:class:`~langres.core.feature.ComparisonVector`, then combines the present
-similarities with :func:`~langres.core.feature.combine_present` using the
+For each candidate the judge reads ``candidate.comparison`` and combines the
+present similarities with :func:`~langres.core.feature.combine_present` using the
 FeatureSpec weights **normalized to sum to 1.0** (the 0.5 evidence floor is only
 meaningful against a unit-weight total). It emits a
 :class:`~langres.core.models.PairwiseJudgement` whose ``decision_step`` records
@@ -23,9 +28,8 @@ can score a single ComparisonVector without going through ``forward``.
 """
 
 from collections.abc import Iterator
-from typing import ClassVar
+from typing import ClassVar, cast
 
-from langres.core.comparator import Comparator
 from langres.core.feature import ComparisonVector, FeatureSpec, combine_present
 from langres.core.models import ERCandidate, PairwiseJudgement
 from langres.core.module import Module, SchemaT
@@ -51,8 +55,9 @@ def _normalized_weights(specs: list[FeatureSpec]) -> dict[str, float]:
 class WeightedAverageJudge(Module[SchemaT]):
     """Heuristic scorer: weighted average of present similarities + evidence floor.
 
-    Arg-free to construct; the Resolver supplies the Comparator at ``forward``
-    time. The score combiner and the over-merge evidence floor live in
+    Owns its FeatureSpecs (the weights). Consumes each candidate's attached
+    ``comparison`` (a :class:`~langres.core.feature.ComparisonVector`). The score
+    combiner and the over-merge evidence floor live in
     :func:`~langres.core.feature.combine_present`.
     """
 
@@ -60,45 +65,49 @@ class WeightedAverageJudge(Module[SchemaT]):
     # serialization helper can discover the type name (see resolver.py).
     type_name: ClassVar[str] = "weighted_average_judge"
 
-    def score(self, vector: ComparisonVector, specs: list[FeatureSpec]) -> float:
-        """Combine a ComparisonVector into a score in ``[0, 1]``.
-
-        Weights are taken from ``specs`` and normalized to sum to 1.0 before
-        applying the evidence floor.
-        """
-        weights = _normalized_weights(specs)
-        return combine_present(vector.similarities, weights)
-
-    def forward(
-        self,
-        candidates: Iterator[ERCandidate[SchemaT]],
-        *,
-        comparator: Comparator[SchemaT] | None = None,
-    ) -> Iterator[PairwiseJudgement]:
-        """Score each candidate via ``comparator`` and yield PairwiseJudgements.
+    def __init__(self, feature_specs: list[FeatureSpec]) -> None:
+        """Initialize with the features (and their weights) to score on.
 
         Args:
-            candidates: Stream of normalized pairs from a Blocker.
-            comparator: The Comparator that turns each pair into a
-                ComparisonVector. Supplied by the Resolver. Required.
+            feature_specs: The features to combine. Their weights are normalized
+                to sum to 1.0 at scoring time. These should match the
+                Comparator's features so the comparison vector and the weights
+                line up.
+        """
+        self.feature_specs = feature_specs
+
+    def score(self, vector: ComparisonVector) -> float:
+        """Combine a ComparisonVector into a score in ``[0, 1]``.
+
+        Weights are taken from :attr:`feature_specs` and normalized to sum to
+        1.0 before applying the evidence floor.
+        """
+        weights = _normalized_weights(self.feature_specs)
+        return combine_present(vector.similarities, weights)
+
+    def forward(self, candidates: Iterator[ERCandidate[SchemaT]]) -> Iterator[PairwiseJudgement]:
+        """Score each candidate's attached comparison and yield PairwiseJudgements.
+
+        Args:
+            candidates: Stream of normalized pairs from a Blocker, each carrying
+                a ``comparison`` vector attached by a Comparator stage.
 
         Yields:
             One PairwiseJudgement per candidate, with provenance carrying the
             per-feature levels and similarities.
 
         Raises:
-            ValueError: If ``comparator`` is not provided.
+            ValueError: If a candidate carries no comparison vector.
         """
-        if comparator is None:
-            raise ValueError(
-                "WeightedAverageJudge.forward requires a comparator "
-                "(the Resolver supplies it: forward(candidates, comparator=...))."
-            )
-        specs = comparator.feature_specs
-        weights = _normalized_weights(specs)
+        weights = _normalized_weights(self.feature_specs)
 
         for candidate in candidates:
-            vector = comparator.compare(candidate.left, candidate.right)
+            vector = candidate.comparison
+            if vector is None:
+                raise ValueError(
+                    "WeightedAverageJudge requires candidates carrying a comparison "
+                    "vector — add a Comparator to the pipeline."
+                )
             score = combine_present(vector.similarities, weights)
             decision_step = self._decision_step(vector, score)
             yield PairwiseJudgement(
@@ -130,10 +139,13 @@ class WeightedAverageJudge(Module[SchemaT]):
 
     @property
     def config(self) -> dict[str, object]:
-        """Serializable config. The judge is stateless, so config is empty."""
-        return {}
+        """Serializable config: the FeatureSpecs (names + weights) it scores on."""
+        return {"feature_specs": [spec.model_dump() for spec in self.feature_specs]}
 
     @classmethod
     def from_config(cls, config: dict[str, object]) -> "WeightedAverageJudge[SchemaT]":
-        """Reconstruct from :attr:`config` (stateless)."""
-        return cls()
+        """Reconstruct from :attr:`config`, rebuilding the FeatureSpecs."""
+        specs = [
+            FeatureSpec.model_validate(s) for s in cast("list[object]", config["feature_specs"])
+        ]
+        return cls(feature_specs=specs)

--- a/src/langres/core/judges/weighted_average.py
+++ b/src/langres/core/judges/weighted_average.py
@@ -33,9 +33,8 @@ from typing import ClassVar, cast
 from langres.core.feature import ComparisonVector, FeatureSpec, combine_present
 from langres.core.models import ERCandidate, PairwiseJudgement
 from langres.core.module import Module, SchemaT
-from langres.core.modules.llm_judge import _inspect_scores_impl
 from langres.core.registry import register
-from langres.core.reports import ScoreInspectionReport
+from langres.core.reports import ScoreInspectionReport, _inspect_scores_impl
 
 
 def _normalized_weights(specs: list[FeatureSpec]) -> dict[str, float]:

--- a/src/langres/core/models.py
+++ b/src/langres/core/models.py
@@ -14,6 +14,7 @@ from typing import Any, Generic, Literal, Protocol, TypeVar
 
 from pydantic import BaseModel, Field
 
+from langres.core.feature import ComparisonVector
 from langres.core.registry import register_schema
 
 
@@ -70,12 +71,15 @@ class ERCandidate(BaseModel, Generic[SchemaT]):
         right: The right entity in the pair
         blocker_name: Name of the blocker that generated this candidate pair
         similarity_score: Optional similarity score in [0, 1] for ranking evaluation
+        comparison: Per-feature comparison vector attached by a Comparator stage;
+            consumed by comparison-aware judges. None for raw judges.
     """
 
     left: SchemaT
     right: SchemaT
     blocker_name: str
     similarity_score: float | None = Field(default=None, ge=0.0, le=1.0)
+    comparison: ComparisonVector | None = None
 
 
 class PairwiseJudgement(BaseModel):

--- a/src/langres/core/models.py
+++ b/src/langres/core/models.py
@@ -71,8 +71,13 @@ class ERCandidate(BaseModel, Generic[SchemaT]):
         right: The right entity in the pair
         blocker_name: Name of the blocker that generated this candidate pair
         similarity_score: Optional similarity score in [0, 1] for ranking evaluation
-        comparison: Per-feature comparison vector attached by a Comparator stage;
-            consumed by comparison-aware judges. None for raw judges.
+        comparison: Per-feature ``ComparisonVector`` for the two-phase pipeline.
+            In phase one a Comparator stage attaches it (one entry per feature);
+            in phase two the judge runs. Comparison-aware judges (e.g.
+            ``WeightedAverageJudge``) consume this vector and raise if it is
+            ``None`` (the Comparator stage was skipped). Self-contained judges
+            (e.g. ``LLMJudge``) ignore it and read the raw ``left``/``right``
+            entities directly, so it stays ``None`` for them.
     """
 
     left: SchemaT

--- a/src/langres/core/modules/__init__.py
+++ b/src/langres/core/modules/__init__.py
@@ -1,7 +1,7 @@
 """Module implementations for entity comparison."""
 
 from langres.core.modules.cascade import CascadeModule
-from langres.core.modules.llm_judge import LLMJudgeModule
+from langres.core.modules.llm_judge import LLMJudge, LLMJudgeModule
 from langres.core.modules.rapidfuzz import RapidfuzzModule
 
-__all__ = ["RapidfuzzModule", "LLMJudgeModule", "CascadeModule"]
+__all__ = ["RapidfuzzModule", "LLMJudge", "LLMJudgeModule", "CascadeModule"]

--- a/src/langres/core/modules/cascade.py
+++ b/src/langres/core/modules/cascade.py
@@ -351,7 +351,7 @@ class CascadeModule(Module[SchemaT]):
             Cost in USD (``0.0`` when unavailable)
         """
         try:
-            return float(litellm.completion_cost(completion_response=response))
+            return float(litellm.completion_cost(completion_response=response))  # type: ignore[attr-defined]
         except Exception:  # unknown model / missing usage — never raise/flake
             logger.warning(
                 "completion_cost unavailable for model %s; reporting 0.0", self.llm_model

--- a/src/langres/core/modules/cascade.py
+++ b/src/langres/core/modules/cascade.py
@@ -18,10 +18,9 @@ from langres.core.models import ERCandidate, PairwiseJudgement
 from langres.core.module import Module, SchemaT
 from langres.core.modules.llm_judge import (
     DEFAULT_PROMPT,
-    _inspect_scores_impl,
     render_default_prompt,
 )
-from langres.core.reports import ScoreInspectionReport
+from langres.core.reports import ScoreInspectionReport, _inspect_scores_impl
 
 logger = logging.getLogger(__name__)
 
@@ -351,7 +350,7 @@ class CascadeModule(Module[SchemaT]):
             Cost in USD (``0.0`` when unavailable)
         """
         try:
-            return float(litellm.completion_cost(completion_response=response))  # type: ignore[attr-defined]
+            return float(litellm.completion_cost(completion_response=response))
         except Exception:  # unknown model / missing usage — never raise/flake
             logger.warning(
                 "completion_cost unavailable for model %s; reporting 0.0", self.llm_model

--- a/src/langres/core/modules/cascade.py
+++ b/src/langres/core/modules/cascade.py
@@ -9,32 +9,26 @@ import logging
 import re
 from collections.abc import Iterator
 
+import litellm
 import numpy as np
 from openai import OpenAI
 from sentence_transformers import SentenceTransformer
 
 from langres.core.models import ERCandidate, PairwiseJudgement
 from langres.core.module import Module, SchemaT
-from langres.core.modules.llm_judge import _inspect_scores_impl
+from langres.core.modules.llm_judge import (
+    DEFAULT_PROMPT,
+    _inspect_scores_impl,
+    render_default_prompt,
+)
 from langres.core.reports import ScoreInspectionReport
 
 logger = logging.getLogger(__name__)
 
-# Default prompt template for LLM judgment
-DEFAULT_PROMPT = """You are an expert at entity resolution. Determine if these two company records refer to the same real-world company.
-
-Company A:
-{left}
-
-Company B:
-{right}
-
-Respond in exactly this format:
-MATCH or NO_MATCH
-Score: <probability between 0.0 and 1.0>
-Reasoning: <brief explanation>
-
-The score should be your confidence that these are the same company (1.0 = definitely same, 0.0 = definitely different)."""
+# The neutral LLM prompt is centralized in ``llm_judge`` (single source of
+# truth). ``DEFAULT_PROMPT`` is re-exported here for backward compatibility;
+# new code should call ``render_default_prompt(entity_noun)``.
+__all__ = ["CascadeModule", "DEFAULT_PROMPT"]
 
 
 class CascadeModule(Module[SchemaT]):
@@ -87,6 +81,7 @@ class CascadeModule(Module[SchemaT]):
         high_threshold: float = 0.9,
         llm_temperature: float = 0.0,
         llm_prompt_template: str | None = None,
+        entity_noun: str = "entity",
     ):
         """Initialize CascadeModule.
 
@@ -97,7 +92,11 @@ class CascadeModule(Module[SchemaT]):
             low_threshold: Embedding similarity threshold for early exit (no match)
             high_threshold: Embedding similarity threshold for early exit (match)
             llm_temperature: LLM sampling temperature (0.0 = deterministic)
-            llm_prompt_template: Custom LLM prompt (uses DEFAULT_PROMPT if None)
+            llm_prompt_template: Custom LLM prompt (uses the neutral
+                :data:`~langres.core.modules.llm_judge.DEFAULT_PROMPT`, rendered
+                for ``entity_noun``, if None)
+            entity_noun: Domain noun woven into the default prompt (e.g.
+                "company", "product"). Ignored when ``llm_prompt_template`` is given.
 
         Raises:
             ValueError: If thresholds are invalid or API key is missing
@@ -117,7 +116,8 @@ class CascadeModule(Module[SchemaT]):
         self.low_threshold = low_threshold
         self.high_threshold = high_threshold
         self.llm_temperature = llm_temperature
-        self.llm_prompt_template = llm_prompt_template or DEFAULT_PROMPT
+        self.entity_noun = entity_noun
+        self.llm_prompt_template = llm_prompt_template or render_default_prompt(entity_noun)
 
         # Lazy-load models
         self._embedding_model: SentenceTransformer | None = None
@@ -337,34 +337,26 @@ class CascadeModule(Module[SchemaT]):
         return content
 
     def _calculate_cost(self, response) -> float:  # type: ignore[no-untyped-def]
-        """Calculate API call cost in USD.
+        """Calculate API call cost in USD via LiteLLM's own pricing.
+
+        Delegates to ``litellm.completion_cost`` so pricing stays honest for
+        whatever model is actually used (no hardcoded table). Returns ``0.0`` if
+        the model is unknown to LiteLLM or usage is missing — cost tracking is
+        observability, so it must never raise or flake.
 
         Args:
-            response: OpenAI API response
+            response: LLM API response (OpenAI shape)
 
         Returns:
-            Cost in USD
+            Cost in USD (``0.0`` when unavailable)
         """
-        if not response.usage:
+        try:
+            return float(litellm.completion_cost(completion_response=response))
+        except Exception:  # unknown model / missing usage — never raise/flake
+            logger.warning(
+                "completion_cost unavailable for model %s; reporting 0.0", self.llm_model
+            )
             return 0.0
-
-        prompt_tokens = response.usage.prompt_tokens
-        completion_tokens = response.usage.completion_tokens
-
-        # Pricing per 1M tokens (approximate)
-        if "gpt-4o-mini" in self.llm_model:
-            input_price = 0.150
-            output_price = 0.600
-        elif "gpt-4" in self.llm_model:
-            input_price = 30.0
-            output_price = 60.0
-        else:
-            # Default to gpt-4o-mini pricing
-            input_price = 0.150
-            output_price = 0.600
-
-        cost = (prompt_tokens * input_price + completion_tokens * output_price) / 1_000_000
-        return float(cost)
 
     def inspect_scores(
         self, judgements: list[PairwiseJudgement], sample_size: int = 10

--- a/src/langres/core/modules/cascade.py
+++ b/src/langres/core/modules/cascade.py
@@ -69,6 +69,17 @@ class CascadeModule(Module[SchemaT]):
         - low_threshold: 0.2-0.4 (below this is definitely not a match)
         - high_threshold: 0.85-0.95 (above this is definitely a match)
         - The gap between them determines LLM usage (larger gap = fewer LLM calls)
+
+    Note:
+        Known debt tracked for M2 consolidation:
+        - Not yet serializable: it carries no ``type_name`` / ``@register``, so it
+          cannot live in a ``Resolver`` slot that ``save`` / ``load`` (unlike
+          ``LLMJudge``).
+        - Instantiates ``SentenceTransformer`` internally rather than taking an
+          injected client — an SRP/dependency-injection gap vs. the injected-client
+          pattern ``LLMJudge`` uses.
+        - ``_extract_score`` / ``_extract_reasoning`` / ``_calculate_cost``
+          duplicate the same helpers in ``LLMJudge``.
     """
 
     def __init__(

--- a/src/langres/core/modules/llm_judge.py
+++ b/src/langres/core/modules/llm_judge.py
@@ -15,7 +15,6 @@ from collections.abc import Iterator
 from typing import Any, ClassVar
 
 import litellm
-import numpy as np
 from openai import OpenAI
 
 # Type checking for litellm exceptions
@@ -27,7 +26,7 @@ except ImportError:
 from langres.core.models import ERCandidate, PairwiseJudgement
 from langres.core.module import Module, SchemaT
 from langres.core.registry import register
-from langres.core.reports import ScoreInspectionReport
+from langres.core.reports import ScoreInspectionReport, _inspect_scores_impl
 
 logger = logging.getLogger(__name__)
 
@@ -602,7 +601,7 @@ class LLMJudge(Module[SchemaT]):
             Cost in USD (``0.0`` when unavailable)
         """
         try:
-            return float(litellm.completion_cost(completion_response=response))  # type: ignore[attr-defined]
+            return float(litellm.completion_cost(completion_response=response))
         except Exception:  # unknown model / missing usage — never raise/flake
             logger.warning("completion_cost unavailable for model %s; reporting 0.0", self.model)
             return 0.0
@@ -633,164 +632,3 @@ class LLMJudge(Module[SchemaT]):
 # Backward-compatible public alias. ``LLMJudge`` is the public name; existing
 # imports of ``LLMJudgeModule`` keep working.
 LLMJudgeModule = LLMJudge
-
-
-def _inspect_scores_impl(
-    judgements: list[PairwiseJudgement], sample_size: int = 10
-) -> ScoreInspectionReport:
-    """Shared implementation of inspect_scores for all Module types.
-
-    This function provides common score inspection logic that works for all
-    Module implementations since they all return PairwiseJudgement objects.
-
-    Args:
-        judgements: List of PairwiseJudgement objects to analyze
-        sample_size: Number of examples to include (default: 10)
-
-    Returns:
-        ScoreInspectionReport with statistics, examples, and recommendations
-    """
-    # Handle empty judgements
-    if not judgements:
-        return ScoreInspectionReport(
-            total_judgements=0,
-            score_distribution={},
-            high_scoring_examples=[],
-            low_scoring_examples=[],
-            recommendations=[
-                "No judgements to analyze - generate some predictions first",
-                "Run Module.forward() on candidates to produce judgements",
-            ],
-        )
-
-    # Extract scores
-    scores = [j.score for j in judgements]
-    total = len(judgements)
-
-    # Compute statistics
-    score_distribution = {
-        "mean": float(np.mean(scores)),
-        "median": float(np.median(scores)),
-        "std": float(np.std(scores)),
-        "p25": float(np.percentile(scores, 25)),
-        "p50": float(np.percentile(scores, 50)),
-        "p75": float(np.percentile(scores, 75)),
-        "p90": float(np.percentile(scores, 90)),
-        "p95": float(np.percentile(scores, 95)),
-        "min": float(np.min(scores)),
-        "max": float(np.max(scores)),
-    }
-
-    # Extract high-scoring examples (top sample_size)
-    sorted_by_score_desc = sorted(judgements, key=lambda j: j.score, reverse=True)
-    high_scoring_examples = [
-        {
-            "left_id": j.left_id,
-            "right_id": j.right_id,
-            "score": j.score,
-            "reasoning": j.reasoning if j.reasoning else "",
-        }
-        for j in sorted_by_score_desc[:sample_size]
-    ]
-
-    # Extract low-scoring examples (bottom sample_size)
-    sorted_by_score_asc = sorted(judgements, key=lambda j: j.score)
-    low_scoring_examples = [
-        {
-            "left_id": j.left_id,
-            "right_id": j.right_id,
-            "score": j.score,
-            "reasoning": j.reasoning if j.reasoning else "",
-        }
-        for j in sorted_by_score_asc[:sample_size]
-    ]
-
-    # Generate recommendations
-    recommendations = _generate_recommendations_impl(
-        total_judgements=total,
-        score_distribution=score_distribution,
-        scores=scores,
-    )
-
-    return ScoreInspectionReport(
-        total_judgements=total,
-        score_distribution=score_distribution,
-        high_scoring_examples=high_scoring_examples,
-        low_scoring_examples=low_scoring_examples,
-        recommendations=recommendations,
-    )
-
-
-def _generate_recommendations_impl(
-    total_judgements: int,
-    score_distribution: dict[str, float],
-    scores: list[float],
-) -> list[str]:
-    """Generate rule-based recommendations based on score distribution.
-
-    Args:
-        total_judgements: Total number of judgements
-        score_distribution: Statistics dictionary
-        scores: List of all scores
-
-    Returns:
-        List of actionable recommendations
-    """
-    recommendations = []
-
-    # 1. Threshold suggestion based on median
-    median = score_distribution["median"]
-    if median > 0.7:
-        recommendations.append(
-            "High median score (>0.7) suggests most pairs are matches. "
-            "Consider threshold=0.6 for balanced precision/recall."
-        )
-    elif median < 0.3:
-        recommendations.append(
-            "Low median score (<0.3) suggests most pairs are non-matches. "
-            "Consider threshold=0.2 as starting point."
-        )
-    else:
-        recommendations.append(
-            f"Median score is {median:.2f}. Consider threshold={median:.1f} as starting point."
-        )
-
-    # 2. Score separation analysis
-    sorted_scores = sorted(scores)
-    n = len(sorted_scores)
-    high_scores = sorted_scores[int(0.75 * n) :]  # Top 25%
-    low_scores = sorted_scores[: int(0.25 * n)]  # Bottom 25%
-
-    if high_scores and low_scores:
-        separation = abs(float(np.mean(high_scores)) - float(np.mean(low_scores)))
-        if separation < 0.3:
-            recommendations.append(
-                "⚠️ Poor score separation (<0.3) - scores are not well-calibrated. "
-                "Consider tuning the prompt or using a different model."
-            )
-
-    # 3. Variance analysis
-    std = score_distribution["std"]
-    if std < 0.1:
-        recommendations.append(
-            "⚠️ Very uniform distribution (std<0.1) - scores lack discriminative power. "
-            "Consider more diverse scoring or feature engineering."
-        )
-    elif std > 0.35:
-        recommendations.append(
-            "✅ Good score variance (std>0.35) - indicates discriminative scoring."
-        )
-
-    # 4. Sample size guidance
-    if total_judgements < 50:
-        recommendations.append(
-            "Small sample (<50 judgements) - results may not be representative. "
-            "Generate more predictions for reliable analysis."
-        )
-    elif total_judgements > 1000:
-        recommendations.append(
-            "Large sample (>1000 judgements) - consider sampling a subset for faster iteration "
-            "during parameter tuning."
-        )
-
-    return recommendations

--- a/src/langres/core/modules/llm_judge.py
+++ b/src/langres/core/modules/llm_judge.py
@@ -602,7 +602,7 @@ class LLMJudge(Module[SchemaT]):
             Cost in USD (``0.0`` when unavailable)
         """
         try:
-            return float(litellm.completion_cost(completion_response=response))
+            return float(litellm.completion_cost(completion_response=response))  # type: ignore[attr-defined]
         except Exception:  # unknown model / missing usage — never raise/flake
             logger.warning("completion_cost unavailable for model %s; reporting 0.0", self.model)
             return 0.0

--- a/src/langres/core/modules/llm_judge.py
+++ b/src/langres/core/modules/llm_judge.py
@@ -10,12 +10,10 @@ import asyncio
 import logging
 import re
 import time
-from collections import defaultdict
 from collections.abc import Iterator
 from typing import Any, ClassVar
 
 import litellm
-from openai import OpenAI
 
 # Type checking for litellm exceptions
 try:
@@ -91,45 +89,55 @@ class _RateLimiter:
 
         Args:
             estimated_tokens: Estimated tokens for this request (default: 1000)
+
+        Note:
+            ``asyncio.sleep`` is **never** awaited while holding ``self._lock``.
+            Each iteration locks only long enough to prune the 1-minute sliding
+            windows and check the RPM/TPM limits; if the request fits it is
+            recorded and we return, otherwise we compute the required wait,
+            release the lock, sleep outside the critical section, and retry.
+            Holding the lock across the sleep would block every other coroutine
+            calling :meth:`acquire`/:meth:`record_usage_async`, stalling the
+            whole pipeline on the first rate-limit hit.
         """
-        async with self._lock:
-            now = time.time()
-            one_minute_ago = now - 60.0
-
-            # Remove old entries outside the 1-minute window
-            self._request_times = [t for t in self._request_times if t > one_minute_ago]
-            self._token_usage = [(t, c) for t, c in self._token_usage if t > one_minute_ago]
-
-            # Wait if we're at RPM limit
-            while len(self._request_times) >= self.rpm_limit:
-                oldest_request = self._request_times[0]
-                sleep_time = 60.0 - (now - oldest_request) + 0.1  # Add 100ms buffer
-                logger.debug("RPM limit reached, sleeping for %.2fs", sleep_time)
-                await asyncio.sleep(sleep_time)
-
-                # Refresh window
+        while True:
+            async with self._lock:
                 now = time.time()
                 one_minute_ago = now - 60.0
+
+                # Remove old entries outside the 1-minute window
                 self._request_times = [t for t in self._request_times if t > one_minute_ago]
-
-            # Wait if we're at TPM limit
-            current_tokens = sum(count for _, count in self._token_usage)
-            while current_tokens + estimated_tokens > self.tpm_limit:
-                oldest_token_time = self._token_usage[0][0]
-                sleep_time = 60.0 - (now - oldest_token_time) + 0.1  # Add 100ms buffer
-                logger.debug(
-                    "TPM limit reached (%d tokens), sleeping for %.2fs", current_tokens, sleep_time
-                )
-                await asyncio.sleep(sleep_time)
-
-                # Refresh window
-                now = time.time()
-                one_minute_ago = now - 60.0
                 self._token_usage = [(t, c) for t, c in self._token_usage if t > one_minute_ago]
-                current_tokens = sum(count for _, count in self._token_usage)
 
-            # Record this request
-            self._request_times.append(now)
+                # Compute how long we must wait (0.0 means "clear to proceed").
+                sleep_time = 0.0
+
+                # RPM sliding window
+                if len(self._request_times) >= self.rpm_limit:
+                    oldest_request = self._request_times[0]
+                    rpm_sleep = 60.0 - (now - oldest_request) + 0.1  # Add 100ms buffer
+                    logger.debug("RPM limit reached, sleeping for %.2fs", rpm_sleep)
+                    sleep_time = max(sleep_time, rpm_sleep)
+
+                # TPM sliding window
+                current_tokens = sum(count for _, count in self._token_usage)
+                if current_tokens + estimated_tokens > self.tpm_limit:
+                    oldest_token_time = self._token_usage[0][0]
+                    tpm_sleep = 60.0 - (now - oldest_token_time) + 0.1  # Add 100ms buffer
+                    logger.debug(
+                        "TPM limit reached (%d tokens), sleeping for %.2fs",
+                        current_tokens,
+                        tpm_sleep,
+                    )
+                    sleep_time = max(sleep_time, tpm_sleep)
+
+                # Within both limits → reserve this request and return.
+                if sleep_time == 0.0:
+                    self._request_times.append(now)
+                    return
+
+            # Lock released: sleep outside the critical section, then retry.
+            await asyncio.sleep(sleep_time)
 
     async def record_usage_async(self, token_count: int) -> None:
         """Record actual token usage after API call (async, thread-safe).

--- a/src/langres/core/modules/llm_judge.py
+++ b/src/langres/core/modules/llm_judge.py
@@ -1,4 +1,4 @@
-"""LLMJudgeModule implementation for LLM-based entity matching.
+"""LLMJudge: serializable LLM-based entity-matching Module.
 
 This module uses OpenAI API (or compatible) for match judgments with natural
 language reasoning and calibrated probability scores.
@@ -12,7 +12,7 @@ import re
 import time
 from collections import defaultdict
 from collections.abc import Iterator
-from typing import Any
+from typing import Any, ClassVar
 
 import litellm
 import numpy as np
@@ -26,17 +26,23 @@ except ImportError:
 
 from langres.core.models import ERCandidate, PairwiseJudgement
 from langres.core.module import Module, SchemaT
+from langres.core.registry import register
 from langres.core.reports import ScoreInspectionReport
 
 logger = logging.getLogger(__name__)
 
-# Default prompt template for LLM judgment
-DEFAULT_PROMPT = """You are an expert at entity resolution. Determine if these two company records refer to the same real-world company.
+# Default prompt template for LLM judgment.
+#
+# Single source of truth for the neutral prompt (Cascade imports this too). It is
+# domain-neutral: ``{entity_noun}`` is woven in at render time so the same
+# template serves companies, products, people, etc. ``{left}`` / ``{right}`` stay
+# unfilled here and are formatted with the two records at judgement time.
+DEFAULT_PROMPT = """You are an expert at entity resolution. Determine if these two {entity_noun} records refer to the same real-world {entity_noun}.
 
-Company A:
+Record A:
 {left}
 
-Company B:
+Record B:
 {right}
 
 Respond in exactly this format:
@@ -44,7 +50,16 @@ MATCH or NO_MATCH
 Score: <probability between 0.0 and 1.0>
 Reasoning: <brief explanation>
 
-The score should be your confidence that these are the same company (1.0 = definitely same, 0.0 = definitely different)."""
+The score should be your confidence that these are the same {entity_noun} (1.0 = definitely same, 0.0 = definitely different)."""
+
+
+def render_default_prompt(entity_noun: str = "entity") -> str:
+    """Render :data:`DEFAULT_PROMPT` for ``entity_noun``, leaving ``{left}``/``{right}``.
+
+    Substitutes only the ``{entity_noun}`` placeholder so the result is still a
+    ``str.format`` template expecting ``left`` and ``right`` at judgement time.
+    """
+    return DEFAULT_PROMPT.replace("{entity_noun}", entity_noun)
 
 
 class _RateLimiter:
@@ -131,85 +146,76 @@ class _RateLimiter:
             self._token_usage.append((time.time(), token_count))
 
 
-class LLMJudgeModule(Module[SchemaT]):
+@register("llm_judge")
+class LLMJudge(Module[SchemaT]):
     """Schema-agnostic LLM-based matching module using LiteLLM.
 
-    This module uses an LLM (like GPT-4) to make match judgments with
-    natural language reasoning. It provides calibrated probability scores
-    and tracks API costs for observability.
+    This module uses an LLM to make match judgments with natural language
+    reasoning. It provides calibrated probability scores and tracks API costs
+    (via LiteLLM's own pricing) for observability.
 
-    The module accepts a pre-configured LiteLLM client, enabling:
+    It is a first-class, serializable Resolver component: it carries a registry
+    ``type_name`` and a pure :attr:`config` (model, temperature, prompt,
+    entity_noun) so a Resolver with an LLM judge in the ``module`` slot can
+    ``save`` / ``load``. The LLM ``client`` is **never** serialized — it is
+    reconstructed from environment at load time via the lazy-client path.
+
+    The client is optional. When omitted, it is lazily built from the
+    environment with ``create_llm_client(Settings())`` on first use, enabling:
     - Automatic Langfuse tracing for observability
     - Support for multiple LLM providers (OpenAI, Azure, etc.)
-    - Proper separation of concerns (client configuration vs. matching logic)
+    - Serialization without persisting any secret
 
     Example:
-        from langres.clients import create_llm_client
-        from langres.clients.settings import Settings
-
-        settings = Settings()
-        llm_client = create_llm_client(settings)
-
-        module = LLMJudgeModule(
-            client=llm_client,
-            model="gpt-4o-mini",
-            temperature=0.0,
-        )
+        # Happy path: build the client from environment.
+        module = LLMJudge.from_env(model="gpt-5-mini")
 
         for judgement in module.forward(candidates):
             print(f"{judgement.left_id} vs {judgement.right_id}: {judgement.score}")
             print(f"Reasoning: {judgement.reasoning}")
             print(f"Cost: ${judgement.provenance['cost_usd']}")
 
-    Note:
-        The module uses gpt-4o-mini by default for cost efficiency. For higher
-        quality, use gpt-4 (but costs ~30x more).
+    Example:
+        # Escape hatch: inject a pre-configured client (e.g. in tests).
+        from langres.clients import create_llm_client, Settings
+
+        module = LLMJudge(client=create_llm_client(Settings()), model="gpt-5-mini")
 
     Note:
-        Cost tracking uses approximate pricing:
-        - gpt-5-mini: $0.150/1M input tokens, $0.600/1M output tokens
-        - gpt-4: $30/1M input tokens, $60/1M output tokens
+        Defaults to ``gpt-5-mini`` at ``temperature=1.0``. Cost tracking is
+        delegated to ``litellm.completion_cost`` so pricing stays honest for
+        whatever model is actually used (no hardcoded table).
     """
+
+    # Registry key, mirrored as a class attribute so the Resolver's uniform
+    # serialization helper can discover the type name (see resolver.py).
+    type_name: ClassVar[str] = "llm_judge"
 
     def __init__(
         self,
-        client: Any,
+        client: Any = None,
         model: str = "gpt-5-mini",
         temperature: float = 1.0,
         prompt_template: str | None = None,
+        entity_noun: str = "entity",
     ):
-        """Initialize LLMJudgeModule.
+        """Initialize LLMJudge.
 
         Args:
-            client: Pre-configured LLM client (LiteLLM or OpenAI client).
-                   Use langres.clients.create_llm_client() to create a client
-                   with Langfuse tracing enabled.
-            model: Model name (e.g., "gpt-4o-mini", "azure/gpt-5-mini")
+            client: Optional pre-configured LLM client (LiteLLM or OpenAI
+                client). When ``None`` (the default), the client is lazily built
+                from the environment via ``create_llm_client(Settings())`` on
+                first use. Inject a client only as an escape hatch (e.g. tests
+                or a custom client); use :meth:`from_env` for the happy path.
+            model: Model name (e.g., "gpt-5-mini", "azure/gpt-5-mini")
             temperature: Sampling temperature (0.0 = deterministic, 2.0 = random)
-            prompt_template: Custom prompt template (uses DEFAULT_PROMPT if None)
+            prompt_template: Custom prompt template (uses the neutral
+                :data:`DEFAULT_PROMPT`, rendered for ``entity_noun``, if None)
+            entity_noun: Domain noun woven into the default prompt (e.g.
+                "company", "product"). Ignored when ``prompt_template`` is given.
 
         Raises:
             ValueError: If temperature out of range
-
-        Example:
-            # Create LiteLLM client with tracing
-            from langres.clients import create_llm_client
-            from langres.clients.settings import Settings
-
-            settings = Settings()
-            llm_client = create_llm_client(settings)
-
-            # Initialize module with client
-            module = LLMJudgeModule(
-                client=llm_client,
-                model="azure/gpt-5-mini",
-                temperature=0.0
-            )
-
-        Note:
-            The client handles all authentication and tracing configuration.
-            Use langres.clients.create_llm_client() to create a properly
-            configured client with Langfuse observability.
         """
         if not 0.0 <= temperature <= 2.0:
             raise ValueError("temperature must be between 0.0 and 2.0")
@@ -217,7 +223,55 @@ class LLMJudgeModule(Module[SchemaT]):
         self.client = client
         self.model = model
         self.temperature = temperature
-        self.prompt_template = prompt_template if prompt_template else DEFAULT_PROMPT
+        self.entity_noun = entity_noun
+        self.prompt_template = (
+            prompt_template if prompt_template else render_default_prompt(entity_noun)
+        )
+
+    @classmethod
+    def from_env(
+        cls,
+        model: str = "gpt-5-mini",
+        **kwargs: Any,
+    ) -> "LLMJudge[SchemaT]":
+        """Build an LLMJudge with a client constructed from the environment.
+
+        The documented happy path: reads provider/tracing config from env via
+        ``create_llm_client(Settings())``. ``kwargs`` are forwarded to
+        ``__init__`` (``temperature``, ``prompt_template``, ``entity_noun``).
+        """
+        from langres.clients import Settings, create_llm_client
+
+        return cls(client=create_llm_client(Settings()), model=model, **kwargs)
+
+    def _get_client(self) -> Any:
+        """Return the client, lazily building one from env on first use."""
+        if self.client is None:
+            from langres.clients import Settings, create_llm_client
+
+            self.client = create_llm_client(Settings())
+        return self.client
+
+    @property
+    def config(self) -> dict[str, object]:
+        """Pure, serializable construction config (never the client or secrets)."""
+        return {
+            "model": self.model,
+            "temperature": self.temperature,
+            "prompt_template": self.prompt_template,
+            "entity_noun": self.entity_noun,
+        }
+
+    @classmethod
+    def from_config(cls, config: dict[str, object]) -> "LLMJudge[SchemaT]":
+        """Rebuild from :attr:`config` via the lazy-client path (client from env)."""
+        return cls(
+            client=None,
+            model=str(config["model"]),
+            temperature=float(config["temperature"]),  # type: ignore[arg-type]
+            prompt_template=str(config["prompt_template"]),
+            entity_noun=str(config["entity_noun"]),
+        )
 
     def forward(self, candidates: Iterator[ERCandidate[SchemaT]]) -> Iterator[PairwiseJudgement]:
         """Compare entity pairs using LLM judgment.
@@ -248,7 +302,7 @@ class LLMJudgeModule(Module[SchemaT]):
             )
 
             # Call client (works for both LiteLLM and OpenAI)
-            response = self.client.completion(
+            response = self._get_client().completion(
                 model=self.model,
                 messages=[{"role": "user", "content": prompt}],
                 temperature=self.temperature,
@@ -455,9 +509,10 @@ class LLMJudgeModule(Module[SchemaT]):
         Note:
             Implements exponential backoff: 1s, 2s, 4s, 8s, ... up to 60s max
         """
+        client = self._get_client()
         for attempt in range(max_retries):
             try:
-                response = await self.client.acompletion(
+                response = await client.acompletion(
                     model=self.model,
                     messages=[{"role": "user", "content": prompt}],
                     temperature=self.temperature,
@@ -533,39 +588,24 @@ class LLMJudgeModule(Module[SchemaT]):
         return content
 
     def _calculate_cost(self, response) -> float:  # type: ignore[no-untyped-def]
-        """Calculate API call cost in USD.
+        """Calculate API call cost in USD via LiteLLM's own pricing.
+
+        Delegates to ``litellm.completion_cost`` so pricing stays honest for
+        whatever model is actually used (no hardcoded table). Returns ``0.0`` if
+        the model is unknown to LiteLLM or usage is missing — cost tracking is
+        observability, so it must never raise or flake.
 
         Args:
-            response: OpenAI API response
+            response: LLM API response (LiteLLM/OpenAI shape)
 
         Returns:
-            Cost in USD
-
-        Note:
-            Uses approximate pricing as of 2024:
-            - gpt-4o-mini: $0.150/1M input, $0.600/1M output
-            - gpt-4: $30/1M input, $60/1M output
+            Cost in USD (``0.0`` when unavailable)
         """
-        if not response.usage:
+        try:
+            return float(litellm.completion_cost(completion_response=response))
+        except Exception:  # unknown model / missing usage — never raise/flake
+            logger.warning("completion_cost unavailable for model %s; reporting 0.0", self.model)
             return 0.0
-
-        prompt_tokens = response.usage.prompt_tokens
-        completion_tokens = response.usage.completion_tokens
-
-        # Pricing per 1M tokens (approximate)
-        if "gpt-4o-mini" in self.model:
-            input_price = 0.150
-            output_price = 0.600
-        elif "gpt-4" in self.model:
-            input_price = 30.0
-            output_price = 60.0
-        else:
-            # Default to gpt-4o-mini pricing
-            input_price = 0.150
-            output_price = 0.600
-
-        cost = (prompt_tokens * input_price + completion_tokens * output_price) / 1_000_000
-        return float(cost)
 
     def inspect_scores(
         self, judgements: list[PairwiseJudgement], sample_size: int = 10
@@ -588,6 +628,11 @@ class LLMJudgeModule(Module[SchemaT]):
             ScoreInspectionReport with statistics, examples, and recommendations
         """
         return _inspect_scores_impl(judgements, sample_size)
+
+
+# Backward-compatible public alias. ``LLMJudge`` is the public name; existing
+# imports of ``LLMJudgeModule`` keep working.
+LLMJudgeModule = LLMJudge
 
 
 def _inspect_scores_impl(

--- a/src/langres/core/modules/llm_judge.py
+++ b/src/langres/core/modules/llm_judge.py
@@ -19,9 +19,9 @@ from openai import OpenAI
 
 # Type checking for litellm exceptions
 try:
-    from litellm import RateLimitError  # type: ignore[attr-defined]
+    from litellm import RateLimitError
 except ImportError:
-    RateLimitError = Exception  # type: ignore[misc, assignment]
+    RateLimitError = Exception
 
 from langres.core.models import ERCandidate, PairwiseJudgement
 from langres.core.module import Module, SchemaT

--- a/src/langres/core/modules/rapidfuzz.py
+++ b/src/langres/core/modules/rapidfuzz.py
@@ -12,8 +12,7 @@ from rapidfuzz import fuzz
 
 from langres.core.models import ERCandidate, PairwiseJudgement
 from langres.core.module import Module, SchemaT
-from langres.core.modules.llm_judge import _inspect_scores_impl
-from langres.core.reports import ScoreInspectionReport
+from langres.core.reports import ScoreInspectionReport, _inspect_scores_impl
 
 # Supported rapidfuzz algorithms
 Algorithm = Literal["ratio", "token_sort_ratio", "token_set_ratio"]

--- a/src/langres/core/reports.py
+++ b/src/langres/core/reports.py
@@ -23,11 +23,12 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, Any
 
+import numpy as np
 from pydantic import BaseModel, ConfigDict, Field, model_validator
 
 if TYPE_CHECKING:
     from langres.core.diagnostics import DiagnosticExamples
-    from langres.core.models import ERCandidate
+    from langres.core.models import ERCandidate, PairwiseJudgement
 
 
 class CandidateInspectionReport(BaseModel):
@@ -957,3 +958,167 @@ class BlockerEvaluationReport(BaseModel):
             missed_matches=missed,
             false_positives=false_pos,
         )
+
+
+def _inspect_scores_impl(
+    judgements: list["PairwiseJudgement"], sample_size: int = 10
+) -> ScoreInspectionReport:
+    """Shared implementation of inspect_scores for all Module types.
+
+    This function provides common score inspection logic that works for all
+    Module implementations since they all return PairwiseJudgement objects. It
+    lives here (not in any single Module) so every Module — including the
+    dependency-light WeightedAverageJudge — can reuse it without importing a
+    heavier Module (e.g. the LLM judge that pulls in litellm/openai).
+
+    Args:
+        judgements: List of PairwiseJudgement objects to analyze
+        sample_size: Number of examples to include (default: 10)
+
+    Returns:
+        ScoreInspectionReport with statistics, examples, and recommendations
+    """
+    # Handle empty judgements
+    if not judgements:
+        return ScoreInspectionReport(
+            total_judgements=0,
+            score_distribution={},
+            high_scoring_examples=[],
+            low_scoring_examples=[],
+            recommendations=[
+                "No judgements to analyze - generate some predictions first",
+                "Run Module.forward() on candidates to produce judgements",
+            ],
+        )
+
+    # Extract scores
+    scores = [j.score for j in judgements]
+    total = len(judgements)
+
+    # Compute statistics
+    score_distribution = {
+        "mean": float(np.mean(scores)),
+        "median": float(np.median(scores)),
+        "std": float(np.std(scores)),
+        "p25": float(np.percentile(scores, 25)),
+        "p50": float(np.percentile(scores, 50)),
+        "p75": float(np.percentile(scores, 75)),
+        "p90": float(np.percentile(scores, 90)),
+        "p95": float(np.percentile(scores, 95)),
+        "min": float(np.min(scores)),
+        "max": float(np.max(scores)),
+    }
+
+    # Extract high-scoring examples (top sample_size)
+    sorted_by_score_desc = sorted(judgements, key=lambda j: j.score, reverse=True)
+    high_scoring_examples = [
+        {
+            "left_id": j.left_id,
+            "right_id": j.right_id,
+            "score": j.score,
+            "reasoning": j.reasoning if j.reasoning else "",
+        }
+        for j in sorted_by_score_desc[:sample_size]
+    ]
+
+    # Extract low-scoring examples (bottom sample_size)
+    sorted_by_score_asc = sorted(judgements, key=lambda j: j.score)
+    low_scoring_examples = [
+        {
+            "left_id": j.left_id,
+            "right_id": j.right_id,
+            "score": j.score,
+            "reasoning": j.reasoning if j.reasoning else "",
+        }
+        for j in sorted_by_score_asc[:sample_size]
+    ]
+
+    # Generate recommendations
+    recommendations = _generate_recommendations_impl(
+        total_judgements=total,
+        score_distribution=score_distribution,
+        scores=scores,
+    )
+
+    return ScoreInspectionReport(
+        total_judgements=total,
+        score_distribution=score_distribution,
+        high_scoring_examples=high_scoring_examples,
+        low_scoring_examples=low_scoring_examples,
+        recommendations=recommendations,
+    )
+
+
+def _generate_recommendations_impl(
+    total_judgements: int,
+    score_distribution: dict[str, float],
+    scores: list[float],
+) -> list[str]:
+    """Generate rule-based recommendations based on score distribution.
+
+    Args:
+        total_judgements: Total number of judgements
+        score_distribution: Statistics dictionary
+        scores: List of all scores
+
+    Returns:
+        List of actionable recommendations
+    """
+    recommendations = []
+
+    # 1. Threshold suggestion based on median
+    median = score_distribution["median"]
+    if median > 0.7:
+        recommendations.append(
+            "High median score (>0.7) suggests most pairs are matches. "
+            "Consider threshold=0.6 for balanced precision/recall."
+        )
+    elif median < 0.3:
+        recommendations.append(
+            "Low median score (<0.3) suggests most pairs are non-matches. "
+            "Consider threshold=0.2 as starting point."
+        )
+    else:
+        recommendations.append(
+            f"Median score is {median:.2f}. Consider threshold={median:.1f} as starting point."
+        )
+
+    # 2. Score separation analysis
+    sorted_scores = sorted(scores)
+    n = len(sorted_scores)
+    high_scores = sorted_scores[int(0.75 * n) :]  # Top 25%
+    low_scores = sorted_scores[: int(0.25 * n)]  # Bottom 25%
+
+    if high_scores and low_scores:
+        separation = abs(float(np.mean(high_scores)) - float(np.mean(low_scores)))
+        if separation < 0.3:
+            recommendations.append(
+                "⚠️ Poor score separation (<0.3) - scores are not well-calibrated. "
+                "Consider tuning the prompt or using a different model."
+            )
+
+    # 3. Variance analysis
+    std = score_distribution["std"]
+    if std < 0.1:
+        recommendations.append(
+            "⚠️ Very uniform distribution (std<0.1) - scores lack discriminative power. "
+            "Consider more diverse scoring or feature engineering."
+        )
+    elif std > 0.35:
+        recommendations.append(
+            "✅ Good score variance (std>0.35) - indicates discriminative scoring."
+        )
+
+    # 4. Sample size guidance
+    if total_judgements < 50:
+        recommendations.append(
+            "Small sample (<50 judgements) - results may not be representative. "
+            "Generate more predictions for reliable analysis."
+        )
+    elif total_judgements > 1000:
+        recommendations.append(
+            "Large sample (>1000 judgements) - consider sampling a subset for faster iteration "
+            "during parameter tuning."
+        )
+
+    return recommendations

--- a/src/langres/core/resolver.py
+++ b/src/langres/core/resolver.py
@@ -88,7 +88,13 @@ def _component_spec(obj: object, slot: str) -> ComponentSpec:
     ``slot`` name so :meth:`Resolver.load` can map the spec back self-describingly
     rather than by position or hard-coded ``type_name``.
     """
-    type_name = obj.type_name  # type: ignore[attr-defined]
+    type_name = getattr(obj, "type_name", None)
+    if not isinstance(type_name, str):
+        raise TypeError(
+            f"{type(obj).__name__} is not serializable (no `type_name`/@register). "
+            f"Use a registered component (e.g. LLMJudge, WeightedAverageJudge) in "
+            f"the {slot!r} slot."
+        )
     return ComponentSpec(type_name=type_name, slot=slot, config=_component_config_dict(obj))
 
 
@@ -478,11 +484,14 @@ class Resolver:
         """Validate artifact compatibility; raise on an unreadably-new artifact.
 
         ``ARTIFACT_VERSION`` is a monotonic integer-valued string bumped on an
-        incompatible layout change. An artifact at an older-or-equal layout is
-        fine to read; a *strictly newer* (or malformed/non-integer) layout we
-        cannot understand is a hard error. A ``langres_version`` mismatch is
-        logged as a warning, not a failure — configs are forward-compatible
-        within a layout version.
+        incompatible layout change. Each bump breaks the config schema, so only
+        an artifact at the *exact* supported layout is readable: a *newer* layout
+        (this build is too old), an *older* layout (predates an incompatible
+        bump), or a malformed/non-integer layout are all hard errors — without
+        this guard an older artifact would fall through to a raw ``KeyError`` on
+        the changed config. A ``langres_version`` mismatch is logged as a
+        warning, not a failure — configs are forward-compatible *within* a layout
+        version.
         """
         try:
             artifact_v = int(manifest.artifact_version)
@@ -496,6 +505,12 @@ class Resolver:
             raise ValueError(
                 f"Artifact version {manifest.artifact_version!r} is newer than this "
                 f"langres build supports ({ARTIFACT_VERSION!r}); upgrade langres to load it."
+            )
+        if artifact_v < current_v:
+            raise ValueError(
+                f"Artifact version {manifest.artifact_version!r} predates the supported "
+                f"layout ({ARTIFACT_VERSION!r}) and is no longer readable (the config "
+                f"schema changed incompatibly); re-save with this langres build."
             )
         if manifest.langres_version != langres.__version__:
             logger.warning(

--- a/src/langres/core/resolver.py
+++ b/src/langres/core/resolver.py
@@ -172,10 +172,11 @@ class Resolver:
         clusterer: Groups matched pairs into entity clusters.
 
     Example:
+        comparator = Comparator.from_schema(CompanySchema, weights={"name": 0.6, ...})
         resolver = Resolver(
             blocker=AllPairsBlocker(schema=CompanySchema),
-            comparator=Comparator.from_schema(CompanySchema, weights={"name": 0.6, ...}),
-            module=WeightedAverageJudge(),
+            comparator=comparator,
+            module=WeightedAverageJudge(feature_specs=comparator.feature_specs),
             clusterer=Clusterer(threshold=0.7),
         )
         clusters = resolver.resolve(COMPANY_RECORDS)
@@ -231,10 +232,15 @@ class Resolver:
         """
         from langres.core.blockers.all_pairs import AllPairsBlocker
 
+        comparator: Comparator[Any] = Comparator.from_schema(
+            schema, exclude=exclude, weights=weights
+        )
         return cls(
             blocker=AllPairsBlocker(schema=schema),
-            comparator=Comparator.from_schema(schema, exclude=exclude, weights=weights),
-            module=WeightedAverageJudge(),
+            comparator=comparator,
+            # The judge scores on the same FeatureSpecs (weights) the comparator
+            # compares on, so the comparison vector and the weights line up.
+            module=WeightedAverageJudge(feature_specs=comparator.feature_specs),
             clusterer=Clusterer(threshold=threshold),
         )
 
@@ -263,7 +269,11 @@ class Resolver:
         self._ensure_index_built(records)
         candidates = self.blocker.stream(records)
         if self.comparator is not None:
-            return self.module.forward(candidates, comparator=self.comparator)  # type: ignore[call-arg]
+            comparator = self.comparator
+            candidates = (
+                c.model_copy(update={"comparison": comparator.compare(c.left, c.right)})
+                for c in candidates
+            )
         return self.module.forward(candidates)
 
     def predict(self, records: list[Any]) -> list[PairwiseJudgement]:

--- a/src/langres/core/serialization.py
+++ b/src/langres/core/serialization.py
@@ -20,7 +20,7 @@ from typing import Protocol, runtime_checkable
 from pydantic import BaseModel, Field
 
 # Bump when the on-disk artifact layout changes incompatibly.
-ARTIFACT_VERSION = "0"
+ARTIFACT_VERSION = "1"
 
 
 @runtime_checkable

--- a/tests/core/blockers/test_vector.py
+++ b/tests/core/blockers/test_vector.py
@@ -15,6 +15,7 @@ import pytest
 
 from langres.core.blockers.vector import VectorBlocker
 from langres.core.embeddings import SentenceTransformerEmbedder
+from langres.core.indexes.reranking_vector_index import FakeHybridRerankingVectorIndex
 from langres.core.indexes.vector_index import FAISSIndex, FakeVectorIndex
 from langres.core.models import CompanySchema
 
@@ -481,3 +482,34 @@ def test_vector_blocker_with_no_query_prompt():
     mock_index.search_all.assert_called_once()
     call_args = mock_index.search_all.call_args
     assert call_args[1]["query_prompt"] is None
+
+
+def test_stream_with_fake_hybrid_reranking_index_end_to_end():
+    """VectorBlocker drives FakeHybridRerankingVectorIndex.stream() without TypeError.
+
+    VectorBlocker.stream() calls ``search_all(k, query_prompt=...)``; before the
+    fix this fake lacked ``query_prompt`` and raised TypeError. This exercises the
+    full path (search_all + to_similarities) with a query_prompt set.
+    """
+    index = FakeHybridRerankingVectorIndex()
+    blocker = VectorBlocker(
+        schema_factory=company_factory,
+        text_field_extractor=lambda x: x.name,
+        vector_index=index,
+        k_neighbors=2,
+        query_prompt="Represent the company name for retrieval:",
+    )
+
+    data = [
+        {"id": "c1", "name": "Apple"},
+        {"id": "c2", "name": "Google"},
+        {"id": "c3", "name": "Microsoft"},
+    ]
+    index.create_index([d["name"] for d in data])
+
+    candidates = list(blocker.stream(data))
+
+    assert len(candidates) > 0
+    # to_similarities mapped fake distances into [0, 1] similarity scores.
+    for candidate in candidates:
+        assert 0.0 <= candidate.similarity_score <= 1.0

--- a/tests/core/blockers/test_vector_blocker_scores.py
+++ b/tests/core/blockers/test_vector_blocker_scores.py
@@ -7,12 +7,95 @@ similarity_score field in ERCandidate objects, enabling ranking evaluation.
 import logging
 
 import numpy as np
+import pytest
 
 from langres.core.blockers.vector import VectorBlocker
-from langres.core.indexes import FakeVectorIndex
+from langres.core.indexes import FAISSIndex, FakeVectorIndex
 from langres.core.models import CompanySchema
 
 logger = logging.getLogger(__name__)
+
+
+class _StubEmbedder:
+    """Deterministic embedder mapping known texts to fixed vectors.
+
+    Lets a golden test build a *real* FAISSIndex with controlled geometry (no
+    model download, no ``@pytest.mark.slow``): a near-duplicate pair is placed
+    close together and a non-pair far apart, so distance/score ordering is known.
+    """
+
+    def __init__(self, mapping: dict[str, list[float]]) -> None:
+        self._mapping = mapping
+        self.embedding_dim = len(next(iter(mapping.values())))
+
+    def encode(self, texts: list[str], prompt: str | None = None) -> np.ndarray:
+        return np.array([self._mapping[t] for t in texts], dtype=np.float32)
+
+
+def _score_for_pair(candidates: list, id_a: str, id_b: str) -> float:
+    """Return the similarity_score of the candidate for the unordered pair {a, b}."""
+    for candidate in candidates:
+        if {candidate.left.id, candidate.right.id} == {id_a, id_b}:
+            assert candidate.similarity_score is not None
+            return candidate.similarity_score
+    raise AssertionError(f"No candidate found for pair ({id_a}, {id_b})")
+
+
+@pytest.mark.parametrize("metric", ["cosine", "L2"])
+def test_vector_blocker_near_duplicate_outscores_non_pair(metric: str) -> None:
+    """GOLDEN regression guard for the distance->similarity inversion.
+
+    A known near-duplicate pair MUST receive a strictly higher similarity_score
+    than a known non-pair, for BOTH metrics. Geometry is fixed via _StubEmbedder:
+    c1 and c2 sit almost on top of each other; c3 is far away.
+
+    This FAILS on the old heuristic for metric="L2": FAISS L2 returns *squared*
+    distances (here ~26 for the non-pair, > 2.0), which the old code clipped to
+    1.0 — inverting it into the MOST-similar score. The index-owned
+    ``to_similarities`` converts L2 with ``1/(1+sqrt(d))`` and keeps order.
+    """
+    entities = [
+        {"id": "c1", "name": "apple inc"},
+        {"id": "c2", "name": "apple incorporated"},
+        {"id": "c3", "name": "microsoft corp"},
+    ]
+    # Near-duplicate c1/c2 are nearly identical; c3 is far along another axis.
+    embedder = _StubEmbedder(
+        {
+            "apple inc": [1.0, 0.0, 0.0],
+            "apple incorporated": [1.0, 0.05, 0.0],
+            "microsoft corp": [0.0, 5.0, 0.0],
+        }
+    )
+    index = FAISSIndex(embedder=embedder, metric=metric)  # type: ignore[arg-type]
+
+    blocker = VectorBlocker(
+        schema_factory=lambda x: CompanySchema(**x),
+        text_field_extractor=lambda x: x.name,
+        vector_index=index,
+        k_neighbors=2,  # k+1 == N: every pair is generated
+    )
+
+    texts = [e["name"] for e in entities]
+    index.create_index(texts)
+
+    candidates = list(blocker.stream(entities))
+
+    near_dup = _score_for_pair(candidates, "c1", "c2")
+    non_pair = _score_for_pair(candidates, "c1", "c3")
+
+    logger.info(
+        "metric=%s near_dup(c1,c2)=%.4f non_pair(c1,c3)=%.4f",
+        metric,
+        near_dup,
+        non_pair,
+    )
+    assert near_dup > non_pair, (
+        f"metric={metric}: near-duplicate score {near_dup} must exceed "
+        f"non-pair score {non_pair} (distance->similarity inversion?)"
+    )
+    # Sanity: both are valid similarities.
+    assert 0.0 <= non_pair <= near_dup <= 1.0
 
 
 def test_vector_blocker_populates_similarity_scores() -> None:

--- a/tests/core/blockers/test_vector_config.py
+++ b/tests/core/blockers/test_vector_config.py
@@ -20,6 +20,7 @@ import numpy as np
 import pytest
 
 from langres.core.blockers.vector import VectorBlocker
+from langres.core.indexes.vector_index import inverse_distances_to_similarities
 from langres.core.models import CompanySchema
 from langres.core.registry import get_component, register
 from langres.core.serialization import ComponentSpec, SerializableState
@@ -69,6 +70,10 @@ class _FakeSerializableIndex:
                 indices[i, j] = (i + j) % self._n_samples
                 distances[i, j] = j * 0.1
         return distances, indices
+
+    def to_similarities(self, distances: np.ndarray) -> np.ndarray:
+        # Synthetic distances are rank-ordered (lower = closer), like FakeVectorIndex.
+        return inverse_distances_to_similarities(distances)
 
     # --- SerializableState --------------------------------------------
     def save_state(self, state_dir: Path) -> None:
@@ -273,6 +278,9 @@ def test_from_config_without_state_dir_when_not_serializable() -> None:
                     indices[i, j] = (i + j) % self._n_samples
                     distances[i, j] = j * 0.1
             return distances, indices
+
+        def to_similarities(self, distances: np.ndarray) -> np.ndarray:
+            return inverse_distances_to_similarities(distances)
 
     index = _PlainIndex(label="companies")
     index.create_index([r["name"] for r in COMPANY_DATA])

--- a/tests/core/indexes/test_hybrid_vector_index.py
+++ b/tests/core/indexes/test_hybrid_vector_index.py
@@ -805,3 +805,32 @@ class TestHybridVectorIndexProtocol:
         assert callable(index.create_index)
         assert callable(index.search)
         assert callable(index.search_all)
+
+
+class TestHybridToSimilarities:
+    """Tests for the hybrid indexes' distance->similarity conversion."""
+
+    def test_qdrant_hybrid_to_similarities_clips_scores(self):
+        """QdrantHybridIndex: fusion scores (higher=better) clipped to [0, 1], NaN -> 0."""
+        index = QdrantHybridIndex(
+            client=MagicMock(),
+            collection_name="test",
+            dense_embedder=FakeEmbedder(embedding_dim=8),
+            sparse_embedder=FakeSparseEmbedder(),
+        )
+        # Higher score = more similar; >1 clips down, NaN padding -> 0.0.
+        scores = np.array([[1.5, 0.4, np.nan], [0.9, -0.2, 0.1]])
+
+        sims = index.to_similarities(scores)
+
+        np.testing.assert_allclose(sims, [[1.0, 0.4, 0.0], [0.9, 0.0, 0.1]])
+
+    def test_fake_hybrid_to_similarities(self):
+        """FakeHybridVectorIndex: synthetic distances (lower=closer) -> 1/(1+d), NaN -> 0."""
+        index = FakeHybridVectorIndex()
+        distances = np.array([[0.0, 0.1, np.nan]])
+
+        sims = index.to_similarities(distances)
+
+        np.testing.assert_allclose(sims, [[1.0, 1.0 / 1.1, 0.0]])
+        assert sims[0, 0] > sims[0, 1]

--- a/tests/core/indexes/test_reranking_vector_index.py
+++ b/tests/core/indexes/test_reranking_vector_index.py
@@ -1379,3 +1379,32 @@ class TestQdrantHybridRerankingIndexPrecomputedEmbeddings:
         # Verify results are valid
         assert distances.shape == (4, 3)
         assert indices.shape == (4, 3)
+
+
+class TestRerankingToSimilarities:
+    """Tests for the reranking indexes' distance->similarity conversion."""
+
+    def test_qdrant_reranking_to_similarities_clips_scores(self):
+        """QdrantHybridRerankingIndex: MaxSim scores (higher=better) clipped, NaN -> 0."""
+        index = QdrantHybridRerankingIndex(
+            client=MagicMock(),
+            collection_name="test",
+            dense_embedder=FakeEmbedder(embedding_dim=8),
+            sparse_embedder=FakeSparseEmbedder(),
+            reranking_embedder=FakeLateInteractionEmbedder(embedding_dim=8),
+        )
+        scores = np.array([[1.2, 0.6, np.nan], [0.8, -0.1, 0.0]])
+
+        sims = index.to_similarities(scores)
+
+        np.testing.assert_allclose(sims, [[1.0, 0.6, 0.0], [0.8, 0.0, 0.0]])
+
+    def test_fake_reranking_to_similarities(self):
+        """FakeHybridRerankingVectorIndex: distances (lower=closer) -> 1/(1+d), NaN -> 0."""
+        index = FakeHybridRerankingVectorIndex()
+        distances = np.array([[0.0, 0.1, np.nan]])
+
+        sims = index.to_similarities(distances)
+
+        np.testing.assert_allclose(sims, [[1.0, 1.0 / 1.1, 0.0]])
+        assert sims[0, 0] > sims[0, 1]

--- a/tests/core/indexes/test_vector_index.py
+++ b/tests/core/indexes/test_vector_index.py
@@ -6,7 +6,12 @@ import numpy as np
 import pytest
 
 from langres.core.embeddings import FakeEmbedder, SentenceTransformerEmbedder
-from langres.core.indexes.vector_index import FAISSIndex, FakeVectorIndex
+from langres.core.indexes.vector_index import (
+    FAISSIndex,
+    FakeVectorIndex,
+    clip_scores_to_similarities,
+    inverse_distances_to_similarities,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -673,3 +678,75 @@ class TestFAISSIndexWithCachedEmbedder:
         assert info2["hits_hot"] == 0  # No cache operations for pre-computed
         assert info2["hits_cold"] == 0
         assert info2["cold_size"] == 2  # Still just corpus
+
+
+class TestToSimilarities:
+    """Tests for the index-owned distance->similarity conversion."""
+
+    def test_faiss_l2_to_similarities(self):
+        """FAISS L2: squared distances (lower=closer) -> 1/(1+sqrt(d)) in (0, 1]."""
+        index = FAISSIndex(embedder=FakeEmbedder(embedding_dim=4), metric="L2")
+        distances = np.array([[0.0, 0.25, 4.0]])  # sqrt -> 0, 0.5, 2
+
+        sims = index.to_similarities(distances)
+
+        np.testing.assert_allclose(sims, [[1.0, 1.0 / 1.5, 1.0 / 3.0]])
+        # Monotonically decreasing in distance and within (0, 1].
+        assert sims[0, 0] > sims[0, 1] > sims[0, 2] > 0.0
+
+    def test_faiss_l2_to_similarities_large_distance_not_inverted(self):
+        """Regression: a large squared-L2 distance (>2) must score LOW, not ~1.0."""
+        index = FAISSIndex(embedder=FakeEmbedder(embedding_dim=4), metric="L2")
+        distances = np.array([[0.0025, 26.0]])  # near vs. far (the inversion case)
+
+        sims = index.to_similarities(distances)
+
+        # The far point (26) must be far less similar than the near point.
+        assert sims[0, 0] > sims[0, 1]
+        assert sims[0, 1] < 0.2  # not clipped up to ~1.0 like the old heuristic
+
+    def test_faiss_l2_to_similarities_nan(self):
+        """FAISS L2: NaN distance -> 0.0 (least similar)."""
+        index = FAISSIndex(embedder=FakeEmbedder(embedding_dim=4), metric="L2")
+        sims = index.to_similarities(np.array([[0.0, np.nan]]))
+        np.testing.assert_allclose(sims, [[1.0, 0.0]])
+
+    def test_faiss_cosine_to_similarities(self):
+        """FAISS cosine: inner products in [-1, 1] -> (ip+1)/2 in [0, 1]."""
+        index = FAISSIndex(embedder=FakeEmbedder(embedding_dim=4), metric="cosine")
+        distances = np.array([[1.0, 0.0, -1.0]])
+
+        sims = index.to_similarities(distances)
+
+        np.testing.assert_allclose(sims, [[1.0, 0.5, 0.0]])
+        assert sims[0, 0] > sims[0, 1] > sims[0, 2]
+
+    def test_faiss_cosine_to_similarities_nan(self):
+        """FAISS cosine: NaN inner product -> 0.0."""
+        index = FAISSIndex(embedder=FakeEmbedder(embedding_dim=4), metric="cosine")
+        sims = index.to_similarities(np.array([[1.0, np.nan]]))
+        np.testing.assert_allclose(sims, [[1.0, 0.0]])
+
+    def test_fake_to_similarities(self):
+        """FakeVectorIndex: synthetic distances (lower=closer) -> 1/(1+d), NaN -> 0."""
+        index = FakeVectorIndex()
+        distances = np.array([[0.0, 0.1, 0.2], [0.0, np.nan, 1.0]])
+
+        sims = index.to_similarities(distances)
+
+        np.testing.assert_allclose(
+            sims,
+            [[1.0, 1.0 / 1.1, 1.0 / 1.2], [1.0, 0.0, 0.5]],
+        )
+        # Ordering preserved for the clean row (nearest neighbor scores highest).
+        assert sims[0, 0] > sims[0, 1] > sims[0, 2]
+
+    def test_inverse_distances_helper(self):
+        """Shared helper: 1/(1+d) with negative clamp and NaN -> 0."""
+        sims = inverse_distances_to_similarities(np.array([0.0, -5.0, 3.0, np.nan]))
+        np.testing.assert_allclose(sims, [1.0, 1.0, 0.25, 0.0])
+
+    def test_clip_scores_helper(self):
+        """Shared helper: clip already-similarity-like scores to [0, 1], NaN -> 0."""
+        sims = clip_scores_to_similarities(np.array([1.5, 0.3, -0.2, np.nan]))
+        np.testing.assert_allclose(sims, [1.0, 0.3, 0.0, 0.0])

--- a/tests/core/modules/test_cascade.py
+++ b/tests/core/modules/test_cascade.py
@@ -638,15 +638,17 @@ def test_cascade_module_llm_client_reused_across_calls(mocker):
 
 
 @pytest.mark.slow
-def test_cascade_module_gpt4_pricing(mocker):
-    """Test that GPT-4 pricing is calculated correctly."""
+def test_cascade_module_cost_uses_litellm_completion_cost(mocker):
+    """Cascade reports whatever litellm.completion_cost returns for the LLM call."""
     mock_client = Mock()
     mocker.patch("langres.core.modules.cascade.OpenAI", return_value=mock_client)
+    completion_cost = mocker.patch(
+        "langres.core.modules.cascade.litellm.completion_cost", return_value=0.036
+    )
 
-    # Use gpt-4 model (different pricing than gpt-4o-mini)
     module = CascadeModule(
         embedding_model_name="all-MiniLM-L6-v2",
-        llm_model="gpt-4",  # Standard GPT-4
+        llm_model="gpt-4",
         llm_api_key="test_key",
         low_threshold=0.3,
         high_threshold=0.9,
@@ -673,22 +675,21 @@ def test_cascade_module_gpt4_pricing(mocker):
     # Process candidate
     judgements = list(module.forward([candidate]))
 
-    # Should have cost calculated (GPT-4 pricing is higher than gpt-4o-mini)
     assert len(judgements) == 1
-    assert "llm_cost_usd" in judgements[0].provenance
-    # GPT-4: $30/1M input, $60/1M output
-    # Cost = (1000 * 30 + 100 * 60) / 1_000_000 = 0.036
-    expected_cost = (1000 * 30.0 + 100 * 60.0) / 1_000_000
-    assert abs(judgements[0].provenance["llm_cost_usd"] - expected_cost) < 0.001
+    assert judgements[0].provenance["llm_cost_usd"] == 0.036
+    completion_cost.assert_called_once_with(completion_response=mock_response)
 
 
 @pytest.mark.slow
-def test_cascade_module_unknown_model_pricing(mocker):
-    """Test that unknown models default to gpt-4o-mini pricing."""
+def test_cascade_module_cost_falls_back_to_zero_on_exception(mocker):
+    """If litellm.completion_cost raises, Cascade reports 0.0 (never flakes)."""
     mock_client = Mock()
     mocker.patch("langres.core.modules.cascade.OpenAI", return_value=mock_client)
+    mocker.patch(
+        "langres.core.modules.cascade.litellm.completion_cost",
+        side_effect=Exception("unknown model"),
+    )
 
-    # Use an unknown model name
     module = CascadeModule(
         embedding_model_name="all-MiniLM-L6-v2",
         llm_model="gpt-5-future",  # Unknown model
@@ -713,11 +714,7 @@ def test_cascade_module_unknown_model_pricing(mocker):
 
     judgements = list(module.forward([candidate]))
 
-    # Should use default (gpt-4o-mini) pricing
-    assert "llm_cost_usd" in judgements[0].provenance
-    # Default: $0.150/1M input, $0.600/1M output
-    expected_cost = (100 * 0.150 + 20 * 0.600) / 1_000_000
-    assert abs(judgements[0].provenance["llm_cost_usd"] - expected_cost) < 0.001
+    assert judgements[0].provenance["llm_cost_usd"] == 0.0
 
 
 def test_cascade_module_inspect_scores():

--- a/tests/core/modules/test_llm_judge.py
+++ b/tests/core/modules/test_llm_judge.py
@@ -106,8 +106,8 @@ def test_llm_judge_extracts_score_from_response(mock_llm_client):
     assert j.score == 0.15
 
 
-def test_llm_judge_tracks_cost_in_provenance(mock_llm_client):
-    """Test LLMJudgeModule tracks API cost in provenance."""
+def test_llm_judge_tracks_cost_in_provenance(mock_llm_client, mocker):
+    """Test LLMJudgeModule tracks API cost in provenance via litellm pricing."""
     mock_response = Mock()
     mock_response.choices = [Mock()]
     mock_response.choices[0].message.content = "MATCH\nScore: 0.90\nReasoning: Same company."
@@ -115,6 +115,11 @@ def test_llm_judge_tracks_cost_in_provenance(mock_llm_client):
     mock_response.usage.prompt_tokens = 100
     mock_response.usage.completion_tokens = 50
     mock_llm_client.completion.return_value = mock_response
+
+    # litellm.completion_cost owns pricing; stub it so the Mock response prices.
+    completion_cost = mocker.patch(
+        "langres.core.modules.llm_judge.litellm.completion_cost", return_value=0.000123
+    )
 
     module = LLMJudgeModule(client=mock_llm_client, model="gpt-4o-mini")
 
@@ -127,10 +132,11 @@ def test_llm_judge_tracks_cost_in_provenance(mock_llm_client):
     judgements = list(module.forward([candidate]))
     j = judgements[0]
 
-    # Should have cost tracking in provenance
+    # Should have cost tracking in provenance, sourced from litellm.completion_cost
     assert "cost_usd" in j.provenance
     assert isinstance(j.provenance["cost_usd"], float)
-    assert j.provenance["cost_usd"] > 0
+    assert j.provenance["cost_usd"] == 0.000123
+    completion_cost.assert_called_once_with(completion_response=mock_response)
     assert "prompt_tokens" in j.provenance
     assert j.provenance["prompt_tokens"] == 100
     assert "completion_tokens" in j.provenance
@@ -261,8 +267,8 @@ def test_llm_judge_reasoning_extraction_fallback():
     assert "similar companies" in judgements[0].reasoning.lower()
 
 
-def test_llm_judge_gpt4_pricing():
-    """Test that GPT-4 pricing is calculated correctly."""
+def test_llm_judge_cost_uses_litellm_completion_cost(mocker):
+    """The reported cost is whatever litellm.completion_cost returns."""
     mock_client = Mock()
     mock_response = Mock()
     mock_response.choices = [Mock()]
@@ -272,7 +278,11 @@ def test_llm_judge_gpt4_pricing():
     mock_response.usage.completion_tokens = 100
     mock_client.completion.return_value = mock_response
 
-    module = LLMJudgeModule(client=mock_client, model="gpt-4")  # Standard GPT-4
+    completion_cost = mocker.patch(
+        "langres.core.modules.llm_judge.litellm.completion_cost", return_value=0.036
+    )
+
+    module = LLMJudgeModule(client=mock_client, model="gpt-4")
 
     candidate = ERCandidate(
         left=CompanySchema(id="c1", name="Acme"),
@@ -282,13 +292,12 @@ def test_llm_judge_gpt4_pricing():
 
     judgements = list(module.forward([candidate]))
 
-    # GPT-4: $30/1M input, $60/1M output
-    expected_cost = (1000 * 30.0 + 100 * 60.0) / 1_000_000
-    assert abs(judgements[0].provenance["cost_usd"] - expected_cost) < 0.001
+    assert judgements[0].provenance["cost_usd"] == 0.036
+    completion_cost.assert_called_once_with(completion_response=mock_response)
 
 
-def test_llm_judge_unknown_model_pricing():
-    """Test that unknown models default to gpt-4o-mini pricing."""
+def test_llm_judge_cost_falls_back_to_zero_on_exception(mocker, caplog):
+    """If litellm.completion_cost raises (unknown model/usage), cost is 0.0."""
     mock_client = Mock()
     mock_response = Mock()
     mock_response.choices = [Mock()]
@@ -298,6 +307,11 @@ def test_llm_judge_unknown_model_pricing():
     mock_response.usage.completion_tokens = 20
     mock_client.completion.return_value = mock_response
 
+    mocker.patch(
+        "langres.core.modules.llm_judge.litellm.completion_cost",
+        side_effect=Exception("unknown model"),
+    )
+
     module = LLMJudgeModule(client=mock_client, model="gpt-future-5")  # Unknown model
 
     candidate = ERCandidate(
@@ -306,11 +320,11 @@ def test_llm_judge_unknown_model_pricing():
         blocker_name="test",
     )
 
-    judgements = list(module.forward([candidate]))
+    with caplog.at_level(logging.WARNING):
+        judgements = list(module.forward([candidate]))
 
-    # Should use default (gpt-4o-mini) pricing
-    expected_cost = (100 * 0.150 + 20 * 0.600) / 1_000_000
-    assert abs(judgements[0].provenance["cost_usd"] - expected_cost) < 0.001
+    assert judgements[0].provenance["cost_usd"] == 0.0
+    assert "completion_cost unavailable" in caplog.text
 
 
 # Client Integration Tests

--- a/tests/core/modules/test_llm_judge_async.py
+++ b/tests/core/modules/test_llm_judge_async.py
@@ -260,6 +260,73 @@ async def test_rate_limiter_concurrent_usage_recording():
     assert total_tokens == 10000
 
 
+@pytest.mark.asyncio
+async def test_acquire_does_not_hold_lock_while_sleeping(monkeypatch) -> None:
+    """A waiting ``acquire`` must release the lock before sleeping (no deadlock).
+
+    Regression for the rate-limiter deadlock: the old ``acquire`` awaited
+    ``asyncio.sleep`` *inside* ``async with self._lock``, so a single rate-limited
+    coroutine blocked every other coroutine touching the limiter until it woke.
+    Here we drive one ``acquire`` into its RPM-wait sleep and prove a concurrent
+    ``record_usage_async`` (which also needs the lock) makes progress meanwhile.
+    With the old code this assertion times out; with the fix it passes.
+    """
+    limiter = _RateLimiter(rpm_limit=1, tpm_limit=10**9)
+    # Seed at the RPM limit so the next acquire is forced to wait.
+    limiter._request_times.append(time.time())
+
+    sleep_entered = asyncio.Event()
+    release_sleep = asyncio.Event()
+
+    async def controlled_sleep(_seconds: float) -> None:
+        # Signal we are sleeping (lock must already be released here), then block
+        # until the test lets us continue, then "expire" the window so the retry
+        # succeeds.
+        sleep_entered.set()
+        await release_sleep.wait()
+        limiter._request_times.clear()
+
+    monkeypatch.setattr(asyncio, "sleep", controlled_sleep)
+
+    waiter = asyncio.create_task(limiter.acquire(estimated_tokens=1))
+
+    # Wait until the waiter is parked in its sleep (i.e. has hit the RPM branch).
+    await asyncio.wait_for(sleep_entered.wait(), timeout=2.0)
+
+    # The lock must be free now: a concurrent locked operation must NOT block.
+    # Old (buggy) code holds the lock across the sleep, so this times out.
+    await asyncio.wait_for(limiter.record_usage_async(5), timeout=2.0)
+
+    # Let the waiter finish; it should complete promptly once the window clears.
+    release_sleep.set()
+    await asyncio.wait_for(waiter, timeout=2.0)
+    assert len(limiter._request_times) == 1  # the waiter recorded its request
+
+
+@pytest.mark.asyncio
+async def test_acquire_tpm_wait_branch_releases_and_retries(monkeypatch) -> None:
+    """The TPM-wait branch sleeps outside the lock, then retries successfully."""
+    limiter = _RateLimiter(rpm_limit=1000, tpm_limit=500)
+    # Pre-fill token usage so the next request would exceed the TPM limit.
+    await limiter.record_usage_async(400)
+
+    sleeps: list[float] = []
+
+    async def fake_sleep(seconds: float) -> None:
+        sleeps.append(seconds)
+        # Simulate the 1-minute token window passing so the retry clears.
+        limiter._token_usage.clear()
+
+    monkeypatch.setattr(asyncio, "sleep", fake_sleep)
+
+    # 400 (recorded) + 200 (estimated) = 600 > 500 → must hit the TPM-wait branch.
+    await limiter.acquire(estimated_tokens=200)
+
+    assert len(sleeps) == 1  # slept exactly once, then proceeded
+    assert sleeps[0] > 0.0  # a positive wait was computed
+    assert len(limiter._request_times) == 1  # request reserved after the wait
+
+
 # Retry Logic Tests
 
 

--- a/tests/core/modules/test_llm_judge_async.py
+++ b/tests/core/modules/test_llm_judge_async.py
@@ -382,9 +382,11 @@ async def test_forward_async_retries_with_exponential_backoff(mock_llm_client, m
 
 
 @pytest.mark.asyncio
-async def test_forward_async_tracks_cost(mock_llm_client, mock_llm_response):
-    """Test forward_async() tracks API costs in provenance."""
+async def test_forward_async_tracks_cost(mock_llm_client, mock_llm_response, mocker):
+    """Test forward_async() tracks API costs in provenance via litellm pricing."""
     mock_llm_client.acompletion.return_value = mock_llm_response
+
+    mocker.patch("langres.core.modules.llm_judge.litellm.completion_cost", return_value=0.000123)
 
     module = LLMJudgeModule(client=mock_llm_client, model="gpt-4o-mini")
 
@@ -399,7 +401,7 @@ async def test_forward_async_tracks_cost(mock_llm_client, mock_llm_response):
     j = judgements[0]
     assert "cost_usd" in j.provenance
     assert isinstance(j.provenance["cost_usd"], float)
-    assert j.provenance["cost_usd"] > 0
+    assert j.provenance["cost_usd"] == 0.000123
     assert "prompt_tokens" in j.provenance
     assert "completion_tokens" in j.provenance
     assert j.provenance["method"] == "async_batch"

--- a/tests/core/modules/test_llm_judge_inspect.py
+++ b/tests/core/modules/test_llm_judge_inspect.py
@@ -438,6 +438,33 @@ class TestLLMJudgeModuleInspection:
             "sampling" in recommendations_text.lower() or "faster" in recommendations_text.lower()
         )
 
+    def test_inspect_scores_medium_sample_no_size_recommendation(self, mock_llm_client) -> None:
+        """Medium sample (50 <= n <= 1000) triggers neither small- nor large-sample advice.
+
+        Covers the fall-through branch in ``_generate_recommendations_impl`` where
+        both the ``< 50`` and ``> 1000`` size guards are false.
+        """
+        judgements = [
+            PairwiseJudgement(
+                left_id=f"left_{i}",
+                right_id=f"right_{i}",
+                score=0.2 + (i % 7) * 0.1,
+                score_type="prob_llm",
+                decision_step="llm_judgment",
+                reasoning="Test",
+                provenance={},
+            )
+            for i in range(60)
+        ]
+
+        module = LLMJudgeModule(client=mock_llm_client, model="gpt-4o-mini")
+        report = module.inspect_scores(judgements, sample_size=5)
+
+        assert report.total_judgements == 60
+        recommendations_text = " ".join(report.recommendations)
+        assert "Small sample" not in recommendations_text
+        assert "Large sample" not in recommendations_text
+
     def test_inspect_scores_medium_variance_no_special_recommendation(
         self, mock_llm_client
     ) -> None:

--- a/tests/core/modules/test_llm_judge_serialization.py
+++ b/tests/core/modules/test_llm_judge_serialization.py
@@ -8,7 +8,11 @@ path, and a Resolver with an LLMJudge in the ``module`` slot can ``save`` /
 """
 
 import json
+import subprocess
+import sys
 from pathlib import Path
+
+import pytest
 
 from langres.core.modules.llm_judge import (
     DEFAULT_PROMPT,
@@ -168,3 +172,50 @@ def test_resolver_with_llm_judge_module_saves_and_loads(tmp_path: Path, mocker) 
     assert isinstance(reloaded.module, LLMJudge)
     assert reloaded.module.client is None  # lazy — not built at load
     assert reloaded.module.config == judge.config
+
+
+@pytest.mark.slow
+def test_resolver_load_registers_llm_judge_in_a_fresh_process(tmp_path: Path) -> None:
+    """A clean process can ``Resolver.load`` an LLMJudge artifact via ``langres.core`` alone.
+
+    Regression for the load-path registration bug: ``@register("llm_judge")`` only
+    fires when ``langres.core.modules.llm_judge`` is imported. ``langres.core`` must
+    import it so a fresh process that *only* does ``from langres.core import
+    Resolver`` finds ``llm_judge`` in the registry. Without the ``__init__`` import,
+    ``Resolver.load`` raises ``UnknownComponentType`` here (this test fails); with
+    it, load succeeds and stays offline (the client is rebuilt lazily, not at load).
+
+    The subprocess deliberately does NOT import ``langres.core.modules.llm_judge``
+    — that is the whole point of the check.
+    """
+    from langres.core import AllPairsBlocker, Clusterer, Resolver
+    from langres.core.models import CompanySchema
+
+    judge: LLMJudge[CompanySchema] = LLMJudge(
+        model="openrouter/openai/gpt-4o-mini",
+        client=object(),
+        entity_noun="company",
+    )
+    resolver = Resolver(
+        blocker=AllPairsBlocker(schema=CompanySchema),
+        comparator=None,
+        module=judge,
+        clusterer=Clusterer(threshold=0.7),
+    )
+    resolver.save(tmp_path)
+
+    result = subprocess.run(
+        [
+            sys.executable,
+            "-c",
+            f"from langres.core import Resolver; Resolver.load(r'{tmp_path}')",
+        ],
+        capture_output=True,
+        text=True,
+    )
+
+    assert result.returncode == 0, (
+        "fresh-process Resolver.load failed (LLMJudge not registered on the "
+        f"import-langres.core path).\nSTDOUT:\n{result.stdout}\nSTDERR:\n{result.stderr}"
+    )
+    assert "UnknownComponentType" not in result.stderr

--- a/tests/core/modules/test_llm_judge_serialization.py
+++ b/tests/core/modules/test_llm_judge_serialization.py
@@ -1,0 +1,170 @@
+"""Serialization, lazy-client, and neutral-prompt tests for LLMJudge.
+
+These cover the M0.5 W-C contract: LLMJudge is a first-class, serializable
+Resolver Module — it registers under ``llm_judge``, exposes a pure ``config``
+that never carries the client/secrets, rebuilds from env via the lazy-client
+path, and a Resolver with an LLMJudge in the ``module`` slot can ``save`` /
+``load`` with no network.
+"""
+
+import json
+from pathlib import Path
+
+from langres.core.modules.llm_judge import (
+    DEFAULT_PROMPT,
+    LLMJudge,
+    LLMJudgeModule,
+    render_default_prompt,
+)
+from langres.core.registry import get_component
+
+
+def test_llm_judge_is_registered_with_type_name() -> None:
+    """LLMJudge is discoverable in the component registry under ``llm_judge``."""
+    assert get_component("llm_judge") is LLMJudge
+    assert LLMJudge.type_name == "llm_judge"
+    # Backward-compat alias keeps old imports working.
+    assert LLMJudgeModule is LLMJudge
+
+
+def test_config_excludes_client_and_secrets() -> None:
+    """``config`` carries only pure, serializable data — never the client."""
+    judge = LLMJudge(
+        model="openrouter/openai/gpt-4o-mini",
+        client=object(),  # non-serializable stub client
+        temperature=0.3,
+        entity_noun="company",
+    )
+
+    config = judge.config
+
+    assert set(config) == {"model", "temperature", "prompt_template", "entity_noun"}
+    assert config["model"] == "openrouter/openai/gpt-4o-mini"
+    assert config["temperature"] == 0.3
+    assert config["entity_noun"] == "company"
+    # The client (and any secret it holds) is never serialized.
+    assert "client" not in config
+    assert object() not in config.values()
+    # Whole config must be JSON-serializable.
+    json.dumps(config)
+
+
+def test_from_config_round_trips_via_lazy_client_path() -> None:
+    """``from_config`` rebuilds an equivalent judge with the client left lazy."""
+    original = LLMJudge(
+        model="gpt-5-mini",
+        client=object(),
+        temperature=0.7,
+        entity_noun="product",
+    )
+
+    rebuilt = LLMJudge.from_config(original.config)
+
+    assert rebuilt.config == original.config
+    # Client is NOT persisted — it is reconstructed from env on first use.
+    assert rebuilt.client is None
+    assert rebuilt.model == "gpt-5-mini"
+    assert rebuilt.temperature == 0.7
+    assert rebuilt.entity_noun == "product"
+    assert rebuilt.prompt_template == original.prompt_template
+
+
+def test_from_env_builds_client_from_environment(mocker) -> None:
+    """``from_env`` is the happy path: client comes from ``create_llm_client``."""
+    sentinel = object()
+    create = mocker.patch("langres.clients.create_llm_client", return_value=sentinel)
+
+    judge = LLMJudge.from_env(model="gpt-5-mini", temperature=0.0, entity_noun="person")
+
+    assert judge.client is sentinel
+    assert judge.model == "gpt-5-mini"
+    assert judge.temperature == 0.0
+    assert judge.entity_noun == "person"
+    create.assert_called_once()
+
+
+def test_client_is_lazily_built_from_env_when_omitted(mocker) -> None:
+    """An omitted client is built once from env on first use, then cached."""
+    built = object()
+    create = mocker.patch("langres.clients.create_llm_client", return_value=built)
+
+    judge: LLMJudge = LLMJudge(model="gpt-5-mini")  # no client
+    assert judge.client is None  # not built at construction
+
+    first = judge._get_client()
+    second = judge._get_client()
+
+    assert first is built
+    assert second is built
+    assert judge.client is built  # cached on the instance
+    create.assert_called_once()  # built exactly once
+
+
+def test_default_prompt_is_domain_neutral() -> None:
+    """The default prompt mentions no specific domain (no 'company')."""
+    rendered = render_default_prompt()
+    assert "company" not in rendered.lower()
+    assert "entity" in rendered.lower()
+    # The default judge (no overrides) uses the neutral prompt.
+    assert "company" not in LLMJudge(client=object()).prompt_template.lower()
+    # The centralized template placeholder is the single source of truth.
+    assert "{entity_noun}" in DEFAULT_PROMPT
+
+
+def test_entity_noun_is_woven_into_the_prompt() -> None:
+    """``entity_noun`` parametrizes the default prompt for a specific domain."""
+    judge = LLMJudge(client=object(), entity_noun="company")
+    assert "company" in judge.prompt_template.lower()
+    # ``{left}`` / ``{right}`` survive for judgement-time formatting.
+    assert "{left}" in judge.prompt_template
+    assert "{right}" in judge.prompt_template
+
+
+def test_custom_prompt_template_is_the_escape_hatch() -> None:
+    """An explicit ``prompt_template`` wins and ignores ``entity_noun``."""
+    custom = "Same? A={left} B={right}"
+    judge = LLMJudge(client=object(), prompt_template=custom, entity_noun="company")
+    assert judge.prompt_template == custom
+
+
+def test_resolver_with_llm_judge_module_saves_and_loads(tmp_path: Path, mocker) -> None:
+    """A Resolver with an LLMJudge in the module slot round-trips with no network.
+
+    Save serializes only the pure config; load rebuilds the judge with a lazy
+    (env-reconstructed) client. We patch ``create_llm_client`` to raise so the
+    test fails loudly if load ever tries to build a client (it must not).
+    """
+    from langres.core import AllPairsBlocker, Clusterer, Resolver
+    from langres.core.models import CompanySchema
+
+    # If load builds a client, this blows up — proving load stays offline/lazy.
+    mocker.patch(
+        "langres.clients.create_llm_client",
+        side_effect=AssertionError("client must not be built during save/load"),
+    )
+
+    judge: LLMJudge[CompanySchema] = LLMJudge(
+        model="openrouter/openai/gpt-4o-mini",
+        client=object(),
+        entity_noun="company",
+    )
+    resolver = Resolver(
+        blocker=AllPairsBlocker(schema=CompanySchema),
+        comparator=None,
+        module=judge,
+        clusterer=Clusterer(threshold=0.7),
+    )
+
+    resolver.save(tmp_path)
+
+    manifest = json.loads((tmp_path / "resolver.json").read_text())
+    module_spec = next(c for c in manifest["components"] if c["slot"] == "module")
+    assert module_spec["type_name"] == "llm_judge"
+    assert module_spec["config"]["model"] == "openrouter/openai/gpt-4o-mini"
+    assert module_spec["config"]["entity_noun"] == "company"
+    assert "client" not in module_spec["config"]
+
+    reloaded = Resolver.load(tmp_path)
+    assert isinstance(reloaded.module, LLMJudge)
+    assert reloaded.module.client is None  # lazy — not built at load
+    assert reloaded.module.config == judge.config

--- a/tests/core/test_serialization.py
+++ b/tests/core/test_serialization.py
@@ -17,8 +17,8 @@ from langres.core.serialization import (
 
 
 class TestArtifactVersion:
-    def test_artifact_version_is_zero(self) -> None:
-        assert ARTIFACT_VERSION == "0"
+    def test_artifact_version_is_one(self) -> None:
+        assert ARTIFACT_VERSION == "1"
 
 
 class TestComponentSpec:
@@ -48,7 +48,7 @@ class TestArtifactManifest:
         )
         restored = ArtifactManifest.model_validate_json(manifest.model_dump_json())
         assert restored == manifest
-        assert restored.artifact_version == "0"
+        assert restored.artifact_version == "1"
         assert len(restored.components) == 2
 
     def test_checksums_optional_default_empty(self) -> None:

--- a/tests/core/test_weighted_average_judge.py
+++ b/tests/core/test_weighted_average_judge.py
@@ -1,9 +1,9 @@
 """Unit tests for WeightedAverageJudge (M0 Wave 2a scorer Module).
 
-The judge is arg-free (``WeightedAverageJudge()``). The Resolver drives the
-Comparator and feeds the judge per-pair via ``forward``; the judge owns the
-scoring rule (weight normalization + the evidence floor from
-``combine_present``). These tests pin that behavior.
+The judge owns its FeatureSpecs (``WeightedAverageJudge(feature_specs=...)``) and
+the scoring rule (weight normalization + the evidence floor from
+``combine_present``). It reads each candidate's attached ``comparison`` vector;
+the Resolver attaches it from the Comparator. These tests pin that behavior.
 """
 
 import pytest
@@ -14,8 +14,21 @@ from langres.core.judges.weighted_average import WeightedAverageJudge
 from langres.core.models import CompanySchema, ERCandidate, PairwiseJudgement
 
 
-def _candidate(left: CompanySchema, right: CompanySchema) -> ERCandidate[CompanySchema]:
-    return ERCandidate(left=left, right=right, blocker_name="test")
+def _candidate(
+    left: CompanySchema,
+    right: CompanySchema,
+    comparison: ComparisonVector | None = None,
+) -> ERCandidate[CompanySchema]:
+    return ERCandidate(left=left, right=right, blocker_name="test", comparison=comparison)
+
+
+def _compared(
+    comparator: StringComparator[CompanySchema],
+    left: CompanySchema,
+    right: CompanySchema,
+) -> ERCandidate[CompanySchema]:
+    """Build a candidate with its comparison vector attached (as the Resolver does)."""
+    return _candidate(left, right, comparison=comparator.compare(left, right))
 
 
 def _company(**kwargs: object) -> CompanySchema:
@@ -28,71 +41,71 @@ class TestScore:
     def test_weighted_average_correct(self) -> None:
         # Two present features, weights 0.6 / 0.4, similarities 1.0 / 0.5.
         specs = [FeatureSpec(name="name", weight=0.6), FeatureSpec(name="address", weight=0.4)]
-        judge = WeightedAverageJudge()
+        judge = WeightedAverageJudge(feature_specs=specs)
         vec = ComparisonVector(
             levels={"name": ComparisonLevel.PRESENT, "address": ComparisonLevel.PRESENT},
             similarities={"name": 1.0, "address": 0.5},
         )
         # Normalized weights already sum to 1.0: 0.6*1.0 + 0.4*0.5 = 0.8.
-        assert judge.score(vec, specs) == pytest.approx(0.8)
+        assert judge.score(vec) == pytest.approx(0.8)
 
     def test_weights_normalized_to_one(self) -> None:
         # Raw weights 6 / 4 must normalize to 0.6 / 0.4 -> same 0.8 result.
         specs = [FeatureSpec(name="name", weight=6.0), FeatureSpec(name="address", weight=4.0)]
-        judge = WeightedAverageJudge()
+        judge = WeightedAverageJudge(feature_specs=specs)
         vec = ComparisonVector(
             levels={"name": ComparisonLevel.PRESENT, "address": ComparisonLevel.PRESENT},
             similarities={"name": 1.0, "address": 0.5},
         )
-        assert judge.score(vec, specs) == pytest.approx(0.8)
+        assert judge.score(vec) == pytest.approx(0.8)
 
     def test_evidence_floor_single_low_weight_forces_zero(self) -> None:
         # Single present feature carrying < 0.5 of total weight -> floor -> 0.0.
         specs = [FeatureSpec(name="name", weight=0.3), FeatureSpec(name="address", weight=0.7)]
-        judge = WeightedAverageJudge()
+        judge = WeightedAverageJudge(feature_specs=specs)
         vec = ComparisonVector(
             levels={"name": ComparisonLevel.PRESENT, "address": ComparisonLevel.MISSING},
             similarities={"name": 0.95},
         )
-        assert judge.score(vec, specs) == 0.0
+        assert judge.score(vec) == 0.0
 
     def test_single_high_weight_present_clears_floor(self) -> None:
         # Single present feature with >= 0.5 of total weight scores normally.
         specs = [FeatureSpec(name="name", weight=0.6), FeatureSpec(name="address", weight=0.4)]
-        judge = WeightedAverageJudge()
+        judge = WeightedAverageJudge(feature_specs=specs)
         vec = ComparisonVector(
             levels={"name": ComparisonLevel.PRESENT, "address": ComparisonLevel.MISSING},
             similarities={"name": 0.9},
         )
-        assert judge.score(vec, specs) == pytest.approx(0.9)
+        assert judge.score(vec) == pytest.approx(0.9)
 
     def test_all_missing_scores_zero(self) -> None:
         specs = [FeatureSpec(name="name", weight=0.6), FeatureSpec(name="address", weight=0.4)]
-        judge = WeightedAverageJudge()
+        judge = WeightedAverageJudge(feature_specs=specs)
         vec = ComparisonVector(
             levels={"name": ComparisonLevel.MISSING, "address": ComparisonLevel.MISSING},
             similarities={},
         )
-        assert judge.score(vec, specs) == 0.0
+        assert judge.score(vec) == 0.0
 
     def test_empty_specs_scores_zero(self) -> None:
         # Defensive: scoring with no specs yields an empty weight map, which
         # combine_present treats as no-evidence -> 0.0 (never divides by zero).
-        judge = WeightedAverageJudge()
+        judge: WeightedAverageJudge[CompanySchema] = WeightedAverageJudge(feature_specs=[])
         vec = ComparisonVector(levels={}, similarities={})
-        assert judge.score(vec, []) == 0.0
+        assert judge.score(vec) == 0.0
 
     def test_all_zero_weights_falls_back_to_even_split(self) -> None:
         # When every spec has weight 0, normalization splits evenly (1/n each)
         # rather than dividing by zero. Two present features clear the floor.
         specs = [FeatureSpec(name="name", weight=0.0), FeatureSpec(name="address", weight=0.0)]
-        judge = WeightedAverageJudge()
+        judge = WeightedAverageJudge(feature_specs=specs)
         vec = ComparisonVector(
             levels={"name": ComparisonLevel.PRESENT, "address": ComparisonLevel.PRESENT},
             similarities={"name": 1.0, "address": 0.0},
         )
         # Even split 0.5 / 0.5: 0.5*1.0 + 0.5*0.0 = 0.5.
-        assert judge.score(vec, specs) == pytest.approx(0.5)
+        assert judge.score(vec) == pytest.approx(0.5)
 
 
 class TestForward:
@@ -101,12 +114,13 @@ class TestForward:
 
     def test_emits_valid_pairwise_judgement(self) -> None:
         comp = StringComparator(self._specs())
-        judge = WeightedAverageJudge()
-        cand = _candidate(
+        judge = WeightedAverageJudge(feature_specs=self._specs())
+        cand = _compared(
+            comp,
             _company(id="a", name="Acme", address="123 Main"),
             _company(id="b", name="Acme", address="123 Main"),
         )
-        results = list(judge.forward([cand], comparator=comp))
+        results = list(judge.forward([cand]))
         assert len(results) == 1
         j = results[0]
         assert isinstance(j, PairwiseJudgement)
@@ -121,43 +135,46 @@ class TestForward:
 
     def test_decision_step_all_features_missing(self) -> None:
         comp = StringComparator(self._specs())
-        judge = WeightedAverageJudge()
-        cand = _candidate(
+        judge = WeightedAverageJudge(feature_specs=self._specs())
+        cand = _compared(
+            comp,
             _company(id="a", name="", address=None),
             _company(id="b", name="", address=None),
         )
-        j = next(iter(judge.forward([cand], comparator=comp)))
+        j = next(iter(judge.forward([cand])))
         assert j.score == 0.0
         assert j.decision_step == "all_features_missing"
 
     def test_decision_step_below_evidence_floor(self) -> None:
         specs = [FeatureSpec(name="name", weight=0.3), FeatureSpec(name="address", weight=0.7)]
         comp = StringComparator(specs)
-        judge = WeightedAverageJudge()
+        judge = WeightedAverageJudge(feature_specs=specs)
         # name present (low weight), address missing -> below floor -> 0.0.
-        cand = _candidate(
+        cand = _compared(
+            comp,
             _company(id="a", name="Acme", address=None),
             _company(id="b", name="Acme", address=None),
         )
-        j = next(iter(judge.forward([cand], comparator=comp)))
+        j = next(iter(judge.forward([cand])))
         assert j.score == 0.0
         assert j.decision_step == "below_evidence_floor"
 
     def test_streams_lazily(self) -> None:
-        comp = StringComparator(self._specs())
-        judge = WeightedAverageJudge()
-        gen = judge.forward(iter([]), comparator=comp)
+        judge = WeightedAverageJudge(feature_specs=self._specs())
+        gen = judge.forward(iter([]))
         assert list(gen) == []
 
-    def test_forward_without_comparator_raises(self) -> None:
-        judge: WeightedAverageJudge[CompanySchema] = WeightedAverageJudge()
-        with pytest.raises(ValueError, match="requires a comparator"):
-            list(judge.forward(iter([])))
+    def test_forward_without_comparison_raises(self) -> None:
+        judge = WeightedAverageJudge(feature_specs=self._specs())
+        # Candidate carries no comparison vector -> the judge cannot score it.
+        cand = _candidate(_company(id="a"), _company(id="b"))
+        with pytest.raises(ValueError, match="requires candidates carrying a comparison"):
+            list(judge.forward([cand]))
 
 
 class TestInspectScores:
     def test_inspect_scores_delegates(self) -> None:
-        judge = WeightedAverageJudge()
+        judge = WeightedAverageJudge(feature_specs=[FeatureSpec(name="name")])
         judgements = [
             PairwiseJudgement(
                 left_id="a",
@@ -176,12 +193,15 @@ class TestConfigRoundTrip:
     def test_config_is_serializable(self) -> None:
         import json
 
-        json.dumps(WeightedAverageJudge().config)
+        json.dumps(WeightedAverageJudge(feature_specs=[FeatureSpec(name="name")]).config)
 
-    def test_from_config_reconstructs(self) -> None:
-        judge = WeightedAverageJudge()
+    def test_from_config_reconstructs_feature_specs(self) -> None:
+        specs = [FeatureSpec(name="name", weight=0.6), FeatureSpec(name="address", weight=0.4)]
+        judge = WeightedAverageJudge(feature_specs=specs)
         rebuilt = WeightedAverageJudge.from_config(judge.config)
         assert isinstance(rebuilt, WeightedAverageJudge)
+        # The weights survive the round-trip so scoring is identical.
+        assert rebuilt.feature_specs == specs
 
     def test_registered_under_weighted_average_judge(self) -> None:
         from langres.core.registry import get_component
@@ -193,29 +213,32 @@ class TestCompanyFixtureBehavior:
     """Behavioral test on company-like records: name-only match merges, a
     low-weight-only shared field scores 0.0."""
 
+    def _name_dominant_comparator(self) -> StringComparator[CompanySchema]:
+        return StringComparator.from_schema(
+            CompanySchema, weights={"name": 0.6, "address": 0.2, "phone": 0.1, "website": 0.1}
+        )
+
     def test_name_only_match_scores_high(self) -> None:
         # Mirrors c4 / c4_partial: identical name, all other fields missing.
         # name carries 0.6 of total weight (0.6 / (0.6+0.2+0.1+0.1)) -> clears
         # the 0.5 evidence floor on a name-only match.
-        comp = StringComparator.from_schema(
-            CompanySchema, weights={"name": 0.6, "address": 0.2, "phone": 0.1, "website": 0.1}
-        )
-        judge = WeightedAverageJudge()
-        cand = _candidate(
+        comp = self._name_dominant_comparator()
+        judge = WeightedAverageJudge(feature_specs=comp.feature_specs)
+        cand = _compared(
+            comp,
             _company(id="c4", name="DataFlow Solutions", address="321 Tech Way"),
             _company(id="c4_partial", name="DataFlow Solutions"),
         )
-        j = next(iter(judge.forward([cand], comparator=comp)))
+        j = next(iter(judge.forward([cand])))
         assert j.score >= 0.7  # would merge at a 0.7 clusterer threshold
 
     def test_share_only_low_weight_field_scores_zero(self) -> None:
         # Only a single low-weight feature (website) is present on both sides;
         # everything else differs/missing -> below evidence floor -> 0.0.
-        comp = StringComparator.from_schema(
-            CompanySchema, weights={"name": 0.6, "address": 0.2, "phone": 0.1, "website": 0.1}
-        )
-        judge = WeightedAverageJudge()
-        cand = _candidate(
+        comp = self._name_dominant_comparator()
+        judge = WeightedAverageJudge(feature_specs=comp.feature_specs)
+        cand = _compared(
+            comp,
             _company(id="a", name="Quantum Dynamics", website="https://shared.com"),
             _company(
                 id="b",
@@ -226,5 +249,5 @@ class TestCompanyFixtureBehavior:
         # name present too (both sides) but differs strongly; website matches.
         # name (0.6) + website (0.1) present -> 2 present features clears floor,
         # but the weighted average is dominated by the near-zero name match.
-        j = next(iter(judge.forward([cand], comparator=comp)))
+        j = next(iter(judge.forward([cand])))
         assert j.score < 0.7

--- a/tests/examples/test_person_resolution.py
+++ b/tests/examples/test_person_resolution.py
@@ -1,0 +1,140 @@
+"""Deterministic proof that the Person embeddings + LLM strong path runs end-to-end.
+
+Drives the importable core of ``examples/person_resolution.py`` (``build_resolver``
++ ``run_demo``) with its deterministic fake LLM client — no network in the
+default suite. Asserts the M1-critical blocking signal (Pair-Completeness over
+the known duplicates), that the pipeline recovers the known duplicate clusters,
+that a save/reload round-trip is identical, and that honest cost is a real float.
+
+The live path (one real OpenRouter call) is gated behind ``OPENROUTER_API_KEY``.
+"""
+
+from __future__ import annotations
+
+import os
+
+import pytest
+
+from examples.person_resolution import (
+    KNOWN_DUPLICATE_GROUPS,
+    KNOWN_DUPLICATE_PAIRS,
+    PERSON_RECORDS,
+    FakeLLMClient,
+    PersonSchema,
+    build_resolver,
+    run_demo,
+)
+from langres.core import Resolver
+from langres.core.blockers.vector import VectorBlocker
+from langres.core.metrics import evaluate_blocking
+
+
+def _canonical(clusters: list[set[str]]) -> frozenset[frozenset[str]]:
+    return frozenset(frozenset(c) for c in clusters)
+
+
+def test_fake_client_mirrors_llm_judgement() -> None:
+    """The fake matcher catches the realistic variations and rejects look-alikes."""
+    from examples.person_resolution import _names_match
+
+    # Duplicates: accents, abbreviation, name-order, order-swap.
+    assert _names_match("Joséphine Goube", "Josephine Goube")
+    assert _names_match("J. Goube", "Joséphine Goube")
+    assert _names_match("Goube, Josephine", "Joséphine Goube")
+    assert _names_match("Liang Wei", "Wei Liang")
+    # Non-duplicates: shared first name, near-name.
+    assert not _names_match("Maria Garcia", "Maria Silva")
+    assert not _names_match("John Smith", "Jonathan Smith")
+
+
+def test_run_demo_strong_path_is_deterministic_and_correct() -> None:
+    """End-to-end: blocking recall, cluster recovery, save/reload, honest cost."""
+    results = run_demo()
+
+    # 1. Blocking Pair-Completeness — the duplicates must reach the judge.
+    assert results["blocking_recall"] >= 0.95
+    assert results["blocking_stats"].missed_matches_count == 0
+
+    # 2. The pipeline recovers exactly the known duplicate clusters.
+    assert _canonical(results["clusters"]) == _canonical(KNOWN_DUPLICATE_GROUPS)
+    assert results["bcubed"]["f1"] >= 0.95
+    assert results["pairwise"]["f1"] >= 0.95
+
+    # 3. save -> load -> re-resolve is identical (pickle-free manifest).
+    assert results["identical"] is True
+    assert _canonical(results["reloaded_clusters"]) == _canonical(KNOWN_DUPLICATE_GROUPS)
+
+    # 4. Honest cost is a real, non-negative float (0.0 with the fake client).
+    assert isinstance(results["total_cost"], float)
+    assert results["total_cost"] >= 0.0
+    assert results["num_judgements"] > 0
+
+
+def test_predicted_pairs_cover_known_duplicate_pairs() -> None:
+    """Every known duplicate pair ends up co-clustered (pairwise recall == 1.0)."""
+    results = run_demo()
+    predicted_pairs = {
+        frozenset({a, b})
+        for cluster in results["clusters"]
+        for a in cluster
+        for b in cluster
+        if a < b
+    }
+    assert KNOWN_DUPLICATE_PAIRS <= predicted_pairs
+
+
+def test_run_demo_is_repeatable() -> None:
+    """Two independent runs produce byte-identical clusters and cost."""
+    first = run_demo()
+    second = run_demo()
+    assert _canonical(first["clusters"]) == _canonical(second["clusters"])
+    assert first["total_cost"] == second["total_cost"]
+
+
+def test_manifest_is_pickle_free_and_secret_free() -> None:
+    """The persisted resolver.json carries the model ref but no client/secret."""
+    manifest = run_demo()["manifest"]
+    assert "openrouter/openai/gpt-4o-mini" in manifest  # model ref persisted
+    assert "client" not in manifest  # no live client
+    assert "api_key" not in manifest.lower()
+    assert "pickle" not in manifest.lower()
+
+
+def test_serialized_blocker_recovers_blocking(tmp_path) -> None:  # type: ignore[no-untyped-def]
+    """A reloaded Resolver's blocker still captures the duplicate pairs."""
+    resolver = build_resolver(FakeLLMClient())
+    blocker = resolver.blocker
+    assert isinstance(blocker, VectorBlocker)  # narrows Blocker[Any] -> VectorBlocker
+    texts = [str(r["name"]) for r in PERSON_RECORDS]
+    blocker.vector_index.create_index(texts)
+
+    resolver.save(tmp_path / "person_v0")
+    reloaded = Resolver.load(tmp_path / "person_v0")
+    reloaded.module.client = FakeLLMClient()  # type: ignore[attr-defined]
+
+    candidates = list(reloaded.blocker.stream(PERSON_RECORDS))
+    stats = evaluate_blocking(candidates, KNOWN_DUPLICATE_GROUPS)
+    assert stats.candidate_recall >= 0.95
+
+
+@pytest.mark.integration
+@pytest.mark.skipif(
+    not os.getenv("OPENROUTER_API_KEY"),
+    reason="requires OPENROUTER_API_KEY for a real LLM call",
+)
+def test_live_smoke_single_pair() -> None:
+    """One real OpenRouter pair returns a usable judgement (gated on a key)."""
+    from langres.core.models import ERCandidate
+    from langres.core.modules.llm_judge import LLMJudge
+
+    judge: LLMJudge[PersonSchema] = LLMJudge.from_env(
+        model="openrouter/openai/gpt-4o-mini", temperature=0.0, entity_noun="person"
+    )
+    pair: ERCandidate[PersonSchema] = ERCandidate(
+        left=PersonSchema(**PERSON_RECORDS[0]),
+        right=PersonSchema(**PERSON_RECORDS[1]),
+        blocker_name="manual",
+    )
+    judgement = next(iter(judge.forward(iter([pair]))))
+    assert 0.0 <= judgement.score <= 1.0
+    assert isinstance(judgement.provenance["cost_usd"], float)

--- a/tests/test_resolver_roundtrip.py
+++ b/tests/test_resolver_roundtrip.py
@@ -11,10 +11,11 @@ floor so the missing-fields group is recovered. The bare
 ``Resolver.from_schema(CompanySchema)`` one-liner (equal weights) is covered
 separately and only asserts the >= 0.70 accuracy floor (it need not recover c4).
 
+    comparator = Comparator.from_schema(CompanySchema, weights=NAME_DOMINANT_WEIGHTS)
     resolver = Resolver(
         blocker=AllPairsBlocker(schema=CompanySchema),
-        comparator=Comparator.from_schema(CompanySchema, weights=NAME_DOMINANT_WEIGHTS),
-        module=WeightedAverageJudge(),   # the scorer slot, typed Module
+        comparator=comparator,
+        module=WeightedAverageJudge(feature_specs=comparator.feature_specs),  # scorer slot
         clusterer=Clusterer(threshold=0.7),
     )
     clusters_before = resolver.resolve(COMPANY_RECORDS)
@@ -87,10 +88,11 @@ def test_resolver_roundtrip_in_process(tmp_path: Path) -> None:
     )
     from langres.core.models import CompanySchema
 
+    comparator = Comparator.from_schema(CompanySchema, weights=NAME_DOMINANT_WEIGHTS)
     resolver = Resolver(
         blocker=AllPairsBlocker(schema=CompanySchema),
-        comparator=Comparator.from_schema(CompanySchema, weights=NAME_DOMINANT_WEIGHTS),
-        module=WeightedAverageJudge(),
+        comparator=comparator,
+        module=WeightedAverageJudge(feature_specs=comparator.feature_specs),
         clusterer=Clusterer(threshold=0.7),
     )
 
@@ -143,10 +145,11 @@ def test_resolver_roundtrip_fresh_process(tmp_path: Path) -> None:
     )
     from langres.core.models import CompanySchema
 
+    comparator = Comparator.from_schema(CompanySchema, weights=NAME_DOMINANT_WEIGHTS)
     resolver = Resolver(
         blocker=AllPairsBlocker(schema=CompanySchema),
-        comparator=Comparator.from_schema(CompanySchema, weights=NAME_DOMINANT_WEIGHTS),
-        module=WeightedAverageJudge(),
+        comparator=comparator,
+        module=WeightedAverageJudge(feature_specs=comparator.feature_specs),
         clusterer=Clusterer(threshold=0.7),
     )
     clusters_before = resolver.resolve(COMPANY_RECORDS)
@@ -277,10 +280,11 @@ def _vector_resolver() -> "object":
         text_field="name",
         k_neighbors=5,
     )
+    comparator = Comparator.from_schema(CompanySchema, weights=NAME_DOMINANT_WEIGHTS)
     return Resolver(
         blocker=blocker,
-        comparator=Comparator.from_schema(CompanySchema, weights=NAME_DOMINANT_WEIGHTS),
-        module=WeightedAverageJudge(),
+        comparator=comparator,
+        module=WeightedAverageJudge(feature_specs=comparator.feature_specs),
         clusterer=Clusterer(threshold=0.7),
     )
 
@@ -428,12 +432,13 @@ def test_resolver_without_comparator_uses_plain_module() -> None:
 def test_resolver_save_without_comparator_omits_slot(tmp_path: Path) -> None:
     """A comparator=None Resolver writes a 3-component manifest (no comparator)."""
     from langres.core import AllPairsBlocker, Clusterer, Resolver, WeightedAverageJudge
+    from langres.core.feature import FeatureSpec
     from langres.core.models import CompanySchema
 
     resolver = Resolver(
         blocker=AllPairsBlocker(schema=CompanySchema),
         comparator=None,
-        module=WeightedAverageJudge(),
+        module=WeightedAverageJudge(feature_specs=[FeatureSpec(name="name")]),
         clusterer=Clusterer(threshold=0.7),
     )
     resolver.save(tmp_path)
@@ -515,7 +520,7 @@ def test_resolver_round_trips_comparator_subclass_with_custom_type_name(
     resolver = Resolver(
         blocker=AllPairsBlocker(schema=CompanySchema),
         comparator=PhoneticComparator(),
-        module=WeightedAverageJudge(),
+        module=WeightedAverageJudge(feature_specs=[FeatureSpec(name="name", weight=1.0)]),
         clusterer=Clusterer(threshold=0.5),
     )
     resolver.save(tmp_path)
@@ -686,6 +691,7 @@ def test_resolver_round_trips_glinker_adapter_slot(tmp_path: Path) -> None:
     """
     from langres.core import AllPairsBlocker, Clusterer, Resolver, WeightedAverageJudge
     from langres.core.adapters.glinker import GLinkerAdapter, GLinkerConfig
+    from langres.core.feature import FeatureSpec
     from langres.core.models import CompanySchema
 
     adapter: GLinkerAdapter[CompanySchema] = GLinkerAdapter(
@@ -694,7 +700,7 @@ def test_resolver_round_trips_glinker_adapter_slot(tmp_path: Path) -> None:
     resolver = Resolver(
         blocker=adapter,
         comparator=None,
-        module=WeightedAverageJudge(),
+        module=WeightedAverageJudge(feature_specs=[FeatureSpec(name="name")]),
         clusterer=Clusterer(threshold=0.7),
     )
     resolver.save(tmp_path)

--- a/tests/test_resolver_roundtrip.py
+++ b/tests/test_resolver_roundtrip.py
@@ -116,7 +116,7 @@ def test_resolver_roundtrip_in_process(tmp_path: Path) -> None:
     import langres
 
     manifest = json.loads((tmp_path / "resolver.json").read_text())
-    assert manifest["artifact_version"] == "0"
+    assert manifest["artifact_version"] == "1"
     assert manifest["langres_version"] == langres.__version__
     type_names = [component["type_name"] for component in manifest["components"]]
     assert type_names == [
@@ -237,6 +237,48 @@ def test_resolver_load_rejects_newer_artifact(tmp_path: Path) -> None:
 
     with pytest.raises(ValueError, match="newer than this langres build"):
         Resolver.load(tmp_path)
+
+
+def test_resolver_load_rejects_older_artifact(tmp_path: Path) -> None:
+    """A strictly-older artifact_version is a clean error, not a raw KeyError.
+
+    M0.5 bumped ARTIFACT_VERSION to "1" with an incompatible config schema. An
+    artifact written by pre-M0.5 code (version "0", old configs) must fail with
+    the clean version error rather than falling through to a KeyError when
+    rebuilding components from the changed config.
+    """
+    from langres.core import Resolver
+    from langres.core.models import CompanySchema
+
+    Resolver.from_schema(CompanySchema).save(tmp_path)
+    manifest_path = tmp_path / "resolver.json"
+    manifest = json.loads(manifest_path.read_text())
+    manifest["artifact_version"] = "0"
+    manifest_path.write_text(json.dumps(manifest))
+
+    with pytest.raises(ValueError, match="predates the supported layout"):
+        Resolver.load(tmp_path)
+
+
+def test_resolver_save_rejects_unserializable_component(tmp_path: Path) -> None:
+    """save() raises a clear TypeError naming an unregistered slot component.
+
+    A component without a registry ``type_name`` (e.g. CascadeModule in the
+    module slot) must fail with a readable message instead of an opaque
+    AttributeError from the spec/save path.
+    """
+    from langres.core import Resolver
+    from langres.core.models import CompanySchema
+
+    resolver = Resolver.from_schema(CompanySchema)
+
+    class _UnregisteredModule:
+        """Stands in for any component lacking `type_name`/@register."""
+
+    resolver.module = _UnregisteredModule()  # type: ignore[assignment]
+
+    with pytest.raises(TypeError, match="_UnregisteredModule is not serializable"):
+        resolver.save(tmp_path)
 
 
 def test_resolver_load_warns_on_langres_version_skew(


### PR DESCRIPTION
## M0.5 — Seam consolidation (fundamentals before M1)

A focused **consolidation pass** that fixes the contract inconsistencies M1 would otherwise multiply, and ships the first **runnable embeddings + LLM strong-path proof**. Surgical, not a rewrite. Scope was deliberately **narrowed to M1-blockers** — the declarative `from_schema(blocker=,judge=)` builder, uniform component-instance API, config-convention unification, and typed feature-bag extension are explicitly **deferred to M2**.

### What changed

**1. Unified `Module`/judge contract.** Every judge now has one signature: `forward(candidates)`. `ERCandidate` carries an optional `comparison: ComparisonVector | None`; the `Resolver`'s comparator stage attaches it, and `WeightedAverageJudge` (which now owns its `feature_specs`/weights) reads it — raising a clear error if it's missing. Removes the forked `forward(..., *, comparator=)` kwarg and the `# type: ignore[call-arg]` bridge in `resolver.py`. Self-contained judges (`LLMJudge`) ignore `comparison` and read raw entities.

**2. Vector similarity correctness (bug fix).** Each `VectorIndex` now owns `to_similarities(distances)` using its known metric (FAISS L2 → `1/(1+√d)`, cosine → `(ip+1)/2`). This kills a real **L2 inversion bug**: the old `VectorBlocker` heuristic clipped raw squared-L2 distances, mapping the *least* similar pair to the *highest* score — which would have corrupted M1's hard-negative mining band. Golden regression test asserts near-dup > non-pair for both metrics.

**3. Serializable `LLMJudge`.** `@register("llm_judge")`, optional/lazy client (`from_env`), `config`/`from_config` that **never serialize the client or any secret**, honest cost via `litellm.completion_cost`, and a domain-neutral prompt (`entity_noun`) shared with `CascadeModule`. A Resolver with an LLM judge now saves/loads.

**4. Person strong-path proof.** New `examples/person_resolution.py` wires `VectorBlocker(FAISS cosine) → LLMJudge → Clusterer` on Person-shaped records, deterministically (fake LLM), and reports blocking Pair-Completeness, honest cost, and save/reload identity. Backed by `tests/examples/test_person_resolution.py` so it can't rot again. The previously-rotted `deduplication_example.py` (and 6 other examples) repaired to current import paths.

**Review fixes (from the gStack review pass):** artifact version bump `0→1` + a clean "older artifact" rejection (was a raw `KeyError` on cross-version load); removed an inverted `judges → llm_judge` dependency (moved `_inspect_scores_impl`/`_generate_recommendations_impl` to `reports.py`); `FakeHybridRerankingVectorIndex` protocol parity (latent `TypeError`); clear `TypeError` for unserializable components in a Resolver slot; honest docstrings on lossy score-clipping; and a mypy override that treats `litellm` as untyped so `# type: ignore` comments stop flipping needed/unused across environments.

### Verification (real numbers, not just green tests)
- **879+ tests pass**, ≥97% coverage; mypy strict clean (deterministic cold+warm cache); ruff clean.
- **rapidfuzz baseline regression:** clusters **byte-identical** to pre-change baseline, BCubed F1 = **1.000**, save/reload identical.
- **Person strong-path:** blocking **Pair-Completeness = 1.000** (target ≥0.95), BCubed/Pairwise F1 = **1.000**, save/reload identical, live OpenRouter smoke gates cleanly on key presence.

### Deferred (tracked, not forgotten)
M2: declarative vector `from_schema` builder, uniform component-instance API, config dict-vs-Pydantic unification, typed feature-bag (aliases/anchor-veto/MISMATCH). Follow-ups noted in review: parsing-helper dedup between LLMJudge/Cascade, `CascadeModule.llm_api_key` retained as a plain attribute (pre-existing secret-exposure smell), compact-JSON prompt tokens.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
