### PR TITLE
M1 Wave 3: agreement/calibration metrics (kappa, MCC, Brier, ECE) + bootstrap report

### DIFF
--- a/src/langres/bootstrap/report.py
+++ b/src/langres/bootstrap/report.py
@@ -42,8 +42,8 @@ from langres.core.metrics import (
 )
 from langres.core.models import ERCandidate
 
+# Metadata/provenance keys searched, in order, for a USD cost figure.
 _COST_KEYS = ("total_cost_usd", "cost_usd", "cost")
-"""Metadata/provenance keys searched, in order, for a USD cost figure."""
 
 
 def _f1(precision: float, recall: float) -> float:
@@ -284,14 +284,19 @@ class BootstrapReport(BaseModel):
         """Compute teacher-vs-truth agreement, or ``None`` if no labeled pair has truth."""
         if not teacher_labels:
             return None
-        tp = sum(1 for t, p in zip(truth_labels, teacher_labels, strict=True) if t and p)
-        fp = sum(1 for t, p in zip(truth_labels, teacher_labels, strict=True) if not t and p)
-        fn = sum(1 for t, p in zip(truth_labels, teacher_labels, strict=True) if t and not p)
+        tp = fp = fn = tn = 0
+        for truth, teacher in zip(truth_labels, teacher_labels, strict=True):
+            if truth and teacher:
+                tp += 1
+            elif not truth and teacher:
+                fp += 1
+            elif truth and not teacher:
+                fn += 1
+            else:
+                tn += 1
         precision = tp / (tp + fp) if (tp + fp) > 0 else 0.0
         recall = tp / (tp + fn) if (tp + fn) > 0 else 0.0
-        accuracy = sum(
-            1 for t, p in zip(truth_labels, teacher_labels, strict=True) if t == p
-        ) / len(teacher_labels)
+        accuracy = (tp + tn) / len(teacher_labels)
         return AgreementStats(
             n_evaluated=len(teacher_labels),
             accuracy=accuracy,
@@ -424,7 +429,11 @@ class BootstrapReport(BaseModel):
         return "\n".join(lines)
 
     def render(self) -> str:
-        """Alias for :meth:`to_markdown`."""
+        """Render the report as Markdown.
+
+        Provided alongside :meth:`to_markdown` so callers expecting either the
+        generic ``render()`` name or the format-specific one get the same output.
+        """
         return self.to_markdown()
 
 

--- a/src/langres/bootstrap/report.py
+++ b/src/langres/bootstrap/report.py
@@ -254,9 +254,15 @@ class BootstrapReport(BaseModel):
         # --- Routing / coverage + honest cost ----------------------------------
         labeled = len(pairs)
         total_candidates = len(candidates)
+        mined_value = metadata.get("mined")
+        mined = (
+            int(mined_value)
+            if isinstance(mined_value, (int, float)) and not isinstance(mined_value, bool)
+            else labeled
+        )
         coverage = CoverageStats(
             total_candidates=total_candidates,
-            mined=int(metadata.get("mined", labeled)),  # type: ignore[arg-type]
+            mined=mined,
             labeled=labeled,
             skipped=max(total_candidates - labeled, 0),
             with_ground_truth=len(teacher_labels),

--- a/src/langres/bootstrap/report.py
+++ b/src/langres/bootstrap/report.py
@@ -1,0 +1,446 @@
+"""Coverage and calibration report for cold-start gold-set bootstrapping (M1).
+
+:class:`BootstrapReport` turns the artefacts of a bootstrap run -- the
+teacher-labeled pairs, the post-blocking candidates, and whatever ground truth
+is available -- into a single, honest health check answering three questions:
+
+1. **Did blocking keep the true matches?** -- blocking pair-completeness
+   (candidate recall) from :func:`langres.core.metrics.evaluate_blocking`.
+2. **Does the teacher agree with truth?** -- accuracy / precision / recall / F1
+   plus Cohen's kappa **and** MCC on the pairs that have a ground-truth label.
+   Under the ~2% positive prevalence of bootstrap labeling kappa collapses
+   (prevalence paradox), so the headline gate is F1/MCC, not kappa alone (W5).
+3. **Are the teacher's confidences trustworthy?** -- Brier (primary, no binning)
+   and a verbalized-confidence ECE with equal-mass bins, plus reliability bins
+   for a diagram (W6).
+
+It also reports an agreement-convergence curve (teacher F1-vs-truth as the
+evaluated sample grows, by deterministically subsampling already-collected
+labels -- no re-labeling, zero extra spend; W8) and honest routing/cost
+coverage read from the gold-set metadata and pair provenance.
+
+This is a PLAIN Pydantic model: not ``@register``-ed, not part of the
+``SerializableState`` protocol. The builder is pure and deterministic, so it is
+fully testable from synthetic :class:`~langres.bootstrap.models.GoldPair` data
+with no LLM and no embeddings.
+"""
+
+from typing import Any
+
+from pydantic import BaseModel
+
+from langres.bootstrap.models import GoldPair, GoldSet
+from langres.core.metrics import (
+    ReliabilityBin,
+    brier_score,
+    cohens_kappa,
+    evaluate_blocking,
+    expected_calibration_error,
+    matthews_corrcoef,
+    pairs_from_clusters,
+    reliability_bins,
+)
+from langres.core.models import ERCandidate
+
+_COST_KEYS = ("total_cost_usd", "cost_usd", "cost")
+"""Metadata/provenance keys searched, in order, for a USD cost figure."""
+
+
+def _f1(precision: float, recall: float) -> float:
+    """Harmonic mean of precision and recall; ``0.0`` when both are zero."""
+    if precision + recall == 0.0:
+        return 0.0
+    return 2 * precision * recall / (precision + recall)
+
+
+class BlockingCoverage(BaseModel):
+    """How well blocking kept the true matches (pair-completeness).
+
+    Attributes:
+        pair_completeness: Fraction of ground-truth match pairs that appear among
+            the candidates (a.k.a. candidate recall / pair-completeness). The
+            single most important blocking number -- matches dropped here cannot
+            be recovered downstream.
+        candidate_precision: Fraction of candidate pairs that are true matches.
+        total_candidates: Number of unique candidate pairs after blocking.
+        missed_matches: Number of true match pairs *not* captured by blocking.
+    """
+
+    pair_completeness: float
+    candidate_precision: float
+    total_candidates: int
+    missed_matches: int
+
+
+class AgreementStats(BaseModel):
+    """Teacher-vs-truth agreement on pairs that have a ground-truth label.
+
+    The positive class is "match" (``label is True``). ``cohens_kappa`` and
+    ``mcc`` are reported together: kappa is the familiar chance-corrected number
+    but degrades under low positive prevalence (W5), so MCC is the robust
+    companion and, with F1, the headline agreement gate.
+
+    Attributes:
+        n_evaluated: Number of teacher pairs that had a ground-truth label.
+        accuracy: Fraction of teacher labels matching truth.
+        precision: Match precision (TP / (TP + FP)).
+        recall: Match recall (TP / (TP + FN)).
+        f1: Harmonic mean of precision and recall.
+        cohens_kappa: Chance-corrected agreement (see caveat above).
+        mcc: Matthews correlation coefficient (prevalence-robust).
+    """
+
+    n_evaluated: int
+    accuracy: float
+    precision: float
+    recall: float
+    f1: float
+    cohens_kappa: float
+    mcc: float
+
+
+class CalibrationStats(BaseModel):
+    """Calibration of teacher confidence against label-correctness.
+
+    ``confidence`` is the teacher's verbalized self-confidence in its own label;
+    the outcome being calibrated is whether that label was actually correct
+    (``teacher_label == truth_label``). So this answers "when the teacher says it
+    is 80% sure, is it right 80% of the time?".
+
+    Attributes:
+        n_evaluated: Number of teacher pairs with both a confidence and a
+            ground-truth label.
+        brier: Brier score -- the primary, binning-free proper score (lower is
+            better) (W6).
+        ece: Verbalized-confidence Expected Calibration Error with equal-mass
+            bins (secondary, binning-dependent diagnostic).
+        n_bins: Number of bins requested for ECE / reliability.
+        reliability: Per-bin reliability points (lowest to highest confidence).
+    """
+
+    n_evaluated: int
+    brier: float
+    ece: float
+    n_bins: int
+    reliability: list[ReliabilityBin]
+
+
+class ConvergencePoint(BaseModel):
+    """One point on the agreement-convergence curve (W8).
+
+    Attributes:
+        n_labeled: Number of already-collected labels evaluated (a prefix).
+        f1: Teacher F1-vs-truth computed on that prefix.
+    """
+
+    n_labeled: int
+    f1: float
+
+
+class CoverageStats(BaseModel):
+    """Routing / coverage counts and the honest run cost.
+
+    Attributes:
+        total_candidates: Candidate pairs produced by blocking.
+        mined: Candidates selected for labeling (from metadata, else ``labeled``).
+        labeled: Teacher-labeled pairs in the gold set.
+        skipped: Candidates not labeled (``total_candidates - labeled``, floored
+            at 0).
+        with_ground_truth: Labeled pairs that had a ground-truth label and so
+            contributed to the agreement/calibration numbers.
+        total_cost_usd: Honest total spend, from gold-set metadata if present,
+            else summed from per-pair provenance.
+    """
+
+    total_candidates: int
+    mined: int
+    labeled: int
+    skipped: int
+    with_ground_truth: int
+    total_cost_usd: float
+
+
+class BootstrapReport(BaseModel):
+    """Coverage + calibration report for one bootstrap run.
+
+    Build it with :meth:`build` and serialize it with the usual Pydantic
+    ``model_dump_json``; render a human-readable digest with :meth:`to_markdown`.
+
+    Attributes:
+        blocking: Blocking pair-completeness coverage.
+        agreement: Teacher-vs-truth agreement, or ``None`` when no labeled pair
+            had a ground-truth label.
+        calibration: Teacher-confidence calibration, or ``None`` when no labeled
+            pair had both a confidence and a ground-truth label.
+        convergence: Agreement-convergence curve (possibly empty).
+        coverage: Routing counts and honest cost.
+    """
+
+    blocking: BlockingCoverage
+    agreement: AgreementStats | None
+    calibration: CalibrationStats | None
+    convergence: list[ConvergencePoint]
+    coverage: CoverageStats
+
+    @classmethod
+    def build(
+        cls,
+        gold: GoldSet | list[GoldPair],
+        candidates: list[ERCandidate[Any]],
+        truth_clusters: list[set[str]],
+        *,
+        n_bins: int = 8,
+    ) -> "BootstrapReport":
+        """Build a report from teacher labels, candidates, and ground-truth clusters.
+
+        Pure and deterministic: identical inputs always produce an identical
+        report (the convergence curve walks labels in a fixed ``(left_id,
+        right_id)`` order). No network, LLM, or embedding calls.
+
+        Args:
+            gold: The teacher-labeled pairs -- either a
+                :class:`~langres.bootstrap.models.GoldSet` (metadata is used for
+                cost/mined counts) or a bare ``list[GoldPair]``.
+            candidates: Post-blocking candidate pairs, used only for blocking
+                pair-completeness via
+                :func:`~langres.core.metrics.evaluate_blocking` (not reimplemented).
+            truth_clusters: Ground-truth entity clusters (sets of record ids). A
+                teacher pair has a ground-truth label only when *both* of its ids
+                appear in these clusters; its truth label is then whether the two
+                ids share a cluster.
+            n_bins: Bins for the calibration ECE / reliability diagram.
+
+        Returns:
+            The assembled :class:`BootstrapReport`.
+        """
+        pairs = gold.pairs if isinstance(gold, GoldSet) else gold
+        metadata = gold.metadata if isinstance(gold, GoldSet) else {}
+
+        # --- Blocking pair-completeness (reuse evaluate_blocking) ---------------
+        blocking_stats = evaluate_blocking(candidates, truth_clusters)
+        blocking = BlockingCoverage(
+            pair_completeness=blocking_stats.candidate_recall,
+            candidate_precision=blocking_stats.candidate_precision,
+            total_candidates=blocking_stats.total_candidates,
+            missed_matches=blocking_stats.missed_matches_count,
+        )
+
+        # --- Resolve ground truth for each teacher pair ------------------------
+        truth_entities = {e for cluster in truth_clusters for e in cluster}
+        truth_match_pairs = pairs_from_clusters(truth_clusters)
+
+        # Deterministic order so the convergence curve is reproducible.
+        ordered_pairs = sorted(pairs, key=lambda p: (p.left_id, p.right_id))
+
+        teacher_labels: list[bool] = []
+        truth_labels: list[bool] = []
+        confidences: list[float] = []
+        correctness: list[bool] = []
+        for pair in ordered_pairs:
+            if pair.left_id not in truth_entities or pair.right_id not in truth_entities:
+                continue  # No ground truth for this pair -> excluded, honestly.
+            key = tuple(sorted((pair.left_id, pair.right_id)))
+            truth_label = key in truth_match_pairs
+            teacher_labels.append(pair.label)
+            truth_labels.append(truth_label)
+            if pair.confidence is not None:
+                confidences.append(pair.confidence)
+                correctness.append(pair.label == truth_label)
+
+        agreement = cls._build_agreement(teacher_labels, truth_labels)
+        calibration = cls._build_calibration(confidences, correctness, n_bins)
+        convergence = cls._build_convergence(teacher_labels, truth_labels)
+
+        # --- Routing / coverage + honest cost ----------------------------------
+        labeled = len(pairs)
+        total_candidates = len(candidates)
+        coverage = CoverageStats(
+            total_candidates=total_candidates,
+            mined=int(metadata.get("mined", labeled)),  # type: ignore[arg-type]
+            labeled=labeled,
+            skipped=max(total_candidates - labeled, 0),
+            with_ground_truth=len(teacher_labels),
+            total_cost_usd=_resolve_cost(metadata, pairs),
+        )
+
+        return cls(
+            blocking=blocking,
+            agreement=agreement,
+            calibration=calibration,
+            convergence=convergence,
+            coverage=coverage,
+        )
+
+    @staticmethod
+    def _build_agreement(
+        teacher_labels: list[bool], truth_labels: list[bool]
+    ) -> AgreementStats | None:
+        """Compute teacher-vs-truth agreement, or ``None`` if no labeled pair has truth."""
+        if not teacher_labels:
+            return None
+        tp = sum(1 for t, p in zip(truth_labels, teacher_labels, strict=True) if t and p)
+        fp = sum(1 for t, p in zip(truth_labels, teacher_labels, strict=True) if not t and p)
+        fn = sum(1 for t, p in zip(truth_labels, teacher_labels, strict=True) if t and not p)
+        precision = tp / (tp + fp) if (tp + fp) > 0 else 0.0
+        recall = tp / (tp + fn) if (tp + fn) > 0 else 0.0
+        accuracy = sum(
+            1 for t, p in zip(truth_labels, teacher_labels, strict=True) if t == p
+        ) / len(teacher_labels)
+        return AgreementStats(
+            n_evaluated=len(teacher_labels),
+            accuracy=accuracy,
+            precision=precision,
+            recall=recall,
+            f1=_f1(precision, recall),
+            cohens_kappa=cohens_kappa(truth_labels, teacher_labels),
+            mcc=matthews_corrcoef(truth_labels, teacher_labels),
+        )
+
+    @staticmethod
+    def _build_calibration(
+        confidences: list[float], correctness: list[bool], n_bins: int
+    ) -> CalibrationStats | None:
+        """Compute confidence calibration, or ``None`` if no pair has confidence + truth."""
+        if not confidences:
+            return None
+        return CalibrationStats(
+            n_evaluated=len(confidences),
+            brier=brier_score(confidences, correctness),
+            ece=expected_calibration_error(
+                confidences, correctness, n_bins=n_bins, strategy="quantile"
+            ),
+            n_bins=n_bins,
+            reliability=reliability_bins(
+                confidences, correctness, n_bins=n_bins, strategy="quantile"
+            ),
+        )
+
+    @staticmethod
+    def _build_convergence(
+        teacher_labels: list[bool], truth_labels: list[bool]
+    ) -> list[ConvergencePoint]:
+        """Teacher F1-vs-truth over growing prefixes of the (already-collected) labels.
+
+        Subsamples the labels already in hand in a fixed order -- no re-labeling,
+        no held-out model, no leakage (W8). One point per prefix length.
+        """
+        points: list[ConvergencePoint] = []
+        tp = fp = fn = 0
+        for n, (truth, teacher) in enumerate(
+            zip(truth_labels, teacher_labels, strict=True), start=1
+        ):
+            if truth and teacher:
+                tp += 1
+            elif teacher and not truth:
+                fp += 1
+            elif truth and not teacher:
+                fn += 1
+            precision = tp / (tp + fp) if (tp + fp) > 0 else 0.0
+            recall = tp / (tp + fn) if (tp + fn) > 0 else 0.0
+            points.append(ConvergencePoint(n_labeled=n, f1=_f1(precision, recall)))
+        return points
+
+    def to_markdown(self) -> str:
+        """Render a human-readable Markdown digest of the report.
+
+        Includes the headline blocking, agreement, calibration, and coverage
+        numbers. Used for quick eyeballing; the model itself is the source of
+        truth and is JSON-serializable.
+
+        Returns:
+            A Markdown string.
+        """
+        lines: list[str] = ["# Bootstrap Report", ""]
+
+        lines += [
+            "## Blocking (pair-completeness)",
+            f"- Pair-completeness (candidate recall): {self.blocking.pair_completeness:.4f}",
+            f"- Candidate precision: {self.blocking.candidate_precision:.4f}",
+            f"- Total candidates: {self.blocking.total_candidates}",
+            f"- Missed matches: {self.blocking.missed_matches}",
+            "",
+        ]
+
+        lines.append("## Teacher-vs-truth agreement")
+        if self.agreement is None:
+            lines.append("- No labeled pair had a ground-truth label.")
+        else:
+            a = self.agreement
+            lines += [
+                f"- Evaluated pairs: {a.n_evaluated}",
+                f"- Accuracy: {a.accuracy:.4f}",
+                f"- Precision: {a.precision:.4f}",
+                f"- Recall: {a.recall:.4f}",
+                f"- F1: {a.f1:.4f}",
+                f"- Cohen's kappa: {a.cohens_kappa:.4f}",
+                f"- MCC: {a.mcc:.4f}",
+            ]
+        lines.append("")
+
+        lines.append("## Calibration (teacher confidence vs. correctness)")
+        if self.calibration is None:
+            lines.append("- No labeled pair had both a confidence and a ground-truth label.")
+        else:
+            c = self.calibration
+            lines += [
+                f"- Evaluated pairs: {c.n_evaluated}",
+                f"- Brier score (primary): {c.brier:.4f}",
+                f"- ECE (equal-mass, {c.n_bins} bins): {c.ece:.4f}",
+                "- Reliability bins (mean_conf -> observed_freq, count):",
+            ]
+            lines += [
+                f"  - {b.mean_confidence:.4f} -> {b.observed_frequency:.4f} (n={b.count})"
+                for b in c.reliability
+            ]
+        lines.append("")
+
+        cov = self.coverage
+        lines += [
+            "## Routing / coverage",
+            f"- Total candidates: {cov.total_candidates}",
+            f"- Mined: {cov.mined}",
+            f"- Labeled: {cov.labeled}",
+            f"- Skipped: {cov.skipped}",
+            f"- With ground truth: {cov.with_ground_truth}",
+            f"- Total cost (USD): {cov.total_cost_usd:.4f}",
+            "",
+        ]
+
+        if self.convergence:
+            last = self.convergence[-1]
+            lines += [
+                "## Agreement convergence",
+                f"- Points: {len(self.convergence)}",
+                f"- Final F1 @ {last.n_labeled} labels: {last.f1:.4f}",
+                "",
+            ]
+
+        return "\n".join(lines)
+
+    def render(self) -> str:
+        """Alias for :meth:`to_markdown`."""
+        return self.to_markdown()
+
+
+def _resolve_cost(metadata: dict[str, object], pairs: list[GoldPair]) -> float:
+    """Resolve honest total USD cost from gold-set metadata, else pair provenance.
+
+    Prefers a run-level cost in ``metadata`` (``total_cost_usd`` / ``cost_usd`` /
+    ``cost``); otherwise sums the first such key found in each pair's
+    ``provenance``. Non-numeric values are ignored.
+    """
+    for key in _COST_KEYS:
+        if key in metadata:
+            value = metadata[key]
+            if isinstance(value, (int, float)) and not isinstance(value, bool):
+                return float(value)
+
+    total = 0.0
+    for pair in pairs:
+        for key in _COST_KEYS:
+            if key in pair.provenance:
+                value = pair.provenance[key]
+                if isinstance(value, (int, float)) and not isinstance(value, bool):
+                    total += float(value)
+                break
+    return total

--- a/src/langres/core/metrics.py
+++ b/src/langres/core/metrics.py
@@ -628,6 +628,8 @@ def cohens_kappa(y_true: list[bool], y_pred: list[bool]) -> float:
     p_pred_pos = sum(y_pred) / n
     p_expected = p_true_pos * p_pred_pos + (1.0 - p_true_pos) * (1.0 - p_pred_pos)
 
+    # p_expected == 1.0 only when a rater is entirely one class, in which case
+    # both marginal products are 0 or 1 exactly -- the == comparison is safe.
     denominator = 1.0 - p_expected
     if denominator == 0.0:
         # No class variance in at least one rater -> kappa undefined; convention 0.0.
@@ -660,11 +662,19 @@ def matthews_corrcoef(y_true: list[bool], y_pred: list[bool]) -> float:
     """
     _validate_binary(y_true, y_pred)
 
-    tp = sum(1 for t, p in zip(y_true, y_pred, strict=True) if t and p)
-    tn = sum(1 for t, p in zip(y_true, y_pred, strict=True) if not t and not p)
-    fp = sum(1 for t, p in zip(y_true, y_pred, strict=True) if not t and p)
-    fn = sum(1 for t, p in zip(y_true, y_pred, strict=True) if t and not p)
+    tp = tn = fp = fn = 0
+    for t, p in zip(y_true, y_pred, strict=True):
+        if t and p:
+            tp += 1
+        elif not t and not p:
+            tn += 1
+        elif not t and p:
+            fp += 1
+        else:
+            fn += 1
 
+    # The radicand is a product of integer counts, so math.sqrt(0) is exactly
+    # 0.0 -- the == comparison is safe (no floating-point near-zero ambiguity).
     denominator = math.sqrt((tp + fp) * (tp + fn) * (tn + fp) * (tn + fn))
     if denominator == 0.0:
         return 0.0
@@ -745,9 +755,18 @@ def brier_score(confidences: list[float], outcomes: list[bool]) -> float:
 def _bin_indices(confidences: list[float], n_bins: int, strategy: BinStrategy) -> list[list[int]]:
     """Group item indices into bins by confidence; drop empty bins.
 
-    ``"quantile"`` produces equal-mass bins (each holds ~``N / n_bins`` items),
-    robust to the clumping of verbalized LLM confidences that leaves equal-width
-    bins mostly empty. ``"uniform"`` produces equal-width ``[0, 1]`` bins.
+    ``"quantile"`` produces (approximately) equal-mass bins (each holds ~``N /
+    n_bins`` items), robust to the clumping of verbalized LLM confidences that
+    leaves equal-width bins mostly empty. ``"uniform"`` produces equal-width
+    ``[0, 1]`` bins.
+
+    Tied confidences are never split across bins: a bin boundary is extended past
+    any run of equal confidence values. This keeps the result independent of
+    input order (deterministic) and keeps calibration honest -- e.g. all-``0.5``
+    predictions land in one bin, so a model that is right half the time scores
+    ECE ``0.0`` rather than a spurious non-zero from an order-dependent split.
+    As a consequence bins may be unequal in mass and fewer than ``n_bins`` may be
+    returned. Empty bins are dropped.
 
     Raises:
         ValueError: If ``n_bins < 1`` or ``strategy`` is unknown.
@@ -756,16 +775,21 @@ def _bin_indices(confidences: list[float], n_bins: int, strategy: BinStrategy) -
         raise ValueError(f"n_bins must be >= 1, got {n_bins}")
 
     if strategy == "quantile":
-        order = sorted(range(len(confidences)), key=lambda i: confidences[i])
-        base, extra = divmod(len(order), n_bins)
+        n = len(confidences)
+        order = sorted(range(n), key=lambda i: confidences[i])
         groups: list[list[int]] = []
         start = 0
         for b in range(n_bins):
-            size = base + (1 if b < extra else 0)
-            if size == 0:
-                continue
-            groups.append(order[start : start + size])
-            start += size
+            if start >= n:
+                break
+            # Target an even cut, but never split equal confidence values and
+            # always take at least one item so each visited bin is non-empty.
+            cut = max(round((b + 1) * n / n_bins), start + 1)
+            cut = min(cut, n)
+            while cut < n and confidences[order[cut]] == confidences[order[cut - 1]]:
+                cut += 1
+            groups.append(order[start:cut])
+            start = cut
         return groups
 
     if strategy == "uniform":

--- a/src/langres/core/metrics.py
+++ b/src/langres/core/metrics.py
@@ -3,6 +3,9 @@
 This module provides metrics for evaluating different pipeline stages:
 - Blocking stage: evaluate_blocking(), evaluate_blocking_with_ranking()
 - Clustering stage: evaluate_clustering(), calculate_bcubed_metrics(), calculate_pairwise_metrics()
+- Agreement (rater-vs-rater): cohens_kappa(), matthews_corrcoef()
+- Calibration (confidence-vs-outcome): brier_score(), expected_calibration_error(),
+  reliability_bins()
 
 References:
     Amigó, E., Gonzalo, J., Artiles, J., & Verdejo, F. (2009).
@@ -10,12 +13,17 @@ References:
     Information Retrieval, 12(4), 461-486.
 """
 
-from typing import Any
+import math
+from typing import Any, Literal
 
+from pydantic import BaseModel
 from ranx import Qrels, Run, evaluate  # type: ignore[import-untyped]
 
 from langres.core.debugging import CandidateStats
 from langres.core.models import ERCandidate
+
+BinStrategy = Literal["quantile", "uniform"]
+"""Binning strategy for calibration metrics: equal-mass quantile bins or equal-width bins."""
 
 
 def calculate_bcubed_precision(
@@ -559,3 +567,306 @@ def evaluate_blocking_with_ranking(
         result[f"precision_at_{k}"] = precision_at_k[k]
 
     return result
+
+
+# ---------------------------------------------------------------------------
+# Agreement metrics (rater-vs-rater)
+# ---------------------------------------------------------------------------
+#
+# These treat two boolean label vectors (e.g. teacher labels vs. ground truth)
+# as a binary classification and quantify *agreement beyond chance*. The
+# positive class is ``True`` (a "match").
+
+
+def _validate_binary(y_true: list[bool], y_pred: list[bool]) -> None:
+    """Validate two boolean label vectors share a non-zero, equal length.
+
+    Raises:
+        ValueError: If the inputs differ in length or are empty.
+    """
+    if len(y_true) != len(y_pred):
+        raise ValueError(
+            f"y_true and y_pred must have equal length, got {len(y_true)} and {len(y_pred)}"
+        )
+    if not y_true:
+        raise ValueError("y_true and y_pred must be non-empty")
+
+
+def cohens_kappa(y_true: list[bool], y_pred: list[bool]) -> float:
+    """Cohen's kappa: chance-corrected agreement between two boolean raters.
+
+    ``kappa = (p_o - p_e) / (1 - p_e)`` where ``p_o`` is observed agreement and
+    ``p_e`` is the agreement expected by chance given each rater's marginal
+    class frequencies.
+
+    Caveat -- the *prevalence paradox*: under the heavily skewed class balance
+    of bootstrap labeling (~2% positives), kappa can be near zero even when raw
+    agreement is very high, because chance agreement ``p_e`` is itself near the
+    observed agreement. Report :func:`matthews_corrcoef` alongside it (W5).
+
+    Args:
+        y_true: Ground-truth boolean labels (positive class is ``True``).
+        y_pred: Predicted boolean labels, aligned with ``y_true``.
+
+    Returns:
+        Kappa in ``[-1.0, 1.0]``. Returns ``0.0`` when chance agreement is
+        perfect (``p_e == 1``, i.e. a rater has no class variance), where kappa
+        is otherwise undefined (``0 / 0``).
+
+    Raises:
+        ValueError: If inputs differ in length or are empty.
+
+    Example:
+        >>> cohens_kappa([True, True, False, False], [True, False, False, False])
+        0.5
+    """
+    _validate_binary(y_true, y_pred)
+    n = len(y_true)
+
+    p_observed = sum(1 for t, p in zip(y_true, y_pred, strict=True) if t == p) / n
+    p_true_pos = sum(y_true) / n
+    p_pred_pos = sum(y_pred) / n
+    p_expected = p_true_pos * p_pred_pos + (1.0 - p_true_pos) * (1.0 - p_pred_pos)
+
+    denominator = 1.0 - p_expected
+    if denominator == 0.0:
+        # No class variance in at least one rater -> kappa undefined; convention 0.0.
+        return 0.0
+    return (p_observed - p_expected) / denominator
+
+
+def matthews_corrcoef(y_true: list[bool], y_pred: list[bool]) -> float:
+    """Matthews correlation coefficient (MCC) for two boolean label vectors.
+
+    ``MCC = (TP*TN - FP*FN) / sqrt((TP+FP)(TP+FN)(TN+FP)(TN+FN))``. MCC is a
+    balanced measure that stays informative under the ~2% positive prevalence of
+    bootstrap labeling, where Cohen's kappa suffers the prevalence paradox (W5).
+
+    Args:
+        y_true: Ground-truth boolean labels (positive class is ``True``).
+        y_pred: Predicted boolean labels, aligned with ``y_true``.
+
+    Returns:
+        MCC in ``[-1.0, 1.0]``. Returns ``0.0`` when the denominator is zero
+        (any of the four marginal sums is empty), where MCC is otherwise
+        undefined.
+
+    Raises:
+        ValueError: If inputs differ in length or are empty.
+
+    Example:
+        >>> matthews_corrcoef([True, True, False, False], [True, False, False, False])
+        0.5773502691896258
+    """
+    _validate_binary(y_true, y_pred)
+
+    tp = sum(1 for t, p in zip(y_true, y_pred, strict=True) if t and p)
+    tn = sum(1 for t, p in zip(y_true, y_pred, strict=True) if not t and not p)
+    fp = sum(1 for t, p in zip(y_true, y_pred, strict=True) if not t and p)
+    fn = sum(1 for t, p in zip(y_true, y_pred, strict=True) if t and not p)
+
+    denominator = math.sqrt((tp + fp) * (tp + fn) * (tn + fp) * (tn + fn))
+    if denominator == 0.0:
+        return 0.0
+    return (tp * tn - fp * fn) / denominator
+
+
+# ---------------------------------------------------------------------------
+# Calibration metrics (confidence-vs-outcome)
+# ---------------------------------------------------------------------------
+#
+# These assess whether a verbalized confidence in ``[0, 1]`` matches the
+# observed outcome frequency. ``confidences[i]`` is a self-reported probability
+# and ``outcomes[i]`` is whether that prediction was borne out (boolean).
+
+
+class ReliabilityBin(BaseModel):
+    """One bin of a reliability diagram.
+
+    Attributes:
+        mean_confidence: Mean predicted confidence of the items in this bin.
+        observed_frequency: Fraction of items in this bin whose outcome was
+            ``True`` (the empirical accuracy for this confidence level).
+        count: Number of items in this bin.
+    """
+
+    mean_confidence: float
+    observed_frequency: float
+    count: int
+
+
+def _validate_calibration(confidences: list[float], outcomes: list[bool]) -> None:
+    """Validate confidences and outcomes are aligned, non-empty, and in range.
+
+    Raises:
+        ValueError: If lengths differ, inputs are empty, or any confidence lies
+            outside ``[0, 1]``.
+    """
+    if len(confidences) != len(outcomes):
+        raise ValueError(
+            f"confidences and outcomes must have equal length, "
+            f"got {len(confidences)} and {len(outcomes)}"
+        )
+    if not confidences:
+        raise ValueError("confidences and outcomes must be non-empty")
+    for p in confidences:
+        if not 0.0 <= p <= 1.0:
+            raise ValueError(f"confidences must lie in [0, 1], got {p}")
+
+
+def brier_score(confidences: list[float], outcomes: list[bool]) -> float:
+    """Brier score: ``mean((p - y)^2)`` -- the primary proper calibration score.
+
+    The Brier score is a strictly proper scoring rule, so unlike ECE it needs no
+    binning and cannot be gamed by bin-edge choices (W6). Lower is better;
+    ``0.0`` is perfect, ``0.25`` is the score of a constant ``0.5`` forecaster.
+
+    Args:
+        confidences: Predicted probabilities in ``[0, 1]``.
+        outcomes: Realized boolean outcomes, aligned with ``confidences``.
+
+    Returns:
+        Mean squared error between confidence and outcome in ``[0.0, 1.0]``.
+
+    Raises:
+        ValueError: If inputs differ in length, are empty, or any confidence is
+            outside ``[0, 1]``.
+
+    Example:
+        >>> brier_score([0.9, 0.1], [True, False])
+        0.009999999999999995
+    """
+    _validate_calibration(confidences, outcomes)
+    return sum(
+        (p - (1.0 if y else 0.0)) ** 2 for p, y in zip(confidences, outcomes, strict=True)
+    ) / len(confidences)
+
+
+def _bin_indices(
+    confidences: list[float], n_bins: int, strategy: BinStrategy
+) -> list[list[int]]:
+    """Group item indices into bins by confidence; drop empty bins.
+
+    ``"quantile"`` produces equal-mass bins (each holds ~``N / n_bins`` items),
+    robust to the clumping of verbalized LLM confidences that leaves equal-width
+    bins mostly empty. ``"uniform"`` produces equal-width ``[0, 1]`` bins.
+
+    Raises:
+        ValueError: If ``n_bins < 1`` or ``strategy`` is unknown.
+    """
+    if n_bins < 1:
+        raise ValueError(f"n_bins must be >= 1, got {n_bins}")
+
+    if strategy == "quantile":
+        order = sorted(range(len(confidences)), key=lambda i: confidences[i])
+        base, extra = divmod(len(order), n_bins)
+        groups: list[list[int]] = []
+        start = 0
+        for b in range(n_bins):
+            size = base + (1 if b < extra else 0)
+            if size == 0:
+                continue
+            groups.append(order[start : start + size])
+            start += size
+        return groups
+
+    if strategy == "uniform":
+        buckets: list[list[int]] = [[] for _ in range(n_bins)]
+        for i, p in enumerate(confidences):
+            idx = min(int(p * n_bins), n_bins - 1)
+            buckets[idx].append(i)
+        return [g for g in buckets if g]
+
+    raise ValueError(f"strategy must be 'quantile' or 'uniform', got {strategy!r}")
+
+
+def expected_calibration_error(
+    confidences: list[float],
+    outcomes: list[bool],
+    *,
+    n_bins: int = 8,
+    strategy: BinStrategy = "quantile",
+) -> float:
+    """Expected Calibration Error: count-weighted mean gap between confidence and accuracy.
+
+    ``ECE = sum_b (n_b / N) * |acc_b - conf_b|`` over non-empty bins. The default
+    is **equal-mass / quantile** binning: verbalized LLM confidences clump into a
+    few values, so equal-width bins leave most items in 2-3 bins and understate
+    miscalibration (W6).
+
+    This is a *verbalized-confidence* ECE -- it calibrates self-reported
+    confidence scores, not softmax logits. It is a secondary, binning-dependent
+    diagnostic; prefer :func:`brier_score` as the headline calibration number.
+
+    Args:
+        confidences: Predicted probabilities in ``[0, 1]``.
+        outcomes: Realized boolean outcomes, aligned with ``confidences``.
+        n_bins: Number of bins (``>= 1``).
+        strategy: ``"quantile"`` (equal-mass, default) or ``"uniform"`` (equal-width).
+
+    Returns:
+        ECE in ``[0.0, 1.0]``; ``0.0`` is perfectly calibrated.
+
+    Raises:
+        ValueError: If inputs differ in length, are empty, any confidence is
+            outside ``[0, 1]``, ``n_bins < 1``, or ``strategy`` is unknown.
+
+    Example:
+        >>> expected_calibration_error([0.8, 0.8], [True, False], n_bins=1)
+        0.30000000000000004
+    """
+    _validate_calibration(confidences, outcomes)
+    n = len(confidences)
+    ece = 0.0
+    for group in _bin_indices(confidences, n_bins, strategy):
+        conf_mean = sum(confidences[i] for i in group) / len(group)
+        accuracy = sum(1.0 for i in group if outcomes[i]) / len(group)
+        ece += (len(group) / n) * abs(accuracy - conf_mean)
+    return ece
+
+
+def reliability_bins(
+    confidences: list[float],
+    outcomes: list[bool],
+    *,
+    n_bins: int = 8,
+    strategy: BinStrategy = "quantile",
+) -> list[ReliabilityBin]:
+    """Per-bin (mean_confidence, observed_frequency, count) for a reliability diagram.
+
+    Uses the same binning as :func:`expected_calibration_error`. A well-calibrated
+    model has ``observed_frequency ~= mean_confidence`` in every bin (points on the
+    diagonal). Only non-empty bins are returned.
+
+    Args:
+        confidences: Predicted probabilities in ``[0, 1]``.
+        outcomes: Realized boolean outcomes, aligned with ``confidences``.
+        n_bins: Number of bins (``>= 1``).
+        strategy: ``"quantile"`` (equal-mass, default) or ``"uniform"`` (equal-width).
+
+    Returns:
+        One :class:`ReliabilityBin` per non-empty bin, ordered from lowest to
+        highest confidence.
+
+    Raises:
+        ValueError: If inputs differ in length, are empty, any confidence is
+            outside ``[0, 1]``, ``n_bins < 1``, or ``strategy`` is unknown.
+
+    Example:
+        >>> bins = reliability_bins([0.2, 0.8], [False, True], n_bins=2)
+        >>> [(b.mean_confidence, b.observed_frequency, b.count) for b in bins]
+        [(0.2, 0.0, 1), (0.8, 1.0, 1)]
+    """
+    _validate_calibration(confidences, outcomes)
+    bins: list[ReliabilityBin] = []
+    for group in _bin_indices(confidences, n_bins, strategy):
+        conf_mean = sum(confidences[i] for i in group) / len(group)
+        accuracy = sum(1.0 for i in group if outcomes[i]) / len(group)
+        bins.append(
+            ReliabilityBin(
+                mean_confidence=conf_mean,
+                observed_frequency=accuracy,
+                count=len(group),
+            )
+        )
+    return bins

--- a/src/langres/core/metrics.py
+++ b/src/langres/core/metrics.py
@@ -742,9 +742,7 @@ def brier_score(confidences: list[float], outcomes: list[bool]) -> float:
     ) / len(confidences)
 
 
-def _bin_indices(
-    confidences: list[float], n_bins: int, strategy: BinStrategy
-) -> list[list[int]]:
+def _bin_indices(confidences: list[float], n_bins: int, strategy: BinStrategy) -> list[list[int]]:
     """Group item indices into bins by confidence; drop empty bins.
 
     ``"quantile"`` produces equal-mass bins (each holds ~``N / n_bins`` items),

--- a/tests/bootstrap/test_report.py
+++ b/tests/bootstrap/test_report.py
@@ -1,0 +1,236 @@
+"""Tests for the bootstrap coverage/calibration report.
+
+The builder is pure and deterministic, so every assertion uses synthetic
+:class:`GoldPair` data with a known ground truth -- no LLM, no embeddings, no
+network. Expected values are hand-computed. Targets 100% coverage of
+``langres.bootstrap.report``.
+"""
+
+from typing import Any
+
+import pytest
+from pydantic import BaseModel
+
+from langres.bootstrap.models import GoldPair, GoldSet
+from langres.bootstrap.report import BootstrapReport
+from langres.core.models import ERCandidate
+
+
+class _Rec(BaseModel):
+    """Minimal entity schema (id only) for building candidate pairs."""
+
+    id: str
+
+
+def _cand(left: str, right: str) -> ERCandidate[Any]:
+    return ERCandidate(left=_Rec(id=left), right=_Rec(id=right), blocker_name="test")
+
+
+def _teacher(
+    left: str,
+    right: str,
+    label: bool,
+    *,
+    confidence: float | None = None,
+    provenance: dict[str, object] | None = None,
+) -> GoldPair:
+    return GoldPair(
+        left_id=left,
+        right_id=right,
+        label=label,
+        source="teacher",
+        confidence=confidence,
+        provenance=provenance or {},
+    )
+
+
+# Shared scenario:
+#   truth clusters: {a,b} and {c,d} -> match pairs (a,b) and (c,d)
+#   candidates capture a-b and a-c (miss c-d) -> pair-completeness 0.5
+#   teacher labels: a-b True (correct), a-c False (correct), c-d False (WRONG),
+#                   x-y True (no ground truth -> excluded)
+_TRUTH = [{"a", "b"}, {"c", "d"}]
+
+
+def _scenario_gold() -> GoldSet:
+    return GoldSet(
+        pairs=[
+            _teacher("a", "b", True, confidence=0.9),
+            _teacher("a", "c", False, confidence=0.8),
+            _teacher("c", "d", False, confidence=0.4),
+            _teacher("x", "y", True, confidence=0.5),
+        ],
+        metadata={"total_cost_usd": 1.25, "mined": 4},
+    )
+
+
+def _scenario_candidates() -> list[ERCandidate[Any]]:
+    return [_cand("a", "b"), _cand("a", "c")]
+
+
+def test_blocking_pair_completeness() -> None:
+    report = BootstrapReport.build(_scenario_gold(), _scenario_candidates(), _TRUTH)
+    # (a,b) captured, (c,d) missed -> recall 0.5; candidate precision 1/2.
+    assert report.blocking.pair_completeness == 0.5
+    assert report.blocking.candidate_precision == 0.5
+    assert report.blocking.total_candidates == 2
+    assert report.blocking.missed_matches == 1
+
+
+def test_agreement_hand_computed() -> None:
+    report = BootstrapReport.build(_scenario_gold(), _scenario_candidates(), _TRUTH)
+    a = report.agreement
+    assert a is not None
+    assert a.n_evaluated == 3  # x-y excluded (no ground truth)
+    assert a.accuracy == pytest.approx(2 / 3)
+    assert a.precision == 1.0  # TP=1, FP=0
+    assert a.recall == 0.5  # TP=1, FN=1
+    assert a.f1 == pytest.approx(2 / 3)
+    assert a.cohens_kappa == pytest.approx(0.4)
+    assert a.mcc == 0.5
+
+
+def test_calibration_hand_computed() -> None:
+    report = BootstrapReport.build(_scenario_gold(), _scenario_candidates(), _TRUTH, n_bins=2)
+    c = report.calibration
+    assert c is not None
+    # confidences [0.9,0.8,0.4], correctness [True,True,False]
+    # Brier: (0.01 + 0.04 + 0.16)/3 = 0.07
+    assert c.n_evaluated == 3
+    assert c.brier == pytest.approx(0.07)
+    # quantile 2 bins: [0.4,0.8] acc .5 conf .6; [0.9] acc 1 conf .9 -> ECE 0.1
+    assert c.ece == pytest.approx(0.1)
+    assert c.n_bins == 2
+    assert len(c.reliability) == 2
+    assert c.reliability[0].mean_confidence == pytest.approx(0.6)
+    assert c.reliability[0].observed_frequency == 0.5
+    assert c.reliability[0].count == 2
+    assert c.reliability[1].mean_confidence == pytest.approx(0.9)
+    assert c.reliability[1].observed_frequency == 1.0
+    assert c.reliability[1].count == 1
+
+
+def test_convergence_curve_deterministic() -> None:
+    report = BootstrapReport.build(_scenario_gold(), _scenario_candidates(), _TRUTH)
+    # Order by (left,right): a-b, a-c, c-d.
+    # n=1 F1=1.0 ; n=2 (a-c TN) F1=1.0 ; n=3 (c-d FN) precision1 recall .5 -> 0.667
+    assert [(p.n_labeled, round(p.f1, 4)) for p in report.convergence] == [
+        (1, 1.0),
+        (2, 1.0),
+        (3, round(2 / 3, 4)),
+    ]
+
+
+def test_convergence_includes_false_positive_branch() -> None:
+    # Teacher says match where truth says non-match (a-c True but truth non-match).
+    gold = GoldSet(
+        pairs=[_teacher("a", "c", True, confidence=0.7)],
+        metadata={},
+    )
+    report = BootstrapReport.build(gold, [_cand("a", "b")], _TRUTH)
+    a = report.agreement
+    assert a is not None
+    # FP=1, TP=0 -> precision 0, recall 0 (no truth positives among evaluated)
+    assert a.precision == 0.0
+    assert a.recall == 0.0
+    assert a.f1 == 0.0
+    assert report.convergence[0].f1 == 0.0
+
+
+def test_coverage_and_cost_from_metadata() -> None:
+    report = BootstrapReport.build(_scenario_gold(), _scenario_candidates(), _TRUTH)
+    cov = report.coverage
+    assert cov.total_candidates == 2
+    assert cov.mined == 4  # from metadata
+    assert cov.labeled == 4
+    assert cov.skipped == 0  # total_candidates(2) - labeled(4) floored at 0
+    assert cov.with_ground_truth == 3
+    assert cov.total_cost_usd == 1.25
+
+
+def test_build_from_plain_list_uses_defaults() -> None:
+    pairs = [_teacher("a", "b", True, confidence=0.9)]
+    report = BootstrapReport.build(pairs, [_cand("a", "b"), _cand("e", "f")], _TRUTH)
+    cov = report.coverage
+    assert cov.labeled == 1
+    assert cov.mined == 1  # fallback to labeled when no metadata
+    assert cov.skipped == 1  # 2 candidates - 1 labeled
+    assert cov.total_cost_usd == 0.0  # no metadata, no provenance cost
+
+
+def test_cost_summed_from_provenance() -> None:
+    pairs = [
+        _teacher("a", "b", True, provenance={"cost_usd": 0.10}),
+        _teacher("c", "d", True, provenance={"cost": 0.05}),
+        _teacher("a", "c", False, provenance={"note": "no cost here"}),
+    ]
+    report = BootstrapReport.build(pairs, [_cand("a", "b")], _TRUTH)
+    assert report.coverage.total_cost_usd == pytest.approx(0.15)
+
+
+def test_cost_metadata_bool_is_ignored_falls_back_to_provenance() -> None:
+    # A bool in metadata must not be read as a cost (isinstance(True, int) is True).
+    gold = GoldSet(
+        pairs=[_teacher("a", "b", True, provenance={"cost": 0.2})],
+        metadata={"total_cost_usd": True},
+    )
+    report = BootstrapReport.build(gold, [_cand("a", "b")], _TRUTH)
+    assert report.coverage.total_cost_usd == pytest.approx(0.2)
+
+
+def test_cost_non_numeric_provenance_ignored() -> None:
+    pairs = [_teacher("a", "b", True, provenance={"cost": "free"})]
+    report = BootstrapReport.build(pairs, [_cand("a", "b")], _TRUTH)
+    assert report.coverage.total_cost_usd == 0.0
+
+
+def test_no_ground_truth_yields_none_sections() -> None:
+    # No labeled pair's ids appear in truth clusters -> agreement/calibration None.
+    pairs = [_teacher("x", "y", True, confidence=0.6)]
+    report = BootstrapReport.build(pairs, [_cand("x", "y")], _TRUTH)
+    assert report.agreement is None
+    assert report.calibration is None
+    assert report.convergence == []
+
+
+def test_calibration_none_when_no_confidence_but_truth_present() -> None:
+    # Pair has ground truth but no confidence -> agreement present, calibration None.
+    pairs = [_teacher("a", "b", True)]
+    report = BootstrapReport.build(pairs, [_cand("a", "b")], _TRUTH)
+    assert report.agreement is not None
+    assert report.calibration is None
+
+
+def test_to_markdown_contains_key_numbers() -> None:
+    report = BootstrapReport.build(_scenario_gold(), _scenario_candidates(), _TRUTH, n_bins=2)
+    md = report.to_markdown()
+    assert "# Bootstrap Report" in md
+    assert "Pair-completeness (candidate recall): 0.5000" in md
+    assert "F1: 0.6667" in md
+    assert "Cohen's kappa: 0.4000" in md
+    assert "MCC: 0.5000" in md
+    assert "Brier score (primary): 0.0700" in md
+    assert "ECE (equal-mass, 2 bins): 0.1000" in md
+    assert "Total cost (USD): 1.2500" in md
+    assert "Final F1 @ 3 labels: 0.6667" in md
+
+
+def test_render_is_markdown_alias() -> None:
+    report = BootstrapReport.build(_scenario_gold(), _scenario_candidates(), _TRUTH)
+    assert report.render() == report.to_markdown()
+
+
+def test_to_markdown_handles_empty_sections() -> None:
+    pairs = [_teacher("x", "y", True)]
+    report = BootstrapReport.build(pairs, [_cand("x", "y")], _TRUTH)
+    md = report.to_markdown()
+    assert "No labeled pair had a ground-truth label." in md
+    assert "No labeled pair had both a confidence and a ground-truth label." in md
+    # Empty convergence -> the convergence section is omitted.
+    assert "## Agreement convergence" not in md
+
+
+def test_report_json_roundtrip() -> None:
+    report = BootstrapReport.build(_scenario_gold(), _scenario_candidates(), _TRUTH, n_bins=2)
+    restored = BootstrapReport.model_validate_json(report.model_dump_json())
+    assert restored == report

--- a/tests/core/test_metrics_calibration.py
+++ b/tests/core/test_metrics_calibration.py
@@ -1,0 +1,245 @@
+"""Tests for agreement (kappa, MCC) and calibration (Brier, ECE, reliability) metrics.
+
+All expected values are hand-computed. Coverage targets 100% of the new pure
+functions in ``langres.core.metrics`` including every validation and edge branch.
+"""
+
+import math
+
+import pytest
+
+from langres.core.metrics import (
+    _bin_indices,
+    brier_score,
+    cohens_kappa,
+    expected_calibration_error,
+    matthews_corrcoef,
+    reliability_bins,
+)
+
+# ---------------------------------------------------------------------------
+# Cohen's kappa
+# ---------------------------------------------------------------------------
+
+
+def test_cohens_kappa_hand_computed() -> None:
+    # y_true has 2 positives, y_pred 1 positive, 3/4 agree.
+    # p_o=0.75, p_e=0.5*0.25 + 0.5*0.75 = 0.5 -> (0.75-0.5)/0.5 = 0.5
+    assert cohens_kappa([True, True, False, False], [True, False, False, False]) == 0.5
+
+
+def test_cohens_kappa_perfect_agreement() -> None:
+    # p_o=1, p_e=0.5 -> 1.0
+    assert cohens_kappa([True, False, True, False], [True, False, True, False]) == 1.0
+
+
+def test_cohens_kappa_prevalence_paradox() -> None:
+    """High raw accuracy but kappa collapses under ~1% prevalence (W5)."""
+    y_true = [True] + [False] * 99
+    y_pred = [False] * 100
+    accuracy = sum(1 for t, p in zip(y_true, y_pred) if t == p) / 100
+    assert accuracy == 0.99
+    # p_e = 0.01*0 + 0.99*1 = 0.99 == p_o -> kappa 0.0 despite 99% accuracy.
+    assert cohens_kappa(y_true, y_pred) == 0.0
+
+
+def test_cohens_kappa_no_variance_returns_zero() -> None:
+    """Both raters all-positive -> p_e == 1 -> undefined, convention 0.0."""
+    assert cohens_kappa([True, True], [True, True]) == 0.0
+
+
+def test_cohens_kappa_negative() -> None:
+    # Perfect disagreement: p_o=0, p_e=0.5 -> (0-0.5)/0.5 = -1.0
+    assert cohens_kappa([True, False], [False, True]) == -1.0
+
+
+def test_cohens_kappa_length_mismatch_raises() -> None:
+    with pytest.raises(ValueError, match="equal length"):
+        cohens_kappa([True], [True, False])
+
+
+def test_cohens_kappa_empty_raises() -> None:
+    with pytest.raises(ValueError, match="non-empty"):
+        cohens_kappa([], [])
+
+
+# ---------------------------------------------------------------------------
+# Matthews correlation coefficient
+# ---------------------------------------------------------------------------
+
+
+def test_mcc_hand_computed() -> None:
+    # TP=1, TN=2, FP=0, FN=1 -> (2-0)/sqrt(1*2*2*3) = 2/sqrt(12)
+    expected = 2 / math.sqrt(12)
+    assert matthews_corrcoef([True, True, False, False], [True, False, False, False]) == expected
+
+
+def test_mcc_perfect() -> None:
+    assert matthews_corrcoef([True, False, True, False], [True, False, True, False]) == 1.0
+
+
+def test_mcc_perfect_inverse() -> None:
+    assert matthews_corrcoef([True, False, True, False], [False, True, False, True]) == -1.0
+
+
+def test_mcc_zero_denominator_returns_zero() -> None:
+    """No predicted positives -> (TP+FP)=0 factor -> denominator 0 -> 0.0."""
+    assert matthews_corrcoef([True, False], [False, False]) == 0.0
+
+
+def test_mcc_prevalence_robust_vs_kappa() -> None:
+    """Under skew, both kappa and MCC flag the useless all-negative predictor."""
+    y_true = [True] + [False] * 99
+    y_pred = [False] * 100
+    assert matthews_corrcoef(y_true, y_pred) == 0.0
+
+
+def test_mcc_length_mismatch_raises() -> None:
+    with pytest.raises(ValueError, match="equal length"):
+        matthews_corrcoef([True], [True, False])
+
+
+def test_mcc_empty_raises() -> None:
+    with pytest.raises(ValueError, match="non-empty"):
+        matthews_corrcoef([], [])
+
+
+# ---------------------------------------------------------------------------
+# Brier score
+# ---------------------------------------------------------------------------
+
+
+def test_brier_hand_computed() -> None:
+    # ((0.9-1)^2 + (0.1-0)^2)/2 = (0.01 + 0.01)/2 = 0.01
+    assert brier_score([0.9, 0.1], [True, False]) == pytest.approx(0.01)
+
+
+def test_brier_perfect_is_zero() -> None:
+    assert brier_score([1.0, 0.0], [True, False]) == 0.0
+
+
+def test_brier_worst_is_one() -> None:
+    assert brier_score([0.0, 1.0], [True, False]) == 1.0
+
+
+def test_brier_constant_half() -> None:
+    assert brier_score([0.5, 0.5], [True, False]) == 0.25
+
+
+def test_brier_length_mismatch_raises() -> None:
+    with pytest.raises(ValueError, match="equal length"):
+        brier_score([0.5], [True, False])
+
+
+def test_brier_empty_raises() -> None:
+    with pytest.raises(ValueError, match="non-empty"):
+        brier_score([], [])
+
+
+def test_brier_confidence_out_of_range_raises() -> None:
+    with pytest.raises(ValueError, match=r"\[0, 1\]"):
+        brier_score([1.5], [True])
+
+
+def test_brier_confidence_negative_raises() -> None:
+    with pytest.raises(ValueError, match=r"\[0, 1\]"):
+        brier_score([-0.1], [True])
+
+
+# ---------------------------------------------------------------------------
+# Expected calibration error
+# ---------------------------------------------------------------------------
+
+
+def test_ece_single_bin() -> None:
+    # One bin: mean conf 0.8, accuracy 0.5 -> |0.8-0.5| = 0.3
+    assert expected_calibration_error([0.8, 0.8], [True, False], n_bins=1) == pytest.approx(0.3)
+
+
+def test_ece_quantile_two_bins_hand_computed() -> None:
+    # confidences sorted [0.4,0.8,0.9]; equal-mass split -> bin0=[0.4,0.8], bin1=[0.9].
+    # bin0: conf 0.6, acc 0.5 (one True one False) -> |0.5-0.6|=0.1, weight 2/3
+    # bin1: conf 0.9, acc 1.0 -> 0.1, weight 1/3
+    # ECE = 2/3*0.1 + 1/3*0.1 = 0.1
+    conf = [0.9, 0.8, 0.4]
+    out = [True, False, True]  # 0.9->True, 0.8->False, 0.4->True
+    assert expected_calibration_error(conf, out, n_bins=2) == pytest.approx(0.1)
+
+
+def test_ece_perfectly_calibrated_is_zero() -> None:
+    # Each bin's accuracy equals its confidence.
+    assert expected_calibration_error([0.0, 1.0], [False, True], n_bins=2) == 0.0
+
+
+def test_ece_uniform_strategy() -> None:
+    # Uniform 2 bins over [0,1]: 0.2->bin0, 0.9->bin1.
+    # bin0: conf 0.2 acc 0 -> 0.2 weight .5 ; bin1 conf 0.9 acc 1 -> 0.1 weight .5
+    # ECE = 0.5*0.2 + 0.5*0.1 = 0.15
+    val = expected_calibration_error([0.2, 0.9], [False, True], n_bins=2, strategy="uniform")
+    assert val == pytest.approx(0.15)
+
+
+def test_ece_uniform_confidence_one_clamps_to_last_bin() -> None:
+    # p=1.0 with n_bins=4 must land in the top bin, not overflow.
+    val = expected_calibration_error([1.0], [True], n_bins=4, strategy="uniform")
+    assert val == 0.0
+
+
+def test_ece_n_bins_below_one_raises() -> None:
+    with pytest.raises(ValueError, match="n_bins must be >= 1"):
+        expected_calibration_error([0.5], [True], n_bins=0)
+
+
+def test_ece_unknown_strategy_raises() -> None:
+    with pytest.raises(ValueError, match="quantile.*uniform"):
+        expected_calibration_error([0.5], [True], strategy="bogus")  # type: ignore[arg-type]
+
+
+def test_ece_length_mismatch_raises() -> None:
+    with pytest.raises(ValueError, match="equal length"):
+        expected_calibration_error([0.5], [True, False])
+
+
+# ---------------------------------------------------------------------------
+# Reliability bins
+# ---------------------------------------------------------------------------
+
+
+def test_reliability_bins_hand_computed() -> None:
+    bins = reliability_bins([0.2, 0.8], [False, True], n_bins=2)
+    assert [(b.mean_confidence, b.observed_frequency, b.count) for b in bins] == [
+        (0.2, 0.0, 1),
+        (0.8, 1.0, 1),
+    ]
+
+
+def test_reliability_bins_more_bins_than_points_drops_empty() -> None:
+    # n_bins=5 but only 2 points -> empty bins are skipped (size==0 branch).
+    bins = reliability_bins([0.3, 0.7], [False, True], n_bins=5)
+    assert len(bins) == 2
+    assert bins[0].count == 1
+    assert bins[1].count == 1
+
+
+def test_reliability_bins_single_bin_aggregates() -> None:
+    bins = reliability_bins([0.4, 0.6], [True, False], n_bins=1)
+    assert len(bins) == 1
+    assert bins[0].mean_confidence == pytest.approx(0.5)
+    assert bins[0].observed_frequency == 0.5
+    assert bins[0].count == 2
+
+
+def test_reliability_bins_empty_raises() -> None:
+    with pytest.raises(ValueError, match="non-empty"):
+        reliability_bins([], [])
+
+
+# ---------------------------------------------------------------------------
+# _bin_indices internals (uniform empty-bin drop)
+# ---------------------------------------------------------------------------
+
+
+def test_bin_indices_uniform_drops_empty_bins() -> None:
+    # Both points fall in the same uniform bin -> only one non-empty group.
+    groups = _bin_indices([0.1, 0.15], n_bins=4, strategy="uniform")
+    assert groups == [[0, 1]]

--- a/tests/core/test_metrics_calibration.py
+++ b/tests/core/test_metrics_calibration.py
@@ -166,6 +166,29 @@ def test_ece_quantile_two_bins_hand_computed() -> None:
     assert expected_calibration_error(conf, out, n_bins=2) == pytest.approx(0.1)
 
 
+def test_ece_ties_stay_in_one_bin_and_are_order_independent() -> None:
+    """Equal confidences must not be split across quantile bins (Codex P2).
+
+    Four identical 0.5 predictions that are right half the time are perfectly
+    calibrated -> ECE 0.0, regardless of row order.
+    """
+    conf = [0.5, 0.5, 0.5, 0.5]
+    assert expected_calibration_error(conf, [True, True, False, False], n_bins=2) == 0.0
+    assert expected_calibration_error(conf, [False, True, False, True], n_bins=2) == 0.0
+    bins = reliability_bins(conf, [True, True, False, False], n_bins=2)
+    assert len(bins) == 1
+    assert bins[0].count == 4
+    assert bins[0].mean_confidence == 0.5
+    assert bins[0].observed_frequency == 0.5
+
+
+def test_ece_partial_ties_extend_boundary() -> None:
+    # Sorted confidences [0.3, 0.5, 0.5, 0.9], n_bins=2. The even cut at index 2
+    # would split the tied 0.5s; the boundary extends so both 0.5s share a bin.
+    bins = reliability_bins([0.9, 0.5, 0.5, 0.3], [True, True, False, False], n_bins=2)
+    assert [b.count for b in bins] == [3, 1]  # {0.3, 0.5, 0.5} then {0.9}
+
+
 def test_ece_perfectly_calibrated_is_zero() -> None:
     # Each bin's accuracy equals its confidence.
     assert expected_calibration_error([0.0, 1.0], [False, True], n_bins=2) == 0.0


### PR DESCRIPTION
## Wave 3 — agreement/calibration metrics + bootstrap coverage report

Runs in parallel with Wave 2. Touches only `core/metrics.py` (append-only), new `bootstrap/report.py`, and their tests. Does **not** touch `bootstrap/__init__.py` (Wave 4 wires the export), `miners.py`, `labelers.py`, or `base.py`.

### 1. New pure metric functions in `core/metrics.py` (W5 + W6)
- `cohens_kappa(y_true, y_pred)` — chance-corrected agreement; returns `0.0` on the no-variance (`p_e == 1`) edge.
- `matthews_corrcoef(y_true, y_pred)` — MCC; prevalence-robust where kappa suffers the prevalence paradox (W5). Zero-denominator → `0.0`.
- `brier_score(confidences, outcomes)` — `mean((p-y)^2)`, the primary proper score, no binning (W6).
- `expected_calibration_error(confidences, outcomes, *, n_bins=8, strategy="quantile")` — verbalized-confidence ECE; **default equal-mass / quantile bins** so clumped LLM confidences don't collapse into 2-3 equal-width bins (W6).
- `reliability_bins(...)` → `list[ReliabilityBin]` (typed Pydantic model: mean_confidence, observed_frequency, count).

All validate inputs (equal lengths, confidences in `[0,1]`, `n_bins >= 1`, known strategy). Hand-computed expected values + prevalence-paradox sanity + edge cases (empty, all-same-class, single bin, more-bins-than-points, uniform clamp).

### 2. `bootstrap/report.py` — `BootstrapReport` (plain Pydantic) + pure builder
`BootstrapReport.build(gold, candidates, truth_clusters, *, n_bins=8)` is pure and deterministic:
- **Blocking pair-completeness** — reuses `evaluate_blocking(...).candidate_recall` (not reimplemented).
- **Teacher-vs-truth agreement** on pairs that have a ground-truth label (both ids present in truth clusters): accuracy/precision/recall/F1 + **Cohen's kappa AND MCC** (headline gate is F1/MCC, not kappa alone — W5).
- **Calibration** of teacher confidence vs. label-correctness: **Brier** (primary), **ECE** (equal-mass), reliability bins (W6).
- **Agreement-convergence curve** (W8): teacher F1-vs-truth over deterministically-ordered prefixes of the already-collected labels — no re-labeling, zero extra spend, no leakage.
- **Routing/coverage** counts + **honest `total_cost_usd`** read from GoldSet metadata, falling back to per-pair provenance.
- `to_markdown()` / `render()` digest; fully JSON-serializable.

`BootstrapReport` is plain Pydantic — not `@register`, not `SerializableState`.

### Gates
- `uv run mypy src/` — clean (48 files).
- `uv run ruff check` + `format` — clean.
- `OMP_NUM_THREADS=1 KMP_DUPLICATE_LIB_OK=1 uv run --env-file .env pytest -m "not integration"` — **1008 passed**, overall coverage **98.77%** (gate 95%).
- New code coverage: `report.py` **100%**; the new metric functions **100%**. The only two residual misses in `metrics.py` (`evaluate_clustering` return at L368, and the `len(top_k)==0` defensive false-branch in `evaluate_blocking_with_ranking`) are **pre-existing gaps in functions Wave 3 did not touch** — no test calls `evaluate_clustering` at base.

### Self-adversarial review (M0.5 failure modes)
- No behavior-flipping `type: ignore` (the one bad ignore was replaced with a type-safe `mined` extraction).
- Binning off-by-one checked: equal-mass split, n_bins>N empty-bin drop, single bin, uniform `p=1.0` clamp all tested.
- kappa/MCC zero-denominator edges return `0.0` and are tested.