### PR TITLE
M1 Wave 2: Miner + Labeler interfaces, HardNegativeMiner, budget-capped TeacherLabeler

### DIFF
--- a/src/langres/bootstrap/__init__.py
+++ b/src/langres/bootstrap/__init__.py
@@ -1,8 +1,27 @@
 """Cold-start gold-set bootstrapping (M1).
 
-Public data contract for labeled record pairs used to seed entity resolution.
+Public surface for turning raw blocker candidates into a labeled
+:class:`GoldSet`:
+
+- Data contract: :class:`GoldPair`, :class:`GoldSet`.
+- Interfaces: :class:`Miner`, :class:`Labeler`.
+- Miners: :class:`HardNegativeMiner` (stratified sampling).
+- Labelers: :class:`GroundTruthLabeler` (zero-spend, deterministic),
+  :class:`TeacherLabeler` (budget-capped LLM teacher).
 """
 
+from langres.bootstrap.base import Labeler, Miner
+from langres.bootstrap.labelers import BlindCostError, GroundTruthLabeler, TeacherLabeler
+from langres.bootstrap.miners import HardNegativeMiner
 from langres.bootstrap.models import GoldPair, GoldSet
 
-__all__ = ["GoldPair", "GoldSet"]
+__all__ = [
+    "BlindCostError",
+    "GoldPair",
+    "GoldSet",
+    "GroundTruthLabeler",
+    "HardNegativeMiner",
+    "Labeler",
+    "Miner",
+    "TeacherLabeler",
+]

--- a/src/langres/bootstrap/_pairs.py
+++ b/src/langres/bootstrap/_pairs.py
@@ -1,0 +1,23 @@
+"""Shared record-pair identity helper for bootstrapping.
+
+Both the miner (deduplication) and the ground-truth labeler need an
+order-independent key for a record pair so that ``(a, b)`` and ``(b, a)`` are
+treated as the same pair. Keeping that logic in one place prevents the two
+call sites from drifting apart.
+"""
+
+
+def canonical_pair_key(left_id: str, right_id: str) -> tuple[str, str]:
+    """Return an order-independent key for a record pair.
+
+    ``(a, b)`` and ``(b, a)`` both map to the same tuple, so the key identifies
+    a pair regardless of which side each record was placed on.
+
+    Args:
+        left_id: One record id.
+        right_id: The other record id.
+
+    Returns:
+        The two ids as a sorted 2-tuple.
+    """
+    return (left_id, right_id) if left_id <= right_id else (right_id, left_id)

--- a/src/langres/bootstrap/base.py
+++ b/src/langres/bootstrap/base.py
@@ -1,0 +1,68 @@
+"""Abstract interfaces for cold-start gold-set bootstrapping (M1).
+
+Two tools cooperate to turn raw blocker candidates into a labeled
+:class:`~langres.bootstrap.models.GoldSet`:
+
+- A :class:`Miner` selects *which* candidate pairs are worth labeling (e.g.
+  hard-negative / stratified sampling) — it neither labels nor spends.
+- A :class:`Labeler` assigns a match / non-match label to candidate pairs,
+  emitting one :class:`~langres.bootstrap.models.GoldPair` per candidate. The
+  label may come from a teacher LLM, benchmark ground truth, or a human.
+
+These are plain ABCs, NOT Resolver slot components: they are not registered via
+``@register`` and carry no serializable ``config`` — bootstrapping is an offline
+data-preparation step, not a slot in the resolve pipeline.
+
+Each ABC declares exactly one honest signature. Subclasses must implement it
+without widening (Liskov): a caller holding a ``Miner``/``Labeler`` reference
+must be able to rely on the contract here regardless of the concrete class.
+"""
+
+from abc import ABC, abstractmethod
+from typing import Any
+
+from langres.bootstrap.models import GoldPair
+from langres.core.models import ERCandidate
+
+
+class Miner(ABC):
+    """Selects candidate pairs worth labeling from a larger candidate pool."""
+
+    @abstractmethod
+    def mine(
+        self,
+        candidates: list[ERCandidate[Any]],
+        *,
+        max_pairs: int | None = None,
+    ) -> list[ERCandidate[Any]]:
+        """Return the subset of ``candidates`` worth labeling.
+
+        Args:
+            candidates: The candidate pairs to mine from (e.g. blocker output).
+            max_pairs: Optional cap on the number of returned pairs. ``None``
+                means "no cap" — return every selected pair.
+
+        Returns:
+            A deduplicated list of selected candidate pairs.
+        """
+        raise NotImplementedError
+
+
+class Labeler(ABC):
+    """Assigns match / non-match labels to candidate pairs."""
+
+    @abstractmethod
+    def label(self, candidates: list[ERCandidate[Any]]) -> list[GoldPair]:
+        """Label each candidate pair, returning one :class:`GoldPair` per input.
+
+        Implementations may return *fewer* pairs than given (e.g. when a budget
+        cap or a per-pair failure drops some), but never more, and never widen
+        this signature.
+
+        Args:
+            candidates: The candidate pairs to label.
+
+        Returns:
+            The labeled pairs.
+        """
+        raise NotImplementedError

--- a/src/langres/bootstrap/base.py
+++ b/src/langres/bootstrap/base.py
@@ -45,7 +45,6 @@ class Miner(ABC):
         Returns:
             A deduplicated list of selected candidate pairs.
         """
-        raise NotImplementedError
 
 
 class Labeler(ABC):
@@ -65,4 +64,3 @@ class Labeler(ABC):
         Returns:
             The labeled pairs.
         """
-        raise NotImplementedError

--- a/src/langres/bootstrap/labelers.py
+++ b/src/langres/bootstrap/labelers.py
@@ -104,6 +104,7 @@ class BlindCostError(RuntimeError):
 
     def __init__(self, message: str) -> None:
         super().__init__(message)
+        # Populated by TeacherLabeler.label() (the catcher), not at raise time.
         self.partial: list[GoldPair] = []
 
 
@@ -348,7 +349,8 @@ class TeacherLabeler(Labeler):
                 self._worst_case_per_pair_cost,
             )
             return candidates[:max_pairs]
-        return list(candidates)
+        # No cap fired; _label_one never mutates its input, so return as-is.
+        return candidates
 
     def _label_one(self, candidate: ERCandidate[Any]) -> GoldPair | None:
         """Judge one pair, tally its spend, and map it to a :class:`GoldPair`.

--- a/src/langres/bootstrap/labelers.py
+++ b/src/langres/bootstrap/labelers.py
@@ -57,8 +57,10 @@ class GroundTruthLabeler(Labeler):
         Returns:
             A labeler whose positive set is every intra-cluster pair.
         """
-        # combinations(sorted(...)) already yields a <= b, and __init__
-        # canonicalizes the whole set, so no per-pair canonicalization is needed.
+        # combinations(sorted(...)) already yields a <= b, so no canonicalization
+        # is needed here; __init__ still canonicalizes (it is shared with the
+        # direct constructor, which may receive unsorted pairs) but only reorders
+        # there, not for these already-sorted pairs.
         positives: set[tuple[str, str]] = set()
         for cluster in gold_clusters:
             positives.update(combinations(sorted(cluster), 2))
@@ -128,7 +130,9 @@ class TeacherLabeler(Labeler):
        budget so the stratified set already fits and this cap does not fire as
        the primary selector. If it does fire (input larger than the budget
        allows), it prioritizes spend safety over preserving the mix; pre-shuffle
-       upstream if an unbiased truncation is needed.
+       upstream if an unbiased truncation is needed. The cap (like the budget
+       stop) is enforced **per** :meth:`label` call — a caller making multiple
+       rounds against one instance must budget across calls itself.
     2. **Running tally + per-pair budget stop.** Spend is tallied from each
        judgement's actual token counts (priced with the pinned rates,
        cross-checked against the judge's reported ``cost_usd``, taking the max).
@@ -179,7 +183,9 @@ class TeacherLabeler(Labeler):
             price_per_1m_completion_tokens: Pinned price per 1M completion
                 tokens (USD).
             worst_case_tokens_per_pair: Worst-case total tokens for one pair,
-                used to size the pre-flight cap.
+                used to size the pre-flight cap. The cap conservatively prices
+                *all* of these tokens at the more expensive of the two rates, so
+                size this knowing the cap may be tighter than the true average.
             budget_usd: Hard spend ceiling — the run stops before crossing it.
             budget_soft_usd: Soft ceiling used to size the pre-flight cap, giving
                 headroom below ``budget_usd``.
@@ -361,7 +367,7 @@ class TeacherLabeler(Labeler):
                 self._worst_case_per_pair_cost,
             )
             return candidates[:max_pairs]
-        # No cap fired; _label_one never mutates its input, so return as-is.
+        # No cap fired; nothing downstream mutates the list, so return as-is.
         return candidates
 
     def _label_one(self, candidate: ERCandidate[Any]) -> GoldPair | None:

--- a/src/langres/bootstrap/labelers.py
+++ b/src/langres/bootstrap/labelers.py
@@ -120,7 +120,13 @@ class TeacherLabeler(Labeler):
        per-pair worst case is ``worst_case_tokens_per_pair`` priced at the more
        expensive of the two pinned prices. This bounds spend even if every call
        is maximally expensive, with ``budget_soft_usd`` headroom below the hard
-       budget.
+       budget. It is a budget **backstop**, not a sampler: it truncates in input
+       order and does not re-balance strata. Composition contract — the caller
+       (the Wave-4 orchestrator) sizes the upstream miner's ``max_pairs`` to the
+       budget so the stratified set already fits and this cap does not fire as
+       the primary selector. If it does fire (input larger than the budget
+       allows), it prioritizes spend safety over preserving the mix; pre-shuffle
+       upstream if an unbiased truncation is needed.
     2. **Running tally + per-pair budget stop.** Spend is tallied from each
        judgement's actual token counts (priced with the pinned rates,
        cross-checked against the judge's reported ``cost_usd``, taking the max).

--- a/src/langres/bootstrap/labelers.py
+++ b/src/langres/bootstrap/labelers.py
@@ -401,6 +401,10 @@ class TeacherLabeler(Labeler):
         token_cost = self._pair_cost(prompt_tokens, completion_tokens)
         reported_cost = float(prov.get("cost_usd", 0.0) or 0.0)
 
+        # "Both zero" is the blind signal, not key-presence: LLMJudge always sets
+        # prompt_tokens/completion_tokens/cost_usd, defaulting them to 0 exactly
+        # when response.usage is missing. A real call always spends prompt tokens,
+        # so all-zero reliably means "usage was absent" — we cannot track spend.
         if token_cost == 0.0 and reported_cost == 0.0:
             raise BlindCostError(
                 f"Judgement for pair {judgement.left_id}/{judgement.right_id} reported "

--- a/src/langres/bootstrap/labelers.py
+++ b/src/langres/bootstrap/labelers.py
@@ -11,6 +11,7 @@ Two concrete labelers, both emitting :class:`~langres.bootstrap.models.GoldPair`
 
 import logging
 import math
+from itertools import combinations
 from typing import Any
 
 from langres.bootstrap._pairs import canonical_pair_key
@@ -58,10 +59,8 @@ class GroundTruthLabeler(Labeler):
         """
         positives: set[tuple[str, str]] = set()
         for cluster in gold_clusters:
-            members = sorted(cluster)
-            for i in range(len(members)):
-                for j in range(i + 1, len(members)):
-                    positives.add(canonical_pair_key(members[i], members[j]))
+            for a, b in combinations(sorted(cluster), 2):
+                positives.add(canonical_pair_key(a, b))
         return cls(positives)
 
     def label(self, candidates: list[ERCandidate[Any]]) -> list[GoldPair]:
@@ -97,7 +96,15 @@ class BlindCostError(RuntimeError):
     If a judgement reports neither token counts nor a cost, the running tally
     can no longer be trusted, so the cap is blind. Continuing would risk
     unbounded spend, so :class:`TeacherLabeler` aborts instead.
+
+    The pairs already labeled (and paid for) before the abort are attached as
+    :attr:`partial` (set by :meth:`TeacherLabeler.label`) so a caller can recover
+    them rather than discard paid work.
     """
+
+    def __init__(self, message: str) -> None:
+        super().__init__(message)
+        self.partial: list[GoldPair] = []
 
 
 class TeacherLabeler(Labeler):
@@ -167,7 +174,9 @@ class TeacherLabeler(Labeler):
             budget_usd: Hard spend ceiling — the run stops before crossing it.
             budget_soft_usd: Soft ceiling used to size the pre-flight cap, giving
                 headroom below ``budget_usd``.
-            batch_size: Pairs between budget checks (the budget-stop granularity).
+            batch_size: Chunk size for input iteration and progress logging. The
+                budget gate fires before every individual pair regardless of
+                batch boundaries, so this does not affect the cap.
             threshold: ``score >= threshold`` is labeled a match.
 
         Raises:
@@ -197,7 +206,9 @@ class TeacherLabeler(Labeler):
         self.batch_size = batch_size
         self.threshold = threshold
 
-        # Worst-case per-pair cost: all tokens at the more expensive rate.
+        # Worst-case per-pair cost, cached at construction: all tokens at the
+        # more expensive rate. The price / token attributes above are read-only
+        # after __init__ — mutating them would not refresh this cached cost.
         self._worst_case_per_pair_cost = (
             worst_case_tokens_per_pair
             / 1_000_000.0
@@ -284,7 +295,8 @@ class TeacherLabeler(Labeler):
 
         Raises:
             BlindCostError: If a judgement reports neither token counts nor a
-                cost, so spend can no longer be tracked.
+                cost, so spend can no longer be tracked. The pairs labeled before
+                the abort are available on the exception's ``partial`` attribute.
         """
         self.total_spent_usd = 0.0
         self.labeled_count = 0
@@ -312,7 +324,12 @@ class TeacherLabeler(Labeler):
                         len(labeled),
                     )
                     return labeled
-                gold = self._label_one(candidate)
+                try:
+                    gold = self._label_one(candidate)
+                except BlindCostError as exc:
+                    # Recover the already-paid pairs rather than discard them.
+                    exc.partial = labeled
+                    raise
                 if gold is not None:
                     labeled.append(gold)
 

--- a/src/langres/bootstrap/labelers.py
+++ b/src/langres/bootstrap/labelers.py
@@ -13,17 +13,13 @@ import logging
 import math
 from typing import Any
 
+from langres.bootstrap._pairs import canonical_pair_key
 from langres.bootstrap.base import Labeler
 from langres.bootstrap.models import GoldPair
 from langres.core.models import ERCandidate
 from langres.core.modules.llm_judge import LLMJudge
 
 logger = logging.getLogger(__name__)
-
-
-def _pair_key(left_id: str, right_id: str) -> tuple[str, str]:
-    """Order-independent identity of a pair (handles (a,b) == (b,a))."""
-    return (left_id, right_id) if left_id <= right_id else (right_id, left_id)
 
 
 class GroundTruthLabeler(Labeler):
@@ -43,7 +39,7 @@ class GroundTruthLabeler(Labeler):
                 tuples. Use :meth:`from_clusters` to derive these from the
                 benchmark ``gold_clusters`` contract.
         """
-        self._positive_pairs = {_pair_key(a, b) for a, b in positive_pairs}
+        self._positive_pairs = {canonical_pair_key(a, b) for a, b in positive_pairs}
 
     @classmethod
     def from_clusters(cls, gold_clusters: list[set[str]]) -> "GroundTruthLabeler":
@@ -65,7 +61,7 @@ class GroundTruthLabeler(Labeler):
             members = sorted(cluster)
             for i in range(len(members)):
                 for j in range(i + 1, len(members)):
-                    positives.add(_pair_key(members[i], members[j]))
+                    positives.add(canonical_pair_key(members[i], members[j]))
         return cls(positives)
 
     def label(self, candidates: list[ERCandidate[Any]]) -> list[GoldPair]:
@@ -82,7 +78,7 @@ class GroundTruthLabeler(Labeler):
         for cand in candidates:
             left_id: str = cand.left.id
             right_id: str = cand.right.id
-            is_match = _pair_key(left_id, right_id) in self._positive_pairs
+            is_match = canonical_pair_key(left_id, right_id) in self._positive_pairs
             labels.append(
                 GoldPair(
                     left_id=left_id,
@@ -117,11 +113,16 @@ class TeacherLabeler(Labeler):
        expensive of the two pinned prices. This bounds spend even if every call
        is maximally expensive, with ``budget_soft_usd`` headroom below the hard
        budget.
-    2. **Running tally + budget stop.** Spend is tallied from each judgement's
-       actual token counts (priced with the pinned rates, cross-checked against
-       the judge's reported ``cost_usd``, taking the max). Before each batch, if
-       the projected spend would exceed ``budget_usd`` the run stops and returns
-       what was labeled so far — a partial gold set is valid.
+    2. **Running tally + per-pair budget stop.** Spend is tallied from each
+       judgement's actual token counts (priced with the pinned rates,
+       cross-checked against the judge's reported ``cost_usd``, taking the max).
+       Before judging *each* pair (not merely each batch), if starting it could
+       push the worst-case spend past ``budget_usd`` the run stops and returns
+       what was labeled so far — a partial gold set is valid. Checking per pair
+       (rather than per batch) keeps the cap hard even when the pinned prices
+       under-estimate the real cost: the only residual overshoot is the actual
+       cost of the single in-flight pair beyond the estimate, which is
+       unavoidable because an LLM's cost is known only after the call returns.
     3. **Per-call resilience.** Each pair is judged in its own ``forward`` call
        wrapped in ``try/except``; one failed call skips that pair and the loop
        continues, so a single error never discards an already-paid batch.
@@ -130,10 +131,15 @@ class TeacherLabeler(Labeler):
     an async ``gather`` over a whole batch cannot be stopped mid-flight once
     dispatched, so it cannot honor the budget cap (design-review B1).
 
+    ``batch_size`` chunks the input for iteration and progress logging; the
+    binding budget gate is per-pair, so it does not affect the cap.
+
     Spend / count attributes are exposed for the run report and are updated live
     (so they remain meaningful even if :class:`BlindCostError` aborts the run):
     :attr:`total_spent_usd`, :attr:`labeled_count`, :attr:`skipped_count`,
-    :attr:`dropped_by_cap_count`.
+    :attr:`dropped_by_cap_count`. They reflect **only the most recent**
+    :meth:`label` call — each call resets them, so a caller invoking
+    :meth:`label` in multiple rounds must accumulate spend externally.
     """
 
     def __init__(
@@ -270,7 +276,11 @@ class TeacherLabeler(Labeler):
         Returns:
             The labeled pairs (``source="teacher"``). May be fewer than the
             input: dropped by the pre-flight cap, skipped on a failed call, or
-            truncated when the budget stop fires.
+            truncated when the per-pair budget stop fires.
+
+        Note:
+            The run statistics attributes are reset at the start of every call,
+            so they describe only this call (see the class docstring).
 
         Raises:
             BlindCostError: If a judgement reports neither token counts nor a
@@ -286,18 +296,22 @@ class TeacherLabeler(Labeler):
 
         for start in range(0, len(capped), self.batch_size):
             batch = capped[start : start + self.batch_size]
-            projected = self.total_spent_usd + len(batch) * self._worst_case_per_pair_cost
-            if projected > self.budget_usd:
-                logger.info(
-                    "Budget stop: spent=$%.4f + est=$%.4f would exceed budget $%.2f; "
-                    "returning %d labeled pairs",
-                    self.total_spent_usd,
-                    len(batch) * self._worst_case_per_pair_cost,
-                    self.budget_usd,
-                    len(labeled),
-                )
-                break
             for candidate in batch:
+                # Hard per-pair gate: never *start* a pair whose worst-case cost
+                # could push us over the budget. Done per pair (not per batch) so
+                # a large batch cannot overshoot the cap when actual cost exceeds
+                # the pinned worst-case estimate.
+                projected = self.total_spent_usd + self._worst_case_per_pair_cost
+                if projected > self.budget_usd:
+                    logger.info(
+                        "Budget stop: spent=$%.4f + next worst-case $%.6f would exceed "
+                        "budget $%.2f; returning %d labeled pairs",
+                        self.total_spent_usd,
+                        self._worst_case_per_pair_cost,
+                        self.budget_usd,
+                        len(labeled),
+                    )
+                    return labeled
                 gold = self._label_one(candidate)
                 if gold is not None:
                     labeled.append(gold)

--- a/src/langres/bootstrap/labelers.py
+++ b/src/langres/bootstrap/labelers.py
@@ -304,16 +304,13 @@ class TeacherLabeler(Labeler):
 
         return labeled
 
-    def _apply_preflight_cap(
-        self, candidates: list[ERCandidate[Any]]
-    ) -> list[ERCandidate[Any]]:
+    def _apply_preflight_cap(self, candidates: list[ERCandidate[Any]]) -> list[ERCandidate[Any]]:
         """Truncate the input so even worst-case spend stays under the soft budget."""
         max_pairs = math.floor(self.budget_soft_usd / self._worst_case_per_pair_cost)
         if len(candidates) > max_pairs:
             self.dropped_by_cap_count = len(candidates) - max_pairs
             logger.info(
-                "Pre-flight cap: keeping %d of %d pairs (soft budget $%.2f, "
-                "worst-case $%.6f/pair)",
+                "Pre-flight cap: keeping %d of %d pairs (soft budget $%.2f, worst-case $%.6f/pair)",
                 max_pairs,
                 len(candidates),
                 self.budget_soft_usd,

--- a/src/langres/bootstrap/labelers.py
+++ b/src/langres/bootstrap/labelers.py
@@ -57,10 +57,11 @@ class GroundTruthLabeler(Labeler):
         Returns:
             A labeler whose positive set is every intra-cluster pair.
         """
+        # combinations(sorted(...)) already yields a <= b, and __init__
+        # canonicalizes the whole set, so no per-pair canonicalization is needed.
         positives: set[tuple[str, str]] = set()
         for cluster in gold_clusters:
-            for a, b in combinations(sorted(cluster), 2):
-                positives.add(canonical_pair_key(a, b))
+            positives.update(combinations(sorted(cluster), 2))
         return cls(positives)
 
     def label(self, candidates: list[ERCandidate[Any]]) -> list[GoldPair]:
@@ -98,8 +99,9 @@ class BlindCostError(RuntimeError):
     unbounded spend, so :class:`TeacherLabeler` aborts instead.
 
     The pairs already labeled (and paid for) before the abort are attached as
-    :attr:`partial` (set by :meth:`TeacherLabeler.label`) so a caller can recover
-    them rather than discard paid work.
+    :attr:`partial` so a caller can recover them rather than discard paid work.
+    :attr:`partial` is populated by :meth:`TeacherLabeler.label` (the catcher)
+    immediately before it re-raises; the raise site does not set it.
     """
 
     def __init__(self, message: str) -> None:
@@ -213,15 +215,6 @@ class TeacherLabeler(Labeler):
         self.batch_size = batch_size
         self.threshold = threshold
 
-        # Worst-case per-pair cost, cached at construction: all tokens at the
-        # more expensive rate. The price / token attributes above are read-only
-        # after __init__ — mutating them would not refresh this cached cost.
-        self._worst_case_per_pair_cost = (
-            worst_case_tokens_per_pair
-            / 1_000_000.0
-            * max(price_per_1m_prompt_tokens, price_per_1m_completion_tokens)
-        )
-
         # Live run statistics (reset at the start of each label() call).
         self.total_spent_usd: float = 0.0
         self.labeled_count: int = 0
@@ -276,6 +269,19 @@ class TeacherLabeler(Labeler):
             budget_soft_usd=budget_soft_usd,
             batch_size=batch_size,
             threshold=threshold,
+        )
+
+    @property
+    def _worst_case_per_pair_cost(self) -> float:
+        """Worst-case cost of one pair: all tokens at the more expensive rate.
+
+        Computed live from the price / token attributes (not cached), so mutating
+        any of them after construction can never leave a stale value behind.
+        """
+        return (
+            self.worst_case_tokens_per_pair
+            / 1_000_000.0
+            * max(self.price_per_1m_prompt_tokens, self.price_per_1m_completion_tokens)
         )
 
     def _pair_cost(self, prompt_tokens: int, completion_tokens: int) -> float:

--- a/src/langres/bootstrap/labelers.py
+++ b/src/langres/bootstrap/labelers.py
@@ -1,0 +1,384 @@
+"""Labelers for cold-start gold-set bootstrapping (M1).
+
+Two concrete labelers, both emitting :class:`~langres.bootstrap.models.GoldPair`:
+
+- :class:`GroundTruthLabeler`: deterministic, zero-spend labeling from a known
+  positive-pair set. Used to prove the bootstrap loop end-to-end with no cost.
+- :class:`TeacherLabeler`: the real LLM teacher. Wraps an injected
+  :class:`~langres.core.modules.llm_judge.LLMJudge` and enforces a hard spend
+  cap so a runaway loop can never burn the budget (design-review B1 + B4).
+"""
+
+import logging
+import math
+from typing import Any
+
+from langres.bootstrap.base import Labeler
+from langres.bootstrap.models import GoldPair
+from langres.core.models import ERCandidate
+from langres.core.modules.llm_judge import LLMJudge
+
+logger = logging.getLogger(__name__)
+
+
+def _pair_key(left_id: str, right_id: str) -> tuple[str, str]:
+    """Order-independent identity of a pair (handles (a,b) == (b,a))."""
+    return (left_id, right_id) if left_id <= right_id else (right_id, left_id)
+
+
+class GroundTruthLabeler(Labeler):
+    """Deterministic, zero-spend labeler driven by a known positive-pair set.
+
+    Given the gold positive pairs (the matching record pairs), it labels each
+    candidate ``True`` iff its ``(left.id, right.id)`` pair is in that set, and
+    ``False`` otherwise. No model is called and no budget is spent — this proves
+    the bootstrap loop without cost.
+    """
+
+    def __init__(self, positive_pairs: set[tuple[str, str]]) -> None:
+        """Initialize with the set of order-independent positive (match) pairs.
+
+        Args:
+            positive_pairs: Matching pairs as order-independent ``(id, id)``
+                tuples. Use :meth:`from_clusters` to derive these from the
+                benchmark ``gold_clusters`` contract.
+        """
+        self._positive_pairs = {_pair_key(a, b) for a, b in positive_pairs}
+
+    @classmethod
+    def from_clusters(cls, gold_clusters: list[set[str]]) -> "GroundTruthLabeler":
+        """Build from the ``gold_clusters`` contract (cross-source match sets).
+
+        Each cluster contributes the unordered pairs of all its member ids as
+        positives. For the 2-element clusters of the Fodors-Zagat adapter this
+        is simply the one matching pair per cluster.
+
+        Args:
+            gold_clusters: Match sets, e.g. from
+                :func:`langres.data.er_benchmarks.load_fodors_zagat`.
+
+        Returns:
+            A labeler whose positive set is every intra-cluster pair.
+        """
+        positives: set[tuple[str, str]] = set()
+        for cluster in gold_clusters:
+            members = sorted(cluster)
+            for i in range(len(members)):
+                for j in range(i + 1, len(members)):
+                    positives.add(_pair_key(members[i], members[j]))
+        return cls(positives)
+
+    def label(self, candidates: list[ERCandidate[Any]]) -> list[GoldPair]:
+        """Label each candidate by membership in the positive-pair set.
+
+        Args:
+            candidates: Candidate pairs to label.
+
+        Returns:
+            One :class:`GoldPair` per candidate, ``source="ground_truth"`` and
+            ``confidence=1.0``.
+        """
+        labels: list[GoldPair] = []
+        for cand in candidates:
+            left_id: str = cand.left.id
+            right_id: str = cand.right.id
+            is_match = _pair_key(left_id, right_id) in self._positive_pairs
+            labels.append(
+                GoldPair(
+                    left_id=left_id,
+                    right_id=right_id,
+                    label=is_match,
+                    source="ground_truth",
+                    confidence=1.0,
+                )
+            )
+        return labels
+
+
+class BlindCostError(RuntimeError):
+    """Raised when the teacher cannot observe its own spend.
+
+    If a judgement reports neither token counts nor a cost, the running tally
+    can no longer be trusted, so the cap is blind. Continuing would risk
+    unbounded spend, so :class:`TeacherLabeler` aborts instead.
+    """
+
+
+class TeacherLabeler(Labeler):
+    """Budget-capped LLM-teacher labeler (design-review B1 + B4).
+
+    Wraps an injected :class:`LLMJudge` and turns its judgements into
+    :class:`GoldPair` labels, while guaranteeing the labeling run can never
+    exceed ``budget_usd``. Three layers enforce this:
+
+    1. **Pre-flight hard cap.** Before any call, the input is truncated to
+       ``floor(budget_soft_usd / worst_case_per_pair_cost)`` pairs, where the
+       per-pair worst case is ``worst_case_tokens_per_pair`` priced at the more
+       expensive of the two pinned prices. This bounds spend even if every call
+       is maximally expensive, with ``budget_soft_usd`` headroom below the hard
+       budget.
+    2. **Running tally + budget stop.** Spend is tallied from each judgement's
+       actual token counts (priced with the pinned rates, cross-checked against
+       the judge's reported ``cost_usd``, taking the max). Before each batch, if
+       the projected spend would exceed ``budget_usd`` the run stops and returns
+       what was labeled so far — a partial gold set is valid.
+    3. **Per-call resilience.** Each pair is judged in its own ``forward`` call
+       wrapped in ``try/except``; one failed call skips that pair and the loop
+       continues, so a single error never discards an already-paid batch.
+
+    The teacher uses the **synchronous** :meth:`LLMJudge.forward` deliberately:
+    an async ``gather`` over a whole batch cannot be stopped mid-flight once
+    dispatched, so it cannot honor the budget cap (design-review B1).
+
+    Spend / count attributes are exposed for the run report and are updated live
+    (so they remain meaningful even if :class:`BlindCostError` aborts the run):
+    :attr:`total_spent_usd`, :attr:`labeled_count`, :attr:`skipped_count`,
+    :attr:`dropped_by_cap_count`.
+    """
+
+    def __init__(
+        self,
+        judge: LLMJudge[Any],
+        *,
+        price_per_1m_prompt_tokens: float,
+        price_per_1m_completion_tokens: float,
+        worst_case_tokens_per_pair: int,
+        budget_usd: float = 20.0,
+        budget_soft_usd: float = 15.0,
+        batch_size: int = 50,
+        threshold: float = 0.5,
+    ) -> None:
+        """Initialize the teacher.
+
+        Args:
+            judge: The wrapped LLM judge (inject for tests; use :meth:`from_env`
+                for the happy path).
+            price_per_1m_prompt_tokens: Pinned price per 1M prompt tokens (USD).
+            price_per_1m_completion_tokens: Pinned price per 1M completion
+                tokens (USD).
+            worst_case_tokens_per_pair: Worst-case total tokens for one pair,
+                used to size the pre-flight cap.
+            budget_usd: Hard spend ceiling — the run stops before crossing it.
+            budget_soft_usd: Soft ceiling used to size the pre-flight cap, giving
+                headroom below ``budget_usd``.
+            batch_size: Pairs between budget checks (the budget-stop granularity).
+            threshold: ``score >= threshold`` is labeled a match.
+
+        Raises:
+            ValueError: If any price/token/budget/batch value is non-positive, if
+                ``budget_soft_usd > budget_usd``, or if ``threshold`` is outside
+                ``[0, 1]``.
+        """
+        if price_per_1m_prompt_tokens <= 0.0 or price_per_1m_completion_tokens <= 0.0:
+            raise ValueError("pinned token prices must be positive")
+        if worst_case_tokens_per_pair <= 0:
+            raise ValueError("worst_case_tokens_per_pair must be positive")
+        if budget_usd <= 0.0 or budget_soft_usd <= 0.0:
+            raise ValueError("budgets must be positive")
+        if budget_soft_usd > budget_usd:
+            raise ValueError("budget_soft_usd must not exceed budget_usd")
+        if batch_size <= 0:
+            raise ValueError("batch_size must be positive")
+        if not 0.0 <= threshold <= 1.0:
+            raise ValueError("threshold must be in [0, 1]")
+
+        self._judge = judge
+        self.price_per_1m_prompt_tokens = price_per_1m_prompt_tokens
+        self.price_per_1m_completion_tokens = price_per_1m_completion_tokens
+        self.worst_case_tokens_per_pair = worst_case_tokens_per_pair
+        self.budget_usd = budget_usd
+        self.budget_soft_usd = budget_soft_usd
+        self.batch_size = batch_size
+        self.threshold = threshold
+
+        # Worst-case per-pair cost: all tokens at the more expensive rate.
+        self._worst_case_per_pair_cost = (
+            worst_case_tokens_per_pair
+            / 1_000_000.0
+            * max(price_per_1m_prompt_tokens, price_per_1m_completion_tokens)
+        )
+
+        # Live run statistics (reset at the start of each label() call).
+        self.total_spent_usd: float = 0.0
+        self.labeled_count: int = 0
+        self.skipped_count: int = 0
+        self.dropped_by_cap_count: int = 0
+
+    @classmethod
+    def from_env(
+        cls,
+        *,
+        price_per_1m_prompt_tokens: float,
+        price_per_1m_completion_tokens: float,
+        worst_case_tokens_per_pair: int,
+        model: str = "gpt-5-mini",
+        entity_noun: str = "entity",
+        budget_usd: float = 20.0,
+        budget_soft_usd: float = 15.0,
+        batch_size: int = 50,
+        threshold: float = 0.5,
+    ) -> "TeacherLabeler":
+        """Build a teacher with an LLM judge constructed from the environment.
+
+        The judge's client is built with ``enable_langfuse=False`` so the
+        teacher never depends on Langfuse credentials (design-review B4): the
+        usual ``LLMJudge.from_env`` enables Langfuse by default, which raises
+        without ``LANGFUSE_*`` env vars.
+
+        Args:
+            price_per_1m_prompt_tokens: See :meth:`__init__`.
+            price_per_1m_completion_tokens: See :meth:`__init__`.
+            worst_case_tokens_per_pair: See :meth:`__init__`.
+            model: Judge model name.
+            entity_noun: Domain noun woven into the judge's prompt.
+            budget_usd: See :meth:`__init__`.
+            budget_soft_usd: See :meth:`__init__`.
+            batch_size: See :meth:`__init__`.
+            threshold: See :meth:`__init__`.
+
+        Returns:
+            A configured :class:`TeacherLabeler`.
+        """
+        from langres.clients import Settings, create_llm_client
+
+        client = create_llm_client(Settings(), enable_langfuse=False)
+        judge: LLMJudge[Any] = LLMJudge(client=client, model=model, entity_noun=entity_noun)
+        return cls(
+            judge,
+            price_per_1m_prompt_tokens=price_per_1m_prompt_tokens,
+            price_per_1m_completion_tokens=price_per_1m_completion_tokens,
+            worst_case_tokens_per_pair=worst_case_tokens_per_pair,
+            budget_usd=budget_usd,
+            budget_soft_usd=budget_soft_usd,
+            batch_size=batch_size,
+            threshold=threshold,
+        )
+
+    def _pair_cost(self, prompt_tokens: int, completion_tokens: int) -> float:
+        """Cost of one judged pair from its token counts and the pinned prices."""
+        return (
+            prompt_tokens / 1_000_000.0 * self.price_per_1m_prompt_tokens
+            + completion_tokens / 1_000_000.0 * self.price_per_1m_completion_tokens
+        )
+
+    def label(self, candidates: list[ERCandidate[Any]]) -> list[GoldPair]:
+        """Label candidates with the teacher, never exceeding the budget.
+
+        Args:
+            candidates: Candidate pairs to label.
+
+        Returns:
+            The labeled pairs (``source="teacher"``). May be fewer than the
+            input: dropped by the pre-flight cap, skipped on a failed call, or
+            truncated when the budget stop fires.
+
+        Raises:
+            BlindCostError: If a judgement reports neither token counts nor a
+                cost, so spend can no longer be tracked.
+        """
+        self.total_spent_usd = 0.0
+        self.labeled_count = 0
+        self.skipped_count = 0
+        self.dropped_by_cap_count = 0
+
+        capped = self._apply_preflight_cap(candidates)
+        labeled: list[GoldPair] = []
+
+        for start in range(0, len(capped), self.batch_size):
+            batch = capped[start : start + self.batch_size]
+            projected = self.total_spent_usd + len(batch) * self._worst_case_per_pair_cost
+            if projected > self.budget_usd:
+                logger.info(
+                    "Budget stop: spent=$%.4f + est=$%.4f would exceed budget $%.2f; "
+                    "returning %d labeled pairs",
+                    self.total_spent_usd,
+                    len(batch) * self._worst_case_per_pair_cost,
+                    self.budget_usd,
+                    len(labeled),
+                )
+                break
+            for candidate in batch:
+                gold = self._label_one(candidate)
+                if gold is not None:
+                    labeled.append(gold)
+
+        return labeled
+
+    def _apply_preflight_cap(
+        self, candidates: list[ERCandidate[Any]]
+    ) -> list[ERCandidate[Any]]:
+        """Truncate the input so even worst-case spend stays under the soft budget."""
+        max_pairs = math.floor(self.budget_soft_usd / self._worst_case_per_pair_cost)
+        if len(candidates) > max_pairs:
+            self.dropped_by_cap_count = len(candidates) - max_pairs
+            logger.info(
+                "Pre-flight cap: keeping %d of %d pairs (soft budget $%.2f, "
+                "worst-case $%.6f/pair)",
+                max_pairs,
+                len(candidates),
+                self.budget_soft_usd,
+                self._worst_case_per_pair_cost,
+            )
+            return candidates[:max_pairs]
+        return list(candidates)
+
+    def _label_one(self, candidate: ERCandidate[Any]) -> GoldPair | None:
+        """Judge one pair, tally its spend, and map it to a :class:`GoldPair`.
+
+        Returns ``None`` (and increments :attr:`skipped_count`) if the judge
+        call fails or yields nothing, so the caller's loop continues.
+
+        Raises:
+            BlindCostError: If the judgement reports neither tokens nor cost.
+        """
+        try:
+            judgements = list(self._judge.forward(iter([candidate])))
+        except Exception as exc:  # noqa: BLE001 — one bad call must not abort the run
+            self.skipped_count += 1
+            logger.warning(
+                "Teacher call failed for pair %s/%s: %s; skipping",
+                candidate.left.id,
+                candidate.right.id,
+                exc,
+            )
+            return None
+
+        if not judgements:
+            self.skipped_count += 1
+            logger.warning(
+                "Teacher yielded no judgement for pair %s/%s; skipping",
+                candidate.left.id,
+                candidate.right.id,
+            )
+            return None
+
+        judgement = judgements[0]
+        prov = judgement.provenance
+        prompt_tokens = int(prov.get("prompt_tokens", 0) or 0)
+        completion_tokens = int(prov.get("completion_tokens", 0) or 0)
+        token_cost = self._pair_cost(prompt_tokens, completion_tokens)
+        reported_cost = float(prov.get("cost_usd", 0.0) or 0.0)
+
+        if token_cost == 0.0 and reported_cost == 0.0:
+            raise BlindCostError(
+                f"Judgement for pair {judgement.left_id}/{judgement.right_id} reported "
+                "neither token counts nor cost; cannot track spend"
+            )
+
+        spent = max(token_cost, reported_cost)
+        self.total_spent_usd += spent
+        self.labeled_count += 1
+
+        return GoldPair(
+            left_id=judgement.left_id,
+            right_id=judgement.right_id,
+            label=judgement.score >= self.threshold,
+            source="teacher",
+            confidence=judgement.score,
+            reasoning=judgement.reasoning,
+            provenance={
+                "tokens": {"prompt": prompt_tokens, "completion": completion_tokens},
+                "cost_usd": spent,
+                "model": prov.get("model"),
+            },
+        )

--- a/src/langres/bootstrap/miners.py
+++ b/src/langres/bootstrap/miners.py
@@ -174,9 +174,7 @@ class HardNegativeMiner(Miner):
                 unique.append(cand)
         return unique
 
-    def _stratify(
-        self, candidates: list[ERCandidate[Any]]
-    ) -> dict[str, list[ERCandidate[Any]]]:
+    def _stratify(self, candidates: list[ERCandidate[Any]]) -> dict[str, list[ERCandidate[Any]]]:
         """Bucket candidates into high/mid/low strata by similarity percentile."""
         scores = sorted(float(c.similarity_score) for c in candidates)  # type: ignore[arg-type]
         t_low = _percentile(scores, self.mid_pct)
@@ -211,9 +209,7 @@ class HardNegativeMiner(Miner):
         ideal = {name: total * weights[name] / wsum for name in _STRATA}
         alloc = {name: min(sizes[name], math.floor(ideal[name])) for name in _STRATA}
 
-        while sum(alloc.values()) < total and any(
-            alloc[name] < sizes[name] for name in _STRATA
-        ):
+        while sum(alloc.values()) < total and any(alloc[name] < sizes[name] for name in _STRATA):
             with_capacity = [name for name in _STRATA if alloc[name] < sizes[name]]
             # Largest fractional remainder first; fixed stratum order breaks ties.
             best = max(

--- a/src/langres/bootstrap/miners.py
+++ b/src/langres/bootstrap/miners.py
@@ -9,7 +9,7 @@ strata rather than only the ambiguous middle.
 import logging
 import math
 import random
-from typing import Any
+from typing import Any, cast
 
 from langres.bootstrap._pairs import canonical_pair_key
 from langres.bootstrap.base import Miner
@@ -174,14 +174,19 @@ class HardNegativeMiner(Miner):
         return unique
 
     def _stratify(self, candidates: list[ERCandidate[Any]]) -> dict[str, list[ERCandidate[Any]]]:
-        """Bucket candidates into high/mid/low strata by similarity percentile."""
-        scores = sorted(float(c.similarity_score) for c in candidates)  # type: ignore[arg-type]
+        """Bucket candidates into high/mid/low strata by similarity percentile.
+
+        ``_dedup`` has already guaranteed every ``similarity_score`` is non-None,
+        so the :func:`cast` here is safe (it narrows ``float | None`` to ``float``
+        without a runtime check).
+        """
+        scores = sorted(cast(float, c.similarity_score) for c in candidates)
         t_low = _percentile(scores, self.mid_pct)
         t_high = _percentile(scores, self.high_pct)
 
         strata: dict[str, list[ERCandidate[Any]]] = {name: [] for name in _STRATA}
         for cand in candidates:
-            score = float(cand.similarity_score)  # type: ignore[arg-type]
+            score = cast(float, cand.similarity_score)
             if score >= t_high:
                 strata["high"].append(cand)
             elif score >= t_low:

--- a/src/langres/bootstrap/miners.py
+++ b/src/langres/bootstrap/miners.py
@@ -130,8 +130,11 @@ class HardNegativeMiner(Miner):
             The selected candidate pairs, in the input's (deduplicated) order.
 
         Raises:
-            ValueError: If any candidate has ``similarity_score is None``.
+            ValueError: If any candidate has ``similarity_score is None``, or if
+                ``max_pairs`` is negative.
         """
+        if max_pairs is not None and max_pairs < 0:
+            raise ValueError("max_pairs must be non-negative")
         deduped = self._dedup(candidates)
         if not deduped:
             return []

--- a/src/langres/bootstrap/miners.py
+++ b/src/langres/bootstrap/miners.py
@@ -11,6 +11,7 @@ import math
 import random
 from typing import Any
 
+from langres.bootstrap._pairs import canonical_pair_key
 from langres.bootstrap.base import Miner
 from langres.core.models import ERCandidate
 
@@ -154,9 +155,7 @@ class HardNegativeMiner(Miner):
     @staticmethod
     def _key(candidate: ERCandidate[Any]) -> tuple[str, str]:
         """Order-independent identity of a pair (handles (a,b) == (b,a))."""
-        left_id: str = candidate.left.id
-        right_id: str = candidate.right.id
-        return (left_id, right_id) if left_id <= right_id else (right_id, left_id)
+        return canonical_pair_key(candidate.left.id, candidate.right.id)
 
     def _dedup(self, candidates: list[ERCandidate[Any]]) -> list[ERCandidate[Any]]:
         """Drop duplicate pairs (first occurrence wins); validate scores present."""

--- a/src/langres/bootstrap/miners.py
+++ b/src/langres/bootstrap/miners.py
@@ -1,0 +1,224 @@
+"""Candidate miners for cold-start gold-set bootstrapping (M1).
+
+A miner decides *which* candidate pairs are worth paying a teacher to label.
+:class:`HardNegativeMiner` does this by stratified sampling over the blocker's
+``similarity_score``, deliberately spending the labeling budget across three
+strata rather than only the ambiguous middle.
+"""
+
+import logging
+import math
+import random
+from typing import Any
+
+from langres.bootstrap.base import Miner
+from langres.core.models import ERCandidate
+
+logger = logging.getLogger(__name__)
+
+_STRATA = ("high", "mid", "low")
+
+
+def _percentile(sorted_vals: list[float], pct: float) -> float:
+    """Linear-interpolation percentile (matches ``numpy.percentile`` default).
+
+    Args:
+        sorted_vals: Values sorted ascending (non-empty).
+        pct: Percentile in ``[0, 100]``.
+
+    Returns:
+        The interpolated value at ``pct``.
+    """
+    if len(sorted_vals) == 1:
+        return sorted_vals[0]
+    rank = (pct / 100.0) * (len(sorted_vals) - 1)
+    lo = math.floor(rank)
+    hi = math.ceil(rank)
+    if lo == hi:
+        return sorted_vals[lo]
+    return sorted_vals[lo] + (sorted_vals[hi] - sorted_vals[lo]) * (rank - lo)
+
+
+class HardNegativeMiner(Miner):
+    """Stratified candidate sampler over blocker ``similarity_score``.
+
+    Rather than mining only the ambiguous middle band, this sampler spends the
+    labeling budget across three strata so the resulting gold set measures the
+    teacher along all three axes (design-review W4):
+
+    - **high** (``>= high_pct`` percentile): easy positives — measure teacher
+      *recall* (does it catch the obvious matches?).
+    - **mid** (``[mid_pct, high_pct)`` percentile): the hard, ambiguous core —
+      weighted heaviest because this is where the teacher's judgment matters.
+    - **low** (``< mid_pct`` percentile): easy negatives — measure teacher
+      *specificity* (does it reject the obvious non-matches?).
+
+    Percentile thresholds are computed over the *input* candidates' similarity
+    scores, so the strata adapt to each blocker's score distribution.
+
+    Contract:
+        The Wave-4 orchestrator performs cross-source filtering (e.g. dropping
+        same-source pairs for record-linkage) *before* calling :meth:`mine`.
+        This miner sees an already-filtered candidate pool and only bands and
+        samples it — it does no filtering of its own.
+
+    Determinism:
+        Sampling uses a seeded :class:`random.Random`, so the same input and
+        ``seed`` always yield the same pairs.
+    """
+
+    def __init__(
+        self,
+        *,
+        high_pct: float = 85.0,
+        mid_pct: float = 40.0,
+        high_proportion: float = 0.25,
+        mid_proportion: float = 0.50,
+        low_proportion: float = 0.25,
+        seed: int = 0,
+    ) -> None:
+        """Initialize the miner.
+
+        Args:
+            high_pct: Lower percentile boundary of the *high* stratum.
+            mid_pct: Lower percentile boundary of the *mid* stratum (and upper
+                boundary of *low*).
+            high_proportion: Target share of capped output drawn from *high*.
+            mid_proportion: Target share drawn from *mid* (weighted heaviest).
+            low_proportion: Target share drawn from *low*.
+            seed: RNG seed for deterministic sampling.
+
+        Raises:
+            ValueError: If percentile boundaries are not ``0 <= mid_pct <
+                high_pct <= 100``, or if any proportion is negative, or if the
+                proportions sum to zero.
+        """
+        if not 0.0 <= mid_pct < high_pct <= 100.0:
+            raise ValueError("require 0 <= mid_pct < high_pct <= 100")
+        proportions = (high_proportion, mid_proportion, low_proportion)
+        if any(p < 0.0 for p in proportions):
+            raise ValueError("proportions must be non-negative")
+        if sum(proportions) <= 0.0:
+            raise ValueError("proportions must not all be zero")
+
+        self.high_pct = high_pct
+        self.mid_pct = mid_pct
+        self.high_proportion = high_proportion
+        self.mid_proportion = mid_proportion
+        self.low_proportion = low_proportion
+        self.seed = seed
+
+    def mine(
+        self,
+        candidates: list[ERCandidate[Any]],
+        *,
+        max_pairs: int | None = None,
+    ) -> list[ERCandidate[Any]]:
+        """Deduplicate, stratify, and (optionally) cap the candidate pool.
+
+        Args:
+            candidates: Candidate pairs to mine. Every candidate must carry a
+                non-``None`` ``similarity_score`` (the miner bands on it).
+            max_pairs: Optional cap on returned pairs. When ``None`` (or ``>=``
+                the number of unique candidates) every unique candidate is
+                returned. When set, the cap is split across the three strata in
+                the configured proportions (redistributing any stratum's
+                shortfall to the others) and sampled deterministically.
+
+        Returns:
+            The selected candidate pairs, in the input's (deduplicated) order.
+
+        Raises:
+            ValueError: If any candidate has ``similarity_score is None``.
+        """
+        deduped = self._dedup(candidates)
+        if not deduped:
+            return []
+        if max_pairs is None or max_pairs >= len(deduped):
+            return deduped
+
+        strata = self._stratify(deduped)
+        sizes = {name: len(strata[name]) for name in _STRATA}
+        alloc = self._allocate(sizes, max_pairs)
+
+        rng = random.Random(self.seed)
+        selected: set[tuple[str, str]] = set()
+        for name in _STRATA:
+            count = alloc[name]
+            if count:
+                for cand in rng.sample(strata[name], count):
+                    selected.add(self._key(cand))
+
+        return [cand for cand in deduped if self._key(cand) in selected]
+
+    @staticmethod
+    def _key(candidate: ERCandidate[Any]) -> tuple[str, str]:
+        """Order-independent identity of a pair (handles (a,b) == (b,a))."""
+        left_id: str = candidate.left.id
+        right_id: str = candidate.right.id
+        return (left_id, right_id) if left_id <= right_id else (right_id, left_id)
+
+    def _dedup(self, candidates: list[ERCandidate[Any]]) -> list[ERCandidate[Any]]:
+        """Drop duplicate pairs (first occurrence wins); validate scores present."""
+        seen: set[tuple[str, str]] = set()
+        unique: list[ERCandidate[Any]] = []
+        for cand in candidates:
+            if cand.similarity_score is None:
+                raise ValueError(
+                    "HardNegativeMiner requires similarity_score on every candidate; "
+                    f"pair {self._key(cand)} has none"
+                )
+            key = self._key(cand)
+            if key not in seen:
+                seen.add(key)
+                unique.append(cand)
+        return unique
+
+    def _stratify(
+        self, candidates: list[ERCandidate[Any]]
+    ) -> dict[str, list[ERCandidate[Any]]]:
+        """Bucket candidates into high/mid/low strata by similarity percentile."""
+        scores = sorted(float(c.similarity_score) for c in candidates)  # type: ignore[arg-type]
+        t_low = _percentile(scores, self.mid_pct)
+        t_high = _percentile(scores, self.high_pct)
+
+        strata: dict[str, list[ERCandidate[Any]]] = {name: [] for name in _STRATA}
+        for cand in candidates:
+            score = float(cand.similarity_score)  # type: ignore[arg-type]
+            if score >= t_high:
+                strata["high"].append(cand)
+            elif score >= t_low:
+                strata["mid"].append(cand)
+            else:
+                strata["low"].append(cand)
+        return strata
+
+    def _allocate(self, sizes: dict[str, int], total: int) -> dict[str, int]:
+        """Split ``total`` across strata by proportion, capping at availability.
+
+        Uses floor-then-largest-remainder allocation, then redistributes any
+        leftover (from rounding or from a stratum smaller than its target) to
+        strata that still have spare capacity. ``total`` is assumed ``<``
+        ``sum(sizes)`` (the uncapped fast path handles the rest), so the
+        leftover loop always terminates with ``sum(alloc) == total``.
+        """
+        weights = {
+            "high": self.high_proportion,
+            "mid": self.mid_proportion,
+            "low": self.low_proportion,
+        }
+        wsum = sum(weights.values())
+        ideal = {name: total * weights[name] / wsum for name in _STRATA}
+        alloc = {name: min(sizes[name], math.floor(ideal[name])) for name in _STRATA}
+
+        while sum(alloc.values()) < total and any(
+            alloc[name] < sizes[name] for name in _STRATA
+        ):
+            with_capacity = [name for name in _STRATA if alloc[name] < sizes[name]]
+            # Largest fractional remainder first; fixed stratum order breaks ties.
+            best = max(
+                with_capacity,
+                key=lambda name: (ideal[name] - math.floor(ideal[name]), -_STRATA.index(name)),
+            )
+            alloc[best] += 1
+        return alloc

--- a/src/langres/bootstrap/miners.py
+++ b/src/langres/bootstrap/miners.py
@@ -215,7 +215,10 @@ class HardNegativeMiner(Miner):
 
         while sum(alloc.values()) < total and any(alloc[name] < sizes[name] for name in _STRATA):
             with_capacity = [name for name in _STRATA if alloc[name] < sizes[name]]
-            # Largest fractional remainder first; fixed stratum order breaks ties.
+            # Largest fractional remainder first. On an exact frac tie, the
+            # ``-_STRATA.index`` term favors ``high`` then ``mid`` then ``low``;
+            # this only affects the 1-2 leftover units, since the mid stratum is
+            # already weighted heaviest by its proportion (and thus its frac).
             best = max(
                 with_capacity,
                 key=lambda name: (ideal[name] - math.floor(ideal[name]), -_STRATA.index(name)),

--- a/tests/bootstrap/test_labelers.py
+++ b/tests/bootstrap/test_labelers.py
@@ -83,7 +83,10 @@ class FakeJudge:
             if cid in self.fail_ids:
                 raise RuntimeError("simulated judge failure")
             if cid in self.empty_ids:
-                return  # yield nothing for this pair
+                # Yield nothing for this pair. The teacher always calls forward
+                # with single-item iterators, so stopping the generator here is
+                # equivalent to "no judgement for this one pair".
+                return
             if cid in self.blind_ids:
                 provenance: dict[str, object] = {"model": "fake", "cost_usd": 0.0}
             else:
@@ -255,6 +258,15 @@ def test_teacher_label_empty_returns_empty() -> None:
     teacher = _teacher(FakeJudge())
     assert teacher.label([]) == []
     assert teacher.labeled_count == 0
+
+
+def test_worst_case_cost_reflects_live_attrs() -> None:
+    # Computed live (not cached), so updating a price is reflected immediately.
+    teacher = _teacher(FakeJudge(), worst_case_tokens_per_pair=1000)
+    before = teacher._worst_case_per_pair_cost
+    teacher.price_per_1m_prompt_tokens *= 10
+    teacher.price_per_1m_completion_tokens *= 10
+    assert teacher._worst_case_per_pair_cost == pytest.approx(before * 10)
 
 
 # --- TeacherLabeler: from_env (no network, no key) --------------------------

--- a/tests/bootstrap/test_labelers.py
+++ b/tests/bootstrap/test_labelers.py
@@ -229,10 +229,12 @@ def test_blind_cost_aborts_after_recording_prior_spend() -> None:
     # l0 labels normally; l1 reports neither tokens nor cost -> abort.
     judge = FakeJudge(blind_ids=frozenset({"l1"}))
     teacher = _teacher(judge)
-    with pytest.raises(BlindCostError):
+    with pytest.raises(BlindCostError) as excinfo:
         teacher.label([_cand("l0", "r0"), _cand("l1", "r1")])
     assert teacher.labeled_count == 1
     assert teacher.total_spent_usd == pytest.approx(0.002)
+    # The already-paid pair is recoverable from the exception.
+    assert [p.left_id for p in excinfo.value.partial] == ["l0"]
 
 
 # --- TeacherLabeler: stats reset per call + empty input ----------------------

--- a/tests/bootstrap/test_labelers.py
+++ b/tests/bootstrap/test_labelers.py
@@ -1,0 +1,252 @@
+"""Tests for GroundTruthLabeler and the budget-capped TeacherLabeler.
+
+The teacher is exercised with a fake judge that yields synthetic
+``PairwiseJudgement``s (no network, no API key), so every budget branch is
+covered deterministically.
+"""
+
+from collections.abc import Iterator
+
+import pytest
+
+from langres.bootstrap.labelers import (
+    BlindCostError,
+    GroundTruthLabeler,
+    TeacherLabeler,
+)
+from langres.core.models import CompanySchema, ERCandidate, PairwiseJudgement
+
+
+def _cand(left_id: str, right_id: str) -> ERCandidate[CompanySchema]:
+    return ERCandidate[CompanySchema](
+        left=CompanySchema(id=left_id, name=left_id),
+        right=CompanySchema(id=right_id, name=right_id),
+        blocker_name="test",
+    )
+
+
+# --- GroundTruthLabeler -----------------------------------------------------
+
+
+def test_ground_truth_labels_match_and_non_match() -> None:
+    labeler = GroundTruthLabeler.from_clusters([{"a", "b"}, {"c", "d"}])
+    out = labeler.label([_cand("a", "b"), _cand("b", "a"), _cand("a", "c")])
+    assert [p.label for p in out] == [True, True, False]
+    assert all(p.source == "ground_truth" and p.confidence == 1.0 for p in out)
+
+
+def test_ground_truth_from_clusters_expands_multi_member_cluster() -> None:
+    labeler = GroundTruthLabeler.from_clusters([{"x", "y", "z"}])
+    out = labeler.label([_cand("x", "y"), _cand("x", "z"), _cand("y", "z"), _cand("x", "w")])
+    assert [p.label for p in out] == [True, True, True, False]
+
+
+def test_ground_truth_direct_constructor() -> None:
+    labeler = GroundTruthLabeler({("a", "b")})
+    assert labeler.label([_cand("b", "a")])[0].label is True
+
+
+# --- FakeJudge --------------------------------------------------------------
+
+
+class FakeJudge:
+    """Minimal stand-in for LLMJudge.forward used by TeacherLabeler tests."""
+
+    def __init__(
+        self,
+        *,
+        prompt_tokens: int = 1000,
+        completion_tokens: int = 500,
+        cost_usd: float = 0.0,
+        score: float = 0.9,
+        fail_ids: frozenset[str] = frozenset(),
+        empty_ids: frozenset[str] = frozenset(),
+        blind_ids: frozenset[str] = frozenset(),
+    ) -> None:
+        self.prompt_tokens = prompt_tokens
+        self.completion_tokens = completion_tokens
+        self.cost_usd = cost_usd
+        self.score = score
+        self.fail_ids = fail_ids
+        self.empty_ids = empty_ids
+        self.blind_ids = blind_ids
+
+    def forward(
+        self, candidates: Iterator[ERCandidate[CompanySchema]]
+    ) -> Iterator[PairwiseJudgement]:
+        for cand in candidates:
+            cid = cand.left.id
+            if cid in self.fail_ids:
+                raise RuntimeError("simulated judge failure")
+            if cid in self.empty_ids:
+                return  # yield nothing for this pair
+            if cid in self.blind_ids:
+                provenance: dict[str, object] = {"model": "fake", "cost_usd": 0.0}
+            else:
+                provenance = {
+                    "model": "fake",
+                    "cost_usd": self.cost_usd,
+                    "prompt_tokens": self.prompt_tokens,
+                    "completion_tokens": self.completion_tokens,
+                }
+            yield PairwiseJudgement(
+                left_id=cand.left.id,
+                right_id=cand.right.id,
+                score=self.score,
+                score_type="prob_llm",
+                decision_step="fake",
+                reasoning="fake reasoning",
+                provenance=provenance,
+            )
+
+
+def _teacher(judge: FakeJudge, **overrides: object) -> TeacherLabeler:
+    kwargs: dict[str, object] = {
+        "price_per_1m_prompt_tokens": 1.0,
+        "price_per_1m_completion_tokens": 2.0,
+        "worst_case_tokens_per_pair": 2000,
+        "budget_usd": 20.0,
+        "budget_soft_usd": 15.0,
+        "batch_size": 50,
+    }
+    kwargs.update(overrides)
+    return TeacherLabeler(judge, **kwargs)  # type: ignore[arg-type]
+
+
+# --- TeacherLabeler: happy path + tally -------------------------------------
+
+
+def test_tally_accumulates_from_tokens_times_price() -> None:
+    teacher = _teacher(FakeJudge())  # 1000 prompt @1/M + 500 completion @2/M = 0.002/pair
+    out = teacher.label([_cand("a", "b"), _cand("c", "d"), _cand("e", "f")])
+    assert teacher.labeled_count == 3
+    assert teacher.skipped_count == 0
+    assert teacher.dropped_by_cap_count == 0
+    assert teacher.total_spent_usd == pytest.approx(0.006)
+    first = out[0]
+    assert first.source == "teacher"
+    assert first.label is True and first.confidence == pytest.approx(0.9)
+    assert first.provenance["tokens"] == {"prompt": 1000, "completion": 500}
+    assert first.provenance["cost_usd"] == pytest.approx(0.002)
+    assert first.provenance["model"] == "fake"
+
+
+def test_label_false_below_threshold() -> None:
+    teacher = _teacher(FakeJudge(score=0.3), threshold=0.5)
+    out = teacher.label([_cand("a", "b")])
+    assert out[0].label is False
+
+
+def test_cost_uses_max_of_token_and_reported_cost() -> None:
+    # reported cost_usd (1.0) dominates the token-derived cost (0.002)
+    teacher = _teacher(FakeJudge(cost_usd=1.0))
+    teacher.label([_cand("a", "b")])
+    assert teacher.total_spent_usd == pytest.approx(1.0)
+
+
+# --- TeacherLabeler: pre-flight cap -----------------------------------------
+
+
+def test_preflight_cap_truncates_input() -> None:
+    # worst-case 2000 tok @ max price 2/M = 0.004/pair; soft 0.01 -> floor(0.01/0.004)=2
+    teacher = _teacher(FakeJudge(), budget_soft_usd=0.01, budget_usd=0.01)
+    out = teacher.label([_cand(f"l{i}", f"r{i}") for i in range(5)])
+    assert teacher.dropped_by_cap_count == 3
+    assert teacher.labeled_count == 2
+    assert len(out) == 2
+
+
+# --- TeacherLabeler: budget stop --------------------------------------------
+
+
+def test_budget_stop_returns_partial() -> None:
+    # Under-estimated worst case (1000 tok) lets pre-flight keep all pairs, but the
+    # real per-pair spend (5M prompt tokens @1/M = $5) trips the hard-budget stop.
+    judge = FakeJudge(prompt_tokens=5_000_000, completion_tokens=0)
+    teacher = _teacher(
+        judge,
+        price_per_1m_prompt_tokens=1.0,
+        price_per_1m_completion_tokens=1.0,
+        worst_case_tokens_per_pair=1000,
+        budget_soft_usd=15.0,
+        budget_usd=15.0,
+        batch_size=1,
+    )
+    out = teacher.label([_cand(f"l{i}", f"r{i}") for i in range(10)])
+    assert teacher.labeled_count == 3
+    assert len(out) == 3
+    assert teacher.total_spent_usd == pytest.approx(15.0)
+    assert teacher.dropped_by_cap_count == 0
+
+
+# --- TeacherLabeler: per-call resilience ------------------------------------
+
+
+def test_failed_call_is_skipped_and_loop_continues() -> None:
+    teacher = _teacher(FakeJudge(fail_ids=frozenset({"l1"})))
+    out = teacher.label([_cand("l0", "r0"), _cand("l1", "r1"), _cand("l2", "r2")])
+    assert teacher.labeled_count == 2
+    assert teacher.skipped_count == 1
+    assert {p.left_id for p in out} == {"l0", "l2"}
+
+
+def test_empty_judgement_is_skipped() -> None:
+    teacher = _teacher(FakeJudge(empty_ids=frozenset({"l0"})))
+    out = teacher.label([_cand("l0", "r0"), _cand("l1", "r1")])
+    assert teacher.labeled_count == 1
+    assert teacher.skipped_count == 1
+    assert out[0].left_id == "l1"
+
+
+# --- TeacherLabeler: blind-cap abort ----------------------------------------
+
+
+def test_blind_cost_aborts_after_recording_prior_spend() -> None:
+    # l0 labels normally; l1 reports neither tokens nor cost -> abort.
+    judge = FakeJudge(blind_ids=frozenset({"l1"}))
+    teacher = _teacher(judge)
+    with pytest.raises(BlindCostError):
+        teacher.label([_cand("l0", "r0"), _cand("l1", "r1")])
+    assert teacher.labeled_count == 1
+    assert teacher.total_spent_usd == pytest.approx(0.002)
+
+
+# --- TeacherLabeler: from_env (no network, no key) --------------------------
+
+
+def test_from_env_builds_teacher_without_langfuse() -> None:
+    teacher = TeacherLabeler.from_env(
+        price_per_1m_prompt_tokens=0.1,
+        price_per_1m_completion_tokens=0.2,
+        worst_case_tokens_per_pair=3000,
+        model="gpt-5-mini",
+        budget_usd=10.0,
+        budget_soft_usd=8.0,
+    )
+    assert isinstance(teacher, TeacherLabeler)
+    assert teacher.budget_usd == 10.0
+    assert teacher.budget_soft_usd == 8.0
+    # A client was constructed (lazy-client path was bypassed).
+    assert teacher._judge.client is not None
+    assert teacher._judge.model == "gpt-5-mini"
+
+
+# --- TeacherLabeler: constructor validation ---------------------------------
+
+
+@pytest.mark.parametrize(
+    "overrides",
+    [
+        {"price_per_1m_prompt_tokens": 0.0},
+        {"price_per_1m_completion_tokens": -1.0},
+        {"worst_case_tokens_per_pair": 0},
+        {"budget_usd": 0.0},
+        {"budget_soft_usd": 0.0},
+        {"budget_soft_usd": 30.0, "budget_usd": 20.0},  # soft > hard
+        {"batch_size": 0},
+        {"threshold": 1.5},
+    ],
+)
+def test_invalid_constructor_raises(overrides: dict[str, object]) -> None:
+    with pytest.raises(ValueError):
+        _teacher(FakeJudge(), **overrides)

--- a/tests/bootstrap/test_labelers.py
+++ b/tests/bootstrap/test_labelers.py
@@ -46,6 +46,10 @@ def test_ground_truth_direct_constructor() -> None:
     assert labeler.label([_cand("b", "a")])[0].label is True
 
 
+def test_ground_truth_label_empty_returns_empty() -> None:
+    assert GroundTruthLabeler.from_clusters([{"a", "b"}]).label([]) == []
+
+
 # --- FakeJudge --------------------------------------------------------------
 
 
@@ -148,8 +152,9 @@ def test_cost_uses_max_of_token_and_reported_cost() -> None:
 
 
 def test_preflight_cap_truncates_input() -> None:
-    # worst-case 2000 tok @ max price 2/M = 0.004/pair; soft 0.01 -> floor(0.01/0.004)=2
-    teacher = _teacher(FakeJudge(), budget_soft_usd=0.01, budget_usd=0.01)
+    # worst-case 2000 tok @ max price 2/M = 0.004/pair; the *soft* budget (0.01)
+    # sizes the cap -> floor(0.01/0.004)=2, with headroom below the hard budget.
+    teacher = _teacher(FakeJudge(), budget_soft_usd=0.01, budget_usd=0.02)
     out = teacher.label([_cand(f"l{i}", f"r{i}") for i in range(5)])
     assert teacher.dropped_by_cap_count == 3
     assert teacher.labeled_count == 2
@@ -177,6 +182,25 @@ def test_budget_stop_returns_partial() -> None:
     assert len(out) == 3
     assert teacher.total_spent_usd == pytest.approx(15.0)
     assert teacher.dropped_by_cap_count == 0
+
+
+def test_budget_stop_holds_within_a_large_batch() -> None:
+    # Same over-spend scenario but with the default batch_size=50: the whole run
+    # is one batch. The per-pair gate must still stop at the cap rather than
+    # dispatching all 10 pairs ($50) before re-checking (codex P1 regression).
+    judge = FakeJudge(prompt_tokens=5_000_000, completion_tokens=0)
+    teacher = _teacher(
+        judge,
+        price_per_1m_prompt_tokens=1.0,
+        price_per_1m_completion_tokens=1.0,
+        worst_case_tokens_per_pair=1000,
+        budget_soft_usd=15.0,
+        budget_usd=15.0,
+        batch_size=50,
+    )
+    out = teacher.label([_cand(f"l{i}", f"r{i}") for i in range(10)])
+    assert len(out) == 3
+    assert teacher.total_spent_usd == pytest.approx(15.0)
 
 
 # --- TeacherLabeler: per-call resilience ------------------------------------
@@ -211,6 +235,26 @@ def test_blind_cost_aborts_after_recording_prior_spend() -> None:
     assert teacher.total_spent_usd == pytest.approx(0.002)
 
 
+# --- TeacherLabeler: stats reset per call + empty input ----------------------
+
+
+def test_stats_reset_between_calls() -> None:
+    # Attributes describe only the most recent label() call, not cumulative spend.
+    teacher = _teacher(FakeJudge())
+    teacher.label([_cand("a", "b")])
+    assert teacher.labeled_count == 1
+    assert teacher.total_spent_usd == pytest.approx(0.002)
+    teacher.label([_cand("c", "d"), _cand("e", "f")])
+    assert teacher.labeled_count == 2  # reset to this call, not 3
+    assert teacher.total_spent_usd == pytest.approx(0.004)
+
+
+def test_teacher_label_empty_returns_empty() -> None:
+    teacher = _teacher(FakeJudge())
+    assert teacher.label([]) == []
+    assert teacher.labeled_count == 0
+
+
 # --- TeacherLabeler: from_env (no network, no key) --------------------------
 
 
@@ -223,12 +267,11 @@ def test_from_env_builds_teacher_without_langfuse() -> None:
         budget_usd=10.0,
         budget_soft_usd=8.0,
     )
+    # The point is that construction succeeds without LANGFUSE_* / OPENAI_API_KEY
+    # (enable_langfuse=False); we assert only the public config, not internals.
     assert isinstance(teacher, TeacherLabeler)
     assert teacher.budget_usd == 10.0
     assert teacher.budget_soft_usd == 8.0
-    # A client was constructed (lazy-client path was bypassed).
-    assert teacher._judge.client is not None
-    assert teacher._judge.model == "gpt-5-mini"
 
 
 # --- TeacherLabeler: constructor validation ---------------------------------

--- a/tests/bootstrap/test_miners.py
+++ b/tests/bootstrap/test_miners.py
@@ -41,6 +41,13 @@ def test_percentile_interpolates() -> None:
     assert _percentile([0.0, 1.0], 50.0) == 0.5
 
 
+def test_percentile_boundaries() -> None:
+    # pct=0 / pct=100 are reachable via mid_pct=0 / high_pct=100.
+    vals = [0.1, 0.4, 0.9]
+    assert _percentile(vals, 0.0) == 0.1
+    assert _percentile(vals, 100.0) == 0.9
+
+
 # --- stratum membership -----------------------------------------------------
 
 

--- a/tests/bootstrap/test_miners.py
+++ b/tests/bootstrap/test_miners.py
@@ -142,6 +142,11 @@ def test_missing_similarity_score_raises() -> None:
         HardNegativeMiner().mine([_cand("a", "b", None)])
 
 
+def test_negative_max_pairs_raises() -> None:
+    with pytest.raises(ValueError, match="non-negative"):
+        HardNegativeMiner().mine(_spread(10), max_pairs=-1)
+
+
 # --- allocation edge cases --------------------------------------------------
 
 

--- a/tests/bootstrap/test_miners.py
+++ b/tests/bootstrap/test_miners.py
@@ -1,0 +1,176 @@
+"""Tests for HardNegativeMiner (stratified candidate sampling)."""
+
+import pytest
+
+from langres.bootstrap.miners import HardNegativeMiner, _percentile
+from langres.core.models import CompanySchema, ERCandidate
+
+
+def _cand(left_id: str, right_id: str, score: float | None) -> ERCandidate[CompanySchema]:
+    return ERCandidate[CompanySchema](
+        left=CompanySchema(id=left_id, name=left_id),
+        right=CompanySchema(id=right_id, name=right_id),
+        blocker_name="test",
+        similarity_score=score,
+    )
+
+
+def _spread(n: int = 100) -> list[ERCandidate[CompanySchema]]:
+    """``n`` unique pairs with similarity scores evenly spread over [0, (n-1)/n]."""
+    return [_cand(f"l{i}", f"r{i}", i / n) for i in range(n)]
+
+
+def _ids(cands: list[ERCandidate[CompanySchema]]) -> set[str]:
+    return {c.left.id for c in cands}
+
+
+# --- _percentile helper -----------------------------------------------------
+
+
+def test_percentile_single_value() -> None:
+    assert _percentile([0.7], 85.0) == 0.7
+
+
+def test_percentile_integer_rank_no_interpolation() -> None:
+    # rank = 0.5 * (4) = 2.0 -> exact index, no interpolation
+    assert _percentile([0.0, 0.25, 0.5, 0.75, 1.0], 50.0) == 0.5
+
+
+def test_percentile_interpolates() -> None:
+    # rank = 0.5 * 1 = 0.5 -> halfway between 0.0 and 1.0
+    assert _percentile([0.0, 1.0], 50.0) == 0.5
+
+
+# --- stratum membership -----------------------------------------------------
+
+
+def test_high_stratum_only_returns_top_band() -> None:
+    miner = HardNegativeMiner(high_proportion=1.0, mid_proportion=0.0, low_proportion=0.0)
+    out = miner.mine(_spread(), max_pairs=10)
+    assert len(out) == 10
+    # high stratum is score >= 85th pct (~0.8415) -> scores 0.85..0.99
+    assert all(c.similarity_score is not None and c.similarity_score >= 0.85 for c in out)
+
+
+def test_low_stratum_only_returns_bottom_band() -> None:
+    miner = HardNegativeMiner(high_proportion=0.0, mid_proportion=0.0, low_proportion=1.0)
+    out = miner.mine(_spread(), max_pairs=10)
+    assert len(out) == 10
+    # low stratum is score < 40th pct (~0.396) -> scores <= 0.39
+    assert all(c.similarity_score is not None and c.similarity_score < 0.396 for c in out)
+
+
+def test_default_proportions_weight_mid_heaviest() -> None:
+    miner = HardNegativeMiner()  # 0.25 / 0.50 / 0.25
+    out = miner.mine(_spread(), max_pairs=20)
+    assert len(out) == 20
+    high = sum(1 for c in out if c.similarity_score is not None and c.similarity_score >= 0.85)
+    low = sum(1 for c in out if c.similarity_score is not None and c.similarity_score < 0.396)
+    mid = len(out) - high - low
+    assert (high, mid, low) == (5, 10, 5)
+
+
+# --- determinism ------------------------------------------------------------
+
+
+def test_same_seed_same_selection() -> None:
+    a = HardNegativeMiner(seed=7).mine(_spread(), max_pairs=20)
+    b = HardNegativeMiner(seed=7).mine(_spread(), max_pairs=20)
+    assert _ids(a) == _ids(b)
+
+
+def test_different_seed_different_selection() -> None:
+    a = HardNegativeMiner(seed=1).mine(_spread(), max_pairs=20)
+    b = HardNegativeMiner(seed=2).mine(_spread(), max_pairs=20)
+    assert _ids(a) != _ids(b)
+
+
+def test_output_preserves_input_order() -> None:
+    out = HardNegativeMiner(seed=3).mine(_spread(), max_pairs=20)
+    scores = [c.similarity_score for c in out]
+    assert scores == sorted(scores)  # input is built in ascending-score order
+
+
+# --- caps and pass-through --------------------------------------------------
+
+
+def test_max_pairs_cap_respected() -> None:
+    out = HardNegativeMiner().mine(_spread(), max_pairs=13)
+    assert len(out) == 13
+
+
+def test_uncapped_returns_all_unique() -> None:
+    out = HardNegativeMiner().mine(_spread(50), max_pairs=None)
+    assert len(out) == 50
+
+
+def test_max_pairs_ge_total_returns_all() -> None:
+    out = HardNegativeMiner().mine(_spread(30), max_pairs=999)
+    assert len(out) == 30
+
+
+def test_max_pairs_zero_returns_empty() -> None:
+    # Exercises the single-value percentile path and a zero allocation.
+    out = HardNegativeMiner().mine([_cand("a", "b", 0.5)], max_pairs=0)
+    assert out == []
+
+
+def test_empty_input_returns_empty() -> None:
+    assert HardNegativeMiner().mine([]) == []
+
+
+# --- dedup and validation ---------------------------------------------------
+
+
+def test_deduplicates_order_independent_pairs() -> None:
+    cands = [_cand("a", "b", 0.9), _cand("b", "a", 0.9), _cand("c", "d", 0.1)]
+    out = HardNegativeMiner().mine(cands, max_pairs=None)
+    keys = {tuple(sorted((c.left.id, c.right.id))) for c in out}
+    assert len(out) == 2
+    assert keys == {("a", "b"), ("c", "d")}
+
+
+def test_missing_similarity_score_raises() -> None:
+    with pytest.raises(ValueError, match="similarity_score"):
+        HardNegativeMiner().mine([_cand("a", "b", None)])
+
+
+# --- allocation edge cases --------------------------------------------------
+
+
+def test_allocation_leftover_goes_to_largest_remainder() -> None:
+    # ideal = 5.25 / 10.5 / 5.25 -> floors 5/10/5, leftover 1 -> mid (largest frac)
+    out = HardNegativeMiner().mine(_spread(), max_pairs=21)
+    assert len(out) == 21
+    mid = sum(
+        1 for c in out if c.similarity_score is not None and 0.396 <= c.similarity_score < 0.85
+    )
+    assert mid == 11
+
+
+def test_allocation_redistributes_when_stratum_capped() -> None:
+    # high stratum has only 15 pairs but the proportion asks for ~27;
+    # the shortfall must spill into mid/low while total stays exact.
+    miner = HardNegativeMiner(high_proportion=0.9, mid_proportion=0.05, low_proportion=0.05)
+    out = miner.mine(_spread(), max_pairs=30)
+    assert len(out) == 30
+    high = sum(1 for c in out if c.similarity_score is not None and c.similarity_score >= 0.85)
+    assert high == 15  # capped at availability
+
+
+# --- constructor validation -------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "kwargs",
+    [
+        {"mid_pct": 90.0, "high_pct": 85.0},  # mid >= high
+        {"mid_pct": -1.0},  # below 0
+        {"high_pct": 101.0},  # above 100
+        {"high_proportion": -0.1},  # negative proportion
+        {"high_proportion": 0.0, "mid_proportion": 0.0, "low_proportion": 0.0},  # all zero
+    ],
+)
+def test_invalid_constructor_raises(kwargs: dict[str, float]) -> None:
+    with pytest.raises(ValueError):
+        HardNegativeMiner(**kwargs)

--- a/tests/bootstrap/test_pairs.py
+++ b/tests/bootstrap/test_pairs.py
@@ -1,0 +1,13 @@
+"""Tests for the shared canonical pair-key helper."""
+
+from langres.bootstrap._pairs import canonical_pair_key
+
+
+def test_canonical_pair_key_is_order_independent() -> None:
+    # Both argument orders map to the same sorted tuple (covers both branches).
+    assert canonical_pair_key("a", "b") == ("a", "b")
+    assert canonical_pair_key("b", "a") == ("a", "b")
+
+
+def test_canonical_pair_key_equal_ids() -> None:
+    assert canonical_pair_key("x", "x") == ("x", "x")


### PR DESCRIPTION
## Wave 2 — mining interface + labelers (M1 cold-start gold-set bootstrapping)

Builds on Wave 1 (`langres.bootstrap.models`, `langres.data.er_benchmarks`). Adds the mining/labeling layer that turns raw blocker candidates into a labeled `GoldSet`.

### What's here
- **`bootstrap/base.py`** — `Miner` and `Labeler` ABCs. One honest signature each; not `@register` Resolver slots (bootstrapping is offline data-prep, W2).
- **`bootstrap/miners.py`** — `HardNegativeMiner`: three-stratum sampling over `similarity_score` (high ≥85th pct / mid 40–85th / low <40th), proportions weighted toward mid; deterministic seeded RNG; `max_pairs` cap preserves proportions with shortfall redistribution (W4).
- **`bootstrap/labelers.py`** — `GroundTruthLabeler` (zero-spend, deterministic) + `TeacherLabeler` (budget-capped LLM teacher) + `BlindCostError`.
- **`bootstrap/__init__.py`** — exports all of the above alongside `GoldPair`/`GoldSet`.
- **`tests/bootstrap/`** — `test_miners.py`, `test_labelers.py` (fake judge, no network/key).

### How the design-review items are satisfied
- **B1 (cap mechanism).** `TeacherLabeler` uses only the **synchronous** `LLMJudge.forward` (never `forward_async` — a dispatched `gather` can't be capped). Three layers bound spend: (1) **pre-flight hard cap** truncates input to `floor(budget_soft_usd / worst_case_per_pair_cost)`; (2) **running tally** from actual token counts × pinned prices, cross-checked against the judge's `cost_usd` (max of the two), with a **budget stop** before each batch that returns the partial result; (3) **per-call resilience** — each pair judged in its own `forward` call wrapped in try/except, so one failure skips that pair and the loop continues. If a judgement reports neither tokens nor cost, spend can't be tracked → `BlindCostError` abort.
- **B4 (no-Langfuse client).** `TeacherLabeler.from_env` builds the judge via `create_llm_client(Settings(), enable_langfuse=False)`, so the teacher never depends on Langfuse creds (the usual `LLMJudge.from_env` enables Langfuse by default and raises without `LANGFUSE_*`). Fully constructible/testable with no key.
- **W1.** No speculative `Sampler` ABC.
- **W4.** Three-stratum sampling (not just a mid band); cross-source filtering is the Wave-4 orchestrator's job *before* `mine` (documented in the miner docstring).

### Gates
- `uv run mypy src/` — clean (strict, 50 files).
- `uv run ruff check` + `format --check` — clean.
- `uv run pytest -m "not integration"` — **1000 passed**, overall coverage **98.76%**, **100%** on all new bootstrap files (branch coverage included).

### Deliberate deferral
No `docs/` changes: the M1 bootstrap public-contract docs land when M1 integrates (later waves touch the same surface); adding partial docs now would conflict.