### PR TITLE
M1 Wave 4: Bootstrapper orchestrator + deterministic Fodors-Zagat e2e

### DIFF
--- a/examples/m1_bootstrap_fodors_zagat.py
+++ b/examples/m1_bootstrap_fodors_zagat.py
@@ -1,0 +1,220 @@
+"""M1 cold-start bootstrapping, end-to-end on Fodors-Zagat (deterministic, free).
+
+This is the runnable proof that the M1 Wave 1-4 pieces compose into one pass:
+real semantic blocking (sentence-transformer embeddings + FAISS) -> cross-source
+filter -> stratified hard-negative mining -> labeling -> a labeled
+:class:`~langres.bootstrap.models.GoldSet` plus a
+:class:`~langres.bootstrap.report.BootstrapReport` (blocking pair-completeness,
+teacher-vs-truth agreement, calibration), saved to disk and round-tripped.
+
+The default run is **deterministic and costs $0**: it labels with
+:class:`~langres.bootstrap.labelers.FakeLabeler`, a similarity-threshold stand-in
+for the real teacher whose over-confident confidence keeps the calibration report
+non-trivial. Embeddings are real (so blocking pair-completeness is honest) but
+involve no network and no API key.
+
+A gated real-GLM branch (``maybe_real_teacher``) shows how Wave 5 swaps in a
+budget-capped :class:`~langres.bootstrap.labelers.TeacherLabeler`; it only runs
+when ``OPENROUTER_API_KEY`` is set and never costs anything otherwise.
+
+Run it::
+
+    OMP_NUM_THREADS=1 KMP_DUPLICATE_LIB_OK=1 uv run python examples/m1_bootstrap_fodors_zagat.py
+
+``print`` is allowed in examples (this is demonstration, not library code).
+"""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+from typing import Any
+
+from langres.bootstrap import (
+    BootstrapReport,
+    Bootstrapper,
+    FakeLabeler,
+    GoldSet,
+    HardNegativeMiner,
+)
+from langres.core.blockers.vector import VectorBlocker
+from langres.core.embeddings import SentenceTransformerEmbedder
+from langres.core.indexes.vector_index import FAISSIndex
+from langres.data.er_benchmarks import (
+    DEFAULT_BLOCKING_K,
+    RestaurantSchema,
+    load_fodors_zagat,
+)
+
+
+def _cross_source(candidate: Any) -> bool:
+    """Keep only candidate pairs whose two records come from different sources.
+
+    The Fodors-Zagat task is a cross-source linkage: intra-source pairs are noise
+    (design-review B2). Passed IN to ``Bootstrapper.build`` so the orchestrator
+    stays entity-type-agnostic.
+    """
+    return bool(candidate.left.source != candidate.right.source)
+
+
+def build_bootstrapper(k_neighbors: int = DEFAULT_BLOCKING_K) -> Bootstrapper:
+    """Wire a real-embedding VectorBlocker + miner + FakeLabeler into a Bootstrapper.
+
+    Args:
+        k_neighbors: Nearest neighbours per record for the vector blocker
+            (``DEFAULT_BLOCKING_K`` clears the >= 0.95 pair-completeness gate).
+
+    Returns:
+        A ready-to-run :class:`Bootstrapper` (deterministic, zero-spend labeler).
+    """
+    blocker: VectorBlocker[RestaurantSchema] = VectorBlocker(
+        vector_index=FAISSIndex(
+            embedder=SentenceTransformerEmbedder("all-MiniLM-L6-v2"),
+            metric="cosine",
+        ),
+        schema=RestaurantSchema,
+        text_field="embed_text",
+        k_neighbors=k_neighbors,
+    )
+    miner = HardNegativeMiner(seed=0)
+    # MiniLM cosine sims for these cross-source pairs cluster high (~0.78-0.97);
+    # 0.9 splits the true matches (which sit at the very top) from the rest,
+    # giving the report a realistic, non-degenerate teacher (TP/FP/FN/TN all
+    # non-zero) rather than an all-positive collapse.
+    labeler = FakeLabeler(threshold=0.9)
+    return Bootstrapper(blocker, miner, labeler)
+
+
+def run_bootstrap(save_dir: Path, *, k_neighbors: int = DEFAULT_BLOCKING_K) -> dict[str, Any]:
+    """Run the deterministic bootstrap end-to-end and round-trip the gold set.
+
+    Loads Fodors-Zagat, runs the bootstrapper with the cross-source filter and
+    the benchmark ground truth, saves the gold set to ``save_dir``, reloads it,
+    and returns everything the demo prints and the test asserts on.
+
+    Args:
+        save_dir: Directory to write ``gold_set.json`` into (created if absent).
+        k_neighbors: Blocker neighbour count.
+
+    Returns:
+        A dict with the gold set, the reloaded gold set, the report, and the
+        round-trip flag.
+    """
+    corpus_records, gold_clusters = load_fodors_zagat()
+    # The blocker's declarative schema_factory consumes plain dicts (same shape
+    # the data adapter's k-sweep feeds stream()).
+    corpus = [r.model_dump() for r in corpus_records]
+
+    bootstrapper = build_bootstrapper(k_neighbors)
+    gold, report = bootstrapper.build(
+        corpus, candidate_filter=_cross_source, gold_clusters=gold_clusters
+    )
+
+    # Save -> reload (round-trip proof).
+    save_dir.mkdir(parents=True, exist_ok=True)
+    path = save_dir / "gold_set.json"
+    gold.save(path)
+    reloaded = GoldSet.load(path)
+    roundtrip_ok = reloaded.model_dump() == gold.model_dump()
+
+    return {
+        "gold": gold,
+        "reloaded": reloaded,
+        "report": report,
+        "roundtrip_ok": roundtrip_ok,
+        "gold_path": path,
+    }
+
+
+def maybe_real_teacher() -> None:
+    """Show how Wave 5 swaps in the budget-capped real teacher (gated on a key).
+
+    Stubbed on purpose: it only constructs a :class:`TeacherLabeler` (no labeling
+    run) and prints what Wave 5 will finish. It never runs or costs anything
+    without ``OPENROUTER_API_KEY``.
+    """
+    if not os.getenv("OPENROUTER_API_KEY"):
+        print("\n[real teacher] OPENROUTER_API_KEY not set — skipping (default run is free).")
+        return
+
+    from langres.bootstrap import TeacherLabeler
+
+    # Wave 5 fills the pinned GLM model + prices and runs this for real. The
+    # prices below are positive placeholders (NOT validated rates) so the branch
+    # constructs cleanly; Wave 5 pins them from the provider's published rates
+    # before any real labeling run.
+    teacher = TeacherLabeler.from_env(
+        price_per_1m_prompt_tokens=1.0,  # TODO(Wave 5): pin real GLM prompt price
+        price_per_1m_completion_tokens=1.0,  # TODO(Wave 5): pin real GLM completion price
+        worst_case_tokens_per_pair=2000,
+        model="gpt-5-mini",  # TODO(Wave 5): pin the GLM model id
+        entity_noun="restaurant",
+        budget_usd=5.0,
+        budget_soft_usd=4.0,
+    )
+    print(
+        "\n[real teacher] Constructed a budget-capped TeacherLabeler "
+        f"(model={teacher._judge.model!r}, budget=${teacher.budget_usd:.2f}). "
+        "Wave 5 pins the GLM model/prices and runs build() with it for real."
+    )
+
+
+def main() -> None:
+    import logging
+
+    logging.getLogger("langres").setLevel(logging.ERROR)
+
+    print("=" * 78)
+    print("M1 cold-start bootstrapping — Fodors-Zagat (real embeddings, $0, deterministic)")
+    print("=" * 78)
+
+    results = run_bootstrap(Path("tmp"))
+    gold: GoldSet = results["gold"]
+    report: BootstrapReport = results["report"]
+
+    pc = report.blocking.pair_completeness
+    print(
+        f"\nBlocking Pair-Completeness (cross-source recall): {pc:.4f}"
+        f"  [target >= 0.95]  {'PASS' if pc >= 0.95 else 'LOW'}"
+    )
+    print(
+        f"  candidates={report.blocking.total_candidates}  "
+        f"missed={report.blocking.missed_matches}  "
+        f"precision={report.blocking.candidate_precision:.4f}"
+    )
+
+    if report.agreement is not None:
+        a = report.agreement
+        print("\nTeacher(fake)-vs-truth agreement:")
+        print(
+            f"  acc={a.accuracy:.4f}  F1={a.f1:.4f}  "
+            f"kappa={a.cohens_kappa:.4f}  MCC={a.mcc:.4f}  (n={a.n_evaluated})"
+        )
+    if report.calibration is not None:
+        c = report.calibration
+        print(
+            f"\nCalibration: Brier={c.brier:.4f}  ECE={c.ece:.4f}  "
+            f"(n={c.n_evaluated}, {c.n_bins} bins)"
+        )
+
+    cov = report.coverage
+    matches = gold.metadata["matches"]
+    print(
+        f"\nLabels: {cov.labeled} total ({matches} match / "
+        f"{gold.metadata['non_matches']} non-match)  "
+        f"mined={cov.mined}  cost=${cov.total_cost_usd:.4f} (fake = free)"
+    )
+
+    print(f"\nGold set saved to {results['gold_path']} and reloaded.")
+    assert results["roundtrip_ok"], "Gold-set round-trip differs from the original!"
+    print("Save/reload round-trip: gold set is IDENTICAL ✓")
+
+    maybe_real_teacher()
+
+    print("\n" + "=" * 78)
+    print("Bootstrap ran end-to-end. ✓")
+    print("=" * 78)
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/m1_bootstrap_fodors_zagat.py
+++ b/examples/m1_bootstrap_fodors_zagat.py
@@ -40,6 +40,7 @@ from langres.bootstrap import (
 from langres.core.blockers.vector import VectorBlocker
 from langres.core.embeddings import SentenceTransformerEmbedder
 from langres.core.indexes.vector_index import FAISSIndex
+from langres.core.models import ERCandidate
 from langres.data.er_benchmarks import (
     DEFAULT_BLOCKING_K,
     RestaurantSchema,
@@ -47,7 +48,7 @@ from langres.data.er_benchmarks import (
 )
 
 
-def _cross_source(candidate: Any) -> bool:
+def _cross_source(candidate: ERCandidate[RestaurantSchema]) -> bool:
     """Keep only candidate pairs whose two records come from different sources.
 
     The Fodors-Zagat task is a cross-source linkage: intra-source pairs are noise
@@ -154,7 +155,7 @@ def maybe_real_teacher() -> None:
     )
     print(
         "\n[real teacher] Constructed a budget-capped TeacherLabeler "
-        f"(model={teacher._judge.model!r}, budget=${teacher.budget_usd:.2f}). "
+        f"(budget=${teacher.budget_usd:.2f}). "
         "Wave 5 pins the GLM model/prices and runs build() with it for real."
     )
 

--- a/src/langres/bootstrap/__init__.py
+++ b/src/langres/bootstrap/__init__.py
@@ -7,16 +7,29 @@ Public surface for turning raw blocker candidates into a labeled
 - Interfaces: :class:`Miner`, :class:`Labeler`.
 - Miners: :class:`HardNegativeMiner` (stratified sampling).
 - Labelers: :class:`GroundTruthLabeler` (zero-spend, deterministic),
+  :class:`FakeLabeler` (zero-spend similarity-threshold teacher stand-in),
   :class:`TeacherLabeler` (budget-capped LLM teacher).
+- Orchestrator: :class:`Bootstrapper` (block -> filter -> mine -> label).
+- Report: :class:`BootstrapReport` (coverage + calibration health check).
 """
 
 from langres.bootstrap.base import Labeler, Miner
-from langres.bootstrap.labelers import BlindCostError, GroundTruthLabeler, TeacherLabeler
+from langres.bootstrap.bootstrapper import Bootstrapper
+from langres.bootstrap.labelers import (
+    BlindCostError,
+    FakeLabeler,
+    GroundTruthLabeler,
+    TeacherLabeler,
+)
 from langres.bootstrap.miners import HardNegativeMiner
 from langres.bootstrap.models import GoldPair, GoldSet
+from langres.bootstrap.report import BootstrapReport
 
 __all__ = [
     "BlindCostError",
+    "BootstrapReport",
+    "Bootstrapper",
+    "FakeLabeler",
     "GoldPair",
     "GoldSet",
     "GroundTruthLabeler",

--- a/src/langres/bootstrap/bootstrapper.py
+++ b/src/langres/bootstrap/bootstrapper.py
@@ -1,0 +1,121 @@
+"""Cold-start gold-set orchestrator (M1 Wave 4).
+
+:class:`Bootstrapper` wires the Wave 1-3 pieces into one pass: it builds the
+blocker's vector index, materializes blocker candidates, optionally filters them
+with a caller-supplied predicate, mines a stratified subset, labels it, and
+assembles a :class:`~langres.bootstrap.models.GoldSet` plus a
+:class:`~langres.bootstrap.report.BootstrapReport`.
+
+It is a plain class with three injected dependencies (design-review W1) and is
+deliberately *entity-type-agnostic*: any domain-specific selection rule (e.g. the
+Fodors-Zagat cross-source rule ``lambda c: c.left.source != c.right.source``) is
+passed IN as ``candidate_filter`` rather than baked in (design-review B2).
+"""
+
+import logging
+from collections.abc import Callable
+from typing import Any
+
+from langres.bootstrap.base import Labeler, Miner
+from langres.bootstrap.models import GoldSet
+from langres.bootstrap.report import BootstrapReport
+from langres.core.blockers.vector import VectorBlocker
+from langres.core.models import ERCandidate
+
+logger = logging.getLogger(__name__)
+
+
+class Bootstrapper:
+    """Orchestrate one cold-start bootstrap run: block -> filter -> mine -> label.
+
+    The three collaborators are injected so each can be swapped or faked:
+
+    Args:
+        blocker: A :class:`VectorBlocker` whose index this orchestrator builds
+            from the corpus (the private ``Resolver._ensure_index_built`` is not
+            reused here -- design-review W3).
+        miner: Selects which candidate pairs are worth labeling.
+        labeler: Assigns match / non-match labels to the mined pairs.
+    """
+
+    def __init__(self, blocker: VectorBlocker[Any], miner: Miner, labeler: Labeler) -> None:
+        self.blocker = blocker
+        self.miner = miner
+        self.labeler = labeler
+
+    def build(
+        self,
+        corpus: list[Any],
+        *,
+        candidate_filter: Callable[[ERCandidate[Any]], bool] | None = None,
+        gold_clusters: list[set[str]] | None = None,
+    ) -> tuple[GoldSet, BootstrapReport]:
+        """Run the bootstrap pipeline and return the gold set plus its report.
+
+        Args:
+            corpus: Raw records (typically dicts) the blocker's ``schema_factory``
+                consumes -- the same shape passed to ``blocker.stream``.
+            candidate_filter: Optional predicate keeping only the candidates worth
+                mining (e.g. cross-source pairs for a linkage task). When ``None``
+                every blocker candidate is mined. Kept as a parameter so the
+                orchestrator stays entity-type-agnostic (design-review B2).
+            gold_clusters: Optional ground-truth match sets, used only by the
+                report for pair-completeness and teacher-vs-truth agreement. When
+                ``None`` the report still builds (with empty ground truth).
+
+        Returns:
+            ``(gold_set, report)``.
+        """
+        # 1. Build the blocker's index from the corpus (W3: orchestrator owns this).
+        #    Reuse the blocker's own factory + text extractor so we stay agnostic
+        #    to the entity type -- this is exactly what stream() does internally.
+        entities = [self.blocker.schema_factory(record) for record in corpus]
+        texts = [self.blocker.text_field_extractor(entity) for entity in entities]
+        self.blocker.vector_index.create_index(texts)
+
+        # 2. Materialize candidates: stream() is a single-pass iterator and the
+        #    miner needs the full list for its percentile strata (W3).
+        candidates = list(self.blocker.stream(corpus))
+
+        # 3. Apply the caller's domain filter (e.g. cross-source -- B2).
+        filtered = (
+            [c for c in candidates if candidate_filter(c)]
+            if candidate_filter is not None
+            else candidates
+        )
+
+        # 4. Mine a stratified subset, then 5. label it.
+        mined = self.miner.mine(filtered)
+        pairs = self.labeler.label(mined)
+
+        logger.info(
+            "Bootstrap: %d candidates -> %d filtered -> %d mined -> %d labeled",
+            len(candidates),
+            len(filtered),
+            len(mined),
+            len(pairs),
+        )
+
+        # 6. Assemble the gold set (honest counts + cost) and its report.
+        matches = sum(1 for p in pairs if p.label)
+        gold = GoldSet(
+            pairs=pairs,
+            metadata={
+                "blocker": type(self.blocker).__name__,
+                "k_neighbors": self.blocker.k_neighbors,
+                "labeler": type(self.labeler).__name__,
+                "total_cost_usd": float(getattr(self.labeler, "total_spent_usd", 0.0)),
+                "corpus_size": len(corpus),
+                "total_candidates": len(candidates),
+                "filtered_candidates": len(filtered),
+                "mined": len(mined),
+                "labeled": len(pairs),
+                "matches": matches,
+                "non_matches": len(pairs) - matches,
+            },
+        )
+        # Pair-completeness is measured on the FILTERED candidates -- for a
+        # linkage task the meaningful blocking output is the cross-source pairs
+        # that actually feed the pipeline (mirrors the data adapter's k-sweep).
+        report = BootstrapReport.build(gold, filtered, gold_clusters or [])
+        return gold, report

--- a/src/langres/bootstrap/labelers.py
+++ b/src/langres/bootstrap/labelers.py
@@ -132,10 +132,11 @@ class FakeLabeler(Labeler):
     def _confidence(self, score: float) -> float:
         """Deterministic, over-confident self-confidence for one label.
 
-        Grows with the margin ``|score - threshold|`` but starts high (``0.7``)
-        even for near-threshold pairs, so the labeler is systematically
+        Grows with the margin ``|score - threshold|`` but starts at a ``0.7``
+        floor even for near-threshold pairs, so the labeler is systematically
         over-confident on the ambiguous band -- a realistic miscalibration that
-        keeps ECE / Brier non-degenerate. Clamped to ``[0, 0.99]``.
+        keeps ECE / Brier non-degenerate. The result lies in ``[0.7, 0.99]``
+        (floor ``0.7`` at the threshold, capped at ``0.99``).
         """
         margin = abs(score - self.threshold)
         return round(min(0.99, 0.7 + 0.6 * margin), 4)

--- a/src/langres/bootstrap/labelers.py
+++ b/src/langres/bootstrap/labelers.py
@@ -1,9 +1,12 @@
 """Labelers for cold-start gold-set bootstrapping (M1).
 
-Two concrete labelers, both emitting :class:`~langres.bootstrap.models.GoldPair`:
+Three concrete labelers, all emitting :class:`~langres.bootstrap.models.GoldPair`:
 
 - :class:`GroundTruthLabeler`: deterministic, zero-spend labeling from a known
   positive-pair set. Used to prove the bootstrap loop end-to-end with no cost.
+- :class:`FakeLabeler`: deterministic, zero-spend similarity-threshold stand-in
+  for the teacher, with an over-confident confidence so the calibration report
+  is non-trivial (the CI stand-in for :class:`TeacherLabeler`).
 - :class:`TeacherLabeler`: the real LLM teacher. Wraps an injected
   :class:`~langres.core.modules.llm_judge.LLMJudge` and enforces a hard spend
   cap so a runaway loop can never burn the budget (design-review B1 + B4).
@@ -88,6 +91,83 @@ class GroundTruthLabeler(Labeler):
                     label=is_match,
                     source="ground_truth",
                     confidence=1.0,
+                )
+            )
+        return labels
+
+
+class FakeLabeler(Labeler):
+    """Deterministic, zero-spend stand-in for the real teacher (M1 Wave 4).
+
+    Labels each candidate by thresholding its blocker ``similarity_score`` and
+    emits a deterministic, deliberately **miscalibrated** ``confidence``
+    (over-confident on the ambiguous near-threshold band) so the calibration
+    report has something non-trivial to measure: unlike
+    :class:`GroundTruthLabeler` (whose labels match truth by construction, giving
+    a trivial agreement of 1.0 and a degenerate Brier/ECE), a similarity-threshold
+    labeler disagrees with truth on the hard middle band, and its inflated
+    confidence there makes Brier and ECE meaningful. This is the CI stand-in for
+    :class:`TeacherLabeler` -- fully deterministic, no network, no spend.
+
+    ``source`` is ``"fake"`` so a gold set never mistakes synthetic labels for a
+    real teacher's.
+    """
+
+    def __init__(self, *, threshold: float = 0.5) -> None:
+        """Initialize the fake labeler.
+
+        Args:
+            threshold: ``similarity_score >= threshold`` is labeled a match.
+
+        Raises:
+            ValueError: If ``threshold`` is outside ``[0, 1]``.
+        """
+        if not 0.0 <= threshold <= 1.0:
+            raise ValueError("threshold must be in [0, 1]")
+        self.threshold = threshold
+        # Zero-spend: exposed so the orchestrator can read it uniformly (it reads
+        # ``total_spent_usd`` off whatever labeler it holds).
+        self.total_spent_usd: float = 0.0
+
+    def _confidence(self, score: float) -> float:
+        """Deterministic, over-confident self-confidence for one label.
+
+        Grows with the margin ``|score - threshold|`` but starts high (``0.7``)
+        even for near-threshold pairs, so the labeler is systematically
+        over-confident on the ambiguous band -- a realistic miscalibration that
+        keeps ECE / Brier non-degenerate. Clamped to ``[0, 0.99]``.
+        """
+        margin = abs(score - self.threshold)
+        return round(min(0.99, 0.7 + 0.6 * margin), 4)
+
+    def label(self, candidates: list[ERCandidate[Any]]) -> list[GoldPair]:
+        """Label each candidate by its similarity score.
+
+        Args:
+            candidates: Candidate pairs to label. Each must carry a non-``None``
+                ``similarity_score`` (the labeler thresholds on it).
+
+        Returns:
+            One :class:`GoldPair` per candidate, ``source="fake"``.
+
+        Raises:
+            ValueError: If any candidate has ``similarity_score is None``.
+        """
+        labels: list[GoldPair] = []
+        for cand in candidates:
+            score = cand.similarity_score
+            if score is None:
+                raise ValueError(
+                    "FakeLabeler requires similarity_score on every candidate; "
+                    f"pair {cand.left.id}/{cand.right.id} has none"
+                )
+            labels.append(
+                GoldPair(
+                    left_id=cand.left.id,
+                    right_id=cand.right.id,
+                    label=score >= self.threshold,
+                    source="fake",
+                    confidence=self._confidence(score),
                 )
             )
         return labels

--- a/src/langres/bootstrap/models.py
+++ b/src/langres/bootstrap/models.py
@@ -16,8 +16,14 @@ from typing import Literal
 
 from pydantic import BaseModel, Field
 
-GoldPairSource = Literal["teacher", "ground_truth", "human"]
-"""Where a gold label came from: a teacher LLM, benchmark ground truth, or a human."""
+GoldPairSource = Literal["teacher", "ground_truth", "human", "fake"]
+"""Where a gold label came from.
+
+``"teacher"`` (a teacher LLM), ``"ground_truth"`` (benchmark ground truth),
+``"human"`` (a reviewer), or ``"fake"`` (a deterministic no-spend stand-in for
+the teacher, e.g. :class:`~langres.bootstrap.labelers.FakeLabeler`, used to
+exercise the bootstrap loop and its calibration report without API spend).
+"""
 
 
 class GoldPair(BaseModel):
@@ -28,7 +34,7 @@ class GoldPair(BaseModel):
         right_id: Globally-unique id of the right record.
         label: ``True`` if the pair is a match, ``False`` otherwise.
         source: Provenance of the label (``"teacher"``, ``"ground_truth"``,
-            or ``"human"``).
+            ``"human"``, or ``"fake"``).
         confidence: Optional label confidence in ``[0, 1]`` (e.g. a teacher
             model's probability). ``None`` when not applicable.
         reasoning: Optional free-text rationale for the label (e.g. a teacher

--- a/tests/bootstrap/test_bootstrapper.py
+++ b/tests/bootstrap/test_bootstrapper.py
@@ -31,8 +31,10 @@ class _RecordingIndex:
 
     def __init__(self) -> None:
         self.created_with: list[str] | None = None
+        self.create_calls = 0
 
     def create_index(self, texts: list[str]) -> None:
+        self.create_calls += 1
         self.created_with = list(texts)
 
 
@@ -109,8 +111,10 @@ def test_build_wires_steps_in_order_and_builds_index() -> None:
         _CORPUS, gold_clusters=[{"a", "b"}]
     )
 
-    # Index built from the blocker's own text extractor, in corpus order.
+    # Index built EXACTLY once from the blocker's own text extractor, in corpus
+    # order (stream() reads the pre-built index, it never re-builds it).
     assert blocker.vector_index.created_with == ["Acme", "Acme Inc", "Globex"]
+    assert blocker.vector_index.create_calls == 1
     # stream received the raw corpus.
     assert blocker.stream_arg == _CORPUS
     # Miner saw the materialized candidate list (one-shot iterator consumed once).
@@ -204,3 +208,36 @@ def test_build_cost_defaults_to_zero_when_labeler_has_no_spend_attr() -> None:
     )
     assert gold.metadata["total_cost_usd"] == 0.0
     assert gold.pairs == []
+
+
+def test_build_with_empty_corpus_produces_empty_gold_set() -> None:
+    """An empty corpus builds an (empty) index and yields no pairs."""
+    blocker = _FakeBlocker([])
+    miner = _RecordingMiner(returns=[])
+    labeler = _RecordingLabeler()
+
+    gold, report = Bootstrapper(blocker, miner, labeler).build([])  # type: ignore[arg-type]
+
+    assert blocker.vector_index.created_with == []
+    assert blocker.vector_index.create_calls == 1
+    assert gold.pairs == []
+    assert gold.metadata["corpus_size"] == 0
+    assert gold.metadata["total_candidates"] == 0
+    assert report.blocking.total_candidates == 0
+
+
+def test_build_filter_dropping_all_candidates_mines_nothing() -> None:
+    """A filter that rejects everything leaves the miner and labeler with []."""
+    candidates = [_cand("a", "b", 0.9), _cand("a", "c", 0.2)]
+    blocker = _FakeBlocker(candidates)
+    miner = _RecordingMiner(returns=[])
+    labeler = _RecordingLabeler()
+
+    gold, _ = Bootstrapper(blocker, miner, labeler).build(  # type: ignore[arg-type]
+        _CORPUS, candidate_filter=lambda c: False
+    )
+
+    assert miner.seen == []
+    assert labeler.seen == []
+    assert gold.pairs == []
+    assert gold.metadata["filtered_candidates"] == 0

--- a/tests/bootstrap/test_bootstrapper.py
+++ b/tests/bootstrap/test_bootstrapper.py
@@ -1,0 +1,206 @@
+"""Fast, network-free tests for the Wave-4 :class:`Bootstrapper` orchestrator.
+
+Every collaborator is faked: a blocker that records its index build and yields
+canned :class:`ERCandidate`s, a miner and a labeler that record the lists they
+receive. This proves the orchestrator wires the steps in order (build index ->
+materialize -> filter -> mine -> label -> assemble), applies the optional
+``candidate_filter``, and assembles a :class:`GoldSet` + :class:`BootstrapReport`
+with honest counts and metadata -- with no embeddings and no LLM.
+"""
+
+from collections.abc import Iterator
+from typing import Any
+
+from langres.bootstrap.bootstrapper import Bootstrapper
+from langres.bootstrap.models import GoldPair, GoldSet
+from langres.bootstrap.report import BootstrapReport
+from langres.core.models import CompanySchema, ERCandidate
+
+
+def _cand(left_id: str, right_id: str, score: float) -> ERCandidate[CompanySchema]:
+    return ERCandidate[CompanySchema](
+        left=CompanySchema(id=left_id, name=left_id),
+        right=CompanySchema(id=right_id, name=right_id),
+        blocker_name="fake",
+        similarity_score=score,
+    )
+
+
+class _RecordingIndex:
+    """Captures the texts passed to ``create_index`` so the test can assert it."""
+
+    def __init__(self) -> None:
+        self.created_with: list[str] | None = None
+
+    def create_index(self, texts: list[str]) -> None:
+        self.created_with = list(texts)
+
+
+class _FakeBlocker:
+    """Duck-typed VectorBlocker: builds an index and yields canned candidates.
+
+    ``stream`` returns a one-shot iterator so the test proves the orchestrator
+    materializes it (a second consumer would otherwise see nothing).
+    """
+
+    def __init__(self, candidates: list[ERCandidate[Any]]) -> None:
+        self._candidates = candidates
+        self.vector_index = _RecordingIndex()
+        self.k_neighbors = 7
+        self.schema_factory = lambda record: CompanySchema(**record)
+        self.text_field_extractor = lambda entity: entity.name
+        self.stream_arg: list[Any] | None = None
+
+    def stream(self, data: list[Any]) -> Iterator[ERCandidate[Any]]:
+        self.stream_arg = data
+        return iter(self._candidates)
+
+
+class _RecordingMiner:
+    """Records the candidates it was asked to mine and returns a fixed subset."""
+
+    def __init__(self, returns: list[ERCandidate[Any]]) -> None:
+        self._returns = returns
+        self.seen: list[ERCandidate[Any]] | None = None
+
+    def mine(
+        self, candidates: list[ERCandidate[Any]], *, max_pairs: int | None = None
+    ) -> list[ERCandidate[Any]]:
+        self.seen = candidates
+        return self._returns
+
+
+class _RecordingLabeler:
+    """Records the mined pairs and emits one canned GoldPair each."""
+
+    def __init__(self, *, total_spent_usd: float = 0.0) -> None:
+        self.seen: list[ERCandidate[Any]] | None = None
+        self.total_spent_usd = total_spent_usd
+
+    def label(self, candidates: list[ERCandidate[Any]]) -> list[GoldPair]:
+        self.seen = candidates
+        return [
+            GoldPair(
+                left_id=c.left.id,
+                right_id=c.right.id,
+                label=c.similarity_score is not None and c.similarity_score >= 0.5,
+                source="fake",
+                confidence=c.similarity_score,
+            )
+            for c in candidates
+        ]
+
+
+_CORPUS: list[dict[str, str]] = [
+    {"id": "a", "name": "Acme"},
+    {"id": "b", "name": "Acme Inc"},
+    {"id": "c", "name": "Globex"},
+]
+
+
+def test_build_wires_steps_in_order_and_builds_index() -> None:
+    """build() builds the index, materializes, mines, labels, and assembles."""
+    candidates = [_cand("a", "b", 0.9), _cand("a", "c", 0.2)]
+    blocker = _FakeBlocker(candidates)
+    miner = _RecordingMiner(returns=candidates)
+    labeler = _RecordingLabeler()
+
+    gold, report = Bootstrapper(blocker, miner, labeler).build(  # type: ignore[arg-type]
+        _CORPUS, gold_clusters=[{"a", "b"}]
+    )
+
+    # Index built from the blocker's own text extractor, in corpus order.
+    assert blocker.vector_index.created_with == ["Acme", "Acme Inc", "Globex"]
+    # stream received the raw corpus.
+    assert blocker.stream_arg == _CORPUS
+    # Miner saw the materialized candidate list (one-shot iterator consumed once).
+    assert miner.seen == candidates
+    # Labeler saw the mined pairs.
+    assert labeler.seen == candidates
+    # GoldSet + report returned with the right shapes.
+    assert isinstance(gold, GoldSet)
+    assert isinstance(report, BootstrapReport)
+    assert len(gold.pairs) == 2
+
+
+def test_build_applies_candidate_filter() -> None:
+    """A candidate_filter drops non-matching candidates before mining."""
+    keep = _cand("a", "b", 0.9)
+    drop = _cand("a", "c", 0.2)
+    blocker = _FakeBlocker([keep, drop])
+    miner = _RecordingMiner(returns=[keep])
+    labeler = _RecordingLabeler()
+
+    gold, _ = Bootstrapper(blocker, miner, labeler).build(  # type: ignore[arg-type]
+        _CORPUS, candidate_filter=lambda c: c.similarity_score == 0.9
+    )
+
+    # The filter kept only the high-score candidate; the miner never saw `drop`.
+    assert miner.seen == [keep]
+    assert gold.metadata["total_candidates"] == 2
+    assert gold.metadata["filtered_candidates"] == 1
+
+
+def test_build_without_filter_mines_all_candidates() -> None:
+    """Without a filter, every blocker candidate reaches the miner."""
+    candidates = [_cand("a", "b", 0.9), _cand("a", "c", 0.2)]
+    blocker = _FakeBlocker(candidates)
+    miner = _RecordingMiner(returns=candidates)
+    labeler = _RecordingLabeler()
+
+    Bootstrapper(blocker, miner, labeler).build(_CORPUS)  # type: ignore[arg-type]
+
+    assert miner.seen == candidates
+
+
+def test_build_metadata_records_counts_and_cost() -> None:
+    """Metadata carries honest counts, the cost from the labeler, and config refs."""
+    candidates = [_cand("a", "b", 0.9), _cand("a", "c", 0.2)]
+    blocker = _FakeBlocker(candidates)
+    miner = _RecordingMiner(returns=candidates)
+    labeler = _RecordingLabeler(total_spent_usd=1.25)
+
+    gold, _ = Bootstrapper(blocker, miner, labeler).build(_CORPUS)  # type: ignore[arg-type]
+
+    md = gold.metadata
+    assert md["blocker"] == "_FakeBlocker"
+    assert md["k_neighbors"] == 7
+    assert md["labeler"] == "_RecordingLabeler"
+    assert md["total_cost_usd"] == 1.25
+    assert md["corpus_size"] == 3
+    assert md["total_candidates"] == 2
+    assert md["mined"] == 2
+    assert md["labeled"] == 2
+    assert md["matches"] == 1  # only (a,b) cleared 0.5
+    assert md["non_matches"] == 1
+
+
+def test_build_without_gold_clusters_still_builds_report() -> None:
+    """gold_clusters=None yields a report with empty ground truth (no agreement)."""
+    candidates = [_cand("a", "b", 0.9)]
+    blocker = _FakeBlocker(candidates)
+    miner = _RecordingMiner(returns=candidates)
+    labeler = _RecordingLabeler()
+
+    _, report = Bootstrapper(blocker, miner, labeler).build(_CORPUS)  # type: ignore[arg-type]
+
+    # No ground truth -> no agreement / calibration, but blocking still reports.
+    assert report.agreement is None
+    assert report.calibration is None
+    assert report.blocking.total_candidates == 1
+
+
+def test_build_cost_defaults_to_zero_when_labeler_has_no_spend_attr() -> None:
+    """A labeler without total_spent_usd is treated as zero-spend."""
+
+    class _NoSpendLabeler:
+        def label(self, candidates: list[ERCandidate[Any]]) -> list[GoldPair]:
+            return []
+
+    blocker = _FakeBlocker([])
+    miner = _RecordingMiner(returns=[])
+    gold, _ = Bootstrapper(blocker, miner, _NoSpendLabeler()).build(  # type: ignore[arg-type]
+        _CORPUS
+    )
+    assert gold.metadata["total_cost_usd"] == 0.0
+    assert gold.pairs == []

--- a/tests/bootstrap/test_labelers.py
+++ b/tests/bootstrap/test_labelers.py
@@ -11,6 +11,7 @@ import pytest
 
 from langres.bootstrap.labelers import (
     BlindCostError,
+    FakeLabeler,
     GroundTruthLabeler,
     TeacherLabeler,
 )
@@ -307,3 +308,63 @@ def test_from_env_builds_teacher_without_langfuse() -> None:
 def test_invalid_constructor_raises(overrides: dict[str, object]) -> None:
     with pytest.raises(ValueError):
         _teacher(FakeJudge(), **overrides)
+
+
+# --- FakeLabeler ------------------------------------------------------------
+
+
+def _scored(left_id: str, right_id: str, score: float) -> ERCandidate[CompanySchema]:
+    return ERCandidate[CompanySchema](
+        left=CompanySchema(id=left_id, name=left_id),
+        right=CompanySchema(id=right_id, name=right_id),
+        blocker_name="test",
+        similarity_score=score,
+    )
+
+
+def test_fake_labeler_thresholds_on_similarity() -> None:
+    out = FakeLabeler(threshold=0.5).label(
+        [_scored("a", "b", 0.9), _scored("c", "d", 0.5), _scored("e", "f", 0.49)]
+    )
+    assert [p.label for p in out] == [True, True, False]
+    assert all(p.source == "fake" for p in out)
+
+
+def test_fake_labeler_confidence_is_in_range_and_overconfident() -> None:
+    out = FakeLabeler(threshold=0.5).label([_scored("a", "b", 0.5), _scored("c", "d", 1.0)])
+    # Near-threshold pair: floor of 0.7 (over-confident on the ambiguous band).
+    assert out[0].confidence == pytest.approx(0.7)
+    # Far-from-threshold pair: higher, capped at 0.99.
+    assert out[1].confidence == pytest.approx(0.99)
+    assert all(p.confidence is not None and 0.0 <= p.confidence <= 1.0 for p in out)
+
+
+def test_fake_labeler_is_deterministic() -> None:
+    cands = [_scored("a", "b", 0.8), _scored("c", "d", 0.2)]
+    first = FakeLabeler().label(cands)
+    second = FakeLabeler().label(cands)
+    assert [(p.label, p.confidence) for p in first] == [(p.label, p.confidence) for p in second]
+
+
+def test_fake_labeler_zero_spend() -> None:
+    assert FakeLabeler().total_spent_usd == 0.0
+
+
+def test_fake_labeler_empty_returns_empty() -> None:
+    assert FakeLabeler().label([]) == []
+
+
+def test_fake_labeler_requires_similarity_score() -> None:
+    cand = ERCandidate[CompanySchema](
+        left=CompanySchema(id="a", name="a"),
+        right=CompanySchema(id="b", name="b"),
+        blocker_name="test",
+    )
+    with pytest.raises(ValueError, match="similarity_score"):
+        FakeLabeler().label([cand])
+
+
+@pytest.mark.parametrize("threshold", [-0.1, 1.1])
+def test_fake_labeler_rejects_out_of_range_threshold(threshold: float) -> None:
+    with pytest.raises(ValueError, match="threshold"):
+        FakeLabeler(threshold=threshold)

--- a/tests/examples/test_m1_bootstrap_fodors_zagat.py
+++ b/tests/examples/test_m1_bootstrap_fodors_zagat.py
@@ -1,0 +1,65 @@
+"""Deterministic proof that the M1 bootstrap pipeline runs end-to-end (real embeddings).
+
+Drives the importable core of ``examples/m1_bootstrap_fodors_zagat.py``
+(``run_bootstrap``) over the real Fodors-Zagat corpus with real sentence-transformer
+embeddings and the zero-spend :class:`FakeLabeler`. Asserts the M1-critical
+blocking signal (cross-source Pair-Completeness >= 0.95), that a non-empty gold set
+and a report with non-trivial agreement + calibration are produced, and that the
+gold set round-trips through ``save``/``load``.
+
+Marked ``slow`` (it loads an embedding model + builds a FAISS index) but
+network-free, so it runs in CI alongside the Person strong-path test. The gated
+real-GLM branch needs no key and is never exercised here.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from examples.m1_bootstrap_fodors_zagat import run_bootstrap
+from langres.bootstrap.models import GoldSet
+from langres.bootstrap.report import BootstrapReport
+
+pytestmark = pytest.mark.slow
+
+
+def test_bootstrap_end_to_end_is_deterministic_and_clears_gate(tmp_path) -> None:  # type: ignore[no-untyped-def]
+    """Pair-completeness clears 0.95; a non-empty gold set + report round-trip."""
+    results = run_bootstrap(tmp_path)
+
+    gold: GoldSet = results["gold"]
+    report: BootstrapReport = results["report"]
+
+    # 1. Blocking pair-completeness — the cross-source matches must survive blocking.
+    assert report.blocking.pair_completeness >= 0.95
+
+    # 2. A non-empty, labeled gold set was produced.
+    assert isinstance(gold, GoldSet)
+    assert len(gold.pairs) > 0
+    assert all(p.source == "fake" for p in gold.pairs)
+    assert gold.metadata["total_cost_usd"] == 0.0  # FakeLabeler never spends
+    # The fake teacher produced a real mix (not an all-positive / all-negative
+    # collapse), so the agreement numbers below are non-degenerate.
+    assert gold.metadata["matches"] > 0
+    assert gold.metadata["non_matches"] > 0
+
+    # 3. The report carries non-trivial agreement + calibration (FakeLabeler
+    #    disagrees with truth on the hard band, so neither is degenerate).
+    assert report.agreement is not None
+    assert report.agreement.n_evaluated > 0
+    assert report.calibration is not None
+    assert 0.0 <= report.calibration.brier <= 1.0
+
+    # 4. Gold-set save/reload round-trip is identical.
+    assert results["roundtrip_ok"] is True
+    assert results["gold_path"].exists()
+    assert results["reloaded"].model_dump() == gold.model_dump()
+
+
+def test_bootstrap_is_repeatable(tmp_path) -> None:  # type: ignore[no-untyped-def]
+    """Two independent runs produce identical labels (determinism)."""
+    first = run_bootstrap(tmp_path / "a")
+    second = run_bootstrap(tmp_path / "b")
+    assert [(p.left_id, p.right_id, p.label, p.confidence) for p in first["gold"].pairs] == [
+        (p.left_id, p.right_id, p.label, p.confidence) for p in second["gold"].pairs
+    ]


### PR DESCRIPTION
## What

The **integration wave** of M1: wires the merged Waves 1-3 pieces into one cold-start orchestrator and proves the loop end-to-end on Fodors-Zagat with **real embeddings, zero spend, full determinism**.

This is composition, not new machinery — it reuses Wave 1's data adapter, Wave 2's Miner/Labeler/HardNegativeMiner/TeacherLabeler, and Wave 3's BootstrapReport unchanged.

## The wiring

`Bootstrapper.build(corpus, *, candidate_filter=None, gold_clusters=None) -> (GoldSet, BootstrapReport)`:

1. Build the blocker's vector index from the corpus (using the blocker's own `schema_factory` + `text_field_extractor`, so the orchestrator is entity-type-agnostic).
2. `candidates = list(blocker.stream(corpus))` — materialize the single-pass iterator (the miner needs the full list for percentile strata).
3. Apply the caller's `candidate_filter` (e.g. cross-source).
4. `miner.mine(filtered)` → `labeler.label(mined)`.
5. Assemble `GoldSet` (honest counts + cost) and a `BootstrapReport` (pair-completeness on the filtered candidates + teacher-vs-truth agreement/calibration).

## Design-review compliance

- **W1** — `Bootstrapper` is a plain class with exactly 3 injected deps (`blocker`, `miner`, `labeler`); describable without "and".
- **W3** — the orchestrator builds the index itself (the private `Resolver._ensure_index_built` is unavailable) and materializes the candidate iterator before mining.
- **B2** — entity-type-agnostic: the Fodors-Zagat cross-source rule (`lambda c: c.left.source != c.right.source`) is passed IN as `candidate_filter`, not baked in.
- **B3** — the e2e example uses real `SentenceTransformerEmbedder("all-MiniLM-L6-v2")` + FAISS at `DEFAULT_BLOCKING_K=5`.

## FakeLabeler (CI stand-in for the teacher)

`GroundTruthLabeler` makes teacher-vs-truth agreement trivially 1.0, so it can't exercise the calibration report. `FakeLabeler` (new, in `labelers.py`, exported) labels by a similarity threshold and emits a deterministic, deliberately miscalibrated `confidence` (over-confident on the ambiguous near-threshold band) so agreement < 1 and Brier/ECE are non-trivial. `source="fake"`, no spend, fully deterministic. `GoldPairSource` is extended with `"fake"` (additive, backward-compatible).

## Measured e2e (deterministic, $0)

| Metric | Value |
|---|---|
| Blocking Pair-Completeness (cross-source) | **0.9911** (gate ≥ 0.95 ✓) |
| Teacher(fake)-vs-truth | acc=0.911, F1=0.915, kappa=MCC=0.821 (n=213) |
| Calibration | Brier=0.106, ECE=0.181 |
| Labels | 127 match / 1254 non-match |
| Cost | $0.0000 |
| GoldSet save→load round-trip | identical ✓ |

## Gated real-GLM branch (Wave 5)

`maybe_real_teacher()` behind `if os.getenv("OPENROUTER_API_KEY")` constructs a budget-capped `TeacherLabeler.from_env(...)` and notes that Wave 5 pins the GLM model/prices and runs it for real. It **only constructs** (never calls `.label()`), so it never spends or hits the network, and CI's pytest never calls `main()`.

## Tests / gates

- `tests/bootstrap/test_bootstrapper.py` (fast, no network): fake blocker/miner/labeler assert build() wires steps in order, builds the index, materializes the iterator, applies/omits the filter, handles gold_clusters present/absent, and records honest counts/cost. **100%** on `bootstrapper.py`.
- `tests/bootstrap/test_labelers.py`: FakeLabeler determinism, threshold correctness, confidence range, `similarity_score is None` guard. **100%** on the new code.
- `tests/examples/test_m1_bootstrap_fodors_zagat.py` (`@pytest.mark.slow`, real embeddings, runs in CI): asserts Pair-Completeness ≥ 0.95, a non-empty GoldSet + non-degenerate agreement/calibration, and the GoldSet round-trips.
- `uv run mypy src/` strict clean; `ruff check`/`format` clean.
- Full combined Waves 1-4 suite: **1078 passed, 0 failed**, overall coverage **98.87%** (gate 95%), **100%** on both new files.

## Integration notes (composing Waves 1-3)

- No source changes needed in Waves 1-3 — they composed cleanly. The only contract touch is the additive `GoldPairSource += "fake"`.
- Observation (not a bug): importing `langres.clients` auto-loads a repo `.env` into `os.environ`, so the example's `os.getenv("OPENROUTER_API_KEY")` gate sees a key even when the shell doesn't. Harmless here because the gated branch only constructs (no spend/call) and tests never invoke it.