### PR TITLE
M1 Wave 5: real GLM-5.2 teacher run + committed gold set + calibration fix

### DIFF
--- a/data/gold_sets/fodors_zagat/gold_set.json
+++ b/data/gold_sets/fodors_zagat/gold_set.json
@@ -1,0 +1,22130 @@
+{
+  "schema_version": "1",
+  "pairs": [
+    {
+      "left_id": "f534",
+      "right_id": "z219",
+      "label": true,
+      "source": "teacher",
+      "confidence": 1.0,
+      "reasoning": "Both records have the same restaurant name, city, and nearly identical address (one ends in \"blv.\", the other \"blvd.\"). The phone numbers are identical when normalized. The types differ (\"american\" vs \"steakhouses\"), but this is a common discrepancy across different sources (Fodor's vs Zagat) and Morton's is a well-known steakhouse, making \"american\" a plausible broader category.",
+      "provenance": {
+        "tokens": {
+          "prompt": 314,
+          "completion": 97
+        },
+        "cost_usd": 0.0006692,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f534",
+      "right_id": "z171",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The records refer to restaurants in different cities (Los Angeles vs. Atlanta), with completely different addresses and phone numbers. While they share a similar chain name (\"Morton's of Chicago\"), they are distinct locations of the same chain, not the same real-world restaurant.",
+      "provenance": {
+        "tokens": {
+          "prompt": 308,
+          "completion": 97
+        },
+        "cost_usd": 0.0006629,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f534",
+      "right_id": "z134",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The records refer to restaurants in entirely different cities (Los Angeles vs. Las Vegas) with different addresses, phone numbers, and slightly different names (\"arnie morton's\" vs \"morton's\"). These are clearly distinct real-world restaurant locations.",
+      "provenance": {
+        "tokens": {
+          "prompt": 312,
+          "completion": 177
+        },
+        "cost_usd": 0.0009471,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f534",
+      "right_id": "z6",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The two records have completely different names, addresses, phone numbers, and cuisine types. There is no overlap in any identifying information to suggest they refer to the same restaurant.",
+      "provenance": {
+        "tokens": {
+          "prompt": 295,
+          "completion": 142
+        },
+        "cost_usd": 0.0008067500000000001,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f535",
+      "right_id": "z220",
+      "label": true,
+      "source": "teacher",
+      "confidence": 1.0,
+      "reasoning": "The records share the exact same address, city, and phone number (only differing in phone formatting). The names \"art's delicatessen\" and \"art's deli\" are clear variants of the same establishment, and they come from different sources (Fodor's and Zagat), which is typical for duplicate records.",
+      "provenance": {
+        "tokens": {
+          "prompt": 282,
+          "completion": 244
+        },
+        "cost_usd": 0.0011501,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f535",
+      "right_id": "z237",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The records have completely different names (\"art's delicatessen\" vs \"pinot bistro\"), different addresses (12224 vs 12969 ventura blvd.), different phone numbers, and different cuisine types. These are clearly distinct restaurants.",
+      "provenance": {
+        "tokens": {
+          "prompt": 288,
+          "completion": 83
+        },
+        "cost_usd": 0.0005929,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f535",
+      "right_id": "z62",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The records have entirely different names (\"art's delicatessen\" vs \"sushi nozawa\"), addresses (12224 vs 11288 ventura blvd.), phone numbers, and cuisine types (american vs japanese). They are clearly different restaurants.",
+      "provenance": {
+        "tokens": {
+          "prompt": 287,
+          "completion": 99
+        },
+        "cost_usd": 0.0006478499999999999,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f535",
+      "right_id": "z57",
+      "label": true,
+      "source": "teacher",
+      "confidence": 1.0,
+      "reasoning": "The records have completely different names, addresses (different street numbers and cities), and phone numbers, clearly indicating they refer to two distinct restaurants.",
+      "provenance": {
+        "tokens": {
+          "prompt": 289,
+          "completion": 146
+        },
+        "cost_usd": 0.00081445,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f535",
+      "right_id": "z47",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The records have entirely different restaurant names, street addresses, cities, phone numbers, and cuisine types. There is no evidence to suggest they refer to the same real-world restaurant.",
+      "provenance": {
+        "tokens": {
+          "prompt": 282,
+          "completion": 157
+        },
+        "cost_usd": 0.0008456,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f536",
+      "right_id": "z221",
+      "label": true,
+      "source": "teacher",
+      "confidence": 1.0,
+      "reasoning": "Both records refer to the same restaurant. They have the same address, city, phone number (with minor formatting differences), and cuisine type. The names are just word-order variations of each other (\"hotel bel-air\" vs \"bel-air hotel\").",
+      "provenance": {
+        "tokens": {
+          "prompt": 276,
+          "completion": 113
+        },
+        "cost_usd": 0.0006853,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f536",
+      "right_id": "z4",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The two records refer to different restaurants. Record A is the Hotel Bel-Air located in Bel Air (701 Stone Canyon Rd), while Record B refers to \"The Belvedere,\" a restaurant located at the Peninsula Beverly Hills hotel in Beverly Hills (9882 Little Santa Monica Blvd). The addresses, cities, and phone numbers are all completely different.",
+      "provenance": {
+        "tokens": {
+          "prompt": 292,
+          "completion": 584
+        },
+        "cost_usd": 0.0023506,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f537",
+      "right_id": "z13",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The two records have completely different names (cafe bizou vs. cafe blanc), addresses, cities (sherman oaks vs. beverly hills), phone numbers, and restaurant types. There is no overlap in any identifying information.",
+      "provenance": {
+        "tokens": {
+          "prompt": 296,
+          "completion": 150
+        },
+        "cost_usd": 0.0008358,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f537",
+      "right_id": "z43",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The records have entirely different names (cafe bizou vs. maxwell's cafe), addresses, cities, phone numbers, and restaurant types. There is no overlap to suggest they refer to the same restaurant.",
+      "provenance": {
+        "tokens": {
+          "prompt": 290,
+          "completion": 154
+        },
+        "cost_usd": 0.0008435000000000001,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f539",
+      "right_id": "z13",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The records have completely different names, addresses, cities, and phone numbers, indicating they are two different restaurants.",
+      "provenance": {
+        "tokens": {
+          "prompt": 290,
+          "completion": 157
+        },
+        "cost_usd": 0.0008539999999999999,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f539",
+      "right_id": "z35",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The records have completely different names (chinois on main vs. la cachette), addresses (2709 main st. vs. 10506 little santa monica blvd.), cities (santa monica vs. century city), and phone numbers. They are clearly two different restaurants.",
+      "provenance": {
+        "tokens": {
+          "prompt": 287,
+          "completion": 191
+        },
+        "cost_usd": 0.00096985,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f539",
+      "right_id": "z5",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The records have completely different names (\"",
+      "provenance": {
+        "tokens": {
+          "prompt": 289,
+          "completion": 24
+        },
+        "cost_usd": 0.00038745,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f541",
+      "right_id": "z226",
+      "label": true,
+      "source": "teacher",
+      "confidence": 0.95,
+      "reasoning": "The phone numbers match exactly, and the addresses are identical (8358 sunset blvd). The city names are variations of the same area (Hollywood vs West Hollywood), and the name \"fenix at the argyle\" indicates the restaurant \"fenix\" is located in the Argyle hotel.",
+      "provenance": {
+        "tokens": {
+          "prompt": 293,
+          "completion": 313
+        },
+        "cost_usd": 0.0014031500000000001,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f541",
+      "right_id": "z18",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The records have completely different names, addresses, phone numbers, and restaurant types, indicating they refer to different real-world restaurants.",
+      "provenance": {
+        "tokens": {
+          "prompt": 283,
+          "completion": 122
+        },
+        "cost_usd": 0.00072415,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f542",
+      "right_id": "z227",
+      "label": true,
+      "source": "teacher",
+      "confidence": 1.0,
+      "reasoning": "Both records have identical names (\"granita\"), addresses (\"23725 w. malibu rd.\"), cities (\"malibu\"), and restaurant types (\"californian\"). The phone numbers match exactly when normalized (310/456-0488 vs 310-456-0488). The only differences are the source (fodors vs zagat) and phone formatting, which are expected when comparing across different restaurant guides. These definitively refer to the same real-world restaurant.",
+      "provenance": {
+        "tokens": {
+          "prompt": 286,
+          "completion": 174
+        },
+        "cost_usd": 0.0009093,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f542",
+      "right_id": "z31",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The records have completely different names (\"granita\" vs \"johnny rockets\"), addresses, cities(malibu vs la), phone numbers, and cuisine types. There is no overlap in any attribute.",
+      "provenance": {
+        "tokens": {
+          "prompt": 282,
+          "completion": 74
+        },
+        "cost_usd": 0.0005551,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f542",
+      "right_id": "z56",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The records have completely different names (granita vs. rae's), addresses, cities, and phone numbers. There is no overlap in any identifying information.",
+      "provenance": {
+        "tokens": {
+          "prompt": 285,
+          "completion": 178
+        },
+        "cost_usd": 0.0009222499999999999,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f543",
+      "right_id": "z228",
+      "label": true,
+      "source": "teacher",
+      "confidence": 0.95,
+      "reasoning": "The phone numbers are identical and the street addresses are exactly the same. The city differs slightly, but Beverly Hills is commonly associated with the Los Angeles area, and the street address confirms the same location. The name in Record B appears to be a truncated or slightly mangled version of Record A's name.",
+      "provenance": {
+        "tokens": {
+          "prompt": 291,
+          "completion": 318
+        },
+        "cost_usd": 0.0014185499999999998,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f543",
+      "right_id": "z67",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The records have completely different names (\"grill on the alley\" vs \"water grill\"), addresses, phone numbers, and cuisine types, indicating they are two distinct restaurants in Los Angeles.",
+      "provenance": {
+        "tokens": {
+          "prompt": 284,
+          "completion": 271
+        },
+        "cost_usd": 0.0012467,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f543",
+      "right_id": "z303",
+      "label": true,
+      "source": "teacher",
+      "confidence": 1.0,
+      "reasoning": "The two records refer to entirely different restaurants. They have different names, are located in different cities (Los Angeles vs. Atlanta), have different addresses, and have different phone numbers. There is no overlapping information to suggest they are the same entity.",
+      "provenance": {
+        "tokens": {
+          "prompt": 289,
+          "completion": 201
+        },
+        "cost_usd": 0.00100695,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f543",
+      "right_id": "z51",
+      "label": true,
+      "source": "teacher",
+      "confidence": 1.0,
+      "reasoning": "The records have completely different names, addresses, cities, phone numbers, and cuisine types. They clearly refer to different restaurants.",
+      "provenance": {
+        "tokens": {
+          "prompt": 291,
+          "completion": 109
+        },
+        "cost_usd": 0.00068705,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f544",
+      "right_id": "z229",
+      "label": true,
+      "source": "teacher",
+      "confidence": 0.98,
+      "reasoning": "The records have identical phone numbers (just different formatting) and the same street address (1972 Hillhurst Ave, with a minor difference in the \"n.\" prefix). \"Los Feliz\" is a neighborhood within Los Angeles, so the city difference is not a conflict. The names \"restaurant katsu\" and \"katsu\" are nearly identical, and the cuisine types (asian and japanese) are compatible.",
+      "provenance": {
+        "tokens": {
+          "prompt": 282,
+          "completion": 249
+        },
+        "cost_usd": 0.0011676,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f544",
+      "right_id": "z148",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The records have completely different names, addresses, cities, phone numbers, and types. They are clearly distinct restaurants.",
+      "provenance": {
+        "tokens": {
+          "prompt": 295,
+          "completion": 58
+        },
+        "cost_usd": 0.00051275,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f545",
+      "right_id": "z230",
+      "label": true,
+      "source": "teacher",
+      "confidence": 1.0,
+      "reasoning": "Both records have the same name, street address, and phone number (with only minor formatting differences). The city differs (\"los angeles\" vs. \"w. hollywood\"), but 903 N La Cienega Blvd is located in the West Hollywood area of Los Angeles, which frequently causes neighborhood and city naming overlaps. The cuisine types also align.",
+      "provenance": {
+        "tokens": {
+          "prompt": 311,
+          "completion": 268
+        },
+        "cost_usd": 0.0012645500000000001,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f545",
+      "right_id": "z231",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The restaurants have completely different names (l'orangerie vs le chardonnay), addresses (903 n. la cienega blvd vs 8284 melrose ave), and phone numbers (310/652-9770 vs 213-655-8880). Despite being French restaurants in Los Angeles, there is no evidence linking these two records to the same establishment.",
+      "provenance": {
+        "tokens": {
+          "prompt": 310,
+          "completion": 161
+        },
+        "cost_usd": 0.000889,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f546",
+      "right_id": "z231",
+      "label": true,
+      "source": "teacher",
+      "confidence": 1.0,
+      "reasoning": "The records have identical names (excluding the city clarifier in B), identical addresses (\"8284 melrose ave.\"), identical cities (\"los angeles\"), and identical phone numbers (just formatted differently: \"213/655-8880\" vs \"213-655-8880\"). The cuisine types (\"french\" vs \"french bistro\") are highly compatible. These records definitely refer to the same real-world restaurant.",
+      "provenance": {
+        "tokens": {
+          "prompt": 301,
+          "completion": 135
+        },
+        "cost_usd": 0.0007885500000000001,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f547",
+      "right_id": "z232",
+      "label": true,
+      "source": "teacher",
+      "confidence": 1.0,
+      "reasoning": "Both records have the exact same name (locanda veneta), city (los angeles), cuisine type (italian), and phone number (310-274-1893 vs 310/274-1893). The address in Record B (8638 w. third st.) simply provides the full street number and a more complete street name compared to Record A's \"3rd st.\". Different sources (fodors vs zagat) further supports these being two descriptions of the same real-world restaurant.",
+      "provenance": {
+        "tokens": {
+          "prompt": 281,
+          "completion": 246
+        },
+        "cost_usd": 0.00115605,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f548",
+      "right_id": "z16",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The records have completely different names (matsuhisa vs diaghilev), addresses, cities, phone numbers, and cuisine types (asian vs russian). There is no overlap in any identifying fields.",
+      "provenance": {
+        "tokens": {
+          "prompt": 302,
+          "completion": 114
+        },
+        "cost_usd": 0.0007161000000000001,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f548",
+      "right_id": "z4",
+      "label": true,
+      "source": "teacher",
+      "confidence": 1.0,
+      "reasoning": "The restaurants have completely different names, addresses, phone numbers, and types. There is no overlap in identifying information, indicating they are different establishments in Beverly Hills.",
+      "provenance": {
+        "tokens": {
+          "prompt": 306,
+          "completion": 115
+        },
+        "cost_usd": 0.0007238,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f548",
+      "right_id": "z230",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The records have completely different restaurant names (matsuhisa vs. l'orangerie), addresses (129 vs. 903 n. la cienega blvd.), and cuisine types (asian vs. french). They are clearly different establishments.",
+      "provenance": {
+        "tokens": {
+          "prompt": 309,
+          "completion": 194
+        },
+        "cost_usd": 0.00100345,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f549",
+      "right_id": "z234",
+      "label": true,
+      "source": "teacher",
+      "confidence": 1.0,
+      "reasoning": "The records have identical street addresses and matching phone numbers (differing only in punctuation). The names are clearly the same restaurant, and the types (\"american\" and \"steakhouses\") are compatible. The cities differ slightly (\"los angeles\" vs \"w. hollywood\"), but West Hollywood is in the Los Angeles area and the exact address and phone confirm they are the same location.",
+      "provenance": {
+        "tokens": {
+          "prompt": 297,
+          "completion": 228
+        },
+        "cost_usd": 0.0011098500000000001,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f549",
+      "right_id": "z56",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The restaurant names (\"the palm\" vs \"rae's\"), addresses (\"9001 santa monica blvd.\" vs \"2901 pico blvd.\"), cities (\"los angeles\" vs \"santa monica\"), phone numbers, and types (\"american\" vs \"diners\") are entirely different. There is no overlap in any identifying information.",
+      "provenance": {
+        "tokens": {
+          "prompt": 282,
+          "completion": 225
+        },
+        "cost_usd": 0.0010836,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f549",
+      "right_id": "z35",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The two records have completely different names (\"the palm\" vs \"la cachette\"), addresses (9001 santa monica blvd. vs 10506 little santa monica blvd.), cities (los angeles vs century city), and phone numbers.",
+      "provenance": {
+        "tokens": {
+          "prompt": 286,
+          "completion": 182
+        },
+        "cost_usd": 0.0009373000000000001,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f550",
+      "right_id": "z63",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The records have completely different names (\"patina\" vs \"sweet lady jane\"), different addresses (5955 vs 8360 melrose ave.), different phone numbers, and different cuisine types (californian vs desserts). These are clearly two distinct restaurants on the same street.",
+      "provenance": {
+        "tokens": {
+          "prompt": 276,
+          "completion": 112
+        },
+        "cost_usd": 0.0006818,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f551",
+      "right_id": "z236",
+      "label": true,
+      "source": "teacher",
+      "confidence": 1.0,
+      "reasoning": "The restaurant names are nearly identical (\"philippe's the original\" vs \"philippe the original\"), the street addresses match exactly, and the phone numbers are the same with just different formatting. The city discrepancy (\"los angeles\" vs \"chinatown\") is explained by Chinatown being the neighborhood in Los Angeles where this famously historic restaurant is located.",
+      "provenance": {
+        "tokens": {
+          "prompt": 296,
+          "completion": 300
+        },
+        "cost_usd": 0.0013608,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f551",
+      "right_id": "z6",
+      "label": true,
+      "source": "teacher",
+      "confidence": 1.0,
+      "reasoning": "The records have completely different names, addresses, and phone numbers. Philippe's the original and Bernard's are distinct restaurants in Los Angeles.",
+      "provenance": {
+        "tokens": {
+          "prompt": 288,
+          "completion": 215
+        },
+        "cost_usd": 0.0010549000000000001,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f551",
+      "right_id": "z230",
+      "label": true,
+      "source": "teacher",
+      "confidence": 1.0,
+      "reasoning": "The two records have completely different restaurant names, addresses, cities, phone numbers, and cuisines. Philippe's the Original is a famous American restaurant in Los Angeles, while L'Orangerie was a classic French restaurant in West Hollywood. They are definitively different establishments.",
+      "provenance": {
+        "tokens": {
+          "prompt": 306,
+          "completion": 134
+        },
+        "cost_usd": 0.0007903000000000001,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f552",
+      "right_id": "z237",
+      "label": true,
+      "source": "teacher",
+      "confidence": 1.0,
+      "reasoning": "The name, street address, and phone number are identical. The difference in city is because Studio City is a neighborhood within Los Angeles. The type is a slight variation (\"french\" vs \"french bistro\"), but all other attributes match perfectly, confirming they refer to the same real-world restaurant.",
+      "provenance": {
+        "tokens": {
+          "prompt": 290,
+          "completion": 238
+        },
+        "cost_usd": 0.0011375,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f553",
+      "right_id": "z6",
+      "label": true,
+      "source": "teacher",
+      "confidence": 1.0,
+      "reasoning": "The two records have completely different names, addresses, phone numbers, and types of cuisine. They are located on the same street but at different street numbers, indicating they are distinct establishments.",
+      "provenance": {
+        "tokens": {
+          "prompt": 284,
+          "completion": 212
+        },
+        "cost_usd": 0.0010402,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f553",
+      "right_id": "z232",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The records have completely different names, addresses, and phone numbers, with no overlap or similarity in any identifying fields.",
+      "provenance": {
+        "tokens": {
+          "prompt": 289,
+          "completion": 50
+        },
+        "cost_usd": 0.00047844999999999995,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f554",
+      "right_id": "z239",
+      "label": true,
+      "source": "teacher",
+      "confidence": 0.92,
+      "reasoning": "The restaurant name (\"spago\" vs \"spago (los angeles)\"), phone number (310/652-4025 vs 310-652-4025), and cuisine type (californian) all match exactly. The cities (\"los angeles\" vs \"w. hollywood\") are adjacent/overlapping, a common discrepancy in this area. The addresses differ, but Horn Ave and Sunset Blvd intersect in West Hollywood, and Spago famously operated on Sunset Blvd; the discrepancy likely reflects a move or a nearby/misrecorded address. The matching phone number and name strongly indicate the same real-world restaurant.",
+      "provenance": {
+        "tokens": {
+          "prompt": 289,
+          "completion": 361
+        },
+        "cost_usd": 0.00156695,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f554",
+      "right_id": "z137",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "Although both restaurants share the name \"Spago\" and are classified as Californian cuisine, they are located in different cities (Los Angeles vs. Las Vegas), have completely different addresses, and different phone numbers. These are distinct branches of the same restaurant brand.",
+      "provenance": {
+        "tokens": {
+          "prompt": 287,
+          "completion": 103
+        },
+        "cost_usd": 0.00066185,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f555",
+      "right_id": "z56",
+      "label": true,
+      "source": "teacher",
+      "confidence": 1.0,
+      "reasoning": "The records have different names (valentino vs rae's), different addresses (3115 pico blvd vs 2901 pico blvd), different phone numbers, and different cuisine types. They are definitively different restaurants on the same street.",
+      "provenance": {
+        "tokens": {
+          "prompt": 285,
+          "completion": 219
+        },
+        "cost_usd": 0.00106575,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f555",
+      "right_id": "z13",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The restaurant names, addresses, cities, phone numbers, and cuisine types are all completely different. There is no evidence to suggest these records refer to the same establishment.",
+      "provenance": {
+        "tokens": {
+          "prompt": 292,
+          "completion": 399
+        },
+        "cost_usd": 0.0017031,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f555",
+      "right_id": "z4",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The records have completely different names (\"valentino\" vs \"belvedere the\"), addresses (\"3115 pico blvd\" vs \"9882 little santa monica blvd\"), cities (\"santa monica\" vs \"beverly hills\"), phone numbers, and restaurant types. There are no matching attributes to suggest they refer to the same restaurant.",
+      "provenance": {
+        "tokens": {
+          "prompt": 297,
+          "completion": 327
+        },
+        "cost_usd": 0.00145635,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f556",
+      "right_id": "z241",
+      "label": true,
+      "source": "teacher",
+      "confidence": 0.95,
+      "reasoning": "The restaurant names, phone numbers, and addresses are identical (with minor formatting variations). The city discrepancy is likely due to one source using the broader metro area (\"los angeles\") while the other uses the actual municipality (\"pasadena\"). The cuisine types are also compatible.",
+      "provenance": {
+        "tokens": {
+          "prompt": 298,
+          "completion": 176
+        },
+        "cost_usd": 0.0009289000000000001,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f556",
+      "right_id": "z197",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The two records have completely different names, addresses, phone numbers, and are located in different cities (Los Angeles vs. San Francisco). There is no overlap in any identifying information.",
+      "provenance": {
+        "tokens": {
+          "prompt": 294,
+          "completion": 174
+        },
+        "cost_usd": 0.0009177,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f556",
+      "right_id": "z144",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The records have completely different names, cities, addresses, phone numbers, and restaurant types. There is no overlap in any identifying information.",
+      "provenance": {
+        "tokens": {
+          "prompt": 302,
+          "completion": 152
+        },
+        "cost_usd": 0.0008491,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f557",
+      "right_id": "z242",
+      "label": true,
+      "source": "teacher",
+      "confidence": 0.99,
+      "reasoning": "Both records have the exact same restaurant name and address. The phone numbers match (only formatting differs). The cities \"new york\" and \"new york city\" are synonymous, and the cuisine types are highly compatible. It is highly certain these refer to the same real-world restaurant.",
+      "provenance": {
+        "tokens": {
+          "prompt": 280,
+          "completion": 271
+        },
+        "cost_usd": 0.0012425,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f557",
+      "right_id": "z264",
+      "label": true,
+      "source": "teacher",
+      "confidence": 1.0,
+      "reasoning": "The records have completely different names (\"21 club\" vs \"manhattan ocean club\"), different addresses (\"21 w. 52nd st.\" vs \"57 w. 58th st.\"), different phone numbers, and different cuisine types. There is no overlap indicating these are the same restaurant.",
+      "provenance": {
+        "tokens": {
+          "prompt": 283,
+          "completion": 96
+        },
+        "cost_usd": 0.0006331500000000001,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f558",
+      "right_id": "z243",
+      "label": true,
+      "source": "teacher",
+      "confidence": 1.0,
+      "reasoning": "The records have identical names, addresses, and matching phone numbers (just formatted differently). The city names are synonymous (\"new york\" vs \"new york city\"), and the types (\"continental\" vs \"scandinavian\") represent overlapping cuisines for a restaurant that is famously Scandinavian.",
+      "provenance": {
+        "tokens": {
+          "prompt": 282,
+          "completion": 322
+        },
+        "cost_usd": 0.0014231,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f558",
+      "right_id": "z269",
+      "label": true,
+      "source": "teacher",
+      "confidence": 1.0,
+      "reasoning": "The two records have completely different names (aquavit vs oceana), different addresses (13w. 54th st. vs 55 e. 54th st.), different phone numbers, and different cuisine types. These are clearly two distinct restaurants in New York City.",
+      "provenance": {
+        "tokens": {
+          "prompt": 281,
+          "completion": 191
+        },
+        "cost_usd": 0.0009635500000000001,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f559",
+      "right_id": "z244",
+      "label": true,
+      "source": "teacher",
+      "confidence": 1.0,
+      "reasoning": "Both records have the exact same name (\"aureole\") and address (\"34 e. 61st st.\"), and the phone numbers match exactly aside from punctuation (\"212/ 319-1660\" vs \"212-319-1660\"). The city (\"new york\" vs \"new york city\") and type (\"american\" vs \"american (new)\") are equivalent or highly related. These are definitively the same real-world restaurant.",
+      "provenance": {
+        "tokens": {
+          "prompt": 285,
+          "completion": 327
+        },
+        "cost_usd": 0.00144375,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f560",
+      "right_id": "z245",
+      "label": true,
+      "source": "teacher",
+      "confidence": 0.99,
+      "reasoning": "The restaurant names match exactly, the addresses are identical, and the phone numbers are the same with only formatting differences (slash vs hyphen). The city fields are equivalent (\"new york\" vs \"new york city\"). The types are also semantically similar. Different sources (Fodor's and Zagat) further support that these are independent listings for the same real-world restaurant.",
+      "provenance": {
+        "tokens": {
+          "prompt": 289,
+          "completion": 133
+        },
+        "cost_usd": 0.00076895,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f561",
+      "right_id": "z246",
+      "label": true,
+      "source": "teacher",
+      "confidence": 0.99,
+      "reasoning": "The restaurant names and addresses are identical. The phone numbers match when accounting for formatting differences (slash vs. dash). The city variation (\"new york\" vs \"new york city\") refers to the same location, and the cuisine types are compatible (continental vs. french classic). Different sources (Fodors and Zagat) further indicate these are listings for the same real-world restaurant.",
+      "provenance": {
+        "tokens": {
+          "prompt": 293,
+          "completion": 209
+        },
+        "cost_usd": 0.00103915,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f561",
+      "right_id": "z270",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The restaurant names, addresses, phone numbers, and cuisine types are completely different. Cafe des Artistes is located at 1 W. 67th St., while Park Avenue Cafe is at 100 E. 63rd St. They are clearly two distinct restaurants.",
+      "provenance": {
+        "tokens": {
+          "prompt": 296,
+          "completion": 239
+        },
+        "cost_usd": 0.0011473,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f562",
+      "right_id": "z247",
+      "label": true,
+      "source": "teacher",
+      "confidence": 1.0,
+      "reasoning": "The records have the exact same restaurant name (\"carmine's\"), cuisine type (\"italian\"), and phone number (with slight formatting differences). The addresses match perfectly, with Record A providing additional cross-street details, and the cities (\"new york\" and \"new york city\") are geographically equivalent.",
+      "provenance": {
+        "tokens": {
+          "prompt": 296,
+          "completion": 222
+        },
+        "cost_usd": 0.0010878,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f563",
+      "right_id": "z248",
+      "label": true,
+      "source": "teacher",
+      "confidence": 1.0,
+      "reasoning": "Both records refer to \"carnegie deli\" at 854 7th Ave. in New York with the same phone number (212-757-2245). The differences in \"7th\" vs \"seventh\", \"new york\" vs \"new york city\", and \"delicatessen\" vs \"delis\" are just formatting variations.",
+      "provenance": {
+        "tokens": {
+          "prompt": 306,
+          "completion": 207
+        },
+        "cost_usd": 0.0010458,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f564",
+      "right_id": "z249",
+      "label": true,
+      "source": "teacher",
+      "confidence": 1.0,
+      "reasoning": "Both records share the same name, exact address, and identical phone number (just formatted differently). The city names \"new york\" and \"new york city\" are synonymous, and minor differences in cuisine type classification are common between different sources like Fodors and Zagat.",
+      "provenance": {
+        "tokens": {
+          "prompt": 287,
+          "completion": 260
+        },
+        "cost_usd": 0.00121135,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f564",
+      "right_id": "z250",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The records have completely different restaurant names (chanterelle vs. daniel), addresses (2 harrison st. vs. 20 e. 76th st.), and phone numbers. They are clearly two different restaurants in New York City.",
+      "provenance": {
+        "tokens": {
+          "prompt": 290,
+          "completion": 124
+        },
+        "cost_usd": 0.0007385,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f565",
+      "right_id": "z250",
+      "label": true,
+      "source": "teacher",
+      "confidence": 1.0,
+      "reasoning": "The restaurant name, street address, and phone number are identical (with minor formatting differences in the phone number). The cities \"new york\" and \"new york city\" are equivalent, and the types \"french\" and \"french (new)\" are highly consistent. These records clearly refer to the same restaurant.",
+      "provenance": {
+        "tokens": {
+          "prompt": 283,
+          "completion": 250
+        },
+        "cost_usd": 0.00117215,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f566",
+      "right_id": "z251",
+      "label": true,
+      "source": "teacher",
+      "confidence": 1.0,
+      "reasoning": "Identical name, identical address, and identical phone number (just formatting difference). \"New York\" vs \"New York City\" and \"Asian\" vs \"Indian\" are minor compatible variations between different sources.",
+      "provenance": {
+        "tokens": {
+          "prompt": 282,
+          "completion": 87
+        },
+        "cost_usd": 0.0006006,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f566",
+      "right_id": "z121",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The two records have completely different names (dawat vs. yama), addresses (210 e. 58th st. vs. 122 e. 17th st.), phone numbers, and cuisine types. There is no overlap in any identifying information.",
+      "provenance": {
+        "tokens": {
+          "prompt": 281,
+          "completion": 88
+        },
+        "cost_usd": 0.0006030499999999999,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f567",
+      "right_id": "z252",
+      "label": true,
+      "source": "teacher",
+      "confidence": 1.0,
+      "reasoning": "The restaurant name, address, cuisine type, and phone number all match perfectly, with only minor formatting differences in the phone number (slash vs hyphen) and the city name (\"new york\" vs \"new york city\"). These are standard variations representing the same real-world entity.",
+      "provenance": {
+        "tokens": {
+          "prompt": 284,
+          "completion": 425
+        },
+        "cost_usd": 0.0017856999999999999,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f568",
+      "right_id": "z253",
+      "label": true,
+      "source": "teacher",
+      "confidence": 0.99,
+      "reasoning": "Both records refer to the famous Four Seasons restaurant located at 99 E. 52nd St. in New York. The address and phone number are identical, and the names \"four seasons\" and \"four seasons grill room\" refer to the same establishment (the Grill Room being a main dining area of the Four Seasons). The city and type are also highly consistent.",
+      "provenance": {
+        "tokens": {
+          "prompt": 286,
+          "completion": 275
+        },
+        "cost_usd": 0.0012628000000000001,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f568",
+      "right_id": "z120",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The records have completely different names, addresses, phone numbers, and cuisine types. They are clearly two different restaurants in New York.",
+      "provenance": {
+        "tokens": {
+          "prompt": 293,
+          "completion": 112
+        },
+        "cost_usd": 0.00069965,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f568",
+      "right_id": "z91",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The records have completely different names, addresses, cities, phone numbers, and cuisine types. There is no overlap in any field, indicating they are clearly different restaurants.",
+      "provenance": {
+        "tokens": {
+          "prompt": 283,
+          "completion": 73
+        },
+        "cost_usd": 0.00055265,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f569",
+      "right_id": "z254",
+      "label": true,
+      "source": "teacher",
+      "confidence": 1.0,
+      "reasoning": "The restaurant names and addresses matchexactly. The phone numbers match exactly aside from standard formatting variations. The cities (\"new york\" and \"new york city\") are equivalent, and the cuisine types are highly compatible. The different sources (\"fodors\" vs \"zagat\") indicate these are duplicate records from different datasets.",
+      "provenance": {
+        "tokens": {
+          "prompt": 298,
+          "completion": 367
+        },
+        "cost_usd": 0.0015974,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f570",
+      "right_id": "z255",
+      "label": true,
+      "source": "teacher",
+      "confidence": 1.0,
+      "reasoning": "The names are identical, the phone numbers match exactly, and the addresses are consistent (\"42 e. 20th st.\" is a subset of the more detailed address in Record A). The cities (\"new york\" vs \"new york city\") and restaurant types (\"american\" vs \"american (new)\") are also compatible variations. These factors make it certain these records refer to the same real-world restaurant.",
+      "provenance": {
+        "tokens": {
+          "prompt": 309,
+          "completion": 197
+        },
+        "cost_usd": 0.00101395,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f570",
+      "right_id": "z282",
+      "label": true,
+      "source": "teacher",
+      "confidence": 1.0,
+      "reasoning": "The records have completely different names (\"gramercy tavern\" vs \"tavern on the green\"), addresses (\"42 e. 20th st.\" vs \"central park west\"), and phone numbers. They are two distinct well-known restaurants in New York City.",
+      "provenance": {
+        "tokens": {
+          "prompt": 302,
+          "completion": 207
+        },
+        "cost_usd": 0.0010416,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f571",
+      "right_id": "z256",
+      "label": true,
+      "source": "teacher",
+      "confidence": 1.0,
+      "reasoning": "Both records have the exact same restaurant name (\"island spice\"), street address (\"402 w. 44th st.\"), and phone number (212/765-1737 and 212-765-1737 are identical). The cities (\"new york\" and \"new york city\") and cuisine types (\"tel caribbean\" and \"caribbean\") are also matching equivalents.",
+      "provenance": {
+        "tokens": {
+          "prompt": 288,
+          "completion": 276
+        },
+        "cost_usd": 0.0012684,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f572",
+      "right_id": "z257",
+      "label": true,
+      "source": "teacher",
+      "confidence": 0.99,
+      "reasoning": "The name and address match exactly, and the phone numbers are identical despite minor formatting differences. The cities \"new york\" and \"new york city\" refer to the same location. The different cuisine types (\"american\" vs \"french bistro\") can be attributed to different editorial perspectives from the Fodors and Zagat guides.",
+      "provenance": {
+        "tokens": {
+          "prompt": 283,
+          "completion": 489
+        },
+        "cost_usd": 0.00200865,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f572",
+      "right_id": "z250",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The restaurant names (\"jo jo\" vs \"daniel\"), addresses (\"160 e. 64th st.\" vs \"20 e. 76th st.\"), and phone numbers are completely different. They are clearly distinct restaurants in New York.",
+      "provenance": {
+        "tokens": {
+          "prompt": 282,
+          "completion": 264
+        },
+        "cost_usd": 0.0012201000000000002,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f573",
+      "right_id": "z258",
+      "label": true,
+      "source": "teacher",
+      "confidence": 1.0,
+      "reasoning": "Both records have the exact same name (\"la caravelle\"), same street address (\"33 w. 55th st.\"), same phone number (just formatted differently), and compatible city (\"new york\" vs \"new york city\") and type (\"french\" vs \"french (classic)\"). These are clearly the same real-world restaurant.",
+      "provenance": {
+        "tokens": {
+          "prompt": 292,
+          "completion": 140
+        },
+        "cost_usd": 0.0007966,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f573",
+      "right_id": "z90",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The restaurant names, addresses, and phone numbers are completely different. \"La Caravelle\" and \"La Grenouille\" are two distinct French restaurants in New York City.",
+      "provenance": {
+        "tokens": {
+          "prompt": 290,
+          "completion": 214
+        },
+        "cost_usd": 0.0010535,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f574",
+      "right_id": "z259",
+      "label": true,
+      "source": "teacher",
+      "confidence": 1.0,
+      "reasoning": "The records have identical restaurant names,matching street addresses, synonymous city names (\"new york\" vs \"new york city\"), and identical phone numbers with slightly different formatting. The restaurant types (\"french\" and \"french (classic)\") are also perfectly compatible. These clearly refer to the same real-world restaurant.",
+      "provenance": {
+        "tokens": {
+          "prompt": 318,
+          "completion": 210
+        },
+        "cost_usd": 0.0010689,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f574",
+      "right_id": "z258",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The restaurant names are completely different (\"la cote basque\" vs \"la caravelle\"), the street addresses are different (60 W 55th St vs 33 W 55th St), and the phone numbers are different. These are two distinct classic French restaurants in New York City.",
+      "provenance": {
+        "tokens": {
+          "prompt": 316,
+          "completion": 275
+        },
+        "cost_usd": 0.0012943,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f574",
+      "right_id": "z272",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The restaurant names, addresses, phone numbers, and cuisine types are completely different. These refer to two distinct restaurants in New York.",
+      "provenance": {
+        "tokens": {
+          "prompt": 313,
+          "completion": 248
+        },
+        "cost_usd": 0.00119665,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f575",
+      "right_id": "z260",
+      "label": true,
+      "source": "teacher",
+      "confidence": 1.0,
+      "reasoning": "The records have identical names and addresses. The phone numbers match except for formatting (slashes vs hyphens). The city names \"new york\" and \"new york city\" refer to the same location. The type differs (french vs seafood), but Le Bernardin is famously a French seafood restaurant, so these are compatible. The sources are different (Fodors vs Zagat), which is expected for duplicate records. All key identifying information aligns perfectly.",
+      "provenance": {
+        "tokens": {
+          "prompt": 283,
+          "completion": 146
+        },
+        "cost_usd": 0.0008081499999999999,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f575",
+      "right_id": "z261",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The restaurant names are completely different (\"le bernardin\" vs \"les celebrites\"), the street addresses are on different streets (51st st. vs 58th st.), and the phone numbers do not match. Despite both being French restaurants in New York, there is no evidence these records refer to the same establishment.",
+      "provenance": {
+        "tokens": {
+          "prompt": 287,
+          "completion": 274
+        },
+        "cost_usd": 0.00126035,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f576",
+      "right_id": "z261",
+      "label": true,
+      "source": "teacher",
+      "confidence": 0.98,
+      "reasoning": "The restaurant names are an exact match, the phone numbers are identical (ignoring formatting differences), and the cuisine types are a close match (French vs French classic). The addresses differ but refer to the same location (the Essex House hotel), where \"160 Central Park S\" and \"155 W. 58th St.\" are often used interchangeably as the building's address.",
+      "provenance": {
+        "tokens": {
+          "prompt": 282,
+          "completion": 499
+        },
+        "cost_usd": 0.0020426,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f577",
+      "right_id": "z262",
+      "label": true,
+      "source": "teacher",
+      "confidence": 0.99,
+      "reasoning": "The two records have matching addresses (\"2 e. 55th st.\") and matching phone numbers (\"212/339-6719\" vs \"212-339-6719\", just formatted differently). The names are also highly similar (\"lespinasse\" vs \"lespinasse (new york city)\"). The difference in cuisine type is minor compared to the exact address and phone number match.",
+      "provenance": {
+        "tokens": {
+          "prompt": 294,
+          "completion": 237
+        },
+        "cost_usd": 0.0011382,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f577",
+      "right_id": "z261",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The restaurants have different names (\"lespinasse\" vs \"les celebrites\"), different addresses (\"2 e. 55th st.\" vs \"155 w. 58th st.\"), different phone numbers (\"212/339-6719\" vs \"212-484-5113\"), and different types (\"american\" vs \"french (Classic)\"). There is no indication these refer to the same real-world restaurant.",
+      "provenance": {
+        "tokens": {
+          "prompt": 287,
+          "completion": 216
+        },
+        "cost_usd": 0.0010573499999999999,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f577",
+      "right_id": "z258",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The records have completely different restaurant names (\"lespinasse\" vs \"la caravelle\"), different street addresses (\"2 e. 55th st.\" vs \"33 w. 55th st.\"), and different phone numbers. They are distinct restaurants on the same street.",
+      "provenance": {
+        "tokens": {
+          "prompt": 289,
+          "completion": 209
+        },
+        "cost_usd": 0.00103495,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f578",
+      "right_id": "z263",
+      "label": true,
+      "source": "teacher",
+      "confidence": 1.0,
+      "reasoning": "The records have identical restaurant names (\"lutece\"), identical street addresses (\"249 e. 50th st.\"), and matching phone numbers (only formatting differs between \"212/752-2225\" and \"212-752-2225\"). The cities are semantically equivalent (\"new york\" vs \"new york city\"), and the cuisine types are consistent (\"french\" vs \"french (classic)\"). The different sources (fodors vs zagat) confirm these are independent listings of the same real-world restaurant.",
+      "provenance": {
+        "tokens": {
+          "prompt": 290,
+          "completion": 273
+        },
+        "cost_usd": 0.00126,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f579",
+      "right_id": "z264",
+      "label": true,
+      "source": "teacher",
+      "confidence": 1.0,
+      "reasoning": "Both records have the same name, address, phone number (formatting aside), and restaurant type. The city difference (\"new york\" vs. \"new york city\") is a trivial variation. The sources differ (Fodor's vs. Zagat), which is expected for matching records across different datasets.",
+      "provenance": {
+        "tokens": {
+          "prompt": 290,
+          "completion": 105
+        },
+        "cost_usd": 0.0006720000000000001,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f579",
+      "right_id": "z269",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.1,
+      "reasoning": "The restaurants have different names (\"manhattan ocean club\" vs \"oceana\"), different addresses (\"57 w. 58th st.\" vs \"55 e. 54th st.\"), and different phone numbers. While both are seafood restaurants in New York, the distinct identifying details indicate they are different establishments.",
+      "provenance": {
+        "tokens": {
+          "prompt": 287,
+          "completion": 144
+        },
+        "cost_usd": 0.00080535,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f580",
+      "right_id": "z265",
+      "label": true,
+      "source": "teacher",
+      "confidence": 1.0,
+      "reasoning": "Both records have the exact same name (\"march\"), address (\"405 e. 58th st.\"), and phone number (212-754-6272). The city names (\"new york\" vs \"new york city\") and cuisine types (\"american\" vs \"american (new)\") are minor variations typical of different data sources. The exact match on address and phone number confirms they are the same restaurant.",
+      "provenance": {
+        "tokens": {
+          "prompt": 286,
+          "completion": 213
+        },
+        "cost_usd": 0.0010458,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f581",
+      "right_id": "z266",
+      "label": true,
+      "source": "teacher",
+      "confidence": 0.99,
+      "reasoning": "The name, address (102 5th ave / 102 fifth ave), city (New York / New York City), and phone number (212/807-7400 / 212-807-7400) are identical or differ only by standard formatting variations.",
+      "provenance": {
+        "tokens": {
+          "prompt": 295,
+          "completion": 198
+        },
+        "cost_usd": 0.00100275,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f582",
+      "right_id": "z267",
+      "label": true,
+      "source": "teacher",
+      "confidence": 0.99,
+      "reasoning": "The records have identical names (\"mi cocina\"), phone numbers (formatting differences only), and restaurant types (\"mexican\"). The addresses match structurally (57 jane st.) with Record A just providing extra directional context, and the cities are synonymous (\"new york\" vs \"new york city\"). All key attributes align perfectly indicating they refer to the same real-world restaurant.",
+      "provenance": {
+        "tokens": {
+          "prompt": 280,
+          "completion": 317
+        },
+        "cost_usd": 0.0014035,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f582",
+      "right_id": "z252",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The two records have completely different names (mi cocina vs. felidia), addresses (57 jane st. vs. 243 e. 58th st.), phone numbers, and cuisines (mexican vs. italian), indicating they are entirely different restaurants.",
+      "provenance": {
+        "tokens": {
+          "prompt": 288,
+          "completion": 181
+        },
+        "cost_usd": 0.0009359000000000001,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f582",
+      "right_id": "z272",
+      "label": true,
+      "source": "teacher",
+      "confidence": 1.0,
+      "reasoning": "The records have completely different restaurant names (mi cocina vs. picholine), addresses (57 jane st. vs. 35 w. 64th st.), phone numbers, and cuisine types (mexican vs. mediterranean). There is no overlap in any field, indicating they refer to different restaurants.",
+      "provenance": {
+        "tokens": {
+          "prompt": 290,
+          "completion": 99
+        },
+        "cost_usd": 0.000651,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f583",
+      "right_id": "z268",
+      "label": true,
+      "source": "teacher",
+      "confidence": 1.0,
+      "reasoning": "The records have identical names, highly",
+      "provenance": {
+        "tokens": {
+          "prompt": 301,
+          "completion": 153
+        },
+        "cost_usd": 0.0008515500000000001,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f583",
+      "right_id": "z247",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The records have completely different names (montrachet vs carmine's), addresses, phone numbers, and cuisine types (French vs Italian), indicating they refer to different restaurants.",
+      "provenance": {
+        "tokens": {
+          "prompt": 294,
+          "completion": 94
+        },
+        "cost_usd": 0.0006376999999999999,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f584",
+      "right_id": "z269",
+      "label": true,
+      "source": "teacher",
+      "confidence": 1.0,
+      "reasoning": "Both records have the exact same name (\"oceana\"), address (\"55 e. 54th st.\"), phone number (just formatted differently), and type (\"seafood\"). The cities (\"new york\" vs \"new york city\") refer to the same location. This is a definitive match.",
+      "provenance": {
+        "tokens": {
+          "prompt": 282,
+          "completion": 109
+        },
+        "cost_usd": 0.0006776,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f584",
+      "right_id": "z243",
+      "label": true,
+      "source": "teacher",
+      "confidence": 1.0,
+      "reasoning": "The records have completely different names (oceana vs aquavit), different addresses (55 e. 54th st. vs 13 w. 54th st.), different phone numbers, and different cuisine types (seafood vs scandinavian). They are clearly distinct restaurants located on opposite sides of 54th Street in New York.",
+      "provenance": {
+        "tokens": {
+          "prompt": 283,
+          "completion": 176
+        },
+        "cost_usd": 0.0009131499999999999,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f584",
+      "right_id": "z264",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The records have completely different names (\"oceana\" vs \"manhattan ocean club\"), addresses (\"55 e. 54th st.\" vs \"57 w. 58th st.\"), and phone numbers. They are clearly distinct restaurants.",
+      "provenance": {
+        "tokens": {
+          "prompt": 285,
+          "completion": 483
+        },
+        "cost_usd": 0.0019897499999999998,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f585",
+      "right_id": "z270",
+      "label": true,
+      "source": "teacher",
+      "confidence": 1.0,
+      "reasoning": "The records have the exact same address, matching phone numbers (differing only by separator), and virtually identical names. The city and type also match, with minor variations in formatting and extra qualifiers. This is clearly the same restaurant.",
+      "provenance": {
+        "tokens": {
+          "prompt": 292,
+          "completion": 248
+        },
+        "cost_usd": 0.0011746,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f585",
+      "right_id": "z78",
+      "label": true,
+      "source": "teacher",
+      "confidence": 1.0,
+      "reasoning": "The restaurant names (\"park avenue cafe\" vs \"edison cafe\"), addresses (\"100 e. 63rd st.\" vs \"228 w. 47th st.\"), and phone numbers are completely different. These are clearly distinct restaurants.",
+      "provenance": {
+        "tokens": {
+          "prompt": 282,
+          "completion": 124
+        },
+        "cost_usd": 0.0007301,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f586",
+      "right_id": "z271",
+      "label": true,
+      "source": "teacher",
+      "confidence": 1.0,
+      "reasoning": "The restaurant names, street addresses, and phone numbers are identical. The city names are semantically equivalent (\"new york\" vs \"new york city\"). The discrepancy in the food type (\"french\" vs \"russian\") is a minor attribute difference and Petrossian is famously known for both its Russian origins and French culinary style.",
+      "provenance": {
+        "tokens": {
+          "prompt": 284,
+          "completion": 186
+        },
+        "cost_usd": 0.0009492000000000001,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f587",
+      "right_id": "z272",
+      "label": true,
+      "source": "teacher",
+      "confidence": 1.0,
+      "reasoning": "Both records have the exact same restaurant name (\"picholine\"), address (\"35 w. 64th st.\"), phone number (just formatted differently), and cuisine type (\"mediterranean\"). The city is also equivalent (\"new york\" vs \"new york city\"). They are clearly the same restaurant.",
+      "provenance": {
+        "tokens": {
+          "prompt": 288,
+          "completion": 217
+        },
+        "cost_usd": 0.0010619,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f587",
+      "right_id": "z252",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The restaurant names (\"picholine\" vs \"felidia\"), addresses (\"35 w. 64th st.\" vs \"243 e. 58th st.\"), phone numbers, and cuisines are all completely different. These are clearly two distinct restaurants in New York.",
+      "provenance": {
+        "tokens": {
+          "prompt": 286,
+          "completion": 275
+        },
+        "cost_usd": 0.0012628000000000001,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f588",
+      "right_id": "z273",
+      "label": true,
+      "source": "teacher",
+      "confidence": 0.99,
+      "reasoning": "The restaurant names are identical, phone numbers match exactly (just formatted differently), street addresses match (Record A simply includes the cross street), and the cuisine type is identical. The city names are also just variations of the same place.",
+      "provenance": {
+        "tokens": {
+          "prompt": 278,
+          "completion": 183
+        },
+        "cost_usd": 0.0009324,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f588",
+      "right_id": "z250",
+      "label": true,
+      "source": "teacher",
+      "confidence": 1.0,
+      "reasoning": "The two records have different names (\"pisces\" vs \"daniel\"), different addresses (\"95 ave. a at 6th st.\" vs \"20 e. 76th st.\"), and different phone numbers. They are definitely not the same restaurant.",
+      "provenance": {
+        "tokens": {
+          "prompt": 286,
+          "completion": 189
+        },
+        "cost_usd": 0.0009618000000000001,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f588",
+      "right_id": "z271",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The records have completely different names (Pisces vs Petrossian), addresses (95 Ave A vs 182 W 58th St), phone numbers, and cuisine types (seafood vs Russian). There is no overlap to suggest they are the same restaurant.",
+      "provenance": {
+        "tokens": {
+          "prompt": 286,
+          "completion": 470
+        },
+        "cost_usd": 0.0019453,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f589",
+      "right_id": "z274",
+      "label": true,
+      "source": "teacher",
+      "confidence": 1.0,
+      "reasoning": "The records have identical restaurant names (\"rainbow room\") and identical addresses (\"30 rockefeller plaza\"). The phone numbers match when normalized (\"212/632-5000\" vs \"212-632-5000\"). The cities are synonymous (\"new york\" vs \"new york city\"), and the cuisine types are compatible (both American). These clearly refer to the same real-world restaurant.",
+      "provenance": {
+        "tokens": {
+          "prompt": 282,
+          "completion": 129
+        },
+        "cost_usd": 0.0007476,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f589",
+      "right_id": "z243",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The records have completely different names (\"rainbow room\" vs \"aquavit\"), addresses (\"30 rockefeller plaza\" vs \"13 w. 54th st.\"), phone numbers, and cuisine types (American vs Scandinavian). They are clearly different restaurants.",
+      "provenance": {
+        "tokens": {
+          "prompt": 287,
+          "completion": 124
+        },
+        "cost_usd": 0.0007353500000000001,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f590",
+      "right_id": "z275",
+      "label": true,
+      "source": "teacher",
+      "confidence": 0.99,
+      "reasoning": "The names are identical, the phone numbers match exactly when normalized (718/522-5200 vs 718-522-5200), the cities match, and the addresses are clearly the same (1 water st. with Record A adding the descriptor \"at the east river\"). The cuisine types are also highly compatible (american vs american (new)). All evidence points to the same real-world restaurant.",
+      "provenance": {
+        "tokens": {
+          "prompt": 274,
+          "completion": 100
+        },
+        "cost_usd": 0.0006376999999999999,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f590",
+      "right_id": "z270",
+      "label": true,
+      "source": "teacher",
+      "confidence": 1.0,
+      "reasoning": "The records have completely different names, addresses, cities, and phone numbers. They are clearly distinct restaurants.",
+      "provenance": {
+        "tokens": {
+          "prompt": 293,
+          "completion": 149
+        },
+        "cost_usd": 0.00082915,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f591",
+      "right_id": "z276",
+      "label": true,
+      "source": "teacher",
+      "confidence": 1.0,
+      "reasoning": "All key attributes match perfectly between the two records. The differences in address punctuation (\"s\" vs \"s.\"), city naming (\"new york\" vs \"new york city\"), and phone formatting (\"212/...\" vs \"212-...\") are simply stylistic variations from the two different sources (Fodor's and Zagat).",
+      "provenance": {
+        "tokens": {
+          "prompt": 274,
+          "completion": 450
+        },
+        "cost_usd": 0.0018627000000000001,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f591",
+      "right_id": "z110",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The records have completely different names (san domenico vs sushisay), addresses (240 central park s vs 38 e. 51st st.), phone numbers, and cuisine types (italian vs japanese).",
+      "provenance": {
+        "tokens": {
+          "prompt": 280,
+          "completion": 478
+        },
+        "cost_usd": 0.001967,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f592",
+      "right_id": "z277",
+      "label": true,
+      "source": "teacher",
+      "confidence": 1.0,
+      "reasoning": "Both records have the exact same restaurant name, identical phone numbers (just different formatting), similar addresses (\"156 2nd ave.\" vs \"156 second ave.\"), and equivalent cities and types. These are clearly referring to the same real-world restaurant.",
+      "provenance": {
+        "tokens": {
+          "prompt": 288,
+          "completion": 299
+        },
+        "cost_usd": 0.0013489,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f593",
+      "right_id": "z278",
+      "label": true,
+      "source": "teacher",
+      "confidence": 0.99,
+      "reasoning": "The records have identical names (\"seryna\"), identical street addresses (\"11 e. 53rd st.\"), and matching phone numbers (only formatting differs). The city values (\"new york\" vs \"new york city\") are clearly equivalent, and the type values (\"asian\" vs \"japanese\") are compatible. Different sources (Fodors vs Zagat) further support these being two listings of the same restaurant.",
+      "provenance": {
+        "tokens": {
+          "prompt": 286,
+          "completion": 167
+        },
+        "cost_usd": 0.0008848,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f593",
+      "right_id": "z252",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The records have different names (seryna vs felidia), addresses (11 e. 53rd st. vs 243 e. 58th st.), phone numbers, and cuisine types (asian vs italian). They are clearly different restaurants.",
+      "provenance": {
+        "tokens": {
+          "prompt": 285,
+          "completion": 103
+        },
+        "cost_usd": 0.00065975,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f594",
+      "right_id": "z279",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.1,
+      "reasoning": "Although the records share the same phone number, the names (\"shun lee west\" vs \"shun lee palace\") and addresses (\"43 w. 65th st.\" vs \"155 e. 55th st.\") are completely different. They are separate restaurants under the same restaurant group, likely sharing a reservation line.",
+      "provenance": {
+        "tokens": {
+          "prompt": 290,
+          "completion": 472
+        },
+        "cost_usd": 0.0019565,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f594",
+      "right_id": "z250",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The restaurant names (\"shun lee",
+      "provenance": {
+        "tokens": {
+          "prompt": 287,
+          "completion": 24
+        },
+        "cost_usd": 0.00038535,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f595",
+      "right_id": "z280",
+      "label": true,
+      "source": "teacher",
+      "confidence": 1.0,
+      "reasoning": "Both records have the exact same restaurant name (\"sign of the dove\"), identical phone numbers (212/861-8080 and 212-861-8080), matching street addresses (1110 3rd ave. at 65th st. vs 1110 third ave.), and the same general location (New York). The cuisine types are also consistent (american vs american (new)). The minor variations in formatting and abbreviations are typical of records coming from different sources (Fodors vs Zagat).",
+      "provenance": {
+        "tokens": {
+          "prompt": 293,
+          "completion": 222
+        },
+        "cost_usd": 0.00108465,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f596",
+      "right_id": "z281",
+      "label": true,
+      "source": "teacher",
+      "confidence": 1.0,
+      "reasoning": "Both records have the same restaurant name and identical phone numbers. The addresses differ slightly in format (\"201 e. 49th st.\" vs \"797 third ave.\") but actually refer to the same physical location in NYC, as 201 E  49th St sits at the corner of Third Avenue (797 Third Ave). The city names are also equivalent.",
+      "provenance": {
+        "tokens": {
+          "prompt": 286,
+          "completion": 221
+        },
+        "cost_usd": 0.0010738,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f596",
+      "right_id": "z120",
+      "label": true,
+      "source": "teacher",
+      "confidence": 0.8,
+      "reasoning": "The records have different names (smith & wollensky vs wollensky's grill), different street addresses (201 vs 205 e. 49th st.), and different phone numbers. While they may be related or located near each other in the real world, they represent distinct restaurants in this context.",
+      "provenance": {
+        "tokens": {
+          "prompt": 294,
+          "completion": 353
+        },
+        "cost_usd": 0.0015442000000000001,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f597",
+      "right_id": "z282",
+      "label": true,
+      "source": "teacher",
+      "confidence": 1.0,
+      "reasoning": "The names exactly match (\"tavern on the green\"), the phone numbers are identical (just different formatting), the addresses refer to the same famous location in Central Park, and the cities are the same. There is no ambiguity here.",
+      "provenance": {
+        "tokens": {
+          "prompt": 284,
+          "completion": 196
+        },
+        "cost_usd": 0.0009842,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f597",
+      "right_id": "z255",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The records have different names (\"tavern on the green\" vs \"gramercy tavern\"), different addresses (\"in central park at 67th st.\" vs \"42 e. 20th st.\"), and different phone numbers. These are two distinct, well-known restaurants in New York City.",
+      "provenance": {
+        "tokens": {
+          "prompt": 291,
+          "completion": 140
+        },
+        "cost_usd": 0.00079555,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f598",
+      "right_id": "z283",
+      "label": true,
+      "source": "teacher",
+      "confidence": 0.9,
+      "reasoning": "The name is an exact match (\"uncle nick's\") and the address matches exactly (\"747 9th ave.\" vs \"747 ninth ave.\"). The city is a variation (\"new york\" vs \"new york city\"). While the phone numbers differ, the combination of the exact name and address strongly indicates these are the same restaurant. The cuisine types (Mediterranean vs Greek) are also highly compatible.",
+      "provenance": {
+        "tokens": {
+          "prompt": 302,
+          "completion": 265
+        },
+        "cost_usd": 0.0012446,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f599",
+      "right_id": "z284",
+      "label": true,
+      "source": "teacher",
+      "confidence": 1.0,
+      "reasoning": "The names, addresses, and phone numbers are identical (formatting differences only). The city and type fields have minor variations (\"new york\" vs \"new york city\", \"american\" vs \"american (new)\") but these are clearly the same restaurant.",
+      "provenance": {
+        "tokens": {
+          "prompt": 286,
+          "completion": 67
+        },
+        "cost_usd": 0.0005348,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f600",
+      "right_id": "z285",
+      "label": true,
+      "source": "teacher",
+      "confidence": 1.0,
+      "reasoning": "Both records have the exact same address (\"152 w. 44th st.\") and phone number (\"212-921-9494\", differing only in formatting). The name \"virgil's\" is a shortened version of \"virgil's real bbq\". The cities \"new york\" and \"new york city\" are equivalent. The slight differences in type (\"american\" vs \"bbq\") and source are consistent with different restaurant guides describing the same establishment.",
+      "provenance": {
+        "tokens": {
+          "prompt": 291,
+          "completion": 242
+        },
+        "cost_usd": 0.00115255,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f600",
+      "right_id": "z260",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The records have entirely different names (virgil's vs. le bernardin), different addresses (152 w. 44th st. vs. 155 w. 51st st.), different phone numbers, and different cuisine types. These are clearly two distinct restaurants in New York.",
+      "provenance": {
+        "tokens": {
+          "prompt": 283,
+          "completion": 96
+        },
+        "cost_usd": 0.0006331500000000001,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f601",
+      "right_id": "z286",
+      "label": true,
+      "source": "teacher",
+      "confidence": 1.0,
+      "reasoning": "The records have identical restaurant names, matching addresses (only a trailing period differs), the same city, and identical phone numbers (formatted differently but same digits). The type discrepancy (asian vs chinese) is a minor variation across different sources (Fodor's vs Zagat). All core identifying fields align perfectly.",
+      "provenance": {
+        "tokens": {
+          "prompt": 286,
+          "completion": 144
+        },
+        "cost_usd": 0.0008043,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f601",
+      "right_id": "z129",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.15,
+      "reasoning": "While both are Asian restaurants on the Las Vegas Strip, the names differ significantly (\"chin's\" vs \"madame ching's\"), the addresses differ (3200 vs 3300 Las Vegas Blvd S), and the phone numbers are completely different. These differences strongly suggest two separate restaurants.",
+      "provenance": {
+        "tokens": {
+          "prompt": 291,
+          "completion": 132
+        },
+        "cost_usd": 0.0007675500000000001,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f602",
+      "right_id": "z287",
+      "label": true,
+      "source": "teacher",
+      "confidence": 1.0,
+      "reasoning": "Both records have identical names (with minor formatting difference), identical addresses, identical phone numbers (formatted differently), same city, and same restaurant type. This is clearly the same real-world restaurant.",
+      "provenance": {
+        "tokens": {
+          "prompt": 305,
+          "completion": 72
+        },
+        "cost_usd": 0.0005722500000000001,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f603",
+      "right_id": "z288",
+      "label": true,
+      "source": "teacher",
+      "confidence": 0.9,
+      "reasoning": "The restaurant names are highly similar (\"le montrachet\" vs \"le montrachet bistro\") and both are located at 3000 Paradise Rd. in Las Vegas, with one just adding a \"W.\" directional prefix. The cuisine types (continental and french bistro) are closely related. The phone numbers share the same area code and prefix but differ in the last four digits, which could be due to different lines, transcription errors, or updates between the Fodors and Zagat sources. Given the exact street number and matching core name, it is highly probable they refer to the same restaurant.",
+      "provenance": {
+        "tokens": {
+          "prompt": 287,
+          "completion": 534
+        },
+        "cost_usd": 0.00217035,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f603",
+      "right_id": "z141",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The records have different names (le montrachet vs tre visi), different addresses (3000 w. paradise rd. vs 3799 las vegas blvd. s.), different phone numbers, and different cuisine types (continental vs italian). There is no evidence suggesting these refer to the same restaurant.",
+      "provenance": {
+        "tokens": {
+          "prompt": 288,
+          "completion": 103
+        },
+        "cost_usd": 0.0006629,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f604",
+      "right_id": "z289",
+      "label": true,
+      "source": "teacher",
+      "confidence": 0.95,
+      "reasoning": "The records have the exact same restaurant name, city, and virtually identical street address (which corresponds to CaesarsPalace in Las Vegas). The slight difference in phone number formatting and digits is likely due to different direct lines, extensions, or typos across the two sources (Fodor's vs. Zagat). The differing cuisine types (continental vs. french (new)) are subjective categorizations often applied to the same restaurant by different publishers. The overwhelming evidence points to them being the same restaurant.",
+      "provenance": {
+        "tokens": {
+          "prompt": 295,
+          "completion": 332
+        },
+        "cost_usd": 0.00147175,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f605",
+      "right_id": "z290",
+      "label": true,
+      "source": "teacher",
+      "confidence": 0.95,
+      "reasoning": "The records have nearly identical names (\"second street grill\" vs \"grille\") and the exact same address (\"200 e. fremont st.\") in the same city (\"las vegas\"). The phone numbers share the same area code and prefix (702-385) but differ in the suffix, which could be due to a data entry error, an outdated number, or a secondary phone line. The exact match on address and name makes it highly likely they refer to the same restaurant.",
+      "provenance": {
+        "tokens": {
+          "prompt": 282,
+          "completion": 384
+        },
+        "cost_usd": 0.0016401000000000002,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f605",
+      "right_id": "z138",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The restaurant names, addresses, phone numbers, and types are all completely different, indicating these are two distinct restaurants on Fremont Street in Las Vegas.",
+      "provenance": {
+        "tokens": {
+          "prompt": 285,
+          "completion": 220
+        },
+        "cost_usd": 0.00106925,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f605",
+      "right_id": "z127",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The records have completely different names, addresses, phone numbers, and cuisine types, making it certain they refer to different restaurants in Las Vegas.",
+      "provenance": {
+        "tokens": {
+          "prompt": 291,
+          "completion": 138
+        },
+        "cost_usd": 0.0007885500000000001,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f606",
+      "right_id": "z291",
+      "label": true,
+      "source": "teacher",
+      "confidence": 1.0,
+      "reasoning": "The records have identical addresses, phone numbers (just formatted differently), and highly similar names and cuisine types. The differences are minor formatting variations typical of different data sources.",
+      "provenance": {
+        "tokens": {
+          "prompt": 300,
+          "completion": 171
+        },
+        "cost_usd": 0.0009135,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f606",
+      "right_id": "z138",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The two records have different names, different addresses (Las Vegas Blvd. S vs E. Fremont St.), and different phone numbers, indicating they are distinct restaurants in Las Vegas.",
+      "provenance": {
+        "tokens": {
+          "prompt": 292,
+          "completion": 169
+        },
+        "cost_usd": 0.0008981,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f606",
+      "right_id": "z108",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The records refer to different restaurants. They are in different cities (Las Vegas vs. New York City), have different addresses, different phone numbers, and different names (\"steak house\" vs \"sparks steak house\"). All evidence indicates these are distinct establishments.",
+      "provenance": {
+        "tokens": {
+          "prompt": 294,
+          "completion": 116
+        },
+        "cost_usd": 0.0007147,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f606",
+      "right_id": "z131",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The records have different names (\"steak house\" vs \"michael's (las vegas)\"), different addresses (2880 vs 3595 Las Vegas Blvd. S), different phone numbers, and different cuisine types. These are clearly two distinct restaurants.",
+      "provenance": {
+        "tokens": {
+          "prompt": 300,
+          "completion": 249
+        },
+        "cost_usd": 0.0011864999999999998,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f607",
+      "right_id": "z292",
+      "label": true,
+      "source": "teacher",
+      "confidence": 0.99,
+      "reasoning": "The records have the exact same address (\"2245 e. flamingo rd.\") and city (\"las vegas\"), as well as the same phone number (\"702/731-4036\" vs \"702-731-4036\", just different formatting). The name is nearly identical (\"tillerman\" vs \"tillerman the\"). While the cuisine type differs (\"seafood\" vs \"steakhouses\"), it is common for restaurants to be categorized differently across sources. These clearly refer to the same restaurant.",
+      "provenance": {
+        "tokens": {
+          "prompt": 291,
+          "completion": 413
+        },
+        "cost_usd": 0.00175105,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f608",
+      "right_id": "z293",
+      "label": true,
+      "source": "teacher",
+      "confidence": 0.98,
+      "reasoning": "Both records share the same name (\"abruzzi\"), city (\"atlanta\"), cuisine type (\"italian\"), and phone number (404-261-8186, formatted differently but identical in digits). The addresses are compatible, with \"2355 peachtree rd. ne\" and \"2355 peachtree rd. peachtree battle shopping center\" referring to the same location, differing only in additional detail. The only difference is the data source (fodors vs zagat), which is expected when comparing multiple listings for the same entity.",
+      "provenance": {
+        "tokens": {
+          "prompt": 296,
+          "completion": 228
+        },
+        "cost_usd": 0.0011088,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f608",
+      "right_id": "z173",
+      "label": true,
+      "source": "teacher",
+      "confidence": 1.0,
+      "reasoning": "The restaurant names, addresses, phone numbers, and cuisines are all completely different. They are two distinct restaurants located on Peachtree Road in Atlanta.",
+      "provenance": {
+        "tokens": {
+          "prompt": 287,
+          "completion": 126
+        },
+        "cost_usd": 0.0007423499999999999,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f609",
+      "right_id": "z294",
+      "label": true,
+      "source": "teacher",
+      "confidence": 0.99,
+      "reasoning": "The records have identical names, street addresses, cities, and phone numbers (with only minor formatting differences in the phone number). The slight difference in cuisine type is likely due to different classification schemes used by the two sources (Fodors vs Zagat). All core identifying fields match perfectly, indicating these refer to the same real-world restaurant.",
+      "provenance": {
+        "tokens": {
+          "prompt": 292,
+          "completion": 187
+        },
+        "cost_usd": 0.0009610999999999999,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f609",
+      "right_id": "z293",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The two records have different names, addresses, phone numbers, and cuisine types, indicating they are completely different restaurants.",
+      "provenance": {
+        "tokens": {
+          "prompt": 294,
+          "completion": 155
+        },
+        "cost_usd": 0.0008512000000000001,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f609",
+      "right_id": "z173",
+      "label": true,
+      "source": "teacher",
+      "confidence": 0.5,
+      "reasoning": "",
+      "provenance": {
+        "tokens": {
+          "prompt": 243,
+          "completion": 134
+        },
+        "cost_usd": 0.00072415,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f610",
+      "right_id": "z295",
+      "label": true,
+      "source": "teacher",
+      "confidence": 1.0,
+      "reasoning": "The restaurant names are nearly identical (\"bone's\" vs \"bone's restaurant\"), the phone numbers match exactly when normalized (404-237-2663), the addresses are the same when accounting for abbreviations and directionals (\"3130 piedmont road\" vs \"3130 piedmont rd. ne\"), and they are located in the same city (atlanta). The restaurant types (\"american\" and \"steakhouses\") are also compatible.",
+      "provenance": {
+        "tokens": {
+          "prompt": 284,
+          "completion": 335
+        },
+        "cost_usd": 0.0014707,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f610",
+      "right_id": "z293",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The records have completely different names (\"bone's\" vs \"abruzzi\"), addresses (\"3130 piedmont road\" vs \"2355 peachtree rd. ne\"), phone numbers, and cuisine types. There is no indication they refer to the same restaurant.",
+      "provenance": {
+        "tokens": {
+          "prompt": 281,
+          "completion": 176
+        },
+        "cost_usd": 0.0009110500000000001,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f610",
+      "right_id": "z176",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The records have completely different names (bone's vs palm the), addresses (3130 piedmont road vs 3391 peachtree rd. ne), and phone numbers (404/237-2663 vs 404-814-1955). They are clearly two different steakhouses in Atlanta.",
+      "provenance": {
+        "tokens": {
+          "prompt": 291,
+          "completion": 160
+        },
+        "cost_usd": 0.0008655500000000001,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f611",
+      "right_id": "z296",
+      "label": true,
+      "source": "teacher",
+      "confidence": 1.0,
+      "reasoning": "The records have identical names, cities, and matching phone numbers (with minor formatting differences). The street address is also identical, with Record A simply providing additional location details (Lenox Square Mall near Neiman Marcus). The cuisine types (\"french\" and \"french bistro\") are also highly consistent. These factors indicate they are the same restaurant.",
+      "provenance": {
+        "tokens": {
+          "prompt": 318,
+          "completion": 187
+        },
+        "cost_usd": 0.0009884,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f611",
+      "right_id": "z308",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The records have different names, addresses (3393 vs 3434 Peachtree Rd), phone numbers, and restaurant types. There is no indication they refer to the same real-world restaurant.",
+      "provenance": {
+        "tokens": {
+          "prompt": 327,
+          "completion": 166
+        },
+        "cost_usd": 0.00092435,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f611",
+      "right_id": "z309",
+      "label": true,
+      "source": "teacher",
+      "confidence": 1.0,
+      "reasoning": "The restaurants have completely different names, phone numbers, cuisines, and slightly different addresses. \"Brasserie Le Coze\" and \"Ritz-Carlton Dining Room\" are distinct establishments in Atlanta.",
+      "provenance": {
+        "tokens": {
+          "prompt": 330,
+          "completion": 171
+        },
+        "cost_usd": 0.0009450000000000001,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f612",
+      "right_id": "z297",
+      "label": true,
+      "source": "teacher",
+      "confidence": 1.0,
+      "reasoning": "The restaurant names are identical, the phone numbers match exactly aside from formatting, and the addresses match (\"road\" vs \"rd.\") in the same city. The slight variation in the type field is simply a difference in categorization detail between the two sources.",
+      "provenance": {
+        "tokens": {
+          "prompt": 284,
+          "completion": 464
+        },
+        "cost_usd": 0.0019222,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f612",
+      "right_id": "z308",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The two records have entirely different names (buckhead diner vs ritz-carlton cafe), addresses (3073 piedmont road vs 3434 peachtree rd. ne), and phone numbers. There is no indication these refer to the same restaurant.",
+      "provenance": {
+        "tokens": {
+          "prompt": 298,
+          "completion": 151
+        },
+        "cost_usd": 0.0008414,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f612",
+      "right_id": "z309",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The records have completely different names (\"buckhead diner\" vs \"ritz-carlton dining room (buckhead)\"), addresses, and phone numbers. They are two distinct restaurants located in the Buckhead neighborhood of Atlanta.",
+      "provenance": {
+        "tokens": {
+          "prompt": 301,
+          "completion": 194
+        },
+        "cost_usd": 0.00099505,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f613",
+      "right_id": "z298",
+      "label": true,
+      "source": "teacher",
+      "confidence": 0.99,
+      "reasoning": "Both records have identical addresses (1529 piedmont ave.), same city (atlanta), matching phone numbers (404-874-7600 vs 404/874-7600, just different formatting), and compatible restaurant types (french vs french (new)). The name in record B includes the word \"restaurant\" but otherwise matches. These are definitively the same real-world restaurant.",
+      "provenance": {
+        "tokens": {
+          "prompt": 286,
+          "completion": 150
+        },
+        "cost_usd": 0.0008253,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f613",
+      "right_id": "z294",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The records have completely different names (Ciboulette vs. Bacchanalia), different addresses (1529 Piedmont Ave vs. 3125 Piedmont Rd), different phone numbers, and different cuisine types. There is no evidence to suggest these refer to the same restaurant.",
+      "provenance": {
+        "tokens": {
+          "prompt": 282,
+          "completion": 158
+        },
+        "cost_usd": 0.0008491,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f613",
+      "right_id": "z297",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The records have completely different names, addresses, phone numbers, and restaurant types. They are clearly two distinct restaurants in Atlanta.",
+      "provenance": {
+        "tokens": {
+          "prompt": 284,
+          "completion": 228
+        },
+        "cost_usd": 0.0010962,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f614",
+      "right_id": "z176",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The names (\"delectables\" vs \"palm the (atlanta)\"), addresses (\"1 margaret mitchell sq.\" vs \"3391 peachtree rd. ne\"), and phone numbers are completely different. They are clearly distinct restaurants.",
+      "provenance": {
+        "tokens": {
+          "prompt": 294,
+          "completion": 159
+        },
+        "cost_usd": 0.0008652,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f614",
+      "right_id": "z146",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The records have completely different names (\"delectables\" vs \"bistro the\"), addresses (\"1 margaret mitchell sq.\" vs \"56 e. andrews dr. nw\"), phone numbers (404/681-2909 vs 404-231-5733), and types (american vs french bistro). There are no overlapping identifiers or matching fields to suggest these refer to the same restaurant.",
+      "provenance": {
+        "tokens": {
+          "prompt": 291,
+          "completion": 125
+        },
+        "cost_usd": 0.0007430500000000001,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f615",
+      "right_id": "z300",
+      "label": true,
+      "source": "teacher",
+      "confidence": 0.98,
+      "reasoning": "The names match exactly, the cities are the same (Atlanta), the phone numbers are identical (just different formatting), and the addresses are consistent (Record A includes the shopping center name, while Record B is the street address only). The slight difference in cuisine type (American vs. Southwestern) is a common discrepancy across different review sources like Fodor's and Zagat.",
+      "provenance": {
+        "tokens": {
+          "prompt": 294,
+          "completion": 164
+        },
+        "cost_usd": 0.0008826999999999999,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f615",
+      "right_id": "z303",
+      "label": true,
+      "source": "teacher",
+      "confidence": 1.0,
+      "reasoning": "The two records have different names (",
+      "provenance": {
+        "tokens": {
+          "prompt": 298,
+          "completion": 144
+        },
+        "cost_usd": 0.0008169,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f616",
+      "right_id": "z301",
+      "label": true,
+      "source": "teacher",
+      "confidence": 0.99,
+      "reasoning": "Both records share the same restaurant name, identical street address (Record B adds a directional suffix \"NE\"), identical city, and identical phone number (just formatted differently). The slight differences in type and source are normal across different restaurant guides, and the name variation \"the\" is a minor article addition. These are definitely the same restaurant.",
+      "provenance": {
+        "tokens": {
+          "prompt": 303,
+          "completion": 110
+        },
+        "cost_usd": 0.00070315,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f616",
+      "right_id": "z178",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The records have completely different names, addresses (490 vs 519 E. Paces Ferry Rd), and phone numbers. There is no evidence suggesting they refer to the same restaurant.",
+      "provenance": {
+        "tokens": {
+          "prompt": 291,
+          "completion": 213
+        },
+        "cost_usd": 0.00105105,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f616",
+      "right_id": "z142",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The restaurantshave completely different names (\"hedgerose heights inn\" vs \"103 west\"), different street numbers (490 vs 103), and are on opposite sides of the street (E. vs W. Paces Ferry Rd.). The phone numbers also do not match. These are distinct restaurants.",
+      "provenance": {
+        "tokens": {
+          "prompt": 287,
+          "completion": 266
+        },
+        "cost_usd": 0.0012323500000000001,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f616",
+      "right_id": "z307",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The two records have completely different names, addresses (different street numbers and East vs. West), and phone numbers, indicating they are distinct restaurants.",
+      "provenance": {
+        "tokens": {
+          "prompt": 300,
+          "completion": 378
+        },
+        "cost_usd": 0.0016380000000000001,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f617",
+      "right_id": "z302",
+      "label": true,
+      "source": "teacher",
+      "confidence": 1.0,
+      "reasoning": "The records have identical names, cities, and matching phone numbers (just different formatting). The address in Record A is a more detailed version of the address in Record B (includes the shopping mall name). The restaurant types (asian vs indian) are highly related.",
+      "provenance": {
+        "tokens": {
+          "prompt": 292,
+          "completion": 320
+        },
+        "cost_usd": 0.0014266,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f617",
+      "right_id": "z22",
+      "label": true,
+      "source": "teacher",
+      "confidence": 1.0,
+      "reasoning": "The records have completely different names, addresses, phone numbers, and cities. They are clearly two different restaurants.",
+      "provenance": {
+        "tokens": {
+          "prompt": 294,
+          "completion": 121
+        },
+        "cost_usd": 0.0007322,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f618",
+      "right_id": "z300",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The records have different names, addresses, phone numbers, and cuisine types, indicating they are clearly distinct restaurants in Atlanta.",
+      "provenance": {
+        "tokens": {
+          "prompt": 284,
+          "completion": 130
+        },
+        "cost_usd": 0.0007532,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f618",
+      "right_id": "z145",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The two records have completely different names, addresses, phone numbers, and restaurant types. They are clearly distinct establishments.",
+      "provenance": {
+        "tokens": {
+          "prompt": 282,
+          "completion": 162
+        },
+        "cost_usd": 0.0008631000000000001,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f618",
+      "right_id": "z67",
+      "label": true,
+      "source": "teacher",
+      "confidence": 1.0,
+      "reasoning": "The restaurant names, addresses, cities, and phone numbers are completely different, clearly indicating these are two distinct restaurants in different cities.",
+      "provenance": {
+        "tokens": {
+          "prompt": 283,
+          "completion": 129
+        },
+        "cost_usd": 0.00074865,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f619",
+      "right_id": "z304",
+      "label": true,
+      "source": "teacher",
+      "confidence": 0.99,
+      "reasoning": "Both records have the same name (\"la grotta\"), city (Atlanta), cuisine type (Italian), phone number (404-231-1368), and street address (2637 Peachtree Rd). The minor differences in address formatting (NE suffix vs. \"peachtree house condominium\") are common variations for the same location.",
+      "provenance": {
+        "tokens": {
+          "prompt": 299,
+          "completion": 154
+        },
+        "cost_usd": 0.00085295,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f619",
+      "right_id": "z173",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The restaurant names, addresses, phone numbers, and cuisine types are all completely different. La Grotta is an Italian restaurant at 2637 Peachtree Rd, while Nava is a Southwestern restaurant at 3060 Peachtree Rd. They are clearly two distinct establishments.",
+      "provenance": {
+        "tokens": {
+          "prompt": 288,
+          "completion": 169
+        },
+        "cost_usd": 0.0008939,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f619",
+      "right_id": "z293",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The records have completely different names (\"la grotta\" vs \"abruzzi\"), addresses (\"2637 peachtree rd.\" vs \"2355 peachtree rd. ne\"), and phone numbers (\"404/231-1368\" vs \"404-261-8186\"). Although both are Italian restaurants in Atlanta, the key identifying details do not match at all.",
+      "provenance": {
+        "tokens": {
+          "prompt": 297,
+          "completion": 333
+        },
+        "cost_usd": 0.00147735,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f620",
+      "right_id": "z144",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The records have completely different names (mary mac's tea room vs baker's cajun cafe), addresses (224 ponce de leon ave. vs 1134 euclid ave.), and phone numbers. They are clearly different restaurants.",
+      "provenance": {
+        "tokens": {
+          "prompt": 297,
+          "completion": 152
+        },
+        "cost_usd": 0.00084385,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f620",
+      "right_id": "z331",
+      "label": true,
+      "source": "teacher",
+      "confidence": 1.0,
+      "reasoning": "The records have completely different names (mary mac's tea room vs. ritz-carltoncafe), addresses (224 ponce de leon ave. vs. 181 peachtree st.), phone numbers, and cuisine types. These are clearly two different restaurants in Atlanta.",
+      "provenance": {
+        "tokens": {
+          "prompt": 297,
+          "completion": 92
+        },
+        "cost_usd": 0.00063385,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f621",
+      "right_id": "z306",
+      "label": true,
+      "source": "teacher",
+      "confidence": 0.99,
+      "reasoning": "The restaurant name, city, cuisine type, and phone number are identical (with only minor formatting differences in the phone number). The address in Record A is a superset of the address in Record B, merely adding the cross street \"at harris st.\" Different sources (fodors vs zagat) further support that these are independent listings of the same real-world restaurant.",
+      "provenance": {
+        "tokens": {
+          "prompt": 291,
+          "completion": 215
+        },
+        "cost_usd": 0.00105805,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f621",
+      "right_id": "z171",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The records have different names (nikolai's roof vs. morton's of chicago), addresses (255 courtland st. vs 303 peachtree st.), phone numbers, and cuisine types (continental vs steakhouses). There are no matching attributes to suggest these refer to the same restaurant.",
+      "provenance": {
+        "tokens": {
+          "prompt": 304,
+          "completion": 97
+        },
+        "cost_usd": 0.0006587,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f621",
+      "right_id": "z143",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The records have completely different names, addresses, phone numbers, and restaurant types, indicating they refer to different real-world restaurants.",
+      "provenance": {
+        "tokens": {
+          "prompt": 295,
+          "completion": 116
+        },
+        "cost_usd": 0.00071575,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f621",
+      "right_id": "z300",
+      "label": true,
+      "source": "teacher",
+      "confidence": 1.0,
+      "reasoning": "The restaurants have completely different names, addresses, phone numbers, and cuisine types, indicating they are clearly two different establishments.",
+      "provenance": {
+        "tokens": {
+          "prompt": 292,
+          "completion": 148
+        },
+        "cost_usd": 0.0008246,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f622",
+      "right_id": "z307",
+      "label": true,
+      "source": "teacher",
+      "confidence": 0.99,
+      "reasoning": "The records have identical addresses, identical cities, and nearly identical names (\"pano's and paul's\" vs \"pano's & paul's\"). The phone numbers match exactly aside from formatting (404/261-3662 vs 404-261-3662). The differing \"type\" field is expected as they come from different sources (Fodor's vs Zagat). All key fields align, confirming these refer to the same real-world restaurant.",
+      "provenance": {
+        "tokens": {
+          "prompt": 302,
+          "completion": 234
+        },
+        "cost_usd": 0.0011361,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f622",
+      "right_id": "z178",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The restaurants have completely different names (\"pano's and paul's\" vs \"riviera\"), different street numbers, and are located on different ends of the same road (\"1232 w.\" vs \"519 e.\" paces ferry rd.). Their phone numbers and cuisine types also do not match.",
+      "provenance": {
+        "tokens": {
+          "prompt": 293,
+          "completion": 615
+        },
+        "cost_usd": 0.00246015,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f622",
+      "right_id": "z151",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The two records have different restaurant names (\"pano's and paul's\" vs \"canoe\"), different addresses (\"1232 w. paces ferry rd.\" vs \"4199 paces ferry rd.\"), and different phone numbers, indicating they are distinct restaurants.",
+      "provenance": {
+        "tokens": {
+          "prompt": 291,
+          "completion": 157
+        },
+        "cost_usd": 0.00085505,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f622",
+      "right_id": "z142",
+      "label": true,
+      "source": "teacher",
+      "confidence": 1.0,
+      "reasoning": "The records have entirely different names (pano's and paul's vs. 103 west), different street addresses (1232 vs. 103 W. Paces Ferry Rd.), and different phone numbers. Although they are in the same city and on the same street, they are clearly distinct restaurants.",
+      "provenance": {
+        "tokens": {
+          "prompt": 289,
+          "completion": 251
+        },
+        "cost_usd": 0.00118195,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f622",
+      "right_id": "z154",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.05,
+      "reasoning": "The restaurant names are completely different (\"pano's and paul's\" vs \"chops\"), and they have different addresses, phone numbers, and cuisine types. Although both are located on W. Paces Ferry Rd in Atlanta, the street numbers are far apart (1232 vs 70), indicating they are distinct establishments.",
+      "provenance": {
+        "tokens": {
+          "prompt": 291,
+          "completion": 140
+        },
+        "cost_usd": 0.00079555,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f623",
+      "right_id": "z308",
+      "label": true,
+      "source": "teacher",
+      "confidence": 1.0,
+      "reasoning": "The records have matching phone numbers (404-237-2700), highly similar names (\"cafe ritz-carlton buckhead\" vs \"ritz-carlton cafe (buckhead)\"), and matching street addresses (3434 peachtree rd.) in the same city (atlanta). These are clearly the same restaurant.",
+      "provenance": {
+        "tokens": {
+          "prompt": 317,
+          "completion": 177
+        },
+        "cost_usd": 0.00095235,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f623",
+      "right_id": "z331",
+      "label": true,
+      "source": "teacher",
+      "confidence": 0.95,
+      "reasoning": "Although both are named \"Ritz-Carlton Cafe\", they are located at completely different addresses in Atlanta (3434 Peachtree Rd in Buckhead vs. 181 Peachtree St downtown) and have different phone numbers. This indicates they are two distinct Ritz-Carlton hotel restaurants in different parts of the city.",
+      "provenance": {
+        "tokens": {
+          "prompt": 309,
+          "completion": 318
+        },
+        "cost_usd": 0.0014374499999999998,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f623",
+      "right_id": "z309",
+      "label": true,
+      "source": "teacher",
+      "confidence": 0.9,
+      "reasoning": "Both records refer to a restaurant at the Ritz-Carlton in Buckhead, Atlanta. They share the same address (3434 Peachtree Rd.) and identical phone numbers (404-237-2700). The slight variation in names (\"cafe ritz-carlton\" vs. \"ritz-carlton dining room\") is common across different review sources like Fodors and Zagat for hotel restaurants.",
+      "provenance": {
+        "tokens": {
+          "prompt": 320,
+          "completion": 388
+        },
+        "cost_usd": 0.0016940000000000002,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f624",
+      "right_id": "z309",
+      "label": true,
+      "source": "teacher",
+      "confidence": 0.98,
+      "reasoning": "The records have highly similar names (\"dining room ritz-carlton buckhead\" vs \"ritz-carlton dining room (buckhead)\"), the same address (3434 peachtree rd. ne), the same city (atlanta), and the same phone number (404/237-2700 vs 404-237-2700, just different formatting). These are clearly the same restaurant, just from different sources (Fodors vs Zagat).",
+      "provenance": {
+        "tokens": {
+          "prompt": 317,
+          "completion": 118
+        },
+        "cost_usd": 0.0007458499999999999,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f624",
+      "right_id": "z308",
+      "label": true,
+      "source": "teacher",
+      "confidence": 0.9,
+      "reasoning": "Both records share the exact same phone number (404-237-2700) and street address (3434 Peachtree Rd.) in Atlanta. Their names both refer to dining establishments located within the Ritz-Carlton Buckhead. The differences in name and cuisine type are likely due to variations in how the different sources (Fodor's vs. Zagat) categorize or name the restaurant.",
+      "provenance": {
+        "tokens": {
+          "prompt": 314,
+          "completion": 829
+        },
+        "cost_usd": 0.0032312,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f624",
+      "right_id": "z310",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.05,
+      "reasoning": "While both records reference a restaurant associated with the Ritz-Carlton in Atlanta, the key differentiators strongly indicate these are different establishments. Record A is located at 3434 Peachtree Rd. in the Buckhead area (as indicated by the name), while Record B is at 181 Peachtree St. in downtown Atlanta—these are different addresses miles apart, corresponding to two separate Ritz-Carlton hotel properties. The phone numbers are completely different (404/237-2700 vs. 404-659-0400), and the cuisine types also differ (international vs. French Classic). These are restaurants at two distinct Ritz-Carlton locations in Atlanta.",
+      "provenance": {
+        "tokens": {
+          "prompt": 299,
+          "completion": 877
+        },
+        "cost_usd": 0.0033834499999999997,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f625",
+      "right_id": "z310",
+      "label": true,
+      "source": "teacher",
+      "confidence": 1.0,
+      "reasoning": "Both records refer to the restaurant at the Ritz-Carlton in Atlanta. The names are variations of \"Ritz-Carlton restaurant\", the address and city are an exact match (\"181 peachtree st.\" in \"atlanta\"), and the phone numbers are identical aside from formatting (\"404/659-0400\" vs \"404-659-0400\"). The slight difference in cuisine type is common across different review sources.",
+      "provenance": {
+        "tokens": {
+          "prompt": 292,
+          "completion": 390
+        },
+        "cost_usd": 0.0016715999999999999,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f625",
+      "right_id": "z331",
+      "label": true,
+      "source": "teacher",
+      "confidence": 0.95,
+      "reasoning": "Both records list the exact same address (181 peachtree st.), city (atlanta), and phone number (404-659-0400). The names are slightly different but both clearly refer to a restaurant at the Ritz-Carlton hotel in Atlanta.",
+      "provenance": {
+        "tokens": {
+          "prompt": 299,
+          "completion": 177
+        },
+        "cost_usd": 0.00093345,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f625",
+      "right_id": "z309",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.05,
+      "reasoning": "Although both records refer to Ritz-Carlton restaurants in Atlanta, they are at different locations (downtown vs. Buckhead), have different addresses, phone numbers, and cuisine types. They are distinct real-world restaurants.",
+      "provenance": {
+        "tokens": {
+          "prompt": 310,
+          "completion": 113
+        },
+        "cost_usd": 0.000721,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f626",
+      "right_id": "z311",
+      "label": true,
+      "source": "teacher",
+      "confidence": 0.99,
+      "reasoning": "The records have identical names (\"toulouse\"), cities (\"atlanta\"), and phone numbers (formatting differences only: \"404/351-9533\" vs \"404-351-9533\"). The address in Record A (\"b peachtree rd.\") appears to be a truncated version of Record B's address (\"293-b peachtree rd.\"). The cuisine types are highly compatible (\"french\" vs \"french (new)\"). These matching identifiers strongly indicate the same real-world restaurant.",
+      "provenance": {
+        "tokens": {
+          "prompt": 275,
+          "completion": 281
+        },
+        "cost_usd": 0.00127225,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f626",
+      "right_id": "z293",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The restaurants have completely different names (\"toulouse\" vs \"abruzzi\"), different cuisines (\"french\" vs \"italian\"), and different phone numbers. While they are located on the same street in Atlanta, they clearly refer to different establishments.",
+      "provenance": {
+        "tokens": {
+          "prompt": 277,
+          "completion": 229
+        },
+        "cost_usd": 0.0010923500000000002,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f626",
+      "right_id": "z300",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The two records have completely different restaurant names (\"toulouse\" vs \"georgia grille\"), phone numbers, and cuisine types. While they are both located on Peachtree Rd. in Atlanta, the street numbers are different and all other key identifying attributes do not match.",
+      "provenance": {
+        "tokens": {
+          "prompt": 274,
+          "completion": 322
+        },
+        "cost_usd": 0.0014147,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f626",
+      "right_id": "z173",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The restaurant names (\"toulouse\" vs \"nava\"), phone numbers (\"404/351-9533\" vs \"404-240-1984\"), and cuisine types (\"french\" vs \"southwestern\") are completely different. Although both are located on Peachtree Rd in Atlanta, the evidence overwhelmingly indicates these are distinct restaurants.",
+      "provenance": {
+        "tokens": {
+          "prompt": 268,
+          "completion": 276
+        },
+        "cost_usd": 0.0012474,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f627",
+      "right_id": "z141",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The two records have entirely different names (veni vidi vici vs. tre visi), addresses, cities (atlanta vs. las vegas), and phone numbers. There is no evidence to suggest these refer to the same restaurant.",
+      "provenance": {
+        "tokens": {
+          "prompt": 291,
+          "completion": 147
+        },
+        "cost_usd": 0.00082005,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f627",
+      "right_id": "z159",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The restaurant names, addresses, phone numbers, and cuisine types are all completely different. There is no overlap in any identifying information, indicating these are distinct restaurants in Atlanta.",
+      "provenance": {
+        "tokens": {
+          "prompt": 290,
+          "completion": 248
+        },
+        "cost_usd": 0.0011725000000000001,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f628",
+      "right_id": "z319",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The records have completely different restaurant names (\"alain rondelli\" vs \"fleur de lys\"), different street addresses (126 clement st. vs 777 sutter st.), and different phone numbers, despite both being French restaurants in San Francisco.",
+      "provenance": {
+        "tokens": {
+          "prompt": 286,
+          "completion": 81
+        },
+        "cost_usd": 0.0005838,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f628",
+      "right_id": "z318",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The records have completely different restaurant names, street addresses, phone numbers, and cuisine types, indicating they are definitely different restaurants.",
+      "provenance": {
+        "tokens": {
+          "prompt": 283,
+          "completion": 470
+        },
+        "cost_usd": 0.00194215,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f629",
+      "right_id": "z217",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The two records have completely different names, addresses, phone numbers, and restaurant types. There is no overlap in any identifying information.",
+      "provenance": {
+        "tokens": {
+          "prompt": 278,
+          "completion": 161
+        },
+        "cost_usd": 0.0008554,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f630",
+      "right_id": "z202",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The restaurants have completely different names (boulevard vs la taqueria), addresses (1 mission st. vs 2889 mission st.), phone numbers, and types (american vs mexican).",
+      "provenance": {
+        "tokens": {
+          "prompt": 277,
+          "completion": 147
+        },
+        "cost_usd": 0.00080535,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f630",
+      "right_id": "z318",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The two records have completely different restaurant names, addresses, and phone numbers, indicating they are distinct restaurants in San Francisco.",
+      "provenance": {
+        "tokens": {
+          "prompt": 276,
+          "completion": 116
+        },
+        "cost_usd": 0.0006958,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f631",
+      "right_id": "z316",
+      "label": true,
+      "source": "teacher",
+      "confidence": 1.0,
+      "reasoning": "The names are identical, the phone numbers are the same (just different formatting), the cities match, and the addresses are functionally identical (\"la.\" and \"ln.\" both being common abbreviations for Lane). The cuisine types are also highly compatible.",
+      "provenance": {
+        "tokens": {
+          "prompt": 282,
+          "completion": 249
+        },
+        "cost_usd": 0.0011676,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f631",
+      "right_id": "z203",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The two records have completely different names, addresses, phone numbers, and cuisine types. They are clearly distinct restaurants in San Francisco.",
+      "provenance": {
+        "tokens": {
+          "prompt": 292,
+          "completion": 174
+        },
+        "cost_usd": 0.0009155999999999999,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f632",
+      "right_id": "z214",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The restaurant names, addresses, phone numbers, and cuisine types are completely different. They are entirely separate businesses.",
+      "provenance": {
+        "tokens": {
+          "prompt": 280,
+          "completion": 161
+        },
+        "cost_usd": 0.0008575,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f633",
+      "right_id": "z318",
+      "label": true,
+      "source": "teacher",
+      "confidence": 0.95,
+      "reasoning": "The records have an exact match on the restaurant name (\"chez michel\"), city (\"san francisco\"), and phone number (415-775-7036). The addresses are functionally identical, with \"804 northpoint\" simply being a concatenation of \"804 north point st.\". The difference in cuisine type (french vs californian) is a minor discrepancy often found across different review sources and does not outweigh the strong matches on other key identifiers.",
+      "provenance": {
+        "tokens": {
+          "prompt": 281,
+          "completion": 639
+        },
+        "cost_usd": 0.00253155,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f634",
+      "right_id": "z201",
+      "label": true,
+      "source": "teacher",
+      "confidence": 1.0,
+      "reasoning": "The two records have completely different names (\"fleur de lys\" vs \"la mediterranee\"), addresses (777 sutter st. vs 288 noe st.), phone numbers, and cuisine types (french vs mediterranean). They are clearly different restaurants in San Francisco.",
+      "provenance": {
+        "tokens": {
+          "prompt": 284,
+          "completion": 93
+        },
+        "cost_usd": 0.0006237,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f635",
+      "right_id": "z320",
+      "label": true,
+      "source": "teacher",
+      "confidence": 1.0,
+      "reasoning": "The restaurant names match exactly. The addresses are equivalent (\"4th\" vs \"fourth\"), the cities match, and the phone numbers are identical up to formatting variations. The type is also highly similar (\"french\" vs \"french bistro\"). All key attributes strongly indicate they refer to the same restaurant.",
+      "provenance": {
+        "tokens": {
+          "prompt": 283,
+          "completion": 281
+        },
+        "cost_usd": 0.00128065,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f635",
+      "right_id": "z318",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The two records have completely different names (\"fringale\" vs \"chez michel\"), different addresses (\"570 4th st.\" vs \"804 north point st.\"), different phone numbers, and different cuisine types (\"french\" vs \"californian\"). There is no indication these refer to the same restaurant.",
+      "provenance": {
+        "tokens": {
+          "prompt": 285,
+          "completion": 236
+        },
+        "cost_usd": 0.00112525,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f635",
+      "right_id": "z213",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The records have completely different names (fringale vs. thep phanom), addresses (570 4th st. vs. 400 waller st.), phone numbers, and cuisine types (french vs. thai). There is no overlap beyond being located in San Francisco.",
+      "provenance": {
+        "tokens": {
+          "prompt": 285,
+          "completion": 219
+        },
+        "cost_usd": 0.00106575,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f636",
+      "right_id": "z192",
+      "label": true,
+      "source": "teacher",
+      "confidence": 1.0,
+      "reasoning": "The two records have completely different names (\"hawthorne lane\" vs \"doidge's\"), addresses (\"22 hawthorne st.\" vs \"2217 union st.\"), and phone numbers (\"415/777-9779\" vs \"415-921-2149\"). There is no overlap in any unique identifiers, confirming they are distinct restaurants.",
+      "provenance": {
+        "tokens": {
+          "prompt": 286,
+          "completion": 220
+        },
+        "cost_usd": 0.0010703000000000002,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f636",
+      "right_id": "z315",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The restaurants have completely different names (\"hawthorne lane\" vs \"boulevard\"), different addresses (\"22 hawthorne st.\" vs \"1 mission st.\"), and different phone numbers. These are clearly two distinct restaurants in San Francisco.",
+      "provenance": {
+        "tokens": {
+          "prompt": 281,
+          "completion": 144
+        },
+        "cost_usd": 0.0007990499999999999,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f637",
+      "right_id": "z115",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The records are in different cities (San Francisco vs. New York City), have completely different addresses and phone numbers, and the restaurant names are not an exact match.",
+      "provenance": {
+        "tokens": {
+          "prompt": 289,
+          "completion": 185
+        },
+        "cost_usd": 0.0009509499999999999,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f637",
+      "right_id": "z194",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The records have completely different names (khan toke thai house vs dusit thai), different addresses (5937 geary blvd vs 3221 mission st), and different phone numbers. These are clearly two distinct restaurants in San Francisco.",
+      "provenance": {
+        "tokens": {
+          "prompt": 294,
+          "completion": 158
+        },
+        "cost_usd": 0.0008617,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f637",
+      "right_id": "z116",
+      "label": true,
+      "source": "teacher",
+      "confidence": 1.0,
+      "reasoning": "The records have completely different names, addresses, phone numbers, and are located in different cities (San Francisco vs. New York City). There is no overlap in any identifying attributes.",
+      "provenance": {
+        "tokens": {
+          "prompt": 288,
+          "completion": 168
+        },
+        "cost_usd": 0.0008904,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f637",
+      "right_id": "z204",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The records have completely different names (\"khan toke thai house\" vs \"marnee thai\"), different addresses (5937 geary blvd vs 2225 irving st), and different phone numbers. These are clearly distinct restaurants in San Francisco.",
+      "provenance": {
+        "tokens": {
+          "prompt": 291,
+          "completion": 86
+        },
+        "cost_usd": 0.00060655,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f638",
+      "right_id": "z323",
+      "label": true,
+      "source": "teacher",
+      "confidence": 0.99,
+      "reasoning": "Both records have the exact same name (\"la folie\"), address (\"2316 polk st.\"), city (\"san francisco\"), and phone number (just formatted slightly differently: \"415/776-5577\" vs \"415-776-5577\"). The cuisine types (\"french\" and \"french (new)\") are also consistent. These are clearly the same real-world restaurant from two different sources.",
+      "provenance": {
+        "tokens": {
+          "prompt": 288,
+          "completion": 177
+        },
+        "cost_usd": 0.0009219,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f638",
+      "right_id": "z216",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The records have completely different names (\"la folie\" vs \"tu lan\"), addresses, phone numbers, and restaurant types (French vs Vietnamese). They clearly refer to two different restaurants in San Francisco.",
+      "provenance": {
+        "tokens": {
+          "prompt": 278,
+          "completion": 72
+        },
+        "cost_usd": 0.0005438999999999999,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f638",
+      "right_id": "z201",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The records have completely different names (\"la folie\" vs \"la mediterranee\"), addresses, phone numbers, and cuisine types. They clearly refer to two different restaurants in San Francisco.",
+      "provenance": {
+        "tokens": {
+          "prompt": 284,
+          "completion": 496
+        },
+        "cost_usd": 0.0020342000000000003,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f638",
+      "right_id": "z319",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The records have completely different names (\"la folie\" vs \"fleur de lys\"), different addresses (2316 polk st. vs 777 sutter st.), and different phone numbers. They are both French restaurants in San Francisco, but are clearly distinct establishments.",
+      "provenance": {
+        "tokens": {
+          "prompt": 288,
+          "completion": 85
+        },
+        "cost_usd": 0.0005999,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f639",
+      "right_id": "z324",
+      "label": true,
+      "source": "teacher",
+      "confidence": 1.0,
+      "reasoning": "Both records have the same address (816 folsom st.), city (san francisco), phone number (415-495-5775), and cuisine type (mediterranean). The name \"lulu\" in Record A matches the primary name in Record B (\"lulu restaurant-bis-cafe\"). These identical details confirm they refer to the same restaurant.",
+      "provenance": {
+        "tokens": {
+          "prompt": 294,
+          "completion": 141
+        },
+        "cost_usd": 0.0008022000000000001,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f639",
+      "right_id": "z320",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The two records have different names (\"lulu\" vs \"fringale\"), different addresses (\"816 folsom st.\" vs \"570 fourth st.\"), and different phone numbers. There is no overlap in any identifying information, indicating they are distinct restaurants.",
+      "provenance": {
+        "tokens": {
+          "prompt": 282,
+          "completion": 147
+        },
+        "cost_usd": 0.0008106000000000001,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f640",
+      "right_id": "z199",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.01,
+      "reasoning": "The restaurant names, addresses, phone numbers, and cuisine types are all completely different. They merely share the same street (Bush St) and city. There is no evidence these refer to the same restaurant.",
+      "provenance": {
+        "tokens": {
+          "prompt": 282,
+          "completion": 121
+        },
+        "cost_usd": 0.0007196,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f640",
+      "right_id": "z321",
+      "label": true,
+      "source": "teacher",
+      "confidence": 1.0,
+      "reasoning": "The two records have completely different restaurant names (\"masa's\" vs \"hawthorne lane\"), street addresses (\"648 bush st.\" vs \"22 hawthorne st.\"), phone numbers, and cuisine types. They are clearly different restaurants in San Francisco.",
+      "provenance": {
+        "tokens": {
+          "prompt": 287,
+          "completion": 153
+        },
+        "cost_usd": 0.0008368500000000001,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f641",
+      "right_id": "z326",
+      "label": true,
+      "source": "teacher",
+      "confidence": 0.99,
+      "reasoning": "Both records have identical addresses (1737 post st. in san francisco), identical phone numbers (formatted differently), and the same core restaurant name (\"mifune\"). Record A's name includes extra location details (\"japan center kintetsu building\") but clearly refers to the same establishment. The cuisine types are compatible (Asian/Japanese).",
+      "provenance": {
+        "tokens": {
+          "prompt": 294,
+          "completion": 186
+        },
+        "cost_usd": 0.0009597,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f641",
+      "right_id": "z328",
+      "label": true,
+      "source": "teacher",
+      "confidence": 1.0,
+      "reasoning": "The two records have completely different names (mifune vs postrio), addresses (1737 post st vs 545 post st), phone numbers, and restaurant types. They are clearly distinct restaurants in San Francisco.",
+      "provenance": {
+        "tokens": {
+          "prompt": 293,
+          "completion": 144
+        },
+        "cost_usd": 0.00081165,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f642",
+      "right_id": "z327",
+      "label": true,
+      "source": "teacher",
+      "confidence": 0.95,
+      "reasoning": "The records have the exact same name, city, and phone number (just formatted differently). The street addresses differ slightly (3201 vs 3127), but this is likely a typo in one of the sources, and given the matching phone number and street name, it is highly probable these refer to the same real-world restaurant.",
+      "provenance": {
+        "tokens": {
+          "prompt": 290,
+          "completion": 385
+        },
+        "cost_usd": 0.001652,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f642",
+      "right_id": "z188",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The records have completely different names (plumpjack cafe vs. cafe flore), addresses (3201 fillmore st. vs. 2298 market st.), phone numbers, and cuisine types. There is no overlap indicating they refer to the same restaurant.",
+      "provenance": {
+        "tokens": {
+          "prompt": 287,
+          "completion": 81
+        },
+        "cost_usd": 0.00058485,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f642",
+      "right_id": "z215",
+      "label": true,
+      "source": "teacher",
+      "confidence": 1.0,
+      "reasoning": "The records have different restaurant names (plumpjack cafe vs trio cafe), different addresses on Fillmore St (3201 vs 1870), different phone numbers, and different cuisine types. These are clearly two distinct restaurants.",
+      "provenance": {
+        "tokens": {
+          "prompt": 283,
+          "completion": 112
+        },
+        "cost_usd": 0.0006891499999999999,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f643",
+      "right_id": "z318",
+      "label": true,
+      "source": "teacher",
+      "confidence": 1.0,
+      "reasoning": "The two records have completely different names, addresses, phone numbers, and cuisine types, clearly indicating they are two different restaurants in San Francisco.",
+      "provenance": {
+        "tokens": {
+          "prompt": 278,
+          "completion": 110
+        },
+        "cost_usd": 0.0006769,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f644",
+      "right_id": "z329",
+      "label": true,
+      "source": "teacher",
+      "confidence": 1.0,
+      "reasoning": "The records have the exact same address (600 stockton st.), city (san francisco), and phone number (415-296-7465, just formatted differently). The names are highly similar variations of each other (\"ritz-carlton restaurant and dining room\" vs \"ritz-carlton dining room\"). The only difference is the cuisine type classified by different review sources (fodors vs zagat), which is common in entity resolution for restaurants.",
+      "provenance": {
+        "tokens": {
+          "prompt": 304,
+          "completion": 260
+        },
+        "cost_usd": 0.0012292,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f644",
+      "right_id": "z310",
+      "label": true,
+      "source": "teacher",
+      "confidence": 1.0,
+      "reasoning": "The two records have different cities (San Francisco vs. Atlanta), different addresses (600 Stockton St. vs. 181 Peachtree St.), and different phone numbers. They are clearly different restaurants located in different states.",
+      "provenance": {
+        "tokens": {
+          "prompt": 290,
+          "completion": 139
+        },
+        "cost_usd": 0.000791,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f644",
+      "right_id": "z331",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The two records are located in different cities (San Francisco vs. Atlanta) and have different addresses, phone numbers, and slightly different names. They clearly refer to different real-world restaurants.",
+      "provenance": {
+        "tokens": {
+          "prompt": 297,
+          "completion": 82
+        },
+        "cost_usd": 0.00059885,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f645",
+      "right_id": "z190",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The two records have completely different names (\"rose pistola\" vs \"campo santo\"), different addresses (\"532 columbus ave.\" vs \"240 columbus ave.\"), different phone numbers, and different cuisine types (Italian vs Mexican). There is no overlap in any identifying attributes, indicating they are clearly two distinct restaurants.",
+      "provenance": {
+        "tokens": {
+          "prompt": 280,
+          "completion": 154
+        },
+        "cost_usd": 0.000833,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f645",
+      "right_id": "z214",
+      "label": true,
+      "source": "teacher",
+      "confidence": 1.0,
+      "reasoning": "The records have completely different names (\"rose pistola\" vs \"ti couz\"), addresses (\"532 columbus ave.\" vs \"3108 16th st.\"), and phone numbers (\"415/399-0499\" vs \"415-252-7373\"). They are clearly different restaurants.",
+      "provenance": {
+        "tokens": {
+          "prompt": 283,
+          "completion": 198
+        },
+        "cost_usd": 0.00099015,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f647",
+      "right_id": "z258",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The records have completely different names (il nido vs la caravelle), addresses (251 e. 53rd st. vs 33 w. 55th st.), phone numbers, and cuisines (italian vs french (classic)). They are clearly distinct restaurants.",
+      "provenance": {
+        "tokens": {
+          "prompt": 292,
+          "completion": 130
+        },
+        "cost_usd": 0.0007616,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f648",
+      "right_id": "z251",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The records have completely different names (remi vs dawat), addresses (145 w. 53rd st. vs 210 e. 58th st.), phone numbers, and cuisine types (italian vs indian), indicating they are entirely different restaurants.",
+      "provenance": {
+        "tokens": {
+          "prompt": 282,
+          "completion": 448
+        },
+        "cost_usd": 0.0018641,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f649",
+      "right_id": "z65",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The restaurants have completely different names (\"adriano's ristorante\" vs \"tommy's\"), addresses (\"2930 beverly glen circle\" vs \"2575 beverly blvd.\"), phone numbers, and cuisine types (Italian vs hamburgers). They are clearly different real-world restaurants.",
+      "provenance": {
+        "tokens": {
+          "prompt": 298,
+          "completion": 168
+        },
+        "cost_usd": 0.0009009,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f649",
+      "right_id": "z56",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The restaurant names, addresses, cities, phone numbers, and types are all completely different. Record A is an Italian restaurant called \"adriano's ristorante\" in Los Angeles, while Record B is a diner called \"rae's\" in Santa Monica.",
+      "provenance": {
+        "tokens": {
+          "prompt": 298,
+          "completion": 464
+        },
+        "cost_usd": 0.0019369,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f650",
+      "right_id": "z4",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The records have completely different restaurant names (\"barney greengrass\" vs \"belvedere the\"), different addresses, and different phone numbers. There is no overlap in any identifying information to suggest they are the same restaurant.",
+      "provenance": {
+        "tokens": {
+          "prompt": 304,
+          "completion": 223
+        },
+        "cost_usd": 0.0010997,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f650",
+      "right_id": "z91",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The records have completely different names",
+      "provenance": {
+        "tokens": {
+          "prompt": 290,
+          "completion": 134
+        },
+        "cost_usd": 0.0007735000000000001,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f650",
+      "right_id": "z65",
+      "label": true,
+      "source": "teacher",
+      "confidence": 1.0,
+      "reasoning": "The records have entirely different names (Barney Greengrass vs Tommy's), addresses, cities, and phone numbers. There is no overlap in any identifying information.",
+      "provenance": {
+        "tokens": {
+          "prompt": 292,
+          "completion": 177
+        },
+        "cost_usd": 0.0009261,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f650",
+      "right_id": "z47",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The records have completely different names, addresses, cities, phone numbers, and cuisine types. There is no indication they refer to the same restaurant.",
+      "provenance": {
+        "tokens": {
+          "prompt": 289,
+          "completion": 125
+        },
+        "cost_usd": 0.00074095,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f651",
+      "right_id": "z227",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The two records have completely different names (\"beaurivage\" vs \"granita\"), addresses (\"26025 pacific coast hwy.\" vs \"23725 w. malibu rd.\"), and phone numbers (\"310/456-5733\" vs \"310-456-0488\"), indicating they refer to distinct restaurants.",
+      "provenance": {
+        "tokens": {
+          "prompt": 287,
+          "completion": 158
+        },
+        "cost_usd": 0.00085435,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f651",
+      "right_id": "z56",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The names, addresses, cities, phone numbers, and restaurant types are completely different, indicating they are entirely different establishments.",
+      "provenance": {
+        "tokens": {
+          "prompt": 286,
+          "completion": 185
+        },
+        "cost_usd": 0.0009477999999999999,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f651",
+      "right_id": "z65",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The records have completely different names (beaurivage vs tommy's), addresses (26025 pacific coast hwy vs 2575 beverly blvd), cities (malibu vs la), phone numbers, and types (french vs hamburgers). They are clearly distinct restaurants.",
+      "provenance": {
+        "tokens": {
+          "prompt": 286,
+          "completion": 110
+        },
+        "cost_usd": 0.0006853,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f652",
+      "right_id": "z146",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The records are located in different cities (Los Angeles vs. Atlanta), have different addresses, different phone numbers, and different restaurant names. These are clearly different restaurants.",
+      "provenance": {
+        "tokens": {
+          "prompt": 290,
+          "completion": 93
+        },
+        "cost_usd": 0.00063,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f652",
+      "right_id": "z7",
+      "label": true,
+      "source": "teacher",
+      "confidence": 1.0,
+      "reasoning": "The restaurants have completely different names (\"bistro garden\" vs \"bistro 45\"), addresses, cities (los angeles vs pasadena), and phone numbers.",
+      "provenance": {
+        "tokens": {
+          "prompt": 281,
+          "completion": 164
+        },
+        "cost_usd": 0.0008690499999999999,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f652",
+      "right_id": "z237",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The two records have completely different names, addresses, cities, phone numbers, and cuisines. They clearly refer to two distinct restaurants.",
+      "provenance": {
+        "tokens": {
+          "prompt": 285,
+          "completion": 183
+        },
+        "cost_usd": 0.00093975,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f653",
+      "right_id": "z67",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The restaurant names, addresses, phone numbers, and types are all completely different, indicating they are distinct restaurants.",
+      "provenance": {
+        "tokens": {
+          "prompt": 273,
+          "completion": 170
+        },
+        "cost_usd": 0.0008816500000000001,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f653",
+      "right_id": "z51",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The two records have completely different names, addresses, cities, phone numbers, and cuisine types. There is no overlap in any of the identifying fields, making it certain that these refer to two different real-world restaurants.",
+      "provenance": {
+        "tokens": {
+          "prompt": 280,
+          "completion": 224
+        },
+        "cost_usd": 0.001078,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f654",
+      "right_id": "z5",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.05,
+      "reasoning": "The records have completely different names (\"broadway deli\" vs \"benita's frites\"), different phone numbers, and different cuisine types. While both are on 3rd Street Promenade in Santa Monica, they are clearly distinct restaurants.",
+      "provenance": {
+        "tokens": {
+          "prompt": 292,
+          "completion": 136
+        },
+        "cost_usd": 0.0007826,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f654",
+      "right_id": "z44",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The restaurant names, phone numbers, exact addresses, and types are completely different. \"Broadway Deli\" and \"Michael's (los angeles)\" are clearly distinct establishments.",
+      "provenance": {
+        "tokens": {
+          "prompt": 292,
+          "completion": 188
+        },
+        "cost_usd": 0.0009645999999999999,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f654",
+      "right_id": "z268",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The records have completely different restaurant names (broadway deli vs. montrachet), cities (santa monica vs. new york city), addresses, and phone numbers. They clearly refer to different real-world restaurants.",
+      "provenance": {
+        "tokens": {
+          "prompt": 290,
+          "completion": 183
+        },
+        "cost_usd": 0.0009450000000000001,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f655",
+      "right_id": "z223",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The records have completely different names (\"ca'brea\" vs \"campanile\"), different addresses (346 s. la brea ave. vs 624 s. la brea ave.), and different phone numbers. Although both are located on La Brea Ave in Los Angeles, the street numbers are significantly different and they are listed as different types of cuisine, indicating they are distinct restaurants.",
+      "provenance": {
+        "tokens": {
+          "prompt": 292,
+          "completion": 189
+        },
+        "cost_usd": 0.0009681000000000002,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f657",
+      "right_id": "z237",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The records have different names (cafe pinot vs. pinot bistro), different addresses (700 w. fifth st. vs. 12969 ventura blvd.), different cities (los angeles vs. studio city), and different phone numbers. These are distinct restaurants, though they may be part of the same restaurant group.",
+      "provenance": {
+        "tokens": {
+          "prompt": 287,
+          "completion": 169
+        },
+        "cost_usd": 0.0008928499999999999,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f657",
+      "right_id": "z188",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The restaurants have completely different names (\"cafe pinot\" vs \"cafe flore\"), addresses, cities (Los Angeles vs San Francisco), and phone numbers. There is no overlap in any uniquely identifying attributes.",
+      "provenance": {
+        "tokens": {
+          "prompt": 285,
+          "completion": 201
+        },
+        "cost_usd": 0.00100275,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f658",
+      "right_id": "z6",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The records have completely different restaurant names (california pizza kitchen vs bernard's), addresses, phone numbers, and cuisine types. There is no overlap in any matching fields.",
+      "provenance": {
+        "tokens": {
+          "prompt": 285,
+          "completion": 127
+        },
+        "cost_usd": 0.00074375,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f658",
+      "right_id": "z24",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The two records have completely different names, addresses, phone numbers, and types. There is no evidence to suggest they refer to the same restaurant.",
+      "provenance": {
+        "tokens": {
+          "prompt": 289,
+          "completion": 214
+        },
+        "cost_usd": 0.00105245,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f658",
+      "right_id": "z13",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The two records have completely different names (california pizza kitchen vs. cafe blanc), addresses, phone numbers, and cities. They clearly refer to two different restaurants.",
+      "provenance": {
+        "tokens": {
+          "prompt": 295,
+          "completion": 184
+        },
+        "cost_usd": 0.0009537500000000001,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f658",
+      "right_id": "z51",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The records have completely different names (California Pizza Kitchen vs Parkway Grill), addresses, cities, and phone numbers. They clearly refer to different restaurants.",
+      "provenance": {
+        "tokens": {
+          "prompt": 292,
+          "completion": 156
+        },
+        "cost_usd": 0.0008526,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f660",
+      "right_id": "z55",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The restaurants have completely different names (\"cava\" vs \"r-23\"), different phone numbers, and different cuisines (mediterranean vs japanese). Although they are both located on Third St. in Los Angeles, all other attributes strongly indicate they are different establishments.",
+      "provenance": {
+        "tokens": {
+          "prompt": 276,
+          "completion": 156
+        },
+        "cost_usd": 0.0008358,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f660",
+      "right_id": "z232",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The two records have completely different names (\"cava\" vs \"locanda veneta\"), different phone numbers (213/658-8898 vs 310-274-1893), and different cuisine types (mediterranean vs italian). While they are both located in Los Angeles on a 3rd street, they are clearly distinct restaurants.",
+      "provenance": {
+        "tokens": {
+          "prompt": 279,
+          "completion": 298
+        },
+        "cost_usd": 0.0013359499999999998,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f661",
+      "right_id": "z6",
+      "label": true,
+      "source": "teacher",
+      "confidence": 1.0,
+      "reasoning": "The records have completely different names, addresses, phone numbers, and cuisine types, indicating they are two distinct restaurants in Los Angeles.",
+      "provenance": {
+        "tokens": {
+          "prompt": 283,
+          "completion": 130
+        },
+        "cost_usd": 0.0007521499999999999,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f662",
+      "right_id": "z16",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The two records have completely different names, addresses, phone numbers, cities, and restaurant types (Asian vs. Russian), indicating they refer to entirely different restaurants.",
+      "provenance": {
+        "tokens": {
+          "prompt": 293,
+          "completion": 152
+        },
+        "cost_usd": 0.00083965,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f663",
+      "right_id": "z13",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The records have completely different names (clearwater cafe vs. cafe blanc), addresses, cities (los angeles vs. beverly hills), phone numbers, and types. There is no overlap in any identifying fields.",
+      "provenance": {
+        "tokens": {
+          "prompt": 294,
+          "completion": 74
+        },
+        "cost_usd": 0.0005677,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f663",
+      "right_id": "z222",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The records have completely different names, addresses, cities, phone numbers, and restaurant types. There is no overlap in any identifying information.",
+      "provenance": {
+        "tokens": {
+          "prompt": 293,
+          "completion": 71
+        },
+        "cost_usd": 0.00055615,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f663",
+      "right_id": "z43",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The records have completely different names, addresses, cities, phone numbers, and restaurant types, indicating they are entirely different establishments.",
+      "provenance": {
+        "tokens": {
+          "prompt": 288,
+          "completion": 110
+        },
+        "cost_usd": 0.0006874000000000001,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f664",
+      "right_id": "z329",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The records are in different cities (Los Angeles vs San Francisco), have different addresses, phone numbers, and distinct names. They clearly refer to different real-world restaurants.",
+      "provenance": {
+        "tokens": {
+          "prompt": 300,
+          "completion": 130
+        },
+        "cost_usd": 0.0007699999999999999,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f664",
+      "right_id": "z24",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The two records have completely different names (\"dining room\" vs \"jan's family restaurant\"), different addresses (\"9500 wilshire blvd.\" vs \"8424 beverly blvd.\"), different phone numbers, and different restaurant types. There is no overlap in any identifying field, indicating these are definitively different restaurants.",
+      "provenance": {
+        "tokens": {
+          "prompt": 287,
+          "completion": 292
+        },
+        "cost_usd": 0.0013233499999999998,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f665",
+      "right_id": "z56",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The records have completely different names (\"dive!\" vs \"rae's\"), addresses (\"10250 santa monica blvd.\" vs \"2901 pico blvd.\"), and phone numbers. They are clearly different restaurants.",
+      "provenance": {
+        "tokens": {
+          "prompt": 283,
+          "completion": 170
+        },
+        "cost_usd": 0.00089215,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f665",
+      "right_id": "z234",
+      "label": true,
+      "source": "teacher",
+      "confidence": 1.0,
+      "reasoning": "The restaurants have completely different names, addresses, phone numbers, and types. They are clearly two distinct establishments on Santa Monica Blvd.",
+      "provenance": {
+        "tokens": {
+          "prompt": 298,
+          "completion": 226
+        },
+        "cost_usd": 0.0011038999999999999,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f666",
+      "right_id": "z56",
+      "label": true,
+      "source": "teacher",
+      "confidence": 1.0,
+      "reasoning": "The two records have completely different names (\"drago\" vs \"rae's\"), addresses (\"2628 wilshire blvd.\" vs \"2901 pico blvd.\"), phone numbers, and types of cuisine (\"italian\" vs \"diners\"). They are clearly different restaurants in Santa Monica.",
+      "provenance": {
+        "tokens": {
+          "prompt": 284,
+          "completion": 212
+        },
+        "cost_usd": 0.0010402,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f666",
+      "right_id": "z240",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The records have completely different names (\"drago\" vs \"valentino\"), addresses (\"2628 wilshire blvd.\" vs \"3115 pico blvd.\"), and phone numbers (\"310/828-1585\" vs \"310-829-4313\"). These are clearly two distinct Italian restaurants in Santa Monica.",
+      "provenance": {
+        "tokens": {
+          "prompt": 284,
+          "completion": 255
+        },
+        "cost_usd": 0.0011907,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f666",
+      "right_id": "z4",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "These records have no matching attributes. The names (\"drago\" vs \"belvedere the\"), addresses (\"2628 wilshire blvd.\" vs \"9882 little santa monica blvd.\"), cities (\"santa monica\" vs \"beverly hills\"), phone numbers (310/828-1585 vs 310-788-2306), and cuisine types (\"italian\" vs \"pacific new wave\") are all completely different. There is no evidence these refer to the same restaurant.",
+      "provenance": {
+        "tokens": {
+          "prompt": 296,
+          "completion": 432
+        },
+        "cost_usd": 0.0018227999999999999,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f668",
+      "right_id": "z65",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The records have completely different names (dynasty room vs tommy's), addresses (930 hilgard ave. vs 2575 beverly blvd.), phone numbers, and restaurant types. They are definitively different restaurants.",
+      "provenance": {
+        "tokens": {
+          "prompt": 280,
+          "completion": 179
+        },
+        "cost_usd": 0.0009205,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f669",
+      "right_id": "z225",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The records have completely different names (\"eclipse\" vs \"citrus\"), different street addresses (8800 vs 6703 Melrose Ave.), and different phone numbers. They are clearly distinct restaurants on the same street.",
+      "provenance": {
+        "tokens": {
+          "prompt": 281,
+          "completion": 556
+        },
+        "cost_usd": 0.0022410499999999996,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f669",
+      "right_id": "z235",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The records have completely different names, addresses, and phone numbers. \"Eclipse\" at 8800 Melrose Ave. and \"Patina\" at 5955 Melrose Ave. are clearly distinct restaurants despite both being Californian cuisine in Los Angeles.",
+      "provenance": {
+        "tokens": {
+          "prompt": 280,
+          "completion": 143
+        },
+        "cost_usd": 0.0007945000000000001,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f670",
+      "right_id": "z232",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The restaurants have completely different names, addresses, phone numbers, and cuisine types. They are clearly distinct real-world restaurants.",
+      "provenance": {
+        "tokens": {
+          "prompt": 288,
+          "completion": 112
+        },
+        "cost_usd": 0.0006944,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f672",
+      "right_id": "z56",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The restaurant names (gilliland's vs. rae's), addresses (2424 main st. vs. 2901 pico blvd.), and phone numbers are completely different, indicating they are distinct establishments.",
+      "provenance": {
+        "tokens": {
+          "prompt": 284,
+          "completion": 140
+        },
+        "cost_usd": 0.0007882,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f672",
+      "right_id": "z224",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The restaurants have completely different names (gilliland's vs chinois on main), different addresses on Main Street (2424 vs 2709), different phone numbers, and different cuisine types. These are clearly two distinct restaurants.",
+      "provenance": {
+        "tokens": {
+          "prompt": 285,
+          "completion": 133
+        },
+        "cost_usd": 0.00076475,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f672",
+      "right_id": "z44",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The records have entirely different names (gilliland's vs michael's), different street addresses (2424 main st. vs 1147 third st.), and different phone numbers. They are clearly distinct restaurants.",
+      "provenance": {
+        "tokens": {
+          "prompt": 290,
+          "completion": 177
+        },
+        "cost_usd": 0.0009239999999999999,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f673",
+      "right_id": "z314",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The restaurant names (gladstone's vs. aqua), addresses, cities (Pacific Palisades vs. San Francisco), and phone numbers are completely different. These are clearly two different restaurants.",
+      "provenance": {
+        "tokens": {
+          "prompt": 303,
+          "completion": 419
+        },
+        "cost_usd": 0.00178465,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f674",
+      "right_id": "z13",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The names, addresses, phone numbers, cities, and types are all completely different. There is no evidence to suggest these two records refer to the same restaurant.",
+      "provenance": {
+        "tokens": {
+          "prompt": 294,
+          "completion": 117
+        },
+        "cost_usd": 0.0007182,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f674",
+      "right_id": "z65",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The names (hard rock cafe vs tommy's), addresses (8600 vs 2575 beverly blvd.), and phone numbers are completely different, indicating they are distinct restaurants on the same street.",
+      "provenance": {
+        "tokens": {
+          "prompt": 287,
+          "completion": 140
+        },
+        "cost_usd": 0.0007913499999999999,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f675",
+      "right_id": "z254",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The records have completely different names, cities, addresses, and phone numbers. Record A is an Italian restaurant in Los Angeles, while Record B is a New American restaurant in New York City.",
+      "provenance": {
+        "tokens": {
+          "prompt": 303,
+          "completion": 353
+        },
+        "cost_usd": 0.0015536500000000002,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f676",
+      "right_id": "z74",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The records refer to restaurants in different cities (Los Angeles vs. New York City), with different addresses, phone numbers, and distinct names.",
+      "provenance": {
+        "tokens": {
+          "prompt": 294,
+          "completion": 112
+        },
+        "cost_usd": 0.0007007000000000001,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f676",
+      "right_id": "z238",
+      "label": true,
+      "source": "teacher",
+      "confidence": 1.0,
+      "reasoning": "The records have completely different names (\"il fornaio cucina italiana\" vs \"rex il ristorante\"), different addresses (\"301 n. beverly dr.\" vs \"617 s. olive st.\"), and different phone numbers. These are clearly two distinct Italian restaurants in Los Angeles.",
+      "provenance": {
+        "tokens": {
+          "prompt": 294,
+          "completion": 196
+        },
+        "cost_usd": 0.0009947,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f677",
+      "right_id": "z67",
+      "label": true,
+      "source": "teacher",
+      "confidence": 1.0,
+      "reasoning": "The restaurants have completely different names, addresses, phone numbers, and types. There is no overlap in the identifying information.",
+      "provenance": {
+        "tokens": {
+          "prompt": 289,
+          "completion": 114
+        },
+        "cost_usd": 0.0007024500000000001,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f677",
+      "right_id": "z51",
+      "label": true,
+      "source": "teacher",
+      "confidence": 1.0,
+      "reasoning": "The two records have completely different names, addresses, cities, phone numbers, and types. There is no overlap in any of the identifying information, making it certain they are different restaurants.",
+      "provenance": {
+        "tokens": {
+          "prompt": 296,
+          "completion": 318
+        },
+        "cost_usd": 0.0014237999999999998,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f678",
+      "right_id": "z39",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The two records have completely different names, addresses, cities, phone numbers, and restaurant types. There is no overlap in any field to suggest these refer to the same restaurant.",
+      "provenance": {
+        "tokens": {
+          "prompt": 293,
+          "completion": 52
+        },
+        "cost_usd": 0.00048965,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f678",
+      "right_id": "z83",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The two records have different names, addresses, cities, phone numbers, and cuisine types, indicating they are entirely different restaurants.",
+      "provenance": {
+        "tokens": {
+          "prompt": 289,
+          "completion": 119
+        },
+        "cost_usd": 0.00071995,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f678",
+      "right_id": "z24",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The restaurant names, street addresses, phone numbers, and types are completely different. They only share the same city (\"los angeles\" vs \"la\") and a street name (\"beverly\"), but there is no evidence suggesting they refer to the same real-world restaurant.",
+      "provenance": {
+        "tokens": {
+          "prompt": 292,
+          "completion": 338
+        },
+        "cost_usd": 0.0014896,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f679",
+      "right_id": "z55",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The records have completely different names (\"jimmy's\" vs \"r-23\"), addresses, phone numbers, and cuisine types (continental vs japanese). There are no shared attributes indicating they refer to the same restaurant.",
+      "provenance": {
+        "tokens": {
+          "prompt": 280,
+          "completion": 81
+        },
+        "cost_usd": 0.0005775,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f679",
+      "right_id": "z65",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The two records have completely different names (jimmy's vs. tommy's), addresses (201 moreno dr. vs. 2575 beverly blvd.), phone numbers, and cuisine types (continental vs. hamburgers). There is no indication they refer to the same restaurant.",
+      "provenance": {
+        "tokens": {
+          "prompt": 281,
+          "completion": 203
+        },
+        "cost_usd": 0.00100555,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f679",
+      "right_id": "z6",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The two records have completely different names, addresses, and phone numbers. There is no evidence to suggest they refer to the same restaurant.",
+      "provenance": {
+        "tokens": {
+          "prompt": 278,
+          "completion": 165
+        },
+        "cost_usd": 0.0008694,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f680",
+      "right_id": "z239",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The records have entirely different names (joss vs spago), addresses (9255 sunset blvd vs 8795 sunset blvd), cities, phone numbers, and types. There is no overlap in any identifying attributes.",
+      "provenance": {
+        "tokens": {
+          "prompt": 291,
+          "completion": 186
+        },
+        "cost_usd": 0.00095655,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f680",
+      "right_id": "z230",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The records have completely different names (\"joss\" vs \"l'orangerie\"), addresses, phone numbers, cuisine types, and cities. There is no overlap indicating they are the same restaurant.",
+      "provenance": {
+        "tokens": {
+          "prompt": 296,
+          "completion": 75
+        },
+        "cost_usd": 0.0005733,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f681",
+      "right_id": "z231",
+      "label": true,
+      "source": "teacher",
+      "confidence": 1.0,
+      "reasoning": "The records have completely different names (le colonial vs le chardonnay), addresses (8783 beverly blvd. vs 8284 melrose ave.), phone numbers (310/289-0660 vs 213-655-8880), and cuisine types (asian vs french bistro). There is no overlap in any identifying information.",
+      "provenance": {
+        "tokens": {
+          "prompt": 300,
+          "completion": 186
+        },
+        "cost_usd": 0.000966,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f683",
+      "right_id": "z65",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The names (\"louise's trattoria\" vs \"tommy's\"), addresses (\"4500 los feliz blvd.\" vs \"2575 beverly blvd.\"), phone numbers, and cuisine types (\"italian\" vs \"hamburgers\") all differ completely, clearly indicating two distinct restaurants.",
+      "provenance": {
+        "tokens": {
+          "prompt": 288,
+          "completion": 144
+        },
+        "cost_usd": 0.0008064000000000001,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f683",
+      "right_id": "z230",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The records have completely different names, addresses, phone numbers, cities, and cuisine types, clearly referring to two different restaurants.",
+      "provenance": {
+        "tokens": {
+          "prompt": 303,
+          "completion": 162
+        },
+        "cost_usd": 0.00088515,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f684",
+      "right_id": "z116",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The records have completely different names, addresses, phonenumbers, and are located in different cities (Los Angeles vs New York City). There is no overlap in any identifying attributes.",
+      "provenance": {
+        "tokens": {
+          "prompt": 283,
+          "completion": 77
+        },
+        "cost_usd": 0.0005666499999999999,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f684",
+      "right_id": "z24",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The records have entirely different names, addresses, phone numbers, and restaurant types. The only similarity is the city, which is not sufficient to identify these as the same restaurant.",
+      "provenance": {
+        "tokens": {
+          "prompt": 289,
+          "completion": 80
+        },
+        "cost_usd": 0.00058345,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f684",
+      "right_id": "z148",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The records have completely different names (mon kee seafood restaurant vs. bradshaw's restaurant), addresses, cities (los angeles vs. atlanta), phone numbers, and cuisine types. There is no overlap in any attribute, indicating they are definitively different restaurants.",
+      "provenance": {
+        "tokens": {
+          "prompt": 296,
+          "completion": 94
+        },
+        "cost_usd": 0.0006398,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f685",
+      "right_id": "z219",
+      "label": true,
+      "source": "teacher",
+      "confidence": 0.95,
+      "reasoning": "Although the names share the \"Morton's\" branding (likely the same restaurant chain), the addresses and phone numbers are completely different, indicating they are different physical restaurant locations.",
+      "provenance": {
+        "tokens": {
+          "prompt": 298,
+          "completion": 403
+        },
+        "cost_usd": 0.0017234,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f685",
+      "right_id": "z134",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The records refer to different restaurant locations. Record A is a Morton's in Los Angeles on Melrose Ave with a 310 area code phone number, while Record B is a Morton's in Las Vegas on Las Vegas Blvd with a 702 area code phone number. Despite the similar chain name, they are distinct real-world restaurants.",
+      "provenance": {
+        "tokens": {
+          "prompt": 296,
+          "completion": 139
+        },
+        "cost_usd": 0.0007972999999999999,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f686",
+      "right_id": "z24",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The restaurant names, addresses, and phone numbers are completely different. They are clearly two distinct restaurants in Los Angeles.",
+      "provenance": {
+        "tokens": {
+          "prompt": 295,
+          "completion": 153
+        },
+        "cost_usd": 0.0008452500000000001,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f687",
+      "right_id": "z223",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The names (nicola vs. campanile), addresses (601 s. figueroa st. vs. 624 s. la brea ave.), and phone numbers are completely different, indicating these are two distinct restaurants in Los Angeles.",
+      "provenance": {
+        "tokens": {
+          "prompt": 291,
+          "completion": 340
+        },
+        "cost_usd": 0.00149555,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f687",
+      "right_id": "z235",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The names (nicola vs. patina), addresses (601 s. figueroa st. vs. 5955 melrose ave.), and phone numbers are completely different between the two records.",
+      "provenance": {
+        "tokens": {
+          "prompt": 284,
+          "completion": 153
+        },
+        "cost_usd": 0.0008337000000000002,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f687",
+      "right_id": "z6",
+      "label": true,
+      "source": "teacher",
+      "confidence": 1.0,
+      "reasoning": "The two records have completely different names (\"nicola\" vs \"bernard's\"), addresses (\"601 s. figueroa st.\" vs \"515 s. olive st.\"), and phone numbers. There is no evidence suggesting they refer to the same restaurant.",
+      "provenance": {
+        "tokens": {
+          "prompt": 284,
+          "completion": 173
+        },
+        "cost_usd": 0.0009037000000000001,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f688",
+      "right_id": "z48",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The restaurants have different names, addresses, and phone numbers. There are no matching identifiers to suggest they are the same restaurant.",
+      "provenance": {
+        "tokens": {
+          "prompt": 283,
+          "completion": 189
+        },
+        "cost_usd": 0.0009586500000000001,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f688",
+      "right_id": "z13",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The records have completely different restaurant names, addresses, cities, and phone numbers. They are clearly distinct establishments.",
+      "provenance": {
+        "tokens": {
+          "prompt": 287,
+          "completion": 176
+        },
+        "cost_usd": 0.0009173499999999999,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f688",
+      "right_id": "z56",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The two records have completely different names, addresses, and phone numbers, making it certain they are distinct restaurants in Santa Monica.",
+      "provenance": {
+        "tokens": {
+          "prompt": 280,
+          "completion": 173
+        },
+        "cost_usd": 0.0008995,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f690",
+      "right_id": "z329",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The two records have completely different names, addresses, cities, phone numbers, and restaurant types. One is the \"pacific dining car\" in Los Angeles and the other is the \"ritz-carlton dining room\" in San Francisco, making it certain they are not the same restaurant.",
+      "provenance": {
+        "tokens": {
+          "prompt": 292,
+          "completion": 122
+        },
+        "cost_usd": 0.0007336,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f691",
+      "right_id": "z314",
+      "label": true,
+      "source": "teacher",
+      "confidence": 1.0,
+      "reasoning": "The two records have entirely different names (paty's vs. aqua), addresses, cities (toluca lake vs. san francisco), and phone numbers. There is no overlap in any field, indicating they are completely different restaurants.",
+      "provenance": {
+        "tokens": {
+          "prompt": 280,
+          "completion": 84
+        },
+        "cost_usd": 0.000588,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f692",
+      "right_id": "z16",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The records have completely different names, addresses, phone numbers, cities, and cuisine types, indicating they are distinct restaurants.",
+      "provenance": {
+        "tokens": {
+          "prompt": 297,
+          "completion": 432
+        },
+        "cost_usd": 0.00182385,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f692",
+      "right_id": "z237",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The records have different names (\"pinot hollywood\" vs \"pinot bistro\"), different addresses (Los Angeles vs Studio City, completely different streets), and different phone numbers. While both may belong to the same restaurant group, they refer to distinct physical restaurant locations.",
+      "provenance": {
+        "tokens": {
+          "prompt": 292,
+          "completion": 226
+        },
+        "cost_usd": 0.0010976,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f692",
+      "right_id": "z230",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The two records have completely different restaurant names (pinot hollywood vs. l'orangerie), addresses, phone numbers, cities, and cuisine types. There is no overlap in any identifying information, so they are definitively different restaurants.",
+      "provenance": {
+        "tokens": {
+          "prompt": 304,
+          "completion": 146
+        },
+        "cost_usd": 0.0008301999999999999,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f693",
+      "right_id": "z47",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The records have completely different names, addresses, phone numbers, and cities. They are definitively different restaurants.",
+      "provenance": {
+        "tokens": {
+          "prompt": 280,
+          "completion": 397
+        },
+        "cost_usd": 0.0016835,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f693",
+      "right_id": "z222",
+      "label": true,
+      "source": "teacher",
+      "confidence": 1.0,
+      "reasoning": "The records have completely different restaurant names (\"posto\" vs \"cafe bizou\"), different addresses (14928 ventura blvd vs 14016 ventura blvd), different phone numbers, and different cuisine types (Italian vs French bistro). These are clearly two separate restaurants on Ventura Blvd in Sherman Oaks.",
+      "provenance": {
+        "tokens": {
+          "prompt": 289,
+          "completion": 178
+        },
+        "cost_usd": 0.0009264499999999999,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f693",
+      "right_id": "z56",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The records have completely different names, addresses, cities, phone numbers, and restaurant types, indicating they refer to different restaurants.",
+      "provenance": {
+        "tokens": {
+          "prompt": 283,
+          "completion": 138
+        },
+        "cost_usd": 0.00078015,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f694",
+      "right_id": "z55",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The records have completely different names (prego vs r-23), addresses (362 n. camden dr. vs 923 e. third st.), phone numbers, and cuisine types (italian vs japanese). There is no indication these refer to the same restaurant.",
+      "provenance": {
+        "tokens": {
+          "prompt": 283,
+          "completion": 143
+        },
+        "cost_usd": 0.00079765,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f695",
+      "right_id": "z65",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The two records have completely different restaurant names (\"rj's the rib joint\" vs \"tommy's\"), different addresses (252 n. beverly dr. vs 2575 beverly blvd.), different phone numbers, and different cuisine types. Despite both being in Los Angeles and on a Beverly street, they clearly refer to different establishments.",
+      "provenance": {
+        "tokens": {
+          "prompt": 293,
+          "completion": 231
+        },
+        "cost_usd": 0.00111615,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f696",
+      "right_id": "z5",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The restaurants have completely different names (\"remi\" vs \"benita's frites\"), phone numbers, and cuisines (Italian vs fast food), despite being on the same street in Santa Monica. They are clearly different establishments.",
+      "provenance": {
+        "tokens": {
+          "prompt": 289,
+          "completion": 207
+        },
+        "cost_usd": 0.00102795,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f696",
+      "right_id": "z44",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The restaurant names (\"remi\" vs \"michael's\"), phone numbers, and cuisine types are completely different, indicating they are separate establishments despite both being located on 3rd Street in Santa Monica.",
+      "provenance": {
+        "tokens": {
+          "prompt": 289,
+          "completion": 187
+        },
+        "cost_usd": 0.00095795,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f697",
+      "right_id": "z41",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The two records have completely different names, addresses, phone numbers, and cuisine types. There is no overlap in any identifying attributes.",
+      "provenance": {
+        "tokens": {
+          "prompt": 291,
+          "completion": 151
+        },
+        "cost_usd": 0.00083405,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f698",
+      "right_id": "z185",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The records have completely different names (roscoe's house of chicken 'n' waffles vs. white house restaurant), addresses (los angeles vs. atlanta), phone numbers, and types. They clearly refer to different restaurants.",
+      "provenance": {
+        "tokens": {
+          "prompt": 303,
+          "completion": 87
+        },
+        "cost_usd": 0.00062265,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f698",
+      "right_id": "z68",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The records have different names (roscoe's house of chicken 'n' waffles vs zankou chicken), different addresses, different cities (los angeles vs glendale), different phone numbers, and different cuisine types (american vs middle eastern). There is no overlap in any field indicating these are two distinct restaurants.",
+      "provenance": {
+        "tokens": {
+          "prompt": 303,
+          "completion": 102
+        },
+        "cost_usd": 0.00067515,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f698",
+      "right_id": "z24",
+      "label": true,
+      "source": "teacher",
+      "confidence": 1.0,
+      "reasoning": "The records have completely different names, addresses, and phone numbers, indicating they are different restaurants.",
+      "provenance": {
+        "tokens": {
+          "prompt": 302,
+          "completion": 199
+        },
+        "cost_usd": 0.0010136000000000001,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f698",
+      "right_id": "z175",
+      "label": true,
+      "source": "teacher",
+      "confidence": 1.0,
+      "reasoning": "The restaurants have completely different names, addresses, cities, and phone numbers. Record A is Roscoe's House of Chicken 'n' Waffles in Los Angeles, while Record B is Original Pancake House in Atlanta. They are clearly different establishments.",
+      "provenance": {
+        "tokens": {
+          "prompt": 305,
+          "completion": 111
+        },
+        "cost_usd": 0.00070875,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f699",
+      "right_id": "z55",
+      "label": true,
+      "source": "teacher",
+      "confidence": 1.0,
+      "reasoning": "The two records have completely different names, addresses, phone numbers, and restaurant types. They are clearly distinct restaurants in Los Angeles.",
+      "provenance": {
+        "tokens": {
+          "prompt": 283,
+          "completion": 160
+        },
+        "cost_usd": 0.0008571500000000001,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f700",
+      "right_id": "z55",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The restaurant names (\"sofi\" vs \"r-23\"), phone numbers, and cuisines (\"mediterranean\" vs \"japanese\") are completely different, indicating they are distinct entities despite both being located on 3rd Street in Los Angeles.",
+      "provenance": {
+        "tokens": {
+          "prompt": 275,
+          "completion": 245
+        },
+        "cost_usd": 0.0011462500000000001,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f700",
+      "right_id": "z232",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The restaurant names (\"sofi\" vs \"locanda veneta\"), phone numbers (213/651-0346 vs 310-274-1893), and cuisines (mediterranean vs italian) are completely different. While both are located on 3rd Street in Los Angeles, there are many restaurants on this street and these records clearly refer to different establishments.",
+      "provenance": {
+        "tokens": {
+          "prompt": 278,
+          "completion": 243
+        },
+        "cost_usd": 0.0011424,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f700",
+      "right_id": "z6",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The records have completely different names, addresses, phone numbers, and restaurant types. There is no overlap in identifying information besides the city, indicating they are different restaurants.",
+      "provenance": {
+        "tokens": {
+          "prompt": 273,
+          "completion": 176
+        },
+        "cost_usd": 0.0009026500000000001,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f701",
+      "right_id": "z65",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The records have different names (swingers vs tommy's), different addresses (8020 beverly blvd vs 2575 beverly blvd), different phone numbers, and different cuisine types. They are clearly two distinct restaurants on Beverly Blvd in Los Angeles.",
+      "provenance": {
+        "tokens": {
+          "prompt": 285,
+          "completion": 106
+        },
+        "cost_usd": 0.0006702500000000001,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f701",
+      "right_id": "z4",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The two records have completely different names (swingers vs belvedere the), addresses (8020 beverly blvd vs 9882 little santa monica blvd), cities (los angeles vs beverly hills), phone numbers, and restaurant types. There is no indication they refer to the same restaurant.",
+      "provenance": {
+        "tokens": {
+          "prompt": 297,
+          "completion": 97
+        },
+        "cost_usd": 0.00065135,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f701",
+      "right_id": "z56",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The records have completely different names, addresses, cities, and phone numbers. They clearly refer to different restaurants.",
+      "provenance": {
+        "tokens": {
+          "prompt": 285,
+          "completion": 94
+        },
+        "cost_usd": 0.0006282499999999999,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f702",
+      "right_id": "z235",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The two records have completely different names, addresses (7371 vs 5955 Melrose Ave.), phone numbers, and restaurant types (italian vs californian). There is no indication they refer to the same restaurant.",
+      "provenance": {
+        "tokens": {
+          "prompt": 285,
+          "completion": 112
+        },
+        "cost_usd": 0.00069125,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f702",
+      "right_id": "z225",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The restaurants have completely different names (\"tavola calda\" vs \"citrus\"), different street addresses on Melrose Ave, different phone numbers, and different cuisine types. They are clearly distinct establishments.",
+      "provenance": {
+        "tokens": {
+          "prompt": 286,
+          "completion": 183
+        },
+        "cost_usd": 0.0009408000000000001,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f703",
+      "right_id": "z225",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The records have different names (\"the mandarin\" vs \"citrus\"), addresses, phone numbers, and restaurant types. They are clearly different establishments that merely share the same city.",
+      "provenance": {
+        "tokens": {
+          "prompt": 282,
+          "completion": 169
+        },
+        "cost_usd": 0.0008876000000000001,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f704",
+      "right_id": "z65",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The two records have completely different addresses, phone numbers, and restaurant types. \"tommy tang's\" is an asian restaurant on melrose ave, while \"tommy's\" is a hamburger restaurant on beverly blvd. They are clearly different real-world restaurants.",
+      "provenance": {
+        "tokens": {
+          "prompt": 286,
+          "completion": 168
+        },
+        "cost_usd": 0.0008883000000000001,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f704",
+      "right_id": "z58",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The two records have completely different names, addresses, cities, phone numbers, and restaurant types, indicating they are clearly distinct restaurants.",
+      "provenance": {
+        "tokens": {
+          "prompt": 289,
+          "completion": 120
+        },
+        "cost_usd": 0.00072345,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f705",
+      "right_id": "z232",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The two records have completely different names, addresses, and phone numbers. There is no evidence to suggest these are the same restaurant, despite both being Italian restaurants in Los Angeles.",
+      "provenance": {
+        "tokens": {
+          "prompt": 286,
+          "completion": 98
+        },
+        "cost_usd": 0.0006433000000000001,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f707",
+      "right_id": "z229",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The tworecords have different names (\"vida\" vs \"katsu\"), different cuisines (\"american\" vs \"japanese\"), different phone numbers, and different street addresses on Hillhurst Ave. They are clearly distinct restaurants.",
+      "provenance": {
+        "tokens": {
+          "prompt": 274,
+          "completion": 145
+        },
+        "cost_usd": 0.0007952,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f708",
+      "right_id": "z12",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The records have completely different names, addresses, cities, and phone numbers, indicating they are distinct restaurants.",
+      "provenance": {
+        "tokens": {
+          "prompt": 284,
+          "completion": 152
+        },
+        "cost_usd": 0.0008302000000000001,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f708",
+      "right_id": "z13",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The records have completely different names (\"west beach cafe\" vs \"cafe blanc\"), addresses, cities (\"los angeles\" vs \"beverly hills\"), and phone numbers. There is no overlap in any identifying information, indicating they are distinct restaurants.",
+      "provenance": {
+        "tokens": {
+          "prompt": 292,
+          "completion": 203
+        },
+        "cost_usd": 0.0010171,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f709",
+      "right_id": "z250",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The records have completely different names, addresses, phone numbers, and cuisine types. \"20 mott\" is an Asian restaurant at 20 Mott St., while \"Daniel\" is a French restaurant at 20 E. 76th St. They are clearly distinct restaurants.",
+      "provenance": {
+        "tokens": {
+          "prompt": 297,
+          "completion": 135
+        },
+        "cost_usd": 0.0007843500000000001,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f710",
+      "right_id": "z251",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The records have completely different names, addresses, phone numbers, and cuisines, indicating they are different restaurants.",
+      "provenance": {
+        "tokens": {
+          "prompt": 278,
+          "completion": 114
+        },
+        "cost_usd": 0.0006909,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f710",
+      "right_id": "z283",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The two records have entirely different names, addresses, phone numbers, and cuisine types. There are no overlapping attributes suggesting they refer to the same restaurant.",
+      "provenance": {
+        "tokens": {
+          "prompt": 275,
+          "completion": 83
+        },
+        "cost_usd": 0.0005792500000000001,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f713",
+      "right_id": "z247",
+      "label": true,
+      "source": "teacher",
+      "confidence": 1.0,
+      "reasoning": "The records have completely different names (aja vs carmine's), addresses (937 broadway vs 2450 broadway), phone numbers, and restaurant types. They are definitely not the same restaurant.",
+      "provenance": {
+        "tokens": {
+          "prompt": 280,
+          "completion": 221
+        },
+        "cost_usd": 0.0010674999999999999,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f714",
+      "right_id": "z269",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The records have different names (alamo vs. oceana), different addresses (304 e. 48th st. vs. 55 e. 54th st.), different phone numbers, and different cuisine types (mexican vs. seafood). These are clearly distinct restaurants.",
+      "provenance": {
+        "tokens": {
+          "prompt": 284,
+          "completion": 95
+        },
+        "cost_usd": 0.0006307000000000001,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f716",
+      "right_id": "z120",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The two records have completely different names, addresses, phone numbers, and cuisines, indicating they are two different restaurants in New York.",
+      "provenance": {
+        "tokens": {
+          "prompt": 295,
+          "completion": 191
+        },
+        "cost_usd": 0.00097825,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f719",
+      "right_id": "z251",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The records have completely different restaurant names, addresses, phone numbers, and cuisine types. There is no overlapping information to suggest they refer to the same establishment.",
+      "provenance": {
+        "tokens": {
+          "prompt": 285,
+          "completion": 423
+        },
+        "cost_usd": 0.00177975,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f720",
+      "right_id": "z92",
+      "label": true,
+      "source": "teacher",
+      "confidence": 1.0,
+      "reasoning": "The restaurants have completely different names (\"arturo's\" vs \"lombardi's\"), addresses (\"106 w. houston st.\" vs \"32 spring st.\"), and phone numbers, clearly indicating they are two different establishments in New York.",
+      "provenance": {
+        "tokens": {
+          "prompt": 287,
+          "completion": 253
+        },
+        "cost_usd": 0.0011868500000000001,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f720",
+      "right_id": "z250",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The restaurant names, addresses, phone numbers, and types are all completely different, indicating they are two separate restaurants in New York.",
+      "provenance": {
+        "tokens": {
+          "prompt": 294,
+          "completion": 110
+        },
+        "cost_usd": 0.0006937,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f723",
+      "right_id": "z76",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The restaurant names (\"barbetta\" vs \"darbar\"), addresses (\"321 w. 46th st.\" vs \"44 w. 56th st.\"), phone numbers (\"212/246-9171\" vs \"212-432-7227\"), and cuisine types (\"italian\" vs \"indian\") are all completely different, indicating they are distinct restaurants.",
+      "provenance": {
+        "tokens": {
+          "prompt": 285,
+          "completion": 303
+        },
+        "cost_usd": 0.00135975,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f724",
+      "right_id": "z242",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The records have different restaurant names (\"ben benson's\" vs \"21 club\"), different addresses (\"123 w. 52nd st.\" vs \"21 w. 52nd st.\"), and different phone numbers. They are distinct restaurants located on the same street in New York.",
+      "provenance": {
+        "tokens": {
+          "prompt": 284,
+          "completion": 179
+        },
+        "cost_usd": 0.0009247000000000001,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f727",
+      "right_id": "z269",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The records have completely different names, addresses, phone numbers, and cuisine types. There is no evidence they refer to the same restaurant.",
+      "provenance": {
+        "tokens": {
+          "prompt": 293,
+          "completion": 56
+        },
+        "cost_usd": 0.00050365,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f731",
+      "right_id": "z11",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The records are in completely different cities (New York vs. Mar Vista) with different addresses and phone numbers. The similarity in names (\"bruno\" vs \"bruno's\") is not enough to consider them the same real-world restaurant.",
+      "provenance": {
+        "tokens": {
+          "prompt": 281,
+          "completion": 202
+        },
+        "cost_usd": 0.00100205,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f732",
+      "right_id": "z254",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The records have completely different restaurant names, addresses, and phone numbers. There is no overlap in identifying information.",
+      "provenance": {
+        "tokens": {
+          "prompt": 331,
+          "completion": 90
+        },
+        "cost_usd": 0.00066255,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f733",
+      "right_id": "z251",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The records have different names (c3 vs dawat), addresses (103 waverly pl vs 210 e. 58th st.), phone numbers, and restaurant types (american vs indian). There are no matching attributes to indicate they are the same restaurant.",
+      "provenance": {
+        "tokens": {
+          "prompt": 286,
+          "completion": 163
+        },
+        "cost_usd": 0.0008708000000000001,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f736",
+      "right_id": "z270",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The records have different names, different addresses, different phone numbers, and different cuisine types. While both are located in New York, the specific details clearly indicate these are two separate restaurants. Cafe Botanica was located at 160 Central Park South, whereas Park Avenue Cafe was at 100 E. 63rd St. There is no meaningful overlap in the identifying attributes.",
+      "provenance": {
+        "tokens": {
+          "prompt": 291,
+          "completion": 196
+        },
+        "cost_usd": 0.00099155,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f736",
+      "right_id": "z282",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The records have completely different names, phone numbers, addresses, and cuisine types, indicating they are definitively distinct restaurants.",
+      "provenance": {
+        "tokens": {
+          "prompt": 278,
+          "completion": 378
+        },
+        "cost_usd": 0.0016149000000000003,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f737",
+      "right_id": "z245",
+      "label": true,
+      "source": "teacher",
+      "confidence": 1.0,
+      "reasoning": "The restaurant names (\"cafe la fortuna\" vs \"cafe lalo\"), addresses (\"69 w. 71st st.\" vs \"201 w. 83rd st.\"), and phone numbers are all completely different, indicating these are distinct establishments.",
+      "provenance": {
+        "tokens": {
+          "prompt": 291,
+          "completion": 119
+        },
+        "cost_usd": 0.0007220500000000001,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f738",
+      "right_id": "z72",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The restaurant names, addresses, phone numbers, and cuisine types are all completely different, indicating they refer to different restaurants.",
+      "provenance": {
+        "tokens": {
+          "prompt": 282,
+          "completion": 125
+        },
+        "cost_usd": 0.0007336,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f738",
+      "right_id": "z115",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The records have completely different names (cafe luxembourg vs thai house cafe), addresses (200 w. 70th st. vs 151 hudson st.), phone numbers, and cuisines (french vs thai). These are clearly different restaurants.",
+      "provenance": {
+        "tokens": {
+          "prompt": 282,
+          "completion": 87
+        },
+        "cost_usd": 0.0006006,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f740",
+      "right_id": "z270",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The two records have completely different names (cafe centro vs. park avenue cafe), addresses (200 Park Ave vs. 100 E. 63rd St.), phone numbers, and cuisine types (French vs. American New). There is no overlap in any identifying information.",
+      "provenance": {
+        "tokens": {
+          "prompt": 311,
+          "completion": 118
+        },
+        "cost_usd": 0.0007395500000000001,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f740",
+      "right_id": "z78",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The records have completely different names (cafe centro vs edison cafe), different street addresses (200 Park Ave vs 228 W. 47th St.), different phone numbers, and different restaurant types (French vs diners). Therefore, they refer to distinct real-world restaurants.",
+      "provenance": {
+        "tokens": {
+          "prompt": 301,
+          "completion": 298
+        },
+        "cost_usd": 0.0013590499999999999,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f743",
+      "right_id": "z189",
+      "label": true,
+      "source": "teacher",
+      "confidence": 1.0,
+      "reasoning": "The records have completely different names, addresses, cities, and phone numbers. They clearly refer to two different restaurants in different states.",
+      "provenance": {
+        "tokens": {
+          "prompt": 279,
+          "completion": 113
+        },
+        "cost_usd": 0.00068845,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f743",
+      "right_id": "z246",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The names, addresses, phone numbers, and types of these two restaurants are completely different. \"Caffe dell'artista\" is a coffee bar at 46 Greenwich Ave with phone 212/645-4431, while \"cafe des artistes\" is a French restaurant at 1 W. 67th St with phone 212-877-3500. They are distinct real-world restaurants.",
+      "provenance": {
+        "tokens": {
+          "prompt": 289,
+          "completion": 202
+        },
+        "cost_usd": 0.00101045,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f746",
+      "right_id": "z78",
+      "label": true,
+      "source": "teacher",
+      "confidence": 1.0,
+      "reasoning": "The records have completely different names (caffe roma vs. edison cafe), addresses (385 broome st. vs. 228 w. 47th st.), phone numbers, and types (coffee bar vs. diners). They are clearly distinct real-world restaurants.",
+      "provenance": {
+        "tokens": {
+          "prompt": 286,
+          "completion": 160
+        },
+        "cost_usd": 0.0008603,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f754",
+      "right_id": "z121",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The two records have different names (chiam vs yama), different addresses (160 e. 48th st. vs 122 e. 17th st.), and different phone numbers (212/371-2323 vs 212-475-0969), clearly indicating they are two separate restaurants.",
+      "provenance": {
+        "tokens": {
+          "prompt": 280,
+          "completion": 244
+        },
+        "cost_usd": 0.001148,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f755",
+      "right_id": "z120",
+      "label": true,
+      "source": "teacher",
+      "confidence": 1.0,
+      "reasoning": "The records have completely different names (china grill vs wollensky's grill), addresses (60 w. 53rd st. vs 205 e. 49th st.), and phone numbers. These are clearly two different restaurants.",
+      "provenance": {
+        "tokens": {
+          "prompt": 288,
+          "completion": 139
+        },
+        "cost_usd": 0.0007888999999999999,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f755",
+      "right_id": "z266",
+      "label": true,
+      "source": "teacher",
+      "confidence": 1.0,
+      "reasoning": "The two records have completely different names (china grill vs. mesa grill), addresses (60 w. 53rd st. vs. 102 fifth ave.), phone numbers, and cuisine types. There is no overlap in any identifying information, indicating they are distinct restaurants.",
+      "provenance": {
+        "tokens": {
+          "prompt": 274,
+          "completion": 97
+        },
+        "cost_usd": 0.0006272000000000001,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f756",
+      "right_id": "z110",
+      "label": true,
+      "source": "teacher",
+      "confidence": 1.0,
+      "reasoning": "The records have completely different names, addresses (120 W vs 38 E 51st St), phone numbers, and cuisine types (French vs Japanese). They are definitively different restaurants.",
+      "provenance": {
+        "tokens": {
+          "prompt": 282,
+          "completion": 272
+        },
+        "cost_usd": 0.0012481,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f757",
+      "right_id": "z276",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The records have completely different restaurant names (\"coco pazzo\" vs \"san domenico\"), addresses (\"23 e. 74th st.\" vs \"240 central park s.\"), and phone numbers. They are clearly different restaurants, only sharing the same city and cuisine type.",
+      "provenance": {
+        "tokens": {
+          "prompt": 282,
+          "completion": 154
+        },
+        "cost_usd": 0.0008351000000000001,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f757",
+      "right_id": "z190",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The names, addresses, cities, phone numbers, and cuisines are completely different. The restaurants are in different cities (New York vs. San Francisco), making it impossible for them to be the same restaurant.",
+      "provenance": {
+        "tokens": {
+          "prompt": 283,
+          "completion": 229
+        },
+        "cost_usd": 0.00109865,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f759",
+      "right_id": "z245",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The records have completely different names (\"corrado cafe\" vs \"cafe lalo\"), different addresses (\"1013 3rd ave.\" vs \"201 w. 83rd st.\"), and different phone numbers. They are clearly two distinct restaurants in New York.",
+      "provenance": {
+        "tokens": {
+          "prompt": 307,
+          "completion": 146
+        },
+        "cost_usd": 0.00083335,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f762",
+      "right_id": "z250",
+      "label": true,
+      "source": "teacher",
+      "confidence": 1.0,
+      "reasoning": "The two records have completely different names (\"dean & deluca\" vs \"daniel\"), addresses (\"121 prince st.\" vs \"20 e. 76th st.\"), and phone numbers. There is no overlap in any identifying information.",
+      "provenance": {
+        "tokens": {
+          "prompt": 283,
+          "completion": 144
+        },
+        "cost_usd": 0.00080115,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f763",
+      "right_id": "z89",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The restaurant names are completely different (diva vs la caridad), the addresses do not match (341 w. broadway vs 2199 broadway), the phone numbers are different, and the cuisine types differ (italian vs cuban). There is no evidence these refer to the same restaurant.",
+      "provenance": {
+        "tokens": {
+          "prompt": 285,
+          "completion": 105
+        },
+        "cost_usd": 0.00066675,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f763",
+      "right_id": "z247",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The two records have completely different restaurant names (\"diva\" vs \"carmine's\"), addresses (\"341 w. broadway\" vs \"2450 broadway\"), and phone numbers. These are clearly two distinct Italian restaurants in New York.",
+      "provenance": {
+        "tokens": {
+          "prompt": 285,
+          "completion": 130
+        },
+        "cost_usd": 0.0007542499999999999,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f766",
+      "right_id": "z270",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The records have completely different names (\"duane park cafe\" vs \"park avenue cafe\"), addresses (157 duane st. vs 100 e. 63rd st.), and phone numbers, indicating they are clearly different restaurants.",
+      "provenance": {
+        "tokens": {
+          "prompt": 311,
+          "completion": 108
+        },
+        "cost_usd": 0.00070455,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f768",
+      "right_id": "z107",
+      "label": true,
+      "source": "teacher",
+      "confidence": 1.0,
+      "reasoning": "The two records have completely different restaurant names (emily's vs sarabeth's), different addresses (1325 5th ave vs 1295 madison ave), and different phone numbers. They are definitively different real-world restaurants.",
+      "provenance": {
+        "tokens": {
+          "prompt": 288,
+          "completion": 156
+        },
+        "cost_usd": 0.0008484,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f769",
+      "right_id": "z269",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The restaurant names (\"empire korea\" vs. \"oceana\"), addresses, phone numbers, and types (asian vs. seafood) are completely different, indicating they are distinct restaurants.",
+      "provenance": {
+        "tokens": {
+          "prompt": 285,
+          "completion": 75
+        },
+        "cost_usd": 0.00056175,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f771",
+      "right_id": "z270",
+      "label": true,
+      "source": "teacher",
+      "confidence": 1.0,
+      "reasoning": "The restaurant names, addresses, and phone numbers are entirely different. \"evergreen cafe\" is at 1288 1st Ave with phone 212/744-3266, while \"park avenue cafe\" is at 100 E. 63rd St with phone 212-644-1900. There is no overlap in any identifying information.",
+      "provenance": {
+        "tokens": {
+          "prompt": 304,
+          "completion": 272
+        },
+        "cost_usd": 0.0012711999999999999,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f771",
+      "right_id": "z78",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The records have completely different names (\"evergreen cafe\" vs \"edison cafe\"), addresses (\"1288 1st ave\" vs \"228 w. 47th st.\"), phone numbers, and restaurant types. They are clearly different restaurants.",
+      "provenance": {
+        "tokens": {
+          "prompt": 294,
+          "completion": 189
+        },
+        "cost_usd": 0.0009702000000000001,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f772",
+      "right_id": "z244",
+      "label": true,
+      "source": "teacher",
+      "confidence": 1.0,
+      "reasoning": "The restaurants have completely different names (\"f. ille ponte ristorante\" vs \"aureole\"), addresses (\"39 desbrosses st.\" vs \"34 e. 61st st.\"), phone numbers, and cuisine types (\"italian\" vs \"american (new)\"). They are definitively different restaurants.",
+      "provenance": {
+        "tokens": {
+          "prompt": 306,
+          "completion": 248
+        },
+        "cost_usd": 0.0011893000000000001,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f772",
+      "right_id": "z75",
+      "label": true,
+      "source": "teacher",
+      "confidence": 1.0,
+      "reasoning": "The restaurants have completely different names, addresses, phone numbers, and cuisines, indicating they are distinct entities.",
+      "provenance": {
+        "tokens": {
+          "prompt": 306,
+          "completion": 150
+        },
+        "cost_usd": 0.0008462999999999999,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f773",
+      "right_id": "z89",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The records have different names (felix vs la caridad), addresses (340 w. broadway vs 2199 broadway), phone numbers, and cuisine types (french vs cuban). They are clearly different restaurants.",
+      "provenance": {
+        "tokens": {
+          "prompt": 280,
+          "completion": 115
+        },
+        "cost_usd": 0.0006965000000000001,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f774",
+      "right_id": "z252",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The two records differ across all key attributes: name (ferrier vs. felidia), address (29 e. 65th st. vs. 243 e. 58th st.), phone (212/772-9000 vs. 212-758-1479), and cuisine type (french vs. italian). They are clearly distinct restaurants in New York.",
+      "provenance": {
+        "tokens": {
+          "prompt": 282,
+          "completion": 112
+        },
+        "cost_usd": 0.0006881000000000001,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f774",
+      "right_id": "z271",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The records have completely different names (ferrier vs. petrossian), addresses (29 e. 65th st. vs. 182 w. 58th st.), phone numbers, and cuisine types (french vs. russian). There is no overlap in any identifying field, indicating these are two distinct restaurants.",
+      "provenance": {
+        "tokens": {
+          "prompt": 282,
+          "completion": 101
+        },
+        "cost_usd": 0.0006496000000000001,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f775",
+      "right_id": "z269",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The records have completely different names (\"fifty seven fifty seven\" vs \"oceana\"), addresses (\"57 e. 57th st.\" vs \"55 e. 54th st.\"), phone numbers, and cuisines, indicating they are different restaurants.",
+      "provenance": {
+        "tokens": {
+          "prompt": 287,
+          "completion": 230
+        },
+        "cost_usd": 0.00110635,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f776",
+      "right_id": "z270",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The restaurants have completely different names (\"film center cafe\" vs \"park avenue cafe\"), different addresses (635 9th ave vs 100 e. 63rd st), and different phone numbers. There is no indication these refer to the same real-world restaurant.",
+      "provenance": {
+        "tokens": {
+          "prompt": 314,
+          "completion": 127
+        },
+        "cost_usd": 0.0007742000000000001,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f781",
+      "right_id": "z319",
+      "label": true,
+      "source": "teacher",
+      "confidence": 1.0,
+      "reasoning": "The records are located in different cities (New York vs. San Francisco), have different addresses, different phone numbers, and slightly different names. They clearly refer to different real-world restaurants.",
+      "provenance": {
+        "tokens": {
+          "prompt": 290,
+          "completion": 202
+        },
+        "cost_usd": 0.0010115,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f781",
+      "right_id": "z257",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The restaurant names, addresses, phone numbers, and types are all completely different, indicating they refer to two distinct real-world restaurants.",
+      "provenance": {
+        "tokens": {
+          "prompt": 289,
+          "completion": 185
+        },
+        "cost_usd": 0.0009509499999999999,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f781",
+      "right_id": "z261",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The records have completely different names, addresses, phone numbers, and restaurant types, clearly indicating they are two distinct restaurants.",
+      "provenance": {
+        "tokens": {
+          "prompt": 291,
+          "completion": 172
+        },
+        "cost_usd": 0.00090755,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f783",
+      "right_id": "z252",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The restaurant names, addresses, and phone numbers are entirely different. While both are Italian restaurants in New York City, there are no matching attributes beyond the city and cuisine type, indicating they are distinct restaurants.",
+      "provenance": {
+        "tokens": {
+          "prompt": 287,
+          "completion": 151
+        },
+        "cost_usd": 0.00082985,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f783",
+      "right_id": "z250",
+      "label": true,
+      "source": "teacher",
+      "confidence": 1.0,
+      "reasoning": "The records have completely different names (follonico vs daniel), addresses (6 w. 24th st. vs 20 e. 76th st.), phone numbers, and cuisine types (italian vs french). They clearly refer to different restaurants.",
+      "provenance": {
+        "tokens": {
+          "prompt": 287,
+          "completion": 183
+        },
+        "cost_usd": 0.0009418499999999999,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f784",
+      "right_id": "z255",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The restaurants have different names (fraunces tavern vs gramercy tavern), different addresses (54 pearl st vs 42 e. 20th st), and different phone numbers. They are clearly distinct establishments in New York.",
+      "provenance": {
+        "tokens": {
+          "prompt": 289,
+          "completion": 107
+        },
+        "cost_usd": 0.00067795,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f784",
+      "right_id": "z282",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The restaurant names are completely different (\"fraunces tavern\" vs \"tavern on the green\"), and they have different addresses and phone numbers. They are two distinct, well-known restaurants in New York.",
+      "provenance": {
+        "tokens": {
+          "prompt": 282,
+          "completion": 220
+        },
+        "cost_usd": 0.0010661000000000002,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f786",
+      "right_id": "z270",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The two records have completely different names (French Roast Cafe vs. Park Avenue Cafe), different addresses (2340 Broadway vs. 100 e. 63rd st.), different phone numbers, and different restaurant types. They clearly refer to distinct establishments.",
+      "provenance": {
+        "tokens": {
+          "prompt": 301,
+          "completion": 235
+        },
+        "cost_usd": 0.00113855,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f789",
+      "right_id": "z107",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The two records have completely different names, addresses, phone numbers, and cuisine types, indicating they refer to entirely different restaurants.",
+      "provenance": {
+        "tokens": {
+          "prompt": 291,
+          "completion": 90
+        },
+        "cost_usd": 0.0006205500000000001,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f790",
+      "right_id": "z242",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The records have different names (\"gallagher's\" vs \"21 club\"), different street addresses (228 vs 21 w. 52nd st.), and different phone numbers. They are clearly two distinct restaurants on the same street in New York.",
+      "provenance": {
+        "tokens": {
+          "prompt": 284,
+          "completion": 111
+        },
+        "cost_usd": 0.0006867,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f791",
+      "right_id": "z250",
+      "label": true,
+      "source": "teacher",
+      "confidence": 1.0,
+      "reasoning": "The two records have entirely different restaurant names (\"gianni's\" vs \"daniel\"), different addresses (15 fulton st. vs 20 e. 76th st.), different phone numbers, and different cuisine types (seafood vs french). There is no indication these refer to the same restaurant.",
+      "provenance": {
+        "tokens": {
+          "prompt": 279,
+          "completion": 150
+        },
+        "cost_usd": 0.00081795,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f791",
+      "right_id": "z121",
+      "label": true,
+      "source": "teacher",
+      "confidence": 1.0,
+      "reasoning": "The records have completely different names (gianni's vs yama), addresses (15fulton st. vs 122 e. 17th st.), phone numbers, and cuisine types (seafood vs japanese). There is no overlap in any identifying fields.",
+      "provenance": {
+        "tokens": {
+          "prompt": 277,
+          "completion": 193
+        },
+        "cost_usd": 0.00096635,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f791",
+      "right_id": "z263",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The two records have completely different names, addresses, phone numbers, and cuisine types, indicating they refer to entirely different restaurants.",
+      "provenance": {
+        "tokens": {
+          "prompt": 283,
+          "completion": 190
+        },
+        "cost_usd": 0.0009621499999999999,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f796",
+      "right_id": "z269",
+      "label": true,
+      "source": "teacher",
+      "confidence": 1.0,
+      "reasoning": "The restaurants have completely different names (halcyon vs. oceana), addresses (151 w. 54th st. vs 55 e. 54th st.), phone numbers, and cuisine types (american vs. seafood). There is no overlap in any identifying information, indicating they are distinct establishments.",
+      "provenance": {
+        "tokens": {
+          "prompt": 300,
+          "completion": 258
+        },
+        "cost_usd": 0.001218,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f797",
+      "right_id": "z270",
+      "label": true,
+      "source": "teacher",
+      "confidence": 1.0,
+      "reasoning": "The records have completely different names, addresses, and phone numbers. They clearly refer to two different restaurants in New York City.",
+      "provenance": {
+        "tokens": {
+          "prompt": 295,
+          "completion": 213
+        },
+        "cost_usd": 0.00105525,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f799",
+      "right_id": "z95",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The records have completely different names, addresses, phone numbers, and cuisine types (American vs Indian). While both are in New York and near Bleecker Street, these are clearly distinct restaurants.",
+      "provenance": {
+        "tokens": {
+          "prompt": 299,
+          "completion": 109
+        },
+        "cost_usd": 0.00069545,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f800",
+      "right_id": "z264",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The restaurants have completely different names, addresses, phone numbers, and cuisine types. They are clearly distinct establishments.",
+      "provenance": {
+        "tokens": {
+          "prompt": 280,
+          "completion": 483
+        },
+        "cost_usd": 0.0019845,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f800",
+      "right_id": "z275",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The records have different names, addresses, cities, and phone numbers. \"Hudson River Club\" was located at the World Financial Center in Manhattan, while \"River Cafe\" is a distinct restaurant at 1 Water St. in Brooklyn.",
+      "provenance": {
+        "tokens": {
+          "prompt": 268,
+          "completion": 170
+        },
+        "cost_usd": 0.0008764,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f802",
+      "right_id": "z82",
+      "label": true,
+      "source": "teacher",
+      "confidence": 1.0,
+      "reasoning": "The restaurants have completely different names (\"il cortile\" vs \"il mulino\"), addresses (\"125 mulberry st.\" vs \"86 w. third st.\"), and phone numbers (\"212/226-6060\" vs \"212-673-3783\"). They only share the same city and cuisine type, which is insufficient for a match.",
+      "provenance": {
+        "tokens": {
+          "prompt": 291,
+          "completion": 266
+        },
+        "cost_usd": 0.00123655,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f803",
+      "right_id": "z268",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The records have completely different names, addresses, phone numbers, and cuisine types. There is no evidence suggesting these refer to the same restaurant.",
+      "provenance": {
+        "tokens": {
+          "prompt": 298,
+          "completion": 383
+        },
+        "cost_usd": 0.0016534,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f804",
+      "right_id": "z272",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The records have completely different names (indochine vs picholine), addresses (430 lafayette st vs 35 w. 64th st), phone numbers, and cuisine types (asian vs mediterranean). They are clearly distinct restaurants.",
+      "provenance": {
+        "tokens": {
+          "prompt": 307,
+          "completion": 127
+        },
+        "cost_usd": 0.00076685,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f805",
+      "right_id": "z270",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The two records have completely different names, addresses, phone numbers, and restaurant types. There are no overlapping attributes to suggest these refer to the same real-world restaurant.",
+      "provenance": {
+        "tokens": {
+          "prompt": 317,
+          "completion": 69
+        },
+        "cost_usd": 0.0005743500000000001,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f806",
+      "right_id": "z243",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The records have different names (ipanema vs. aquavit), different addresses (46th st vs. 54th st), different phone numbers, and different cuisine types. They are clearly distinct restaurants.",
+      "provenance": {
+        "tokens": {
+          "prompt": 285,
+          "completion": 81
+        },
+        "cost_usd": 0.0005827499999999999,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f808",
+      "right_id": "z105",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The restaurant names are similar but distinct",
+      "provenance": {
+        "tokens": {
+          "prompt": 283,
+          "completion": 131
+        },
+        "cost_usd": 0.0007556500000000001,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f808",
+      "right_id": "z258",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The restaurants have completely different names (\"jewel of india\" vs \"la caravelle\"), different addresses (15 w. 44th st. vs 33 w. 55th st.), different phone numbers, and different cuisines (asian vs french (classic)). There is no overlap in any of the identifying fields.",
+      "provenance": {
+        "tokens": {
+          "prompt": 292,
+          "completion": 213
+        },
+        "cost_usd": 0.0010521,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f815",
+      "right_id": "z272",
+      "label": true,
+      "source": "teacher",
+      "confidence": 1.0,
+      "reasoning": "The records have completely different names (l'udo vs picholine), addresses (432 lafayette st vs 35 w. 64th st), and phone numbers. There is no overlap in any identifying field, so these are definitely different restaurants.",
+      "provenance": {
+        "tokens": {
+          "prompt": 297,
+          "completion": 125
+        },
+        "cost_usd": 0.00074935,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f815",
+      "right_id": "z204",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The records have completely different names (l'udo vs marnee thai), addresses, cities (new york vs san francisco), phone numbers, and cuisine types (french vs thai). There are no shared attributes indicating they could be the same restaurant.",
+      "provenance": {
+        "tokens": {
+          "prompt": 292,
+          "completion": 95
+        },
+        "cost_usd": 0.0006391000000000001,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f818",
+      "right_id": "z258",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The two records have completely different names (lattanzi ristorante vs. la caravelle), addresses (361 w. 46th st. vs. 33 w. 55th st.), phone numbers, and cuisine types. They are clearly different restaurants.",
+      "provenance": {
+        "tokens": {
+          "prompt": 297,
+          "completion": 88
+        },
+        "cost_usd": 0.00061985,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f818",
+      "right_id": "z110",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The records have entirely different names, addresses, phone numbers, and cuisine types (Italian vs. Japanese), clearly referring to different restaurants.",
+      "provenance": {
+        "tokens": {
+          "prompt": 293,
+          "completion": 83
+        },
+        "cost_usd": 0.00059815,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f820",
+      "right_id": "z249",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The two records have completely different names, addresses, and phone numbers. \"Le Chantilly\" and \"Chanterelle\" are distinct restaurants located in different parts of New York.",
+      "provenance": {
+        "tokens": {
+          "prompt": 282,
+          "completion": 211
+        },
+        "cost_usd": 0.0010346,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f821",
+      "right_id": "z258",
+      "label": true,
+      "source": "teacher",
+      "confidence": 1.0,
+      "reasoning": "The records have completely different names (\"le colonial\" vs \"la caravelle\"), addresses (\"149 e. 57th st.\" vs \"33 w. 55th st.\"), phone numbers, and restaurant types (asian vs french). They are clearly distinct restaurants.",
+      "provenance": {
+        "tokens": {
+          "prompt": 289,
+          "completion": 112
+        },
+        "cost_usd": 0.00069545,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f821",
+      "right_id": "z261",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The restaurants have completely different names, addresses (149 e. 57th st. vs 155 w. 58th st.), phone numbers, and cuisines (asian vs french), indicating they are different establishments.",
+      "provenance": {
+        "tokens": {
+          "prompt": 287,
+          "completion": 143
+        },
+        "cost_usd": 0.00080185,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f823",
+      "right_id": "z258",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The records have completely different names (\"le jardin\" vs \"la caravelle\"), addresses (\"25 cleveland pl.\" vs \"33 w. 55th st.\"), and phone numbers. They are clearly two distinct French restaurants in New York.",
+      "provenance": {
+        "tokens": {
+          "prompt": 292,
+          "completion": 188
+        },
+        "cost_usd": 0.0009645999999999999,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f824",
+      "right_id": "z260",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The records have completely different names, addresses, phone numbers, and restaurant types. There is no overlap in any identifying information.",
+      "provenance": {
+        "tokens": {
+          "prompt": 284,
+          "completion": 145
+        },
+        "cost_usd": 0.0008057000000000001,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f825",
+      "right_id": "z258",
+      "label": true,
+      "source": "teacher",
+      "confidence": 1.0,
+      "reasoning": "The two records have completely different names, addresses, and phone numbers, indicating they refer to different restaurants in New York.",
+      "provenance": {
+        "tokens": {
+          "prompt": 289,
+          "completion": 120
+        },
+        "cost_usd": 0.00072345,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f826",
+      "right_id": "z90",
+      "label": true,
+      "source": "teacher",
+      "confidence": 0.98,
+      "reasoning": "These are two different French restaurants on the same street in New York City. The names are completely different (\"le perigord\" vs \"la grenouille\"), the addresses differ (405 E. 52nd St. vs 3 E. 52nd St.), and the phone numbers are different. Both are well-known but distinct establishments that happen to be located on East 52nd Street.",
+      "provenance": {
+        "tokens": {
+          "prompt": 292,
+          "completion": 351
+        },
+        "cost_usd": 0.0015351,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f826",
+      "right_id": "z260",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The names (le perigord vs le bernardin), addresses (405 e. 52nd st. vs 155 w. 51st st.), phone numbers, and types (french vs seafood) are all completely different.",
+      "provenance": {
+        "tokens": {
+          "prompt": 288,
+          "completion": 144
+        },
+        "cost_usd": 0.0008064000000000001,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f829",
+      "right_id": "z255",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The restaurants have completely different names (lincoln tavern vs gramercy tavern), addresses (51 w. 64th st vs 42 e. 20th st), and phone numbers. They are clearly distinct entities.",
+      "provenance": {
+        "tokens": {
+          "prompt": 287,
+          "completion": 216
+        },
+        "cost_usd": 0.0010573499999999999,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f829",
+      "right_id": "z282",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The restaurant names (\"lincoln tavern\" vs \"tavern on the green\"), addresses (\"51 w. 64th st.\" vs \"central park west\"), and phone numbers are completely different, indicating these are two distinct restaurants in New York.",
+      "provenance": {
+        "tokens": {
+          "prompt": 280,
+          "completion": 194
+        },
+        "cost_usd": 0.000973,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f832",
+      "right_id": "z247",
+      "label": true,
+      "source": "teacher",
+      "confidence": 1.0,
+      "reasoning": "The records have entirely different restaurant names (\"mad fish\" vs \"carmine's\"), different addresses (2182 Broadway vs 2450 Broadway), different phone numbers, and different cuisine types (seafood vs Italian). These are definitively different restaurants.",
+      "provenance": {
+        "tokens": {
+          "prompt": 293,
+          "completion": 119
+        },
+        "cost_usd": 0.00072415,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f834",
+      "right_id": "z94",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The records have entirely different names (mangia e bevi vs menchanko-tei), addresses (800 9th ave. vs 39 w. 55th st.), phone numbers, and cuisine types (italian vs japanese). They are definitely different restaurants.",
+      "provenance": {
+        "tokens": {
+          "prompt": 302,
+          "completion": 227
+        },
+        "cost_usd": 0.0011116,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f835",
+      "right_id": "z270",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The names, phone numbers, and street addresses are completely different. \"Manhattan Cafe\" is located at 1161 1st Ave, while \"Park Avenue Cafe\" is at 100 E. 63rd St. These are different restaurants.",
+      "provenance": {
+        "tokens": {
+          "prompt": 312,
+          "completion": 265
+        },
+        "cost_usd": 0.0012550999999999999,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f836",
+      "right_id": "z101",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The records have completely different names (\"manila garden\" vs. \"palm\"), addresses (\"325 e. 14th st.\" vs. \"837 second ave.\"), phone numbers, and cuisine types (\"asian\" vs. \"steakhouses\"). There is no overlap in any identifying fields, indicating these are definitively different restaurants.",
+      "provenance": {
+        "tokens": {
+          "prompt": 304,
+          "completion": 177
+        },
+        "cost_usd": 0.0009387,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f840",
+      "right_id": "z107",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The names, addresses, and",
+      "provenance": {
+        "tokens": {
+          "prompt": 289,
+          "completion": 153
+        },
+        "cost_usd": 0.00083895,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f841",
+      "right_id": "z279",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The records have completely different names (\"mavalli palace\" vs \"shun lee palace\"), different addresses (46 e. 29th st. vs 155 e. 55th st.), and different phone numbers. These are clearly two distinct restaurants in New York.",
+      "provenance": {
+        "tokens": {
+          "prompt": 290,
+          "completion": 85
+        },
+        "cost_usd": 0.0006020000000000001,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f841",
+      "right_id": "z258",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The records have completely different names, addresses, phone numbers, and cuisine types, indicating they refer to two distinct restaurants in New York.",
+      "provenance": {
+        "tokens": {
+          "prompt": 292,
+          "completion": 129
+        },
+        "cost_usd": 0.0007581,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f841",
+      "right_id": "z289",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The two records refer to completely different restaurants. They have different names (mavalli palace vs palacecourt), are located in different cities (new york vs las vegas), have different addresses and phone numbers, and serve different cuisines (asian vs french (new)). There is no overlap in identifying information.",
+      "provenance": {
+        "tokens": {
+          "prompt": 293,
+          "completion": 93
+        },
+        "cost_usd": 0.0006331500000000001,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f842",
+      "right_id": "z78",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The records have completely different names (milan cafe vs edison cafe), different addresses (120 w. 23rd st. vs 228 w. 47th st.), different phone numbers, and different restaurant types. There is no evidence to suggest they refer to the same restaurant.",
+      "provenance": {
+        "tokens": {
+          "prompt": 289,
+          "completion": 167
+        },
+        "cost_usd": 0.00088795,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f842",
+      "right_id": "z245",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The two records have completely different names, addresses, and phone numbers. While they are both coffee shops in New York City, the specific details do not overlap at all, indicating they refer to different real-world restaurants.",
+      "provenance": {
+        "tokens": {
+          "prompt": 292,
+          "completion": 169
+        },
+        "cost_usd": 0.0008981,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f843",
+      "right_id": "z269",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The restaurant names (\"monkey bar\" vs \"oceana\"), addresses (\"60 e. 54th st.\" vs \"55 e. 54th st.\"), phone numbers, and types of cuisine are all completely different, indicating these are distinct restaurants.",
+      "provenance": {
+        "tokens": {
+          "prompt": 280,
+          "completion": 171
+        },
+        "cost_usd": 0.0008925000000000001,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f845",
+      "right_id": "z171",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "Although both records refer to the Morton's restaurant chain, they are located in completely different cities (New York vs. Atlanta) with different addresses and phone numbers, indicating they are different individual restaurant locations.",
+      "provenance": {
+        "tokens": {
+          "prompt": 303,
+          "completion": 254
+        },
+        "cost_usd": 0.0012071500000000001,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f845",
+      "right_id": "z134",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The records are located in different cities (New York vs. Las Vegas) and have completely different addresses and phone numbers. While they may belong to the same restaurant chain, they refer to different physical restaurant locations.",
+      "provenance": {
+        "tokens": {
+          "prompt": 307,
+          "completion": 511
+        },
+        "cost_usd": 0.0021108499999999996,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f846",
+      "right_id": "z270",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The names, addresses, and phone numbers are completely different for these two restaurant records, indicating they are distinct entities.",
+      "provenance": {
+        "tokens": {
+          "prompt": 307,
+          "completion": 186
+        },
+        "cost_usd": 0.00097335,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f846",
+      "right_id": "z78",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The restaurant names, addresses, and phone numbers are completely different. \"motown cafe\" is located at 104 w. 57th st. with phone 212/581-8030, while \"edison cafe\" is at 228 w. 47th st. with phone 212-840-5000. These are clearly distinct restaurants in New York City.",
+      "provenance": {
+        "tokens": {
+          "prompt": 297,
+          "completion": 250
+        },
+        "cost_usd": 0.0011868500000000001,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f847",
+      "right_id": "z110",
+      "label": true,
+      "source": "teacher",
+      "confidence": 1.0,
+      "reasoning": "The names, addresses, and phone numbers are entirely different between the two records, clearly indicating they are different restaurants.",
+      "provenance": {
+        "tokens": {
+          "prompt": 297,
+          "completion": 168
+        },
+        "cost_usd": 0.00089985,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f848",
+      "right_id": "z269",
+      "label": true,
+      "source": "teacher",
+      "confidence": 1.0,
+      "reasoning": "The restaurants have completely different names (\"new york noodletown\" vs \"oceana\"), addresses (\"28 1/2 bowery\" vs \"55 e. 54th st.\"), phone numbers, and cuisine types. They are clearly different establishments.",
+      "provenance": {
+        "tokens": {
+          "prompt": 296,
+          "completion": 169
+        },
+        "cost_usd": 0.0009023,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f848",
+      "right_id": "z272",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The records have completely different names, addresses, phone numbers, and restaurant types (Asian vs. Mediterranean), indicating they are distinct restaurants.",
+      "provenance": {
+        "tokens": {
+          "prompt": 299,
+          "completion": 117
+        },
+        "cost_usd": 0.00072345,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f849",
+      "right_id": "z250",
+      "label": true,
+      "source": "teacher",
+      "confidence": 1.0,
+      "reasoning": "The records have completely different names, addresses, and phone numbers. \"newsbar\" is a coffee bar at 2 w. 19th st., while \"daniel\" is a French restaurant at 20 e. 76th st. They are clearly different establishments.",
+      "provenance": {
+        "tokens": {
+          "prompt": 282,
+          "completion": 229
+        },
+        "cost_usd": 0.0010976,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f849",
+      "right_id": "z121",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The records have completely different names, addresses, phone numbers, and restaurant types. There is no overlap in any identifying information, making it certain they refer to different real-world restaurants.",
+      "provenance": {
+        "tokens": {
+          "prompt": 280,
+          "completion": 209
+        },
+        "cost_usd": 0.0010255,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f850",
+      "right_id": "z268",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The two records have completely different names (odeon vs. montrachet), addresses (145 w. broadway vs. 239 w. broadway), phone numbers, and restaurant types. They are clearly distinct restaurants.",
+      "provenance": {
+        "tokens": {
+          "prompt": 288,
+          "completion": 258
+        },
+        "cost_usd": 0.0012054,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f852",
+      "right_id": "z121",
+      "label": true,
+      "source": "teacher",
+      "confidence": 1.0,
+      "reasoning": "The restaurant names (osteria al droge vs. yama), addresses (142 w. 44th st. vs. 122 e. 17th st.), phone numbers, and cuisines (italian vs. japanese) are all completely different. Therefore, these records refer to different restaurants.",
+      "provenance": {
+        "tokens": {
+          "prompt": 287,
+          "completion": 197
+        },
+        "cost_usd": 0.00099085,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f852",
+      "right_id": "z257",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The restaurants have completely different names, addresses, phone numbers, and types (Italian vs. French bistro), indicating they are entirely different establishments.",
+      "provenance": {
+        "tokens": {
+          "prompt": 290,
+          "completion": 164
+        },
+        "cost_usd": 0.0008784999999999999,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f855",
+      "right_id": "z110",
+      "label": true,
+      "source": "teacher",
+      "confidence": 1.0,
+      "reasoning": "The restaurants have completely different names (palio vs sushisay), different addresses (151 w. 51st st. vs 38 e. 51st st.), different cuisines (italian vs japanese), and different phone numbers. These are definitively two different restaurants.",
+      "provenance": {
+        "tokens": {
+          "prompt": 285,
+          "completion": 166
+        },
+        "cost_usd": 0.00088025,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f857",
+      "right_id": "z75",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The two records have completely different names, addresses, and phone numbers. There are no matching attributes besides both being located in New York.",
+      "provenance": {
+        "tokens": {
+          "prompt": 290,
+          "completion": 187
+        },
+        "cost_usd": 0.000959,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f857",
+      "right_id": "z82",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The restaurant names, street addresses, and phone numbers are completely different. There are no matching identifiers beyond the cuisine type and general location.",
+      "provenance": {
+        "tokens": {
+          "prompt": 285,
+          "completion": 142
+        },
+        "cost_usd": 0.0007962500000000001,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f857",
+      "right_id": "z244",
+      "label": true,
+      "source": "teacher",
+      "confidence": 1.0,
+      "reasoning": "The two records have completely different names, addresses, phone numbers, and cuisine types, indicating they refer to distinct restaurants in New York.",
+      "provenance": {
+        "tokens": {
+          "prompt": 290,
+          "completion": 125
+        },
+        "cost_usd": 0.000742,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f863",
+      "right_id": "z18",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The records have completely different names (planet hollywood vs. duke's), addresses, cities, phone numbers, and restaurant types. There is no overlap in any field, indicating they are clearly different restaurants.",
+      "provenance": {
+        "tokens": {
+          "prompt": 282,
+          "completion": 73
+        },
+        "cost_usd": 0.0005516,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f863",
+      "right_id": "z16",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The records have completely different names, addresses, cities, phone numbers, and restaurant types (New York vs West Hollywood, Planet Hollywood vs Diaghilev). They are clearly different restaurants.",
+      "provenance": {
+        "tokens": {
+          "prompt": 290,
+          "completion": 203
+        },
+        "cost_usd": 0.001015,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f865",
+      "right_id": "z270",
+      "label": true,
+      "source": "teacher",
+      "confidence": 1.0,
+      "reasoning": "The records have completely different names, addresses, and phone numbers, indicating they are clearly distinct restaurants in New York City.",
+      "provenance": {
+        "tokens": {
+          "prompt": 307,
+          "completion": 113
+        },
+        "cost_usd": 0.0007178499999999999,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f866",
+      "right_id": "z251",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The restaurant names, addresses, phone numbers, and cuisine types are all completely different. Post House (American, 28 E. 63rd St.) and Dawat (Indian, 210 E. 58th St.) are clearly distinct establishments.",
+      "provenance": {
+        "tokens": {
+          "prompt": 281,
+          "completion": 111
+        },
+        "cost_usd": 0.00068355,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f866",
+      "right_id": "z278",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The records have completely different names (post house vs seryna), addresses (28 e. 63rd st. vs 11 e. 53rd st.), phone numbers, and cuisines (american vs japanese).",
+      "provenance": {
+        "tokens": {
+          "prompt": 283,
+          "completion": 151
+        },
+        "cost_usd": 0.00082565,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f867",
+      "right_id": "z251",
+      "label": true,
+      "source": "teacher",
+      "confidence": 1.0,
+      "reasoning": "The two records have completely different names (\"rain\" vs \"dawat\"), addresses (\"100 w. 82nd st.\" vs \"210 e. 58th st.\"), and phone numbers (\"212/501-0776\" vs \"212-355-7555\"). They are definitely different restaurants.",
+      "provenance": {
+        "tokens": {
+          "prompt": 280,
+          "completion": 250
+        },
+        "cost_usd": 0.001169,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f867",
+      "right_id": "z272",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The records have completely different names, addresses, phone numbers, and cuisines (Asian vs Mediterranean), indicating they refer to entirely different restaurants in New York.",
+      "provenance": {
+        "tokens": {
+          "prompt": 283,
+          "completion": 203
+        },
+        "cost_usd": 0.00100765,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f872",
+      "right_id": "z60",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The records refer to different locations of the Ruth's Chris chain. Record A is in New York (148 w. 51st st.) while Record B is in Beverly Hills (224 s. beverly dr.). Entity resolution for restaurant chains is location-specific, so these are not the same real-world restaurant.",
+      "provenance": {
+        "tokens": {
+          "prompt": 309,
+          "completion": 202
+        },
+        "cost_usd": 0.0010314500000000002,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f872",
+      "right_id": "z257",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The records have completely different names, addresses, phone numbers, and cuisine types. There is no overlap in any field that would suggest these refer to the same restaurant.",
+      "provenance": {
+        "tokens": {
+          "prompt": 288,
+          "completion": 101
+        },
+        "cost_usd": 0.0006559000000000001,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f874",
+      "right_id": "z204",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The records have completely different names (\"sal anthony's\" vs \"marnee thai\"), cities (new york vs san francisco), addresses, phone numbers, and cuisines (italian vs thai). They are clearly different restaurants.",
+      "provenance": {
+        "tokens": {
+          "prompt": 278,
+          "completion": 114
+        },
+        "cost_usd": 0.0006909,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f874",
+      "right_id": "z250",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The restaurant names (\"sal anthony's\" vs \"daniel\"), addresses (\"55 irving pl.\" vs \"20 e. 76th st.\"), phone numbers, and types (Italian vs French) are completely different. These clearly refer to two different restaurants.",
+      "provenance": {
+        "tokens": {
+          "prompt": 281,
+          "completion": 124
+        },
+        "cost_usd": 0.00072905,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f875",
+      "right_id": "z108",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The restaurants have completely different names (\"sammy's roumanian steak house\" vs \"sparks steak house\"), different addresses (157 chrystie st. vs 210 e. 46th st.), and different phone numbers. These are clearly two distinct steakhouses in New York City.",
+      "provenance": {
+        "tokens": {
+          "prompt": 306,
+          "completion": 121
+        },
+        "cost_usd": 0.0007448,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f875",
+      "right_id": "z291",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The restaurants are in different cities (New York vs. Las Vegas) with completely different names, addresses, and phone numbers. There is no overlap in identifying information.",
+      "provenance": {
+        "tokens": {
+          "prompt": 312,
+          "completion": 76
+        },
+        "cost_usd": 0.0005936,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f875",
+      "right_id": "z138",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The records refer to completely different restaurants. Record A is \"Sammy's Roumanian Steak House\" in New York at 157 Chrystie St., while Record B is \"Steakhouse The\" in Las Vegas at 128 E. Fremont St. They have different cities, addresses, phone numbers, and names.",
+      "provenance": {
+        "tokens": {
+          "prompt": 304,
+          "completion": 102
+        },
+        "cost_usd": 0.0006762000000000001,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f876",
+      "right_id": "z269",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The records have completely different names (san pietro vs. oceana), addresses (18 e. 54th st. vs 55 e. 54th st.), phone numbers, and cuisine types (italian vs. seafood). There is no evidence suggesting these refer to the same restaurant.",
+      "provenance": {
+        "tokens": {
+          "prompt": 286,
+          "completion": 228
+        },
+        "cost_usd": 0.0010983000000000002,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f876",
+      "right_id": "z110",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The names, addresses, phone numbers, and restaurant types are all completely different, indicating these are two distinct restaurants.",
+      "provenance": {
+        "tokens": {
+          "prompt": 288,
+          "completion": 102
+        },
+        "cost_usd": 0.0006594000000000001,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f876",
+      "right_id": "z243",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The records have completely different names (san pietro vs aquavit), different addresses (18 e. 54th st. vs 13 w. 54th st.), different phone numbers, and different cuisine types (italian vs scandinavian). These are clearly two distinct restaurants on the same street in New York City.",
+      "provenance": {
+        "tokens": {
+          "prompt": 287,
+          "completion": 194
+        },
+        "cost_usd": 0.00098035,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f878",
+      "right_id": "z107",
+      "label": true,
+      "source": "teacher",
+      "confidence": 0.95,
+      "reasoning": "These records refer to two different locations of the Sarabeth's restaurant chain in New York City. Record A is the Amsterdam Avenue location (423 Amsterdam Ave, phone 212-496-6280), while Record B is the Madison Avenue location (1295 Madison Ave, phone 212-410-7335). Different addresses and phone numbers indicate they are distinct physical restaurants.",
+      "provenance": {
+        "tokens": {
+          "prompt": 297,
+          "completion": 319
+        },
+        "cost_usd": 0.00142835,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f879",
+      "right_id": "z120",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The restaurants have completely different names, addresses (19 w. 49th st. vs 205 e. 49th st.), phone numbers, and cuisine types. They are definitively different establishments.",
+      "provenance": {
+        "tokens": {
+          "prompt": 290,
+          "completion": 235
+        },
+        "cost_usd": 0.001127,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f879",
+      "right_id": "z269",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The names, addresses, and phone numbers are completely different between the two records, indicating they are different restaurants.",
+      "provenance": {
+        "tokens": {
+          "prompt": 282,
+          "completion": 183
+        },
+        "cost_usd": 0.0009366000000000001,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f880",
+      "right_id": "z269",
+      "label": true,
+      "source": "teacher",
+      "confidence": 1.0,
+      "reasoning": "The restaurants have completely different names (serendipity vs oceana), addresses (225 e. 60th st. vs 55 e. 54th st.), phone numbers, and cuisines (american vs seafood). They are clearly different establishments.",
+      "provenance": {
+        "tokens": {
+          "prompt": 289,
+          "completion": 110
+        },
+        "cost_usd": 0.00068845,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f882",
+      "right_id": "z278",
+      "label": true,
+      "source": "teacher",
+      "confidence": 1.0,
+      "reasoning": "The records have completely different names (sfuzzi vs. seryna), addresses (58 w. 65th st. vs. 11 e. 53rd st.), phone numbers, and cuisine types (american vs. japanese). There is no indication these are the same restaurant.",
+      "provenance": {
+        "tokens": {
+          "prompt": 282,
+          "completion": 93
+        },
+        "cost_usd": 0.0006216,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f882",
+      "right_id": "z94",
+      "label": true,
+      "source": "teacher",
+      "confidence": 1.0,
+      "reasoning": "The records have completely different names (sfuzzi vs. menchanko-tei), addresses (58 w. 65th st. vs. 39 w. 55th st.), phone numbers, and cuisine types (american vs. japanese), indicating they refer to distinct restaurants.",
+      "provenance": {
+        "tokens": {
+          "prompt": 284,
+          "completion": 95
+        },
+        "cost_usd": 0.0006307000000000001,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f883",
+      "right_id": "z121",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The records have different names (shaan vs. yama), different addresses (57 w. 48th st. vs. 122 e. 17th st.), and different phone numbers. There is no indication these refer to the same restaurant.",
+      "provenance": {
+        "tokens": {
+          "prompt": 282,
+          "completion": 76
+        },
+        "cost_usd": 0.0005621000000000001,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f883",
+      "right_id": "z250",
+      "label": true,
+      "source": "teacher",
+      "confidence": 1.0,
+      "reasoning": "The records have completely different names (\"shaan\" vs \"daniel\"), addresses, phone numbers, and restaurant types. They are clearly different restaurants.",
+      "provenance": {
+        "tokens": {
+          "prompt": 284,
+          "completion": 62
+        },
+        "cost_usd": 0.0005152000000000001,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f884",
+      "right_id": "z85",
+      "label": true,
+      "source": "teacher",
+      "confidence": 1.0,
+      "reasoning": "The records have completely different names (\"sofia fabulous pizza\" vs \"john's pizzeria\"), addresses (\"1022 madison ave\" vs \"48 w. 65th st.\"), and phone numbers (\"212/734-2676\" vs \"212-721-7001\"). There is no overlap in any identifying information.",
+      "provenance": {
+        "tokens": {
+          "prompt": 299,
+          "completion": 243
+        },
+        "cost_usd": 0.00116445,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f888",
+      "right_id": "z245",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The names, addresses, and phone numbers are completely different, indicating these are distinct restaurants in New York City.",
+      "provenance": {
+        "tokens": {
+          "prompt": 292,
+          "completion": 64
+        },
+        "cost_usd": 0.0005306,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f890",
+      "right_id": "z271",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The records have completely different names (Tang Pavilion vs. Petrossian), addresses (65 w. 55th st. vs. 182 w. 58th st.), phone numbers, and cuisine types (Asian vs. Russian), making it certain they refer to different real-world restaurants.",
+      "provenance": {
+        "tokens": {
+          "prompt": 287,
+          "completion": 231
+        },
+        "cost_usd": 0.00110985,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f895",
+      "right_id": "z247",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The names (\"the savannah club\" vs \"carmine's\"), phone numbers, and cuisine types (american vs italian) are completely different. Although the addresses are on the same street, they are distinct street numbers. These are definitively different restaurants.",
+      "provenance": {
+        "tokens": {
+          "prompt": 287,
+          "completion": 227
+        },
+        "cost_usd": 0.00109585,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f898",
+      "right_id": "z266",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The records have entirely different names (Tribeca Grill vs. Mesa Grill), addresses (375 Greenwich St. vs. 102 Fifth Ave.),and phone numbers (212/941-3900 vs. 212-807-7400). They are clearly distinct restaurants.",
+      "provenance": {
+        "tokens": {
+          "prompt": 285,
+          "completion": 187
+        },
+        "cost_usd": 0.00095375,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f898",
+      "right_id": "z120",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The restaurant names (\"tribeca grill\" vs \"wollensky's grill\"), addresses (\"375 greenwich st.\" vs \"205 e. 49th st.\"), and phone numbers (\"212/941-3900\" vs \"212-753-0444\") are all completely different, clearly indicating these are two distinct restaurants.",
+      "provenance": {
+        "tokens": {
+          "prompt": 299,
+          "completion": 208
+        },
+        "cost_usd": 0.0010419499999999998,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f900",
+      "right_id": "z110",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The two records have different restaurant names (\"tse yang\" vs \"sushisay\"), different addresses (34 vs 38 E. 51st St.), different phone numbers, and different cuisine types (Asian vs Japanese). These are clearly two distinct establishments.",
+      "provenance": {
+        "tokens": {
+          "prompt": 285,
+          "completion": 161
+        },
+        "cost_usd": 0.00086275,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f900",
+      "right_id": "z121",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The restaurant names (tse yang vs yama), addresses (34 e. 51st st. vs 122 e. 17th st.), and phone numbers (212/688-5447 vs 212-475-0969) are all completely different. There is no evidence to suggest these refer to the same real-world restaurant.",
+      "provenance": {
+        "tokens": {
+          "prompt": 282,
+          "completion": 175
+        },
+        "cost_usd": 0.0009086000000000001,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f900",
+      "right_id": "z94",
+      "label": true,
+      "source": "teacher",
+      "confidence": 1.0,
+      "reasoning": "The two records have completely different names, addresses, and phone numbers, indicating they are clearly two different restaurants in New York.",
+      "provenance": {
+        "tokens": {
+          "prompt": 287,
+          "completion": 166
+        },
+        "cost_usd": 0.0008823500000000001,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f901",
+      "right_id": "z113",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The two records have entirely different names (\"turkish kitchen\" vs \"szechuan kitchen\"), addresses, phone numbers, and cuisine types. They clearly refer to different restaurants.",
+      "provenance": {
+        "tokens": {
+          "prompt": 300,
+          "completion": 100
+        },
+        "cost_usd": 0.000665,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f902",
+      "right_id": "z251",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The records have completely different names, addresses, phone numbers, and cuisine types. There is no overlap in any attribute indicating they are different real-world restaurants.",
+      "provenance": {
+        "tokens": {
+          "prompt": 283,
+          "completion": 94
+        },
+        "cost_usd": 0.00062615,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f903",
+      "right_id": "z117",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The restaurant names (\"veniero's pasticceria\" vs \"veselka\"), addresses (\"342 e. 11th st.\" vs \"144 second ave.\"), phone numbers, and cuisine types are all completely different, indicating these are clearly distinct real-world restaurants.",
+      "provenance": {
+        "tokens": {
+          "prompt": 299,
+          "completion": 225
+        },
+        "cost_usd": 0.00110145,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f903",
+      "right_id": "z252",
+      "label": true,
+      "source": "teacher",
+      "confidence": 1.0,
+      "reasoning": "The records have completely different names (veniero's pasticceria vs felidia), different addresses (342 e. 11th st. vs 243 e. 58th st.), different phone numbers, and different restaurant types. They are clearly distinct restaurants.",
+      "provenance": {
+        "tokens": {
+          "prompt": 307,
+          "completion": 86
+        },
+        "cost_usd": 0.00062335,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f904",
+      "right_id": "z204",
+      "label": true,
+      "source": "teacher",
+      "confidence": 1.0,
+      "reasoning": "The records have different names, cities, phone numbers, cuisines, and addresses. They refer to completely different restaurants.",
+      "provenance": {
+        "tokens": {
+          "prompt": 284,
+          "completion": 109
+        },
+        "cost_usd": 0.0006797000000000001,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f904",
+      "right_id": "z250",
+      "label": true,
+      "source": "teacher",
+      "confidence": 1.0,
+      "reasoning": "The records have different names, addresses, and phone numbers, clearly indicating they refer to different restaurants.",
+      "provenance": {
+        "tokens": {
+          "prompt": 287,
+          "completion": 122
+        },
+        "cost_usd": 0.00072835,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f906",
+      "right_id": "z269",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The records have completely different names (vince & eddie's vs oceana), different addresses (70 w. 68th st. vs 55 e. 54th st.), different phone numbers, and different cuisine types. There is no overlap indicating these refer to the same restaurant.",
+      "provenance": {
+        "tokens": {
+          "prompt": 287,
+          "completion": 132
+        },
+        "cost_usd": 0.0007633500000000001,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f907",
+      "right_id": "z269",
+      "label": true,
+      "source": "teacher",
+      "confidence": 1.0,
+      "reasoning": "The records have completely different names (vong vs oceana), phone numbers, cuisines, and street addresses (200 e. 54th st. vs 55 e. 54th st.). They are clearly distinct restaurants.",
+      "provenance": {
+        "tokens": {
+          "prompt": 281,
+          "completion": 198
+        },
+        "cost_usd": 0.0009880499999999999,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f907",
+      "right_id": "z243",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The restaurant names (vong vs. aquavit), addresses (200 e. 54th st. vs. 13 w. 54th st.), phone numbers, and cuisine types (american vs. scandinavian) are completely different, indicating they are distinct restaurants.",
+      "provenance": {
+        "tokens": {
+          "prompt": 282,
+          "completion": 404
+        },
+        "cost_usd": 0.0017101000000000002,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f908",
+      "right_id": "z264",
+      "label": true,
+      "source": "teacher",
+      "confidence": 1.0,
+      "reasoning": "The two records have completely different names, addresses, and phone numbers, indicating they are two separate restaurants in New York.",
+      "provenance": {
+        "tokens": {
+          "prompt": 283,
+          "completion": 223
+        },
+        "cost_usd": 0.0010776499999999999,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f908",
+      "right_id": "z269",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The names (\"water club\" vs \"oceana\"), addresses (\"500 e. 30th st.\" vs \"55 e. 54th st.\"), and phone numbers are all completely different, indicating they are distinct restaurants.",
+      "provenance": {
+        "tokens": {
+          "prompt": 280,
+          "completion": 166
+        },
+        "cost_usd": 0.000875,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f908",
+      "right_id": "z242",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The records have completely different names (water club vs 21 club), addresses (500 e. 30th st. vs 21 w. 52nd st.), and phone numbers. These are clearly two distinct restaurants in New York.",
+      "provenance": {
+        "tokens": {
+          "prompt": 280,
+          "completion": 106
+        },
+        "cost_usd": 0.000665,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f909",
+      "right_id": "z108",
+      "label": true,
+      "source": "teacher",
+      "confidence": 1.0,
+      "reasoning": "The records have completely different names (\"west\" / \"63rd street steakhouse\" vs \"sparks steak house\"), different addresses (44 w. 63rd st. vs 210 e. 46th st.), and different phone numbers. They are clearly distinct restaurants.",
+      "provenance": {
+        "tokens": {
+          "prompt": 295,
+          "completion": 223
+        },
+        "cost_usd": 0.00109025,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f912",
+      "right_id": "z247",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The records have completely different names (\"zoe\" vs \"carmine's\"), addresses (\"90 prince st.\" vs \"2450 broadway\"), phone numbers (212-966-6722 vs 212-362-2200), and cuisine types (American vs Italian). There are no overlapping attributes to suggest they refer to the same restaurant.",
+      "provenance": {
+        "tokens": {
+          "prompt": 288,
+          "completion": 160
+        },
+        "cost_usd": 0.0008624000000000001,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f913",
+      "right_id": "z170",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The restaurant names (\"abbey\" vs \"majestic\"), street addresses (163 vs 1031), phone numbers, and types are completely different. They only share the same street name and city, which is insufficient to consider them the same restaurant.",
+      "provenance": {
+        "tokens": {
+          "prompt": 282,
+          "completion": 479
+        },
+        "cost_usd": 0.0019726,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f913",
+      "right_id": "z305",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The records have completely different names (\"abbey\" vs \"mary mac's tea room\"), different addresses (163 vs 224 ponce de leon ave.), different phone numbers, and different cuisine types. These are clearly two separate restaurants in Atlanta.",
+      "provenance": {
+        "tokens": {
+          "prompt": 289,
+          "completion": 125
+        },
+        "cost_usd": 0.00074095,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f913",
+      "right_id": "z182",
+      "label": true,
+      "source": "teacher",
+      "confidence": 1.0,
+      "reasoning": "The records have completely different restaurant names (\"abbey\" vs \"tortillas\"), different street addresses (163 vs 774), different phone numbers, and different cuisine types (international vs tex-mex). They are definitively not the same restaurant.",
+      "provenance": {
+        "tokens": {
+          "prompt": 289,
+          "completion": 229
+        },
+        "cost_usd": 0.00110495,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f914",
+      "right_id": "z145",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The two records have completely different names, addresses, and phone numbers. The only commonalities are the city (Atlanta) and the general cuisine type (barbecue/bbq), which are not sufficient to establish that they refer to the same real-world restaurant.",
+      "provenance": {
+        "tokens": {
+          "prompt": 288,
+          "completion": 412
+        },
+        "cost_usd": 0.0017444,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f914",
+      "right_id": "z161",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The two records have completely different restaurant names (\"aleck's barbecue heaven\" vs \"harold's barbecue\"), different addresses, and different phone numbers. While both are BBQ restaurants in Atlanta, there is no evidence to suggest they refer to the same real-world establishment.",
+      "provenance": {
+        "tokens": {
+          "prompt": 294,
+          "completion": 157
+        },
+        "cost_usd": 0.0008581999999999999,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f914",
+      "right_id": "z147",
+      "label": true,
+      "source": "teacher",
+      "confidence": 1.0,
+      "reasoning": "The restaurant names, addresses, and phone numbers are completely different between the two records. Aleck's Barbecue Heaven is at 783 MLK Jr. Dr. with phone 404/525-2062, while Bobby & June's Kountry Kitchen is at 375 14th St. with phone 404-876-3872. There is no overlap in any identifying information.",
+      "provenance": {
+        "tokens": {
+          "prompt": 304,
+          "completion": 233
+        },
+        "cost_usd": 0.0011347,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f914",
+      "right_id": "z181",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The records have completely different names, addresses, phone numbers, and types, clearly indicating two different restaurants in Atlanta.",
+      "provenance": {
+        "tokens": {
+          "prompt": 297,
+          "completion": 62
+        },
+        "cost_usd": 0.00052885,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f915",
+      "right_id": "z172",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The records have different names, different addresses (3195 roswell rd. vs 1248 clairmont rd.), and different phone numbers. They are clearly two distinct Thai restaurants in Atlanta.",
+      "provenance": {
+        "tokens": {
+          "prompt": 282,
+          "completion": 115
+        },
+        "cost_usd": 0.0006986000000000001,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f915",
+      "right_id": "z294",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The records have completely different names, addresses, phone numbers, and cuisine types. Annie's Thai Castle and Bacchanalia are distinct restaurants in Atlanta.",
+      "provenance": {
+        "tokens": {
+          "prompt": 285,
+          "completion": 150
+        },
+        "cost_usd": 0.0008242499999999999,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f915",
+      "right_id": "z173",
+      "label": true,
+      "source": "teacher",
+      "confidence": 1.0,
+      "reasoning": "The two records have completely different names (annie's thai castle vs nava), addresses, phone numbers, and cuisine types (asian vs southwestern). There is no overlap in any identifying fields.",
+      "provenance": {
+        "tokens": {
+          "prompt": 278,
+          "completion": 125
+        },
+        "cost_usd": 0.0007294000000000001,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f915",
+      "right_id": "z155",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The records have completely different names (annie's thai castle vs chopstix), different addresses (3195 roswell rd vs 4279 roswell rd), different phone numbers, and different cuisine types (asian/thai vs chinese). There is no evidence these refer to the same restaurant.",
+      "provenance": {
+        "tokens": {
+          "prompt": 287,
+          "completion": 92
+        },
+        "cost_usd": 0.00062335,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f916",
+      "right_id": "z173",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The records have completely different names (anthonys vs nava), different phone numbers, different cuisines (american vs southwestern), and different street addresses (3109 Piedmont Rd vs 3060 Peachtree Rd). They are clearly distinct restaurants in Atlanta.",
+      "provenance": {
+        "tokens": {
+          "prompt": 288,
+          "completion": 192
+        },
+        "cost_usd": 0.0009744,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f916",
+      "right_id": "z293",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The restaurant names (\"anthonys\" vs \"abruzzi\"), addresses, phone numbers, and types are all different. There is no evidence to suggest these refer to the same restaurant.",
+      "provenance": {
+        "tokens": {
+          "prompt": 297,
+          "completion": 139
+        },
+        "cost_usd": 0.00079835,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f916",
+      "right_id": "z294",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The restaurant names, phone numbers, and exact street addresses are completely different. Although both are located on Piedmont Rd in Atlanta, the distinct addresses (3109 vs 3125) and names (\"anthonys\" vs \"bacchanalia\") clearly indicate these are separate restaurants.",
+      "provenance": {
+        "tokens": {
+          "prompt": 295,
+          "completion": 258
+        },
+        "cost_usd": 0.0012127499999999999,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f917",
+      "right_id": "z155",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The records have completely different names, addresses, phone numbers, and cuisine types (American vs Chinese). They are clearly different restaurants in Atlanta.",
+      "provenance": {
+        "tokens": {
+          "prompt": 283,
+          "completion": 94
+        },
+        "cost_usd": 0.00062615,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f918",
+      "right_id": "z297",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The records have completely different names, addresses, phone numbers, and restaurant types. There is no evidence to suggest they refer to the same real-world restaurant.",
+      "provenance": {
+        "tokens": {
+          "prompt": 291,
+          "completion": 168
+        },
+        "cost_usd": 0.00089355,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f918",
+      "right_id": "z142",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The restaurant names, street addresses, and phone numbers are completely different. While they are both located in Atlanta on Paces Ferry Road, they are on opposite sides of the street with different street numbers (260 E vs 103 W) and are clearly distinct establishments.",
+      "provenance": {
+        "tokens": {
+          "prompt": 287,
+          "completion": 176
+        },
+        "cost_usd": 0.0009173499999999999,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f919",
+      "right_id": "z293",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The names (bertolini's vs abruzzi), phone numbers, and street numbers on Peachtree Rd (3500 vs 2355) are completely different, indicating these are two distinct Italian restaurants in Atlanta.",
+      "provenance": {
+        "tokens": {
+          "prompt": 294,
+          "completion": 449
+        },
+        "cost_usd": 0.0018802,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f920",
+      "right_id": "z293",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The two records have completely different restaurant names (\"bistango\" vs \"abruzzi\"), addresses (\"1100 peachtree st.\" vs \"2355 peachtree rd. ne\"), and phone numbers. While both are located in Atlanta and on a street named Peachtree, Peachtree is a very long street in Atlanta with many different addresses. The lack of any matching identifiers makes it highly certain these are different restaurants.",
+      "provenance": {
+        "tokens": {
+          "prompt": 283,
+          "completion": 355
+        },
+        "cost_usd": 0.00153965,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f920",
+      "right_id": "z173",
+      "label": true,
+      "source": "teacher",
+      "confidence": 1.0,
+      "reasoning": "The records have completely different names (bistango vs. nava), addresses (1100 peachtree st. vs. 3060 peachtree rd.), phone numbers, and cuisine types (mediterranean vs. southwestern). These are clearly two different restaurants in Atlanta.",
+      "provenance": {
+        "tokens": {
+          "prompt": 274,
+          "completion": 259
+        },
+        "cost_usd": 0.0011941999999999999,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f920",
+      "right_id": "z294",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The restaurant names (bistango vs bacchanalia), addresses (1100 peachtree st. vs 3125 piedmont rd.), phone numbers, and types are all completely different. These are clearly distinct restaurants in Atlanta.",
+      "provenance": {
+        "tokens": {
+          "prompt": 281,
+          "completion": 87
+        },
+        "cost_usd": 0.0005995499999999999,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f921",
+      "right_id": "z331",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The records have completely different names (\"cafe renaissance\" vs \"ritz-carlton cafe\"), addresses (\"7050 jimmy carter blvd. norcross\" vs \"181 peachtree st.\"), and phone numbers. They are clearly different restaurants.",
+      "provenance": {
+        "tokens": {
+          "prompt": 305,
+          "completion": 73
+        },
+        "cost_usd": 0.00057575,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f921",
+      "right_id": "z308",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The records have completely different names, addresses, and phone numbers. Record A refers to \"cafe renaissance\" located on Jimmy Carter Blvd in Norcross, while Record B refers to \"ritz-carlton cafe (buckhead)\" on Peachtree Rd NE. There is no overlap in identifying information.",
+      "provenance": {
+        "tokens": {
+          "prompt": 313,
+          "completion": 219
+        },
+        "cost_usd": 0.00109515,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f921",
+      "right_id": "z144",
+      "label": true,
+      "source": "teacher",
+      "confidence": 1.0,
+      "reasoning": "The records have entirely different names, addresses, phone numbers, and restaurant types. There is no overlap in any identifying fields to suggest these refer to the same restaurant.",
+      "provenance": {
+        "tokens": {
+          "prompt": 305,
+          "completion": 150
+        },
+        "cost_usd": 0.00084525,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f922",
+      "right_id": "z294",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The records have completely different names, addresses, phone numbers, and cuisine types, with no overlapping identifying information beyond the city.",
+      "provenance": {
+        "tokens": {
+          "prompt": 283,
+          "completion": 110
+        },
+        "cost_usd": 0.0006821500000000001,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f922",
+      "right_id": "z302",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The names, addresses, phone numbers, and restaurant types are all completely different. There is no evidence to suggest these records refer to the same restaurant.",
+      "provenance": {
+        "tokens": {
+          "prompt": 283,
+          "completion": 142
+        },
+        "cost_usd": 0.00079415,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f922",
+      "right_id": "z173",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The two records have completely different restaurant names (\"camille's\" vs \"nava\"), different addresses (\"1186 n. highland ave.\" vs \"3060 peachtree rd.\"), different phone numbers, and different cuisine types (italian vs southwestern). There is no overlap in any identifying field, indicating they are clearly distinct restaurants.",
+      "provenance": {
+        "tokens": {
+          "prompt": 276,
+          "completion": 84
+        },
+        "cost_usd": 0.0005838,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f923",
+      "right_id": "z176",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The records have completelydifferent names, phone numbers, addresses, and restaurant types (Mediterranean vs. Steakhouses), indicating they are two distinct restaurants.",
+      "provenance": {
+        "tokens": {
+          "prompt": 300,
+          "completion": 283
+        },
+        "cost_usd": 0.0013055,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f923",
+      "right_id": "z155",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The restaurant records have entirely different names, addresses, phone numbers, and cuisine types, making it clear they refer to different real-world restaurants.",
+      "provenance": {
+        "tokens": {
+          "prompt": 290,
+          "completion": 192
+        },
+        "cost_usd": 0.0009765000000000002,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f923",
+      "right_id": "z173",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The records have completely different names (cassis vs. nava), addresses (3300 Peachtree Rd vs. 3060 Peachtree Rd), phone numbers, and cuisine types (Mediterranean vs. Southwestern), indicating they are distinct restaurants.",
+      "provenance": {
+        "tokens": {
+          "prompt": 281,
+          "completion": 136
+        },
+        "cost_usd": 0.0007710499999999999,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f924",
+      "right_id": "z300",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The names, addresses, phone numbers, and cuisine types of the two records are completely different. There is no evidence to suggest they refer to the same restaurant.",
+      "provenance": {
+        "tokens": {
+          "prompt": 272,
+          "completion": 220
+        },
+        "cost_usd": 0.0010556,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f924",
+      "right_id": "z303",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The two records have completely different names (\"city grill\" vs \"indigo coastal grill\"), addresses (\"50 hurt plaza\" vs \"1397 n. highland ave.\"), and phone numbers, clearly indicating they are different restaurants in Atlanta.",
+      "provenance": {
+        "tokens": {
+          "prompt": 276,
+          "completion": 147
+        },
+        "cost_usd": 0.0008043,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f924",
+      "right_id": "z266",
+      "label": true,
+      "source": "teacher",
+      "confidence": 1.0,
+      "reasoning": "The records have different restaurant names (city grill vs. mesa grill), different addresses (50 hurt plaza vs. 102 fifth ave.), and are located in different cities (atlanta vs. new york city). These are clearly distinct restaurants.",
+      "provenance": {
+        "tokens": {
+          "prompt": 268,
+          "completion": 179
+        },
+        "cost_usd": 0.0009079,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f925",
+      "right_id": "z308",
+      "label": true,
+      "source": "teacher",
+      "confidence": 1.0,
+      "reasoning": "The two records have completely different restaurant names (\"coco loco\" vs \"ritz-carlton cafe (buckhead)\"), addresses, phone numbers, and cuisines (Caribbean vs American New). They clearly refer to different establishments.",
+      "provenance": {
+        "tokens": {
+          "prompt": 316,
+          "completion": 167
+        },
+        "cost_usd": 0.0009162999999999999,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f926",
+      "right_id": "z295",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The records have completely different names (\"colonnade restaurant\" vs \"bone's restaurant\"), different addresses, different phone numbers, and different types. They are clearly distinct restaurants.",
+      "provenance": {
+        "tokens": {
+          "prompt": 289,
+          "completion": 70
+        },
+        "cost_usd": 0.00054845,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f926",
+      "right_id": "z298",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The records have completely different names, addresses, and phone numbers. There is no evidence to suggest they refer to the same restaurant.",
+      "provenance": {
+        "tokens": {
+          "prompt": 288,
+          "completion": 105
+        },
+        "cost_usd": 0.0006699,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f926",
+      "right_id": "z310",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The restaurants have completely different names, addresses, phone numbers, and cuisine types, making it certain they are different establishments despite both being located in Atlanta.",
+      "provenance": {
+        "tokens": {
+          "prompt": 285,
+          "completion": 167
+        },
+        "cost_usd": 0.00088375,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f926",
+      "right_id": "z185",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The two records have entirely different names, addresses, phone numbers, and cuisine types. There is no overlapping information to suggest these refer to the same real-world restaurant in Atlanta.",
+      "provenance": {
+        "tokens": {
+          "prompt": 287,
+          "completion": 141
+        },
+        "cost_usd": 0.0007948499999999999,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f927",
+      "right_id": "z297",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The restaurant names (\"dante's down the hatch\" vs \"buckhead diner\"), addresses (\"3380 peachtree rd.\" vs \"3073 piedmont rd.\"), phone numbers, and cuisines are all completely different. The only shared element is the city and the neighborhood \"Buckhead\", which is not enough to consider them the same restaurant.",
+      "provenance": {
+        "tokens": {
+          "prompt": 294,
+          "completion": 357
+        },
+        "cost_usd": 0.0015582,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f929",
+      "right_id": "z176",
+      "label": true,
+      "source": "teacher",
+      "confidence": 1.0,
+      "reasoning": "The two records have completely different names (\"fat matt's rib shack\" vs \"palm the (atlanta)\"), addresses, phone numbers, and restaurant types (barbecue vs steakhouses). There is no overlap indicating they refer to the same restaurant.",
+      "provenance": {
+        "tokens": {
+          "prompt": 309,
+          "completion": 155
+        },
+        "cost_usd": 0.00086695,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f929",
+      "right_id": "z295",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The records have completely different names (\"fat matt's rib shack\" vs \"bone's restaurant\"), phone numbers, specific street addresses (1811 vs 3130 Piedmont), and food types (barbecue vs steakhouses). They are distinct restaurants in Atlanta.",
+      "provenance": {
+        "tokens": {
+          "prompt": 302,
+          "completion": 440
+        },
+        "cost_usd": 0.0018571000000000002,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f930",
+      "right_id": "z298",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The records have completely different names, addresses, phone numbers, and types. There is no evidence suggesting these refer to the same restaurant.",
+      "provenance": {
+        "tokens": {
+          "prompt": 302,
+          "completion": 205
+        },
+        "cost_usd": 0.0010346,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f930",
+      "right_id": "z331",
+      "label": true,
+      "source": "teacher",
+      "confidence": 1.0,
+      "reasoning": "The names, addresses, phone numbers, and types are all completely different. There is no evidence to suggest these two records refer to the same real-world restaurant.",
+      "provenance": {
+        "tokens": {
+          "prompt": 306,
+          "completion": 149
+        },
+        "cost_usd": 0.0008427999999999999,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f930",
+      "right_id": "z185",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The names, addresses, phone numbers, and types of the two restaurants are completely different. There is no evidence to suggest these refer to the same establishment.",
+      "provenance": {
+        "tokens": {
+          "prompt": 301,
+          "completion": 116
+        },
+        "cost_usd": 0.00072205,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f931",
+      "right_id": "z293",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The records have completely different names (\"holt bros. bar-b-q\" vs \"abruzzi\"), addresses (\"6359 jimmy carter blvd.\" vs \"2355 peachtree rd. ne\"), phone numbers, and cuisine types (barbecue vs italian). There is no overlap in any identifying information.",
+      "provenance": {
+        "tokens": {
+          "prompt": 320,
+          "completion": 222
+        },
+        "cost_usd": 0.001113,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f932",
+      "right_id": "z303",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The records have different names (horseradish grill vs. indigo coastal grill), different addresses, different phone numbers, and different cuisine types, indicating they are distinct restaurants.",
+      "provenance": {
+        "tokens": {
+          "prompt": 288,
+          "completion": 130
+        },
+        "cost_usd": 0.0007574,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f932",
+      "right_id": "z178",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The records have completely different names (\"horseradish grill\" vs \"riviera\"), addresses (\"4320 powers ferry rd.\" vs \"519 e. paces ferry rd.\"), phone numbers, and restaurant types. They are definitely different restaurants.",
+      "provenance": {
+        "tokens": {
+          "prompt": 287,
+          "completion": 193
+        },
+        "cost_usd": 0.00097685,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f932",
+      "right_id": "z154",
+      "label": true,
+      "source": "teacher",
+      "confidence": 1.0,
+      "reasoning": "The two records have completely different names (horseradish grill vs. chops), addresses, phone numbers, and restaurant types. There is no overlap in any identifying information other than the city.",
+      "provenance": {
+        "tokens": {
+          "prompt": 285,
+          "completion": 179
+        },
+        "cost_usd": 0.0009257499999999999,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f932",
+      "right_id": "z142",
+      "label": true,
+      "source": "teacher",
+      "confidence": 1.0,
+      "reasoning": "The records have completely different names (\"horseradish grill\" vs \"103 west\"), different addresses (\"4320 powers ferry rd.\" vs \"103 w. paces ferry rd.\"), different phone numbers, and different cuisine types. There is no overlap in identifying information.",
+      "provenance": {
+        "tokens": {
+          "prompt": 283,
+          "completion": 142
+        },
+        "cost_usd": 0.00079415,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f933",
+      "right_id": "z185",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The records have completely different names, addresses, phone numbers, and restaurant types. They only share the same city and the common Atlanta street name \"Peachtree.\"",
+      "provenance": {
+        "tokens": {
+          "prompt": 297,
+          "completion": 169
+        },
+        "cost_usd": 0.00090335,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f933",
+      "right_id": "z300",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The two records have completely different names, addresses, phone numbers, and restaurant types (Asian vs. Southwestern), indicating they are clearly distinct restaurants in Atlanta.",
+      "provenance": {
+        "tokens": {
+          "prompt": 293,
+          "completion": 101
+        },
+        "cost_usd": 0.0006611500000000001,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f933",
+      "right_id": "z173",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The records have completely different names (hsu's gourmet vs. nava), addresses (192 Peachtree Center Ave vs. 3060 Peachtree Rd), phone numbers, and cuisine types (asian vs. southwestern). They are clearly different restaurants.",
+      "provenance": {
+        "tokens": {
+          "prompt": 287,
+          "completion": 120
+        },
+        "cost_usd": 0.0007213499999999999,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f934",
+      "right_id": "z173",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The restaurant names (imperial fez vs nava), addresses (2285 peachtree rd. vs 3060 peachtree rd.), phone numbers, and types (mediterranean vs southwestern) are completely different. They are clearly two distinct restaurants in Atlanta.",
+      "provenance": {
+        "tokens": {
+          "prompt": 286,
+          "completion": 226
+        },
+        "cost_usd": 0.0010913,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f935",
+      "right_id": "z293",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The records have completely different names, phone numbers, addresses, and cuisines. Kamogawa is an Asian restaurant at 3300 Peachtree Rd. in the Grand Hyatt, while Abruzzi is an Italian restaurant at 2355 Peachtree Rd. NE.",
+      "provenance": {
+        "tokens": {
+          "prompt": 292,
+          "completion": 180
+        },
+        "cost_usd": 0.0009366000000000001,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f936",
+      "right_id": "z304",
+      "label": true,
+      "source": "teacher",
+      "confidence": 0.9,
+      "reasoning": "Both records are for Italian restaurants named \"La Grotta\" in Atlanta, but they have completely different addresses (Ravinia/Dunwoody vs. Peachtree Rd. NE/Buckhead) and phone numbers, indicating they are separate locations of the La Grotta chain.",
+      "provenance": {
+        "tokens": {
+          "prompt": 320,
+          "completion": 250
+        },
+        "cost_usd": 0.001211,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f937",
+      "right_id": "z308",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The records have completely different names (\"little szechuan\" vs \"ritz-carlton cafe (buckhead)\"), addresses, phone numbers, and cuisine types (Asian vs American New), clearly indicating they are different restaurants.",
+      "provenance": {
+        "tokens": {
+          "prompt": 315,
+          "completion": 117
+        },
+        "cost_usd": 0.00074025,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f937",
+      "right_id": "z309",
+      "label": true,
+      "source": "teacher",
+      "confidence": 1.0,
+      "reasoning": "The records have completely different names, addresses, phone numbers, and cuisine types, making it clear they refer to different restaurants.",
+      "provenance": {
+        "tokens": {
+          "prompt": 318,
+          "completion": 102
+        },
+        "cost_usd": 0.0006908999999999999,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f938",
+      "right_id": "z145",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The restaurant names, addresses, and phone numbers are completely different between the two records, indicating they are distinct restaurants.",
+      "provenance": {
+        "tokens": {
+          "prompt": 296,
+          "completion": 116
+        },
+        "cost_usd": 0.0007168000000000001,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f938",
+      "right_id": "z161",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The records have completely different names",
+      "provenance": {
+        "tokens": {
+          "prompt": 302,
+          "completion": 155
+        },
+        "cost_usd": 0.0008596000000000001,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f938",
+      "right_id": "z303",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The records have completely different names, addresses, phone numbers, and cuisine types, indicating they are distinct restaurants in Atlanta.",
+      "provenance": {
+        "tokens": {
+          "prompt": 302,
+          "completion": 77
+        },
+        "cost_usd": 0.0005866000000000001,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f938",
+      "right_id": "z297",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The records have completely different names (\"lowcountry barbecue\" vs \"buckhead diner\"), addresses,phone numbers, and cuisine types. There is no overlap to suggest these refer to the same restaurant.",
+      "provenance": {
+        "tokens": {
+          "prompt": 301,
+          "completion": 72
+        },
+        "cost_usd": 0.0005680500000000001,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f939",
+      "right_id": "z293",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The restaurant names (\"luna si\" vs \"abruzzi\"), street addresses (1931 vs 2355), phone numbers (404/355-5993 vs 404-261-8186), and types (continental vs italian) are completely different. Although they are on the same street in the same city, they are clearly distinct restaurants.",
+      "provenance": {
+        "tokens": {
+          "prompt": 283,
+          "completion": 307
+        },
+        "cost_usd": 0.0013716499999999999,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f939",
+      "right_id": "z173",
+      "label": true,
+      "source": "teacher",
+      "confidence": 1.0,
+      "reasoning": "The records have completely different names (\"luna si\" vs \"nava\"), addresses (\"1931 peachtree rd.\" vs \"3060 peachtree rd.\"), phone numbers, and restaurant types (\"continental\" vs \"southwestern\"). There is no overlap in any identifying information.",
+      "provenance": {
+        "tokens": {
+          "prompt": 274,
+          "completion": 227
+        },
+        "cost_usd": 0.0010822,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f939",
+      "right_id": "z304",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The records have different names, different street addresses on Peachtree Rd., and different phone numbers. There is no evidence these refer to the same restaurant.",
+      "provenance": {
+        "tokens": {
+          "prompt": 285,
+          "completion": 94
+        },
+        "cost_usd": 0.0006282499999999999,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f940",
+      "right_id": "z298",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The two records have entirely",
+      "provenance": {
+        "tokens": {
+          "prompt": 292,
+          "completion": 37
+        },
+        "cost_usd": 0.00043610000000000003,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f940",
+      "right_id": "z145",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The restaurant names (mambo restaurante cubano vs. barbecue kitchen), addresses (1402 n. highland ave. vs. 1437 virginia ave.), phone numbers, and types (caribbean vs. bbq) are completely different. They refer to different restaurants.",
+      "provenance": {
+        "tokens": {
+          "prompt": 285,
+          "completion": 203
+        },
+        "cost_usd": 0.00100975,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f940",
+      "right_id": "z162",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The two records have different names,different addresses, and different phone numbers, clearly indicating they refer to two distinct restaurants in Atlanta.",
+      "provenance": {
+        "tokens": {
+          "prompt": 289,
+          "completion": 127
+        },
+        "cost_usd": 0.00074795,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f941",
+      "right_id": "z146",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The restaurant names, addresses, and phone numbers are completely different. There is no evidence to suggest these records refer to the same restaurant.",
+      "provenance": {
+        "tokens": {
+          "prompt": 294,
+          "completion": 188
+        },
+        "cost_usd": 0.0009667,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f941",
+      "right_id": "z171",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The records have completely different names, addresses, phone numbers, and restaurant types. Only the city matches, indicating they are completely distinct restaurants.",
+      "provenance": {
+        "tokens": {
+          "prompt": 296,
+          "completion": 414
+        },
+        "cost_usd": 0.0017598,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f943",
+      "right_id": "z62",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The records have completely different names, addresses, cities, and phone numbers, indicating they are two different restaurants in different locations (Atlanta vs. Studio City).",
+      "provenance": {
+        "tokens": {
+          "prompt": 302,
+          "completion": 109
+        },
+        "cost_usd": 0.0006986,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f943",
+      "right_id": "z297",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The records have completely different names, addresses, phone numbers, and cuisine types. There is no indication they refer to the same restaurant.",
+      "provenance": {
+        "tokens": {
+          "prompt": 301,
+          "completion": 102
+        },
+        "cost_usd": 0.00067305,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f944",
+      "right_id": "z294",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The records have completely different names (palisades vs. bacchanalia), addresses (1829 peachtree rd. vs. 3125 piedmont rd.), phone numbers, and restaurant types. There is no evidence to suggest they refer to the same restaurant.",
+      "provenance": {
+        "tokens": {
+          "prompt": 278,
+          "completion": 90
+        },
+        "cost_usd": 0.0006069000000000001,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f945",
+      "right_id": "z176",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The restaurants have completely different names (\"pleasant peasant\" vs \"palm the (atlanta)\"), different addresses (555 peachtree st. vs 3391 peachtree rd. ne), different phone numbers, and different cuisine types (american vs steakhouses). They are clearly distinct establishments.",
+      "provenance": {
+        "tokens": {
+          "prompt": 301,
+          "completion": 187
+        },
+        "cost_usd": 0.0009705499999999999,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f945",
+      "right_id": "z308",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The records have completely different restaurant names (\"pleasant peasant\" vs \"ritz-carlton cafe (buckhead)\"), different street addresses (555 peachtree st. vs 3434 peachtree rd. ne), and different phone numbers. There is no evidence suggesting these refer to the same real-world restaurant.",
+      "provenance": {
+        "tokens": {
+          "prompt": 305,
+          "completion": 168
+        },
+        "cost_usd": 0.00090825,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f946",
+      "right_id": "z311",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The records have completely different names (pricci vs. toulouse), addresses (500 pharr rd. vs. 293-b peachtree rd.), phone numbers, and cuisine types (italian vs. french new). There is no indication they refer to the same restaurant.",
+      "provenance": {
+        "tokens": {
+          "prompt": 278,
+          "completion": 111
+        },
+        "cost_usd": 0.0006804000000000001,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f946",
+      "right_id": "z302",
+      "label": true,
+      "source": "teacher",
+      "confidence": 1.0,
+      "reasoning": "The two records have entirely different names, addresses, phone numbers, and cuisine types, clearly indicating they refer to two different restaurants in Atlanta.",
+      "provenance": {
+        "tokens": {
+          "prompt": 278,
+          "completion": 199
+        },
+        "cost_usd": 0.0009884,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f947",
+      "right_id": "z145",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The records have completely different restaurant names, addresses, phone numbers, and cuisine types, indicating they are distinct restaurants in Atlanta.",
+      "provenance": {
+        "tokens": {
+          "prompt": 294,
+          "completion": 61
+        },
+        "cost_usd": 0.0005222,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f947",
+      "right_id": "z303",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The records have completely different names, phone numbers, and street addresses (870 vs 1397 N. Highland Ave), indicating they are different restaurants.",
+      "provenance": {
+        "tokens": {
+          "prompt": 300,
+          "completion": 180
+        },
+        "cost_usd": 0.000945,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f948",
+      "right_id": "z145",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The two records have completely different names (rib ranch vs. barbecue kitchen), addresses (25 irby ave. vs. 1437 virginia ave.), and phone numbers. While they share the same city and cuisine type, they clearly refer to two distinct restaurants.",
+      "provenance": {
+        "tokens": {
+          "prompt": 273,
+          "completion": 171
+        },
+        "cost_usd": 0.0008851500000000001,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f948",
+      "right_id": "z297",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The records have completely different names (\"rib ranch\" vs \"buckhead diner\"), addresses (\"25 irby ave.\" vs \"3073 piedmont rd.\"), phone numbers, and restaurant types. They only share the same city.",
+      "provenance": {
+        "tokens": {
+          "prompt": 278,
+          "completion": 397
+        },
+        "cost_usd": 0.0016814,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f948",
+      "right_id": "z293",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The restaurants have completely different names (\"rib ranch\" vs \"abruzzi\"), addresses (25 irby ave. vs 2355 peachtree rd. ne), phone numbers, and cuisine types (barbecue vs italian). They are clearly different establishments.",
+      "provenance": {
+        "tokens": {
+          "prompt": 278,
+          "completion": 83
+        },
+        "cost_usd": 0.0005824000000000001,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f949",
+      "right_id": "z173",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The two records have completely different names (sa tsu ki vs. nava), addresses (3043 buford hwy. vs. 3060 peachtree rd.), phone numbers, and cuisine types (asian vs. southwestern). There is no overlap in any identifying fields, indicating they are clearly different restaurants.",
+      "provenance": {
+        "tokens": {
+          "prompt": 277,
+          "completion": 97
+        },
+        "cost_usd": 0.00063035,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f949",
+      "right_id": "z294",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The restaurant names, addresses, phone numbers, and cuisine types are all completely different, indicating they are distinct restaurants.",
+      "provenance": {
+        "tokens": {
+          "prompt": 284,
+          "completion": 180
+        },
+        "cost_usd": 0.0009282000000000001,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f949",
+      "right_id": "z293",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The records have completely different names, addresses, phone numbers, and cuisine types, making it clear they refer to different restaurants.",
+      "provenance": {
+        "tokens": {
+          "prompt": 286,
+          "completion": 161
+        },
+        "cost_usd": 0.0008638000000000001,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f949",
+      "right_id": "z172",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The records have completely different names, addresses, and phone numbers. There is no overlapping information to suggest these refer to the same restaurant.",
+      "provenance": {
+        "tokens": {
+          "prompt": 281,
+          "completion": 359
+        },
+        "cost_usd": 0.00155155,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f950",
+      "right_id": "z62",
+      "label": true,
+      "source": "teacher",
+      "confidence": 1.0,
+      "reasoning": "The two records have completely different names, addresses, cities, and phone numbers. Record A is in Atlanta, GA while Record B is in Studio City, CA.",
+      "provenance": {
+        "tokens": {
+          "prompt": 299,
+          "completion": 172
+        },
+        "cost_usd": 0.00091595,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f951",
+      "right_id": "z181",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The two records have completely different names (\"south city kitchen\" vs \"thelma's kitchen\"), addresses (\"1144 crescent ave.\" vs \"764 marietta st. nw\"), phone numbers, and cuisine types. There is no overlap in the identifying information.",
+      "provenance": {
+        "tokens": {
+          "prompt": 286,
+          "completion": 179
+        },
+        "cost_usd": 0.0009268,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f951",
+      "right_id": "z145",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The two records have completely different names, addresses, and phone numbers. They also have slightly different cuisine types. There is no evidence suggesting they refer to the same real-world restaurant.",
+      "provenance": {
+        "tokens": {
+          "prompt": 277,
+          "completion": 126
+        },
+        "cost_usd": 0.00073185,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f951",
+      "right_id": "z185",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The records have completely different names, addresses, phone numbers, and restaurant types. They only share the same city, which is insufficient to consider them the same restaurant.",
+      "provenance": {
+        "tokens": {
+          "prompt": 283,
+          "completion": 397
+        },
+        "cost_usd": 0.00168665,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f951",
+      "right_id": "z113",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The records have completely different cities (Atlanta vs. New York City), addresses, phone numbers, names, and cuisine types (Southern vs. Chinese). There is no overlap to suggest they are the same restaurant.",
+      "provenance": {
+        "tokens": {
+          "prompt": 278,
+          "completion": 402
+        },
+        "cost_usd": 0.0016989000000000001,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f952",
+      "right_id": "z173",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The names, addresses, phone numbers, and restaurant types are completely different. There is no indication that these refer to the same restaurant.",
+      "provenance": {
+        "tokens": {
+          "prompt": 277,
+          "completion": 103
+        },
+        "cost_usd": 0.00065135,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f952",
+      "right_id": "z142",
+      "label": true,
+      "source": "teacher",
+      "confidence": 1.0,
+      "reasoning": "The records have completely different names, addresses, phone numbers, and cuisine types, indicating they refer to two different restaurants in Atlanta.",
+      "provenance": {
+        "tokens": {
+          "prompt": 282,
+          "completion": 99
+        },
+        "cost_usd": 0.0006426,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f954",
+      "right_id": "z150",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The records have different names, addresses, phone numbers, and cuisine types. There is no evidence to suggest these refer to the same restaurant.",
+      "provenance": {
+        "tokens": {
+          "prompt": 283,
+          "completion": 138
+        },
+        "cost_usd": 0.00078015,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f954",
+      "right_id": "z149",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The records have completely different names, addresses, phone numbers, and cuisine types. They are clearly two different restaurants in Atlanta.",
+      "provenance": {
+        "tokens": {
+          "prompt": 281,
+          "completion": 122
+        },
+        "cost_usd": 0.0007220499999999999,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f954",
+      "right_id": "z308",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The records have completely different names, addresses, and phone numbers. There is no indication they refer to the same restaurant.",
+      "provenance": {
+        "tokens": {
+          "prompt": 298,
+          "completion": 60
+        },
+        "cost_usd": 0.0005229,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f954",
+      "right_id": "z331",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The records have different names (sundown cafe vs. ritz-carlton cafe), different addresses (2165 cheshire bridge rd. vs 181 peachtree st.), and different phone numbers (404/321-1118 vs 404-659-0400). These are clearly two distinct restaurants in Atlanta.",
+      "provenance": {
+        "tokens": {
+          "prompt": 290,
+          "completion": 209
+        },
+        "cost_usd": 0.001036,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f955",
+      "right_id": "z303",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The two records have completely different names, addresses, phone numbers, and cuisine types, indicating they are clearly distinct restaurants in Atlanta.",
+      "provenance": {
+        "tokens": {
+          "prompt": 293,
+          "completion": 180
+        },
+        "cost_usd": 0.00093765,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f955",
+      "right_id": "z185",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The records have completely different names, addresses, and phone numbers. \"Taste of New Orleans\" and \"White House Restaurant\" are clearly distinct establishments.",
+      "provenance": {
+        "tokens": {
+          "prompt": 293,
+          "completion": 66
+        },
+        "cost_usd": 0.0005386500000000001,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f955",
+      "right_id": "z331",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The records have completely different names, addresses (889 W. Peachtree vs 181 Peachtree), phone numbers, and restaurant types. There is no overlap in any identifying information.",
+      "provenance": {
+        "tokens": {
+          "prompt": 298,
+          "completion": 181
+        },
+        "cost_usd": 0.0009464,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f956",
+      "right_id": "z173",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The records have entirely different names (tomtom vs nava), addresses (3393 vs 3060 peachtree rd.), phone numbers, and restaurant types. There is no overlap in any field other than city and street name, indicating these are two distinct restaurants on Peachtree Road in Atlanta.",
+      "provenance": {
+        "tokens": {
+          "prompt": 270,
+          "completion": 149
+        },
+        "cost_usd": 0.0008049999999999999,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f956",
+      "right_id": "z293",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The restaurant names are completely different (\"tomtom\" vs \"abruzzi\"), the street addresses differ (\"3393 peachtree rd.\" vs \"2355 peachtree rd. ne\"), the phone numbers are different, and the cuisine types differ (\"continental\" vs \"italian\"). There is no evidence suggesting these are the same restaurant.",
+      "provenance": {
+        "tokens": {
+          "prompt": 279,
+          "completion": 184
+        },
+        "cost_usd": 0.00093695,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f957",
+      "right_id": "z125",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "Although the street addresses are similar (likely referring to the same hotel or casino, the Rio), the restaurant names (\"antonio's\" vs \"buzio's in the rio\"), phone numbers (702/252-7737 vs 702-252-7697), and cuisine types (italian vs seafood) are entirely different, indicating they are distinct restaurants located at the same general address.",
+      "provenance": {
+        "tokens": {
+          "prompt": 291,
+          "completion": 320
+        },
+        "cost_usd": 0.0014255500000000003,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f958",
+      "right_id": "z129",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The restaurants have different names (\"bally's big kitchen\" vs \"madame ching's\"), different addresses (3645 vs 3300 Las Vegas Blvd. S), different phone numbers, and different cuisine types (buffets vs asian). There is no evidence suggesting they refer to the same real-world restaurant.",
+      "provenance": {
+        "tokens": {
+          "prompt": 299,
+          "completion": 180
+        },
+        "cost_usd": 0.00094395,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f959",
+      "right_id": "z286",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The records have completely different names, addresses, and phone numbers, indicating they are distinct restaurants.",
+      "provenance": {
+        "tokens": {
+          "prompt": 284,
+          "completion": 132
+        },
+        "cost_usd": 0.0007602000000000002,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f960",
+      "right_id": "z139",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The names, addresses, and phone numbers of the two restaurants are completely different. They only share the same city and cuisine type, which is insufficient to consider them the same real-world restaurant.",
+      "provenance": {
+        "tokens": {
+          "prompt": 298,
+          "completion": 166
+        },
+        "cost_usd": 0.0008939,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f960",
+      "right_id": "z123",
+      "label": true,
+      "source": "teacher",
+      "confidence": 1.0,
+      "reasoning": "The records have completely different names (Battista's Hole in the Wall vs. Andre's French Restaurant), addresses, phone numbers, and cuisine types, making it clear they refer to different restaurants in Las Vegas.",
+      "provenance": {
+        "tokens": {
+          "prompt": 308,
+          "completion": 131
+        },
+        "cost_usd": 0.0007819000000000001,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f961",
+      "right_id": "z286",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The two records have completely different names (bertolini's vs chin's), addresses (3570 vs 3200 Las Vegas Blvd. S), phone numbers, and restaurant types (italian vs chinese). There is no overlap in any identifying information, indicating they are definitively different restaurants.",
+      "provenance": {
+        "tokens": {
+          "prompt": 290,
+          "completion": 136
+        },
+        "cost_usd": 0.0007804999999999999,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f963",
+      "right_id": "z286",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The records differ significantly across all key attributes: name (bistro vs. chin's), address (3400 vs. 3200 Las Vegas Blvd. S), phone number (702/791-7111 vs. 702-733-8899), and cuisine type (continental vs. chinese). There is no evidence suggesting these refer to the same restaurant.",
+      "provenance": {
+        "tokens": {
+          "prompt": 285,
+          "completion": 175
+        },
+        "cost_usd": 0.00091175,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f963",
+      "right_id": "z141",
+      "label": true,
+      "source": "teacher",
+      "confidence": 1.0,
+      "reasoning": "The records have completely different names (bistro vs tre visi), different addresses (3400 vs 3799 Las Vegas Blvd. S), different phone numbers, and different cuisine types. There is no overlap to suggest these are the same restaurant.",
+      "provenance": {
+        "tokens": {
+          "prompt": 288,
+          "completion": 238
+        },
+        "cost_usd": 0.0011354000000000002,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f964",
+      "right_id": "z286",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The records have entirely different names, addresses, phone numbers, and cuisine types, indicating they are clearly distinct restaurants.",
+      "provenance": {
+        "tokens": {
+          "prompt": 283,
+          "completion": 58
+        },
+        "cost_usd": 0.00050015,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f965",
+      "right_id": "z287",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The restaurant names, addresses (3555 vs 3799), phone numbers, and types are all completely different, indicating these are two distinct restaurants.",
+      "provenance": {
+        "tokens": {
+          "prompt": 307,
+          "completion": 155
+        },
+        "cost_usd": 0.00086485,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f966",
+      "right_id": "z287",
+      "label": true,
+      "source": "teacher",
+      "confidence": 1.0,
+      "reasoning": "The records have completely different names, addresses, phone numbers, and types, clearly indicating they refer to two different restaurants in Las Vegas.",
+      "provenance": {
+        "tokens": {
+          "prompt": 300,
+          "completion": 199
+        },
+        "cost_usd": 0.0010115,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f967",
+      "right_id": "z287",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The two records have completely different restaurant names (\"cafe roma\" vs \"coyote cafe\"), different addresses (3570 vs 3799 Las Vegas Blvd. S), and different phone numbers. They are clearly distinct establishments.",
+      "provenance": {
+        "tokens": {
+          "prompt": 305,
+          "completion": 84
+        },
+        "cost_usd": 0.00061425,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f968",
+      "right_id": "z286",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The records have completely different restaurant names (capozzoli's vs chin's), addresses (3333 s. maryland pkwy. vs 3200 las vegas blvd. s.), phone numbers, and cuisine types (italian vs chinese). They are definitively different establishments.",
+      "provenance": {
+        "tokens": {
+          "prompt": 292,
+          "completion": 213
+        },
+        "cost_usd": 0.0010521,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f970",
+      "right_id": "z286",
+      "label": true,
+      "source": "teacher",
+      "confidence": 1.0,
+      "reasoning": "The records have completely different names, addresses, phone numbers, and cuisine types. There is no overlapping information to suggest they refer to the same real-world restaurant.",
+      "provenance": {
+        "tokens": {
+          "prompt": 279,
+          "completion": 171
+        },
+        "cost_usd": 0.00089145,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f971",
+      "right_id": "z132",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The restaurant names are completely different (\"circus circus\" vs \"monte carlo\"), as are their addresses, phone numbers, and cuisine types. They are clearly distinct establishments on the Las Vegas Strip.",
+      "provenance": {
+        "tokens": {
+          "prompt": 297,
+          "completion": 167
+        },
+        "cost_usd": 0.00089635,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f971",
+      "right_id": "z129",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The restaurant names, addresses, phone numbers, and types are all completely different, indicating they refer to two distinct restaurants in Las Vegas.",
+      "provenance": {
+        "tokens": {
+          "prompt": 295,
+          "completion": 268
+        },
+        "cost_usd": 0.0012477500000000002,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f971",
+      "right_id": "z286",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The records have completely different names (circus circus vs chin's), different addresses (2880 vs 3200 las vegas blvd. s), different phone numbers, and different restaurant types. There is no overlap in any field to suggest these are the same restaurant.",
+      "provenance": {
+        "tokens": {
+          "prompt": 290,
+          "completion": 222
+        },
+        "cost_usd": 0.0010815,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f972",
+      "right_id": "z289",
+      "label": true,
+      "source": "teacher",
+      "confidence": 0.95,
+      "reasoning": "While both restaurantsshare the same address at 3570 Las Vegas Blvd. S. (Caesars Palace), they have different names (\"Empress Court\" vs \"Palace Court\"), different phone numbers, and different cuisine types (\"Asian\" vs \"French (new)\"). These are historically two distinct restaurants located within the same hotel property.",
+      "provenance": {
+        "tokens": {
+          "prompt": 296,
+          "completion": 223
+        },
+        "cost_usd": 0.0010913,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f972",
+      "right_id": "z129",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.05,
+      "reasoning": "The records have different names, different street addresses (3570 vs 3300 Las Vegas Blvd. S), and different phone numbers. There is no evidence to suggest these refer to the same restaurant.",
+      "provenance": {
+        "tokens": {
+          "prompt": 295,
+          "completion": 128
+        },
+        "cost_usd": 0.00075775,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f973",
+      "right_id": "z291",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The restaurants have completely different names, addresses, phone numbers, and types, making it clear they refer to different entities.",
+      "provenance": {
+        "tokens": {
+          "prompt": 295,
+          "completion": 166
+        },
+        "cost_usd": 0.00089075,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f973",
+      "right_id": "z130",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The two records have completely different names (\"feast\" vs. \"mayflower cuisinier\"), street numbers (2411 vs 4750), phone numbers, and restaurant types. They are clearly two distinct restaurants that happen to be on the same street in Las Vegas.",
+      "provenance": {
+        "tokens": {
+          "prompt": 291,
+          "completion": 418
+        },
+        "cost_usd": 0.0017685500000000002,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f974",
+      "right_id": "z139",
+      "label": true,
+      "source": "teacher",
+      "confidence": 0.9,
+      "reasoning": "Although the records share the same address and phone number (likely becauseStefano's is located inside the Golden Nugget Hotel and shares its main contact info), the restaurant names (\"golden nugget hotel\" vs \"stefano's\") and restaurant types (\"buffets\" vs \"italian\") are distinctly different. Therefore, they refer to different real-world restaurants.",
+      "provenance": {
+        "tokens": {
+          "prompt": 281,
+          "completion": 316
+        },
+        "cost_usd": 0.00140105,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f974",
+      "right_id": "z138",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The records have different names (\"golden nugget hotel\" vs \"steakhouse the\"), different types (\"buffets\" vs \"steakhouses\"), different phone numbers, and slightly different addresses (129 vs 128 E. Fremont St.). These indicate they refer to different establishments.",
+      "provenance": {
+        "tokens": {
+          "prompt": 287,
+          "completion": 334
+        },
+        "cost_usd": 0.0014703499999999998,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f974",
+      "right_id": "z286",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The two records have completely different names (golden nugget hotel vs. chin's), addresses (129 e. fremont st. vs. 3200 las vegas blvd. s.), phone numbers, and restaurant types (buffets vs. chinese). They clearly refer to different restaurants.",
+      "provenance": {
+        "tokens": {
+          "prompt": 286,
+          "completion": 125
+        },
+        "cost_usd": 0.0007378,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f975",
+      "right_id": "z286",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The records have completely different names (golden steer vs. chin's), addresses (308 w. sahara ave. vs. 3200 las vegas blvd. s.), phone numbers, and cuisine types (steak houses vs. chinese). They are definitively different restaurants.",
+      "provenance": {
+        "tokens": {
+          "prompt": 283,
+          "completion": 406
+        },
+        "cost_usd": 0.0017181499999999999,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f976",
+      "right_id": "z139",
+      "label": true,
+      "source": "teacher",
+      "confidence": 0.95,
+      "reasoning": "The records share the exact same phone number (702-385-7111) and essentially the same street address (129 E. Fremont St vs 129 Fremont St) in Las Vegas. The differing names and cuisine types likely reflect either a change in ownership/name over time or a discrepancy between the data sources (Fodors and Zagat). The matching phone number and address are strong indicators they refer to the same physical restaurant.",
+      "provenance": {
+        "tokens": {
+          "prompt": 285,
+          "completion": 335
+        },
+        "cost_usd": 0.00147175,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f976",
+      "right_id": "z286",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The records have completely different names (\"lillie langtry's\" vs \"chin's\"), addresses (\"129 e. fremont st.\" vs \"3200 las vegas blvd. s.\"), and phone numbers. There is no overlap in the key identifying fields, indicating they are distinct restaurants.",
+      "provenance": {
+        "tokens": {
+          "prompt": 290,
+          "completion": 218
+        },
+        "cost_usd": 0.0010675,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f977",
+      "right_id": "z289",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The names, addresses, phone numbers, and restaurant types are all completely different. \"Mandarin Court\" is an Asian restaurant on E. Flamingo Rd., while \"Palace Court\" is a French restaurant on Las Vegas Blvd. S. There is no overlap in any identifying fields.",
+      "provenance": {
+        "tokens": {
+          "prompt": 291,
+          "completion": 176
+        },
+        "cost_usd": 0.00092155,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f978",
+      "right_id": "z129",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The records have completely different names, phone numbers, restaurant types (Mexican vs Asian), and street numbers (3120 vs 3300), indicating they are different establishments.",
+      "provenance": {
+        "tokens": {
+          "prompt": 305,
+          "completion": 501
+        },
+        "cost_usd": 0.00207375,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f978",
+      "right_id": "z286",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The two records have completely different names (Margarita's Mexican Cantina vs. Chin's), different restaurant types (Mexican vs. Chinese), different phone numbers, and different addresses (3120 vs 3200 Las Vegas Blvd. S.). They are clearly different restaurants.",
+      "provenance": {
+        "tokens": {
+          "prompt": 300,
+          "completion": 171
+        },
+        "cost_usd": 0.0009135,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f979",
+      "right_id": "z138",
+      "label": true,
+      "source": "teacher",
+      "confidence": 1.0,
+      "reasoning": "The records have entirely different names (\"mary's diner\" vs \"steakhouse the\"), addresses, phone numbers, and restaurant types. They are clearly different establishments in Las Vegas.",
+      "provenance": {
+        "tokens": {
+          "prompt": 293,
+          "completion": 74
+        },
+        "cost_usd": 0.00056665,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f980",
+      "right_id": "z141",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The records have completely different names, addresses, phone numbers, and cuisine types, indicating they are distinct restaurants.",
+      "provenance": {
+        "tokens": {
+          "prompt": 291,
+          "completion": 178
+        },
+        "cost_usd": 0.00092855,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f983",
+      "right_id": "z286",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The records have completely different restaurant names (\"the bacchanal\" vs \"chin's\"), different street addresses (3570 vs 3200 Las Vegas Blvd.), different phone numbers, and different cuisine types. These are clearly two distinct restaurants in Las Vegas.",
+      "provenance": {
+        "tokens": {
+          "prompt": 294,
+          "completion": 122
+        },
+        "cost_usd": 0.0007356999999999999,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f983",
+      "right_id": "z129",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The two records have completely different restaurant names, addresses (3570 vs 3300 Las Vegas Blvd. S), phone numbers, and cuisine types, indicating they are clearly different establishments.",
+      "provenance": {
+        "tokens": {
+          "prompt": 299,
+          "completion": 101
+        },
+        "cost_usd": 0.00066745,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f984",
+      "right_id": "z141",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The restaurant names, addresses, and phone numbers are all completely different, indicating they are two distinct Italian restaurants in Las Vegas.",
+      "provenance": {
+        "tokens": {
+          "prompt": 291,
+          "completion": 206
+        },
+        "cost_usd": 0.00102655,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f985",
+      "right_id": "z292",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The restaurant names, addresses, phone numbers, and cuisine types are all completely different, indicating they are distinct restaurants.",
+      "provenance": {
+        "tokens": {
+          "prompt": 293,
+          "completion": 207
+        },
+        "cost_usd": 0.00103215,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f986",
+      "right_id": "z135",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The records have completely different names (yolie's vs nicky blair's), different phone numbers, different restaurant types (steak houses vs italian), and slightly different addresses (3900 vs 3925 Paradise Rd). These are clearly two different real-world restaurants.",
+      "provenance": {
+        "tokens": {
+          "prompt": 282,
+          "completion": 124
+        },
+        "cost_usd": 0.0007301,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f986",
+      "right_id": "z286",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The names, addresses, phone numbers, and types of cuisine are all completely different between the two records, indicating they refer to distinct restaurants.",
+      "provenance": {
+        "tokens": {
+          "prompt": 283,
+          "completion": 198
+        },
+        "cost_usd": 0.00099015,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f987",
+      "right_id": "z188",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.05,
+      "reasoning": "The restaurants have different names (\"2223\" vs \"cafe flore\"), different addresses on Market St (2223 vs 2298), and different phone numbers. The only commonality is being in San Francisco on Market St, which is insufficient to consider them the same restaurant.",
+      "provenance": {
+        "tokens": {
+          "prompt": 279,
+          "completion": 163
+        },
+        "cost_usd": 0.00086345,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f987",
+      "right_id": "z214",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The records have completely different names, addresses, phone numbers, and restaurant types, indicating they are clearly two separate establishments.",
+      "provenance": {
+        "tokens": {
+          "prompt": 278,
+          "completion": 462
+        },
+        "cost_usd": 0.0019088999999999998,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f988",
+      "right_id": "z214",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The two records have completely different names (acquarello vs ti couz), addresses, phone numbers, and cuisine types (italian vs french). There is no overlap in any identifying information, so they are definitely different restaurants.",
+      "provenance": {
+        "tokens": {
+          "prompt": 285,
+          "completion": 76
+        },
+        "cost_usd": 0.00056525,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f989",
+      "right_id": "z201",
+      "label": true,
+      "source": "teacher",
+      "confidence": 1.0,
+      "reasoning": "The records have completely different names, addresses, and phone numbers. There is no overlap in the identifying information to suggest they are the same restaurant.",
+      "provenance": {
+        "tokens": {
+          "prompt": 288,
+          "completion": 136
+        },
+        "cost_usd": 0.0007784000000000001,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f989",
+      "right_id": "z318",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The two records have completely different names (bardelli's vs. chez michel), addresses (243 o'farrell st. vs. 804 north point st.), and phone numbers. There is no overlap in any identifying fields to suggest these refer to the same restaurant.",
+      "provenance": {
+        "tokens": {
+          "prompt": 289,
+          "completion": 89
+        },
+        "cost_usd": 0.00061495,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f989",
+      "right_id": "z319",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The two records have completely different names (\"bardelli's\" vs. \"fleur de lys\"), addresses (\"243 o'farrell st.\" vs. \"777 sutter st.\"), and phone numbers, clearly indicating they are two distinct restaurants.",
+      "provenance": {
+        "tokens": {
+          "prompt": 292,
+          "completion": 396
+        },
+        "cost_usd": 0.0016925999999999998,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f990",
+      "right_id": "z192",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The records have completely different names (\"betelnut\" vs \"doidge's\"), different street addresses (2030 vs 2217 union st.), different phone numbers, and different cuisine types. There is no overlap in the identifying attributes.",
+      "provenance": {
+        "tokens": {
+          "prompt": 279,
+          "completion": 195
+        },
+        "cost_usd": 0.0009754499999999999,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f990",
+      "right_id": "z320",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The records have completely different names (betelnut vs fringale), addresses (2030 union st. vs 570 fourth st.), phone numbers, and restaurant types (asian vs french bistro). There is no indication these refer to the same restaurant.",
+      "provenance": {
+        "tokens": {
+          "prompt": 279,
+          "completion": 88
+        },
+        "cost_usd": 0.00060095,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f992",
+      "right_id": "z318",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The restaurant names, addresses, phone numbers, and types are completely different, indicating these are two distinct restaurants in San Francisco.",
+      "provenance": {
+        "tokens": {
+          "prompt": 276,
+          "completion": 119
+        },
+        "cost_usd": 0.0007063,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f993",
+      "right_id": "z318",
+      "label": true,
+      "source": "teacher",
+      "confidence": 1.0,
+      "reasoning": "The names, addresses, phone numbers, and restaurant types are completely different, indicating they are two distinct restaurants in San Francisco.",
+      "provenance": {
+        "tokens": {
+          "prompt": 278,
+          "completion": 201
+        },
+        "cost_usd": 0.0009954,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f993",
+      "right_id": "z328",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The restaurant names (bizou vs postrio), addresses (598 fourth st. vs 545 post st.), phone numbers, and types (french vs californian) are all completely different. These are clearly two distinct restaurants in San Francisco.",
+      "provenance": {
+        "tokens": {
+          "prompt": 274,
+          "completion": 281
+        },
+        "cost_usd": 0.0012712,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f993",
+      "right_id": "z195",
+      "label": true,
+      "source": "teacher",
+      "confidence": 1.0,
+      "reasoning": "The records have completely different names, addresses, phone numbers, and cuisine types (French vs Japanese), clearly indicating they are different restaurants.",
+      "provenance": {
+        "tokens": {
+          "prompt": 271,
+          "completion": 187
+        },
+        "cost_usd": 0.0009390499999999999,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f994",
+      "right_id": "z318",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The records have completely different names (buca giovanni vs chez michel), addresses (800 greenwich st. vs 804 north point st.), phone numbers, and restaurant types. They clearly refer to different establishments.",
+      "provenance": {
+        "tokens": {
+          "prompt": 283,
+          "completion": 186
+        },
+        "cost_usd": 0.00094815,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f994",
+      "right_id": "z328",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The restaurant names, addresses, and types are completely different. The phone numbers share the same exchange but are different numbers. These are clearly two distinct restaurants in San Francisco.",
+      "provenance": {
+        "tokens": {
+          "prompt": 279,
+          "completion": 200
+        },
+        "cost_usd": 0.00099295,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f995",
+      "right_id": "z327",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The two records have different restaurant names (\"cafe adriano\" vs \"plumpjack cafe\"), different addresses (\"3347 fillmore st.\" vs \"3127 fillmore st.\"), different phone numbers, and different cuisine types. They are clearly distinct establishments on the same street.",
+      "provenance": {
+        "tokens": {
+          "prompt": 293,
+          "completion": 263
+        },
+        "cost_usd": 0.00122815,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f995",
+      "right_id": "z188",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The records have completely different names (cafe adriano vs. cafe flore), addresses (3347 fillmore st. vs. 2298 market st.), and phone numbers. They are definitely two different restaurants in San Francisco.",
+      "provenance": {
+        "tokens": {
+          "prompt": 290,
+          "completion": 191
+        },
+        "cost_usd": 0.0009730000000000001,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f995",
+      "right_id": "z215",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The records have different names, different addresses on the same street, different phone numbers, and different cuisine types. These are clearly distinct restaurants in San Francisco.",
+      "provenance": {
+        "tokens": {
+          "prompt": 286,
+          "completion": 106
+        },
+        "cost_usd": 0.0006713000000000001,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f996",
+      "right_id": "z188",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The records have completely different restaurant names (\"cafe marimba\" vs \"cafe flore\"), different addresses (2317 chestnut st. vs 2298 market st.), different phone numbers, and different cuisine types. There is no overlap in any identifying fields.",
+      "provenance": {
+        "tokens": {
+          "prompt": 295,
+          "completion": 116
+        },
+        "cost_usd": 0.00071575,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f996",
+      "right_id": "z203",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The restaurant names, addresses, phone numbers, and cuisine types are all completely different. \"Cafe Marimba\" at 2317 Chestnut St (Mexican/Latin American, 776-1506) and \"Mario's Bohemian Cigar Store Cafe\" at 2209 Polk St (Italian, 776-8226) clearly refer to different establishments.",
+      "provenance": {
+        "tokens": {
+          "prompt": 304,
+          "completion": 409
+        },
+        "cost_usd": 0.0017507,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f997",
+      "right_id": "z203",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The records have completely different names, addresses (625 polk st. vs 2209 polk st.), phone numbers, and cuisine types (french vs italian). They are clearly different restaurants.",
+      "provenance": {
+        "tokens": {
+          "prompt": 294,
+          "completion": 73
+        },
+        "cost_usd": 0.0005641999999999999,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f997",
+      "right_id": "z7",
+      "label": true,
+      "source": "teacher",
+      "confidence": 1.0,
+      "reasoning": "The records have completely different names, addresses, phone numbers, and cities (San Francisco vs. Pasadena), indicating they are clearly distinct restaurants.",
+      "provenance": {
+        "tokens": {
+          "prompt": 283,
+          "completion": 58
+        },
+        "cost_usd": 0.00050015,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f999",
+      "right_id": "z188",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The two records have completely different names (carta vs. cafe flore), addresses (1772 market st. vs. 2298 market st.), and phone numbers. There is no indication they refer to the same restaurant.",
+      "provenance": {
+        "tokens": {
+          "prompt": 278,
+          "completion": 158
+        },
+        "cost_usd": 0.0008449,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f1001",
+      "right_id": "z321",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The restaurants have different names (cypress club vs hawthorne lane), different addresses (500 jackson st. vs 22 hawthorne st.), and different phone numbers (415/296-8555 vs 415-777-9779). There is no overlap in any identifying information.",
+      "provenance": {
+        "tokens": {
+          "prompt": 286,
+          "completion": 149
+        },
+        "cost_usd": 0.0008217999999999999,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f1002",
+      "right_id": "z89",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The records have completely different names, addresses, cities, phone numbers, and cuisine types. They are clearly distinctrestaurants with no overlapping attributes.",
+      "provenance": {
+        "tokens": {
+          "prompt": 278,
+          "completion": 109
+        },
+        "cost_usd": 0.0006734,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f1002",
+      "right_id": "z268",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The restaurants have different names, are located in different cities (San Francisco vs. New York City), have different addresses, and different phone numbers. They are clearly distinct entities.",
+      "provenance": {
+        "tokens": {
+          "prompt": 285,
+          "completion": 96
+        },
+        "cost_usd": 0.00063525,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f1002",
+      "right_id": "z247",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The records have completely different names (\"des alpes\" vs \"carmine's\"), cities (san francisco vs new york city), addresses (732 broadway vs 2450 broadway), phone numbers, and cuisine types. They clearly refer to different real-world restaurants.",
+      "provenance": {
+        "tokens": {
+          "prompt": 278,
+          "completion": 174
+        },
+        "cost_usd": 0.0009008999999999999,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f1003",
+      "right_id": "z318",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The records have completely different names (\"faz\" vs \"chez michel\"), addresses (161 Sutter St vs 804 North Point St), phone numbers, and cuisine types (Greek/Middle Eastern vs Californian). They are clearly distinct restaurants.",
+      "provenance": {
+        "tokens": {
+          "prompt": 282,
+          "completion": 96
+        },
+        "cost_usd": 0.0006321,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f1003",
+      "right_id": "z319",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The restaurant names (\"faz\" vs \"fleur de lys\"), addresses (\"161 sutter st.\" vs \"777 sutter st.\"), phone numbers, and types (\"greek and middle eastern\" vs \"french (new)\") are all completely different. There is no evidence to suggest these records refer to the same restaurant.",
+      "provenance": {
+        "tokens": {
+          "prompt": 285,
+          "completion": 230
+        },
+        "cost_usd": 0.00110425,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f1003",
+      "right_id": "z214",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The two records have completely different names, addresses, phone numbers, and restaurant types, making it certain they refer to different establishments.",
+      "provenance": {
+        "tokens": {
+          "prompt": 282,
+          "completion": 376
+        },
+        "cost_usd": 0.0016121,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f1005",
+      "right_id": "z317",
+      "label": true,
+      "source": "teacher",
+      "confidence": 1.0,
+      "reasoning": "The two records have completely different names, addresses, phone numbers, and restaurant types. They refer to distinct restaurants in San Francisco.",
+      "provenance": {
+        "tokens": {
+          "prompt": 284,
+          "completion": 85
+        },
+        "cost_usd": 0.0005957,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f1007",
+      "right_id": "z203",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The two records have completely different names, addresses, phone numbers, and cuisine types. There is no overlap in any identifying fields, indicating they refer to two distinct real-world restaurants in San Francisco.",
+      "provenance": {
+        "tokens": {
+          "prompt": 295,
+          "completion": 75
+        },
+        "cost_usd": 0.0005722500000000001,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f1008",
+      "right_id": "z323",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The two records have completely different names (\"greens\" vs \"la folie\"), addresses (\"bldg. a fort mason\" vs \"2316 polk st.\"), phone numbers (415/771-6222 vs 415-776-5577), and restaurant types (\"vegetarian\" vs \"french (new)\"). They are clearly distinct restaurants in San Francisco.",
+      "provenance": {
+        "tokens": {
+          "prompt": 287,
+          "completion": 211
+        },
+        "cost_usd": 0.00103985,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f1009",
+      "right_id": "z315",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The two records have completely different names (\"harbor village\" vs \"boulevard\"), addresses (\"4 embarcadero center\" vs \"1 mission st.\"), phone numbers, and restaurant types. There is no overlap in any field, indicating they refer to different real-world restaurants.",
+      "provenance": {
+        "tokens": {
+          "prompt": 276,
+          "completion": 169
+        },
+        "cost_usd": 0.0008813,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f1010",
+      "right_id": "z56",
+      "label": true,
+      "source": "teacher",
+      "confidence": 1.0,
+      "reasoning": "The records have entirely different names (\"harris'\" vs \"rae's\"), addresses, cities (San Francisco vs Santa Monica), phone numbers, and types (steak houses vs diners). There is no overlap in any identifying information.",
+      "provenance": {
+        "tokens": {
+          "prompt": 282,
+          "completion": 101
+        },
+        "cost_usd": 0.0006496000000000001,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f1012",
+      "right_id": "z290",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The records have completely different names, addresses, cities, and phone numbers. Record A is located in San Francisco while Record B is in Las Vegas, clearly referring to two different restaurants.",
+      "provenance": {
+        "tokens": {
+          "prompt": 282,
+          "completion": 184
+        },
+        "cost_usd": 0.0009401000000000001,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f1012",
+      "right_id": "z210",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The two records have completely different names, addresses, phone numbers, and cuisine types. There are no overlapping attributes to suggest these are the same restaurant.",
+      "provenance": {
+        "tokens": {
+          "prompt": 287,
+          "completion": 182
+        },
+        "cost_usd": 0.0009383499999999999,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f1013",
+      "right_id": "z247",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The records have different names (helmand vs. carmine's), different cities (san francisco vs. new york city), different addresses (430 broadway vs. 2450 broadway), different phone numbers, and different cuisines. They clearly refer to completely different restaurants.",
+      "provenance": {
+        "tokens": {
+          "prompt": 277,
+          "completion": 160
+        },
+        "cost_usd": 0.0008508500000000001,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f1013",
+      "right_id": "z89",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The two records differ on every key attribute: name (helmand vs. la caridad), city (san francisco vs. new york city), address (430 broadway vs. 2199 broadway), phone number, and cuisine type. These are clearly distinct restaurants.",
+      "provenance": {
+        "tokens": {
+          "prompt": 277,
+          "completion": 97
+        },
+        "cost_usd": 0.00063035,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f1014",
+      "right_id": "z324",
+      "label": true,
+      "source": "teacher",
+      "confidence": 1.0,
+      "reasoning": "The two records have completely different names, addresses, phone numbers, and cuisine types. There is no overlap in any of the identifying attributes, clearly indicating they are different real-world restaurants.",
+      "provenance": {
+        "tokens": {
+          "prompt": 303,
+          "completion": 153
+        },
+        "cost_usd": 0.0008536500000000001,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f1015",
+      "right_id": "z194",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The records have completely different names (\"hong kong villa\" vs \"dusit thai\"), addresses (2332 clement st. vs 3221 mission st.), and phone numbers. They are clearly different restaurants.",
+      "provenance": {
+        "tokens": {
+          "prompt": 290,
+          "completion": 75
+        },
+        "cost_usd": 0.000567,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f1017",
+      "right_id": "z328",
+      "label": true,
+      "source": "teacher",
+      "confidence": 1.0,
+      "reasoning": "The records have entirely different names, addresses, phone numbers, and cuisine types, indicating they refer to completely different restaurants.",
+      "provenance": {
+        "tokens": {
+          "prompt": 284,
+          "completion": 116
+        },
+        "cost_usd": 0.0007042000000000001,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f1018",
+      "right_id": "z108",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The two records have completely different names, addresses, cities, and phone numbers. Record A is located in San Francisco, while Record B is located in New York City.",
+      "provenance": {
+        "tokens": {
+          "prompt": 296,
+          "completion": 426
+        },
+        "cost_usd": 0.0018017999999999999,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f1018",
+      "right_id": "z295",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The records have different names, are located in different cities (San Francisco vs Atlanta), and have completely different addresses and phone numbers.",
+      "provenance": {
+        "tokens": {
+          "prompt": 296,
+          "completion": 168
+        },
+        "cost_usd": 0.0008988,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f1018",
+      "right_id": "z155",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The records have entirely different names, addresses, cities, phone numbers, and restaurant types. They are clearly different restaurants.",
+      "provenance": {
+        "tokens": {
+          "prompt": 293,
+          "completion": 137
+        },
+        "cost_usd": 0.00078715,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f1018",
+      "right_id": "z210",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The records have different names, addresses, and phone numbers. There is no overlap in any identifying fields, clearly indicating they are two different restaurants in San Francisco.",
+      "provenance": {
+        "tokens": {
+          "prompt": 296,
+          "completion": 67
+        },
+        "cost_usd": 0.0005453000000000001,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f1019",
+      "right_id": "z325",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The records have completely different names (\"jack's\" vs \"masa's\"), addresses (\"615 sacramento st.\" vs \"648 bush st.\"), phone numbers, and restaurant types. They are clearly two distinct restaurants in San Francisco.",
+      "provenance": {
+        "tokens": {
+          "prompt": 281,
+          "completion": 137
+        },
+        "cost_usd": 0.0007745499999999999,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f1020",
+      "right_id": "z62",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The records have completely different names, addresses, cities, and phone numbers, clearly indicating they are two distinct restaurants.",
+      "provenance": {
+        "tokens": {
+          "prompt": 291,
+          "completion": 97
+        },
+        "cost_usd": 0.0006450500000000001,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f1021",
+      "right_id": "z195",
+      "label": true,
+      "source": "teacher",
+      "confidence": 1.0,
+      "reasoning": "The two records have completely different names (katia's vs. ebisu), different addresses (600 5th ave. vs. 1283 ninth ave.), and different phone numbers. There is no overlap in any identifying information, indicating they are distinct restaurants.",
+      "provenance": {
+        "tokens": {
+          "prompt": 274,
+          "completion": 140
+        },
+        "cost_usd": 0.0007777,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f1021",
+      "right_id": "z320",
+      "label": true,
+      "source": "teacher",
+      "confidence": 1.0,
+      "reasoning": "The two records have completely different names, addresses, and phone numbers, indicating they are definitively different restaurants.",
+      "provenance": {
+        "tokens": {
+          "prompt": 279,
+          "completion": 159
+        },
+        "cost_usd": 0.0008494499999999999,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f1024",
+      "right_id": "z319",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The records have completely different names (l'osteria del forno vs fleur de lys), addresses (519 columbus ave vs 777 sutter st), phonenumbers, and restaurant types (italian vs french). These clearly refer to different real-world restaurants.",
+      "provenance": {
+        "tokens": {
+          "prompt": 293,
+          "completion": 124
+        },
+        "cost_usd": 0.0007416500000000001,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f1024",
+      "right_id": "z318",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The records have completely different names (\"l'osteria del forno\" vs \"chez michel\"), addresses (519 columbus ave vs 804 north point st), phone numbers, and cuisine types (italian vs californian). There is no overlap to suggest these refer to the same restaurant.",
+      "provenance": {
+        "tokens": {
+          "prompt": 290,
+          "completion": 168
+        },
+        "cost_usd": 0.0008925000000000001,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f1024",
+      "right_id": "z202",
+      "label": true,
+      "source": "teacher",
+      "confidence": 1.0,
+      "reasoning": "The two records have completely different names, addresses, phone numbers, and cuisine types (Italian vs. Mexican), indicating they are clearly two different restaurants in San Francisco.",
+      "provenance": {
+        "tokens": {
+          "prompt": 291,
+          "completion": 141
+        },
+        "cost_usd": 0.00079905,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f1025",
+      "right_id": "z325",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The records have different restaurant names (le central vs. masa's), different street addresses (453 bush st. vs. 648 bush st.), and different phone numbers, indicating they are distinct restaurants.",
+      "provenance": {
+        "tokens": {
+          "prompt": 278,
+          "completion": 73
+        },
+        "cost_usd": 0.0005474,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f1025",
+      "right_id": "z318",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The records have completely different names (\"le central\" vs \"chez michel\"), addresses (\"453 bush st.\" vs \"804 north point st.\"), phone numbers, and cuisine types, indicating they are distinct restaurants.",
+      "provenance": {
+        "tokens": {
+          "prompt": 279,
+          "completion": 137
+        },
+        "cost_usd": 0.00077245,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f1026",
+      "right_id": "z319",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The records have completely different names (le soleil vs. fleur de lys), addresses (133 clement st. vs. 777 sutter st.), phone numbers, and cuisine types (asian vs. french (new)). They clearly refer to two different restaurants in San Francisco.",
+      "provenance": {
+        "tokens": {
+          "prompt": 282,
+          "completion": 204
+        },
+        "cost_usd": 0.0010101,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f1026",
+      "right_id": "z318",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The two records have completely",
+      "provenance": {
+        "tokens": {
+          "prompt": 279,
+          "completion": 183
+        },
+        "cost_usd": 0.00093345,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f1027",
+      "right_id": "z315",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The two records have completely different names, addresses, and phone numbers, indicating they refer to two distinct restaurants in San Francisco.",
+      "provenance": {
+        "tokens": {
+          "prompt": 275,
+          "completion": 203
+        },
+        "cost_usd": 0.0009992500000000001,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f1027",
+      "right_id": "z328",
+      "label": true,
+      "source": "teacher",
+      "confidence": 1.0,
+      "reasoning": "The two records have completely different names, addresses, phone numbers, and cuisine types. There is no overlap in any identifying information to suggest they refer to the same restaurant.",
+      "provenance": {
+        "tokens": {
+          "prompt": 278,
+          "completion": 187
+        },
+        "cost_usd": 0.0009463999999999999,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f1027",
+      "right_id": "z325",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The records have completely different names, addresses, phone numbers, and cuisine types. There is no overlap in any identifying information.",
+      "provenance": {
+        "tokens": {
+          "prompt": 281,
+          "completion": 208
+        },
+        "cost_usd": 0.00102305,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f1028",
+      "right_id": "z315",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The records have completely different names (\"manora\" vs \"boulevard\"), addresses (\"3226 mission st.\" vs \"1 mission st.\"), phone numbers, and restaurant types. There is no overlap indicating these are the same restaurant.",
+      "provenance": {
+        "tokens": {
+          "prompt": 274,
+          "completion": 220
+        },
+        "cost_usd": 0.0010577,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f1028",
+      "right_id": "z202",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The two records have completely different names, addresses (3226 mission st. vs 2889 mission st.), phone numbers, and cuisine types (asian vs mexican). They are clearly two distinct restaurants on the same street in San Francisco.",
+      "provenance": {
+        "tokens": {
+          "prompt": 282,
+          "completion": 176
+        },
+        "cost_usd": 0.0009121000000000001,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f1028",
+      "right_id": "z194",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The two records have completely different names (manora vs dusit thai), different addresses (3226 vs 3221 mission st.), and different phone numbers, clearly indicating they are distinct restaurants.",
+      "provenance": {
+        "tokens": {
+          "prompt": 282,
+          "completion": 94
+        },
+        "cost_usd": 0.0006251,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f1029",
+      "right_id": "z320",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The records have completely different names, addresses, phone numbers, and cuisine types, indicating they are distinct restaurants in San Francisco.",
+      "provenance": {
+        "tokens": {
+          "prompt": 284,
+          "completion": 100
+        },
+        "cost_usd": 0.0006482,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f1031",
+      "right_id": "z320",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The records have entirely different names (millennium vs fringale), addresses (246 mcallister st. vs 570 fourth st.), phone numbers, and restaurant types (vegetarian vs french bistro), indicating they are definitively different restaurants.",
+      "provenance": {
+        "tokens": {
+          "prompt": 283,
+          "completion": 221
+        },
+        "cost_usd": 0.00107065,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f1031",
+      "right_id": "z214",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The two records have entirely different names (millennium vs. ti couz), addresses (246 mcallister st. vs. 3108 16th st.), phone numbers, and restaurant types (vegetarian vs. french). There is no overlap in any identifying attributes.",
+      "provenance": {
+        "tokens": {
+          "prompt": 285,
+          "completion": 159
+        },
+        "cost_usd": 0.00085575,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f1032",
+      "right_id": "z318",
+      "label": true,
+      "source": "teacher",
+      "confidence": 1.0,
+      "reasoning": "The restaurant names (\"moose's\" vs \"chez michel\"), addresses (\"1652 stockton st.\" vs \"804 north point st.\"), phone numbers, and types are all completely different, clearly indicating they are different establishments.",
+      "provenance": {
+        "tokens": {
+          "prompt": 284,
+          "completion": 200
+        },
+        "cost_usd": 0.0009982,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f1033",
+      "right_id": "z214",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The records have completely different names, addresses, phone numbers, and restaurant types, indicating they are distinct establishments.",
+      "provenance": {
+        "tokens": {
+          "prompt": 282,
+          "completion": 127
+        },
+        "cost_usd": 0.0007406000000000001,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f1034",
+      "right_id": "z188",
+      "label": true,
+      "source": "teacher",
+      "confidence": 1.0,
+      "reasoning": "The records have entirely different names (\"one market\" vs \"cafe flore\"), different street addresses (1 market st. vs 2298market st.), and different phone numbers. These are clearly two distinct restaurants in San Francisco.",
+      "provenance": {
+        "tokens": {
+          "prompt": 277,
+          "completion": 172
+        },
+        "cost_usd": 0.00089285,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f1034",
+      "right_id": "z315",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The restaurant names (\"one market\" vs \"boulevard\"), street addresses (\"1 market st.\" vs \"1 mission st.\"), and phone numbers are completely different, indicating they are two distinct restaurants in San Francisco.",
+      "provenance": {
+        "tokens": {
+          "prompt": 269,
+          "completion": 241
+        },
+        "cost_usd": 0.0011259500000000001,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f1035",
+      "right_id": "z192",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The records have completely different names (oritalia vs doidge's), addresses (1915 fillmore st. vs 2217 union st.), phone numbers, and cuisine types (italian vs american). There are no matching attributes to suggest they are the same restaurant.",
+      "provenance": {
+        "tokens": {
+          "prompt": 282,
+          "completion": 205
+        },
+        "cost_usd": 0.0010136000000000001,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f1036",
+      "right_id": "z328",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The records have different names (\"pacific pan pacific hotel\" vs \"postrio\"), different addresses (500 post st. vs 545 post st.), different phone numbers, and different cuisine types. These are distinct restaurants on the same street.",
+      "provenance": {
+        "tokens": {
+          "prompt": 280,
+          "completion": 256
+        },
+        "cost_usd": 0.00119,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f1037",
+      "right_id": "z318",
+      "label": true,
+      "source": "teacher",
+      "confidence": 1.0,
+      "reasoning": "The two records have completely different names, addresses, phone numbers, and cuisine types. There is no overlap in any identifying information, so they definitely refer to different restaurants.",
+      "provenance": {
+        "tokens": {
+          "prompt": 287,
+          "completion": 196
+        },
+        "cost_usd": 0.00098735,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f1037",
+      "right_id": "z216",
+      "label": true,
+      "source": "teacher",
+      "confidence": 1.0,
+      "reasoning": "The records have completely different names, addresses, phone numbers, and cuisines (Italian vs. Vietnamese), making it clear they refer to two entirely different restaurants in San Francisco.",
+      "provenance": {
+        "tokens": {
+          "prompt": 280,
+          "completion": 183
+        },
+        "cost_usd": 0.0009345,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f1037",
+      "right_id": "z214",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The names, addresses, phone numbers, and cuisine types are completely different, clearly indicating they are two different restaurants in San Francisco.",
+      "provenance": {
+        "tokens": {
+          "prompt": 287,
+          "completion": 222
+        },
+        "cost_usd": 0.00107835,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f1038",
+      "right_id": "z318",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The records have entirely different names (\"pane e vino\" vs \"chez michel\"), addresses,phone numbers, and cuisine types. There is no overlap to suggest these refer to the same real-world restaurant.",
+      "provenance": {
+        "tokens": {
+          "prompt": 282,
+          "completion": 75
+        },
+        "cost_usd": 0.0005586,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f1038",
+      "right_id": "z216",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The records have completely different names, addresses, phone numbers, and cuisine types (Italian vs. Vietnamese). They are clearly distinct restaurants in San Francisco.",
+      "provenance": {
+        "tokens": {
+          "prompt": 275,
+          "completion": 83
+        },
+        "cost_usd": 0.0005792500000000001,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f1038",
+      "right_id": "z201",
+      "label": true,
+      "source": "teacher",
+      "confidence": 1.0,
+      "reasoning": "The records have entirely different names, addresses, phone numbers, and cuisine types, indicating they are clearly different restaurants.",
+      "provenance": {
+        "tokens": {
+          "prompt": 281,
+          "completion": 161
+        },
+        "cost_usd": 0.00085855,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f1040",
+      "right_id": "z192",
+      "label": true,
+      "source": "teacher",
+      "confidence": 1.0,
+      "reasoning": "The records have different names (perry's vs doidge's), different addresses (1944 union st. vs 2217 union st.), and different phone numbers. These are definitively two different restaurants on the same street in San Francisco.",
+      "provenance": {
+        "tokens": {
+          "prompt": 280,
+          "completion": 197
+        },
+        "cost_usd": 0.0009835,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f1040",
+      "right_id": "z323",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The records have completely different names (perry's vs la folie), different addresses (1944 union st. vs 2316 polk st.), and different phone numbers. They are clearly different restaurants in San Francisco.",
+      "provenance": {
+        "tokens": {
+          "prompt": 285,
+          "completion": 83
+        },
+        "cost_usd": 0.00058975,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f1041",
+      "right_id": "z317",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The records have completely different names (r&g lounge vs campton place), addresses (631 b kearny st. vs 340 stockton st.), and phone numbers. They are clearly different restaurants in San Francisco.",
+      "provenance": {
+        "tokens": {
+          "prompt": 297,
+          "completion": 138
+        },
+        "cost_usd": 0.0007948499999999999,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f1042",
+      "right_id": "z214",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The records have completely different names (rubicon vs ti couz), addresses (558 sacramento st. vs 3108 16th st.), phone numbers, and cuisine types (american vs french). They clearly refer to different restaurants.",
+      "provenance": {
+        "tokens": {
+          "prompt": 280,
+          "completion": 197
+        },
+        "cost_usd": 0.0009835,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f1042",
+      "right_id": "z213",
+      "label": true,
+      "source": "teacher",
+      "confidence": 1.0,
+      "reasoning": "The records have completely different names (rubicon vs thep phanom), addresses (558 sacramento st. vs 400 waller st.), phone numbers, and cuisine types (american vs thai). There is no overlap in any identifying fields, indicating they are clearly different restaurants.",
+      "provenance": {
+        "tokens": {
+          "prompt": 280,
+          "completion": 92
+        },
+        "cost_usd": 0.000616,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f1043",
+      "right_id": "z200",
+      "label": true,
+      "source": "teacher",
+      "confidence": 1.0,
+      "reasoning": "The two records have completely different names (\"rumpus\" vs \"la cumbre\"), addresses (\"1 tillman pl.\" vs \"515 valencia st.\"), phone numbers, and cuisines (\"american\" vs \"mexican\"). There is no overlap in any field, indicating they are definitively different restaurants.",
+      "provenance": {
+        "tokens": {
+          "prompt": 280,
+          "completion": 158
+        },
+        "cost_usd": 0.000847,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f1044",
+      "right_id": "z328",
+      "label": true,
+      "source": "teacher",
+      "confidence": 1.0,
+      "reasoning": "The two records have completely different names (\"sanppo\" vs \"postrio\"), addresses (1702 Post St. vs 545 Post St.), phone numbers, and cuisine types (Asian vs Californian). They are definitively different restaurants.",
+      "provenance": {
+        "tokens": {
+          "prompt": 275,
+          "completion": 229
+        },
+        "cost_usd": 0.00109025,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f1044",
+      "right_id": "z326",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The records have completely different restaurant names (\"sanppo\" vs \"mifune\"), different street addresses (1702 vs 1737 Post St.), and different phone numbers. There is no evidence to suggest these refer to the same real-world restaurant.",
+      "provenance": {
+        "tokens": {
+          "prompt": 276,
+          "completion": 143
+        },
+        "cost_usd": 0.0007903000000000001,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f1044",
+      "right_id": "z202",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The records have completely different names (sanppo vs. la taqueria), addresses (1702 post st. vs. 2889 mission st.), phone numbers, and cuisine types (asian vs. mexican). There is no overlap in any identifying field, so these are definitely different restaurants.",
+      "provenance": {
+        "tokens": {
+          "prompt": 280,
+          "completion": 140
+        },
+        "cost_usd": 0.000784,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f1046",
+      "right_id": "z270",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The two records refer to completely different restaurants located in different cities (San Francisco vs. New York City), with different names, addresses, and phone numbers.",
+      "provenance": {
+        "tokens": {
+          "prompt": 289,
+          "completion": 168
+        },
+        "cost_usd": 0.00089145,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f1046",
+      "right_id": "z188",
+      "label": true,
+      "source": "teacher",
+      "confidence": 1.0,
+      "reasoning": "The two records have completely different names (south park cafe vs. cafe flore), addresses (108 south park vs. 2298 market st.), and phone numbers. They are clearly different restaurants.",
+      "provenance": {
+        "tokens": {
+          "prompt": 280,
+          "completion": 130
+        },
+        "cost_usd": 0.0007489999999999999,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f1047",
+      "right_id": "z200",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The two records have completely different restaurant names (\"splendido embarcadero\" vs \"la cumbre\"), different phone numbers, different addresses, and different cuisine types (Mediterranean vs Mexican). There is no indication these refer to the same real-world restaurant.",
+      "provenance": {
+        "tokens": {
+          "prompt": 283,
+          "completion": 167
+        },
+        "cost_usd": 0.0008816499999999999,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f1047",
+      "right_id": "z216",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The two records have entirely",
+      "provenance": {
+        "tokens": {
+          "prompt": 275,
+          "completion": 49
+        },
+        "cost_usd": 0.00046025000000000005,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f1048",
+      "right_id": "z128",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The records have different names (stars vs hugo's cellar), different cities (san francisco vs las vegas), different addresses, and different phone numbers. They are clearly distinct restaurants.",
+      "provenance": {
+        "tokens": {
+          "prompt": 275,
+          "completion": 78
+        },
+        "cost_usd": 0.0005617500000000001,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f1049",
+      "right_id": "z193",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The names, addresses, and phone numbers of the two restaurants are completely different. They are distinct businesses in San Francisco.",
+      "provenance": {
+        "tokens": {
+          "prompt": 283,
+          "completion": 135
+        },
+        "cost_usd": 0.00076965,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f1050",
+      "right_id": "z188",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The two records have completely different names, addresses, phone numbers, and restaurant types, indicating they are entirely different establishments.",
+      "provenance": {
+        "tokens": {
+          "prompt": 295,
+          "completion": 174
+        },
+        "cost_usd": 0.00091875,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f1050",
+      "right_id": "z203",
+      "label": true,
+      "source": "teacher",
+      "confidence": 1.0,
+      "reasoning": "The two records have completely different names, addresses, phone numbers, and cuisine types, indicating they are distinct restaurants.",
+      "provenance": {
+        "tokens": {
+          "prompt": 304,
+          "completion": 98
+        },
+        "cost_usd": 0.0006621999999999999,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f1050",
+      "right_id": "z327",
+      "label": true,
+      "source": "teacher",
+      "confidence": 1.0,
+      "reasoning": "The records have completely different names, addresses, phone numbers, and restaurant types, indicating they are clearly distinct restaurants in San Francisco.",
+      "provenance": {
+        "tokens": {
+          "prompt": 298,
+          "completion": 124
+        },
+        "cost_usd": 0.0007469,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f1051",
+      "right_id": "z43",
+      "label": true,
+      "source": "teacher",
+      "confidence": 1.0,
+      "reasoning": "The records have completely different names, addresses, cities, phone numbers, and restaurant types, clearly indicating they are two different restaurants.",
+      "provenance": {
+        "tokens": {
+          "prompt": 285,
+          "completion": 135
+        },
+        "cost_usd": 0.00077175,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f1053",
+      "right_id": "z67",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The records have completely different restaurant names, cities, addresses, and phone numbers. They are clearly distinct restaurants.",
+      "provenance": {
+        "tokens": {
+          "prompt": 276,
+          "completion": 156
+        },
+        "cost_usd": 0.0008358,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f1053",
+      "right_id": "z218",
+      "label": true,
+      "source": "teacher",
+      "confidence": 1.0,
+      "reasoning": "The two records have completely different names, addresses, phone numbers, and restaurant types. They clearly refer to differentreal-world restaurants in San Francisco.",
+      "provenance": {
+        "tokens": {
+          "prompt": 293,
+          "completion": 110
+        },
+        "cost_usd": 0.0006926500000000001,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f1054",
+      "right_id": "z318",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The records have completely different names (\"the heights\" vs \"chez michel\"), addresses (\"3235 sacramento st.\" vs \"804 north point st.\"), phone numbers, and cuisine types. There is no overlap in any identifying information.",
+      "provenance": {
+        "tokens": {
+          "prompt": 283,
+          "completion": 176
+        },
+        "cost_usd": 0.0009131499999999999,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f1055",
+      "right_id": "z213",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.1,
+      "reasoning": "Although the names are somewhat similar (\"thepin\" could be a truncation or misspelling of \"thep phanom\"), the addresses, phone numbers, and cuisine types are completely different. It is highly unlikely they refer to the same restaurant.",
+      "provenance": {
+        "tokens": {
+          "prompt": 283,
+          "completion": 486
+        },
+        "cost_usd": 0.00199815,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f1056",
+      "right_id": "z214",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The two records have completely different names, addresses, phone numbers, and cuisine types. They clearly refer to different restaurants.",
+      "provenance": {
+        "tokens": {
+          "prompt": 287,
+          "completion": 129
+        },
+        "cost_usd": 0.00075285,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f1056",
+      "right_id": "z205",
+      "label": true,
+      "source": "teacher",
+      "confidence": 1.0,
+      "reasoning": "The records have completely different restaurant names, addresses, phone numbers, and types of cuisine. There are no shared identifiers indicating they refer to the same restaurant.",
+      "provenance": {
+        "tokens": {
+          "prompt": 290,
+          "completion": 135
+        },
+        "cost_usd": 0.000777,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f1058",
+      "right_id": "z192",
+      "label": true,
+      "source": "teacher",
+      "confidence": 1.0,
+      "reasoning": "The two records have completely different names, addresses, phone numbers, and cuisine types, indicating they are clearly different restaurants.",
+      "provenance": {
+        "tokens": {
+          "prompt": 283,
+          "completion": 133
+        },
+        "cost_usd": 0.00076265,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f1058",
+      "right_id": "z200",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The records have completely different names, addresses, phone numbers, and cuisine types. Vivande Porta Via is an Italian restaurant on Fillmore St, while La Cumbre is a Mexican restaurant on Valencia St.",
+      "provenance": {
+        "tokens": {
+          "prompt": 286,
+          "completion": 178
+        },
+        "cost_usd": 0.0009232999999999999,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f1059",
+      "right_id": "z201",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The two records have completely different restaurant names, addresses, phone numbers, and cuisine types, indicating they are distinct restaurants in San Francisco.",
+      "provenance": {
+        "tokens": {
+          "prompt": 286,
+          "completion": 127
+        },
+        "cost_usd": 0.0007448000000000001,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f1059",
+      "right_id": "z318",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The records have completely different restaurant names (\"vivande ristorante\" vs. \"chez michel\"), different addresses, different phone numbers, and different cuisine types. There is no overlap indicating these refer to the same restaurant.",
+      "provenance": {
+        "tokens": {
+          "prompt": 287,
+          "completion": 79
+        },
+        "cost_usd": 0.00057785,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f1060",
+      "right_id": "z328",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The records have completely different names, addresses, and phone numbers. They are clearly two different restaurants in San Francisco.",
+      "provenance": {
+        "tokens": {
+          "prompt": 278,
+          "completion": 64
+        },
+        "cost_usd": 0.0005159,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f1061",
+      "right_id": "z192",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The records have completely different names (\"wu kong\" vs \"doidge's\"), addresses (\"101 spear st.\" vs \"2217 union st.\"), phone numbers, and cuisine types, indicating they are definitively different restaurants.",
+      "provenance": {
+        "tokens": {
+          "prompt": 277,
+          "completion": 375
+        },
+        "cost_usd": 0.0016033500000000001,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f1061",
+      "right_id": "z194",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The two records have entirely different names, addresses, and phone numbers. The only shared attribute is the city, which is insufficient to consider them the same restaurant.",
+      "provenance": {
+        "tokens": {
+          "prompt": 280,
+          "completion": 147
+        },
+        "cost_usd": 0.0008085,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f1062",
+      "right_id": "z315",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The restaurant names (\"yank sing\" vs \"boulevard\") and addresses (\"427 battery st.\" vs \"1 mission st.\") are completely different, clearly indicating these are two separate restaurants in San Francisco.",
+      "provenance": {
+        "tokens": {
+          "prompt": 274,
+          "completion": 144
+        },
+        "cost_usd": 0.0007917,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f1063",
+      "right_id": "z210",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The records have completely different names, addresses, phone numbers, and cuisine types. They only share the same city, so they are definitely different restaurants.",
+      "provenance": {
+        "tokens": {
+          "prompt": 292,
+          "completion": 372
+        },
+        "cost_usd": 0.0016086,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f1063",
+      "right_id": "z196",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The records have completely different names, addresses, phone numbers, and cuisine types, indicating they are clearly distinct restaurants.",
+      "provenance": {
+        "tokens": {
+          "prompt": 286,
+          "completion": 175
+        },
+        "cost_usd": 0.0009128000000000001,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f1064",
+      "right_id": "z328",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The two records have completely different names, addresses, phone numbers, and restaurant types. They are clearly distinct entities.",
+      "provenance": {
+        "tokens": {
+          "prompt": 285,
+          "completion": 164
+        },
+        "cost_usd": 0.0008732499999999999,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f1065",
+      "right_id": "z318",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The records have completely different names (zarzuela vs. chez michel), addresses (2000 hyde st. vs. 804 north point st.), phone numbers, and cuisine types. There is no indication they refer to the same restaurant.",
+      "provenance": {
+        "tokens": {
+          "prompt": 289,
+          "completion": 85
+        },
+        "cost_usd": 0.00060095,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f1065",
+      "right_id": "z122",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The restaurants are in completely different cities (San Francisco vs New York City), have different addresses and phone numbers, and their names are different (Zarzuela vs Zarela).",
+      "provenance": {
+        "tokens": {
+          "prompt": 283,
+          "completion": 116
+        },
+        "cost_usd": 0.00070315,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f1066",
+      "right_id": "z188",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The records have completely different names (\"zuni cafe & grill\" vs \"cafe flore\"), different street addresses (1658 vs 2298 market st.), and different phone numbers. While both are on Market Street in San Francisco, these are clearly distinct restaurants.",
+      "provenance": {
+        "tokens": {
+          "prompt": 287,
+          "completion": 351
+        },
+        "cost_usd": 0.00152985,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f1066",
+      "right_id": "z203",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The names, addresses, and phone numbers are completely different, indicating they are two distinct restaurants in San Francisco.",
+      "provenance": {
+        "tokens": {
+          "prompt": 296,
+          "completion": 196
+        },
+        "cost_usd": 0.0009968,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f1066",
+      "right_id": "z210",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The two records have completely different names, addresses, phone numbers, and restaurant types. There are no matching attributes other than the city, indicating they refer to different restaurants.",
+      "provenance": {
+        "tokens": {
+          "prompt": 290,
+          "completion": 183
+        },
+        "cost_usd": 0.0009450000000000001,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f669",
+      "right_id": "z1",
+      "label": true,
+      "source": "teacher",
+      "confidence": 1.0,
+      "reasoning": "The records have entirely different names (eclipse vs apple pan), addresses (8800 melrose ave. vs 10801 w. pico blvd.), phone numbers, and cuisines. They clearly refer to two completely different restaurants.",
+      "provenance": {
+        "tokens": {
+          "prompt": 285,
+          "completion": 189
+        },
+        "cost_usd": 0.00096075,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f671",
+      "right_id": "z1",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The two records have entirely different restaurant names, addresses, phone numbers, and cuisine types. El Cholo is a Mexican restaurant on S. Western Ave., while The Apple Pan is an American restaurant on W. Pico Blvd.",
+      "provenance": {
+        "tokens": {
+          "prompt": 287,
+          "completion": 238
+        },
+        "cost_usd": 0.0011343500000000001,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f682",
+      "right_id": "z1",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The restaurants have completely different names (\"le dome\" vs \"apple pan the\"), addresses (\"8720 sunset blvd.\" vs \"10801 w. pico blvd.\"), phone numbers, and types (\"french\" vs \"american\"). There is no overlap in any identifying information.",
+      "provenance": {
+        "tokens": {
+          "prompt": 284,
+          "completion": 168
+        },
+        "cost_usd": 0.0008862,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f980",
+      "right_id": "z2",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The records have completely different names (mikado vs asahi ramen), addresses, cities (Las Vegas vs West LA), and phone numbers. They are clearly different restaurants.",
+      "provenance": {
+        "tokens": {
+          "prompt": 289,
+          "completion": 354
+        },
+        "cost_usd": 0.00154245,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f546",
+      "right_id": "z2",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The restaurant names (le chardonnay vs. asahi ramen), addresses (8284 melrose ave. vs. 2027 sawtelle blvd.), and types (french vs. noodle shops) are completely different. There is no overlap in any identifying information.",
+      "provenance": {
+        "tokens": {
+          "prompt": 289,
+          "completion": 169
+        },
+        "cost_usd": 0.00089495,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f656",
+      "right_id": "z2",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The two records have completely different names, addresses, phone numbers, and cuisine types, clearly indicating they are two distinct restaurants.",
+      "provenance": {
+        "tokens": {
+          "prompt": 292,
+          "completion": 423
+        },
+        "cost_usd": 0.0017871,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f663",
+      "right_id": "z3",
+      "label": true,
+      "source": "teacher",
+      "confidence": 1.0,
+      "reasoning": "The records have completely different names, addresses, cities, phone numbers, and restaurant types. There is no overlap in any identifying information.",
+      "provenance": {
+        "tokens": {
+          "prompt": 288,
+          "completion": 100
+        },
+        "cost_usd": 0.0006524,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f537",
+      "right_id": "z3",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The names (cafe bizou vs. baja fresh), addresses (14016 ventura blvd. vs. 3345 kimber dr.), cities (sherman oaks vs. westlake village), and cuisines (french vs. mexican) are completely different. These are clearly two different restaurants.",
+      "provenance": {
+        "tokens": {
+          "prompt": 290,
+          "completion": 161
+        },
+        "cost_usd": 0.0008680000000000001,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f672",
+      "right_id": "z5",
+      "label": true,
+      "source": "teacher",
+      "confidence": 1.0,
+      "reasoning": "The two records have completely different names, addresses, phone numbers, and types, making it certain they refer to different restaurants.",
+      "provenance": {
+        "tokens": {
+          "prompt": 290,
+          "completion": 204
+        },
+        "cost_usd": 0.0010185,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f685",
+      "right_id": "z6",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The records have completely different names (\"morton's\" vs \"bernard's\"), addresses (\"8764 melrose ave.\" vs \"515 s. olive st.\"), phone numbers, and cuisine types. They are clearly two different restaurants in Los Angeles.",
+      "provenance": {
+        "tokens": {
+          "prompt": 279,
+          "completion": 191
+        },
+        "cost_usd": 0.00096145,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f667",
+      "right_id": "z6",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The records have completely different names (drai's vs. bernard's), addresses (730 n. la cienega blvd. vs. 515 s. olive st.), and phone numbers. There are no overlapping attributes suggesting these are the same restaurant.",
+      "provenance": {
+        "tokens": {
+          "prompt": 289,
+          "completion": 89
+        },
+        "cost_usd": 0.00061495,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f963",
+      "right_id": "z7",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The records have different names, addresses, cities, phone numbers, and cuisine types, clearly indicating they refer to different restaurants.",
+      "provenance": {
+        "tokens": {
+          "prompt": 283,
+          "completion": 67
+        },
+        "cost_usd": 0.00053165,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f886",
+      "right_id": "z8",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The records have different names (stage deli vs brent's deli), different cities (New York vs Northridge), different addresses, and different phone numbers. They are clearly distinct restaurants.",
+      "provenance": {
+        "tokens": {
+          "prompt": 303,
+          "completion": 77
+        },
+        "cost_usd": 0.00058765,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f592",
+      "right_id": "z8",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The restaurants have completely different names, addresses, cities (New York vs. Northridge), and phone numbers, indicating they are distinct establishments.",
+      "provenance": {
+        "tokens": {
+          "prompt": 294,
+          "completion": 85
+        },
+        "cost_usd": 0.0006062000000000001,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f962",
+      "right_id": "z9",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The records refer to completely different restaurants. Record A is \"Binion's Coffee Shop\" located in Las Vegas at 128 Fremont St., while Record B is \"Brighton Coffee Shop\" in Beverly Hills at 9600 Brighton Way. The names, addresses, cities, and phone numbers are all different.",
+      "provenance": {
+        "tokens": {
+          "prompt": 287,
+          "completion": 129
+        },
+        "cost_usd": 0.00075285,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f1051",
+      "right_id": "z9",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The records have completely different names, addresses, cities, and phone numbers, clearly indicating they are two distinct restaurants.",
+      "provenance": {
+        "tokens": {
+          "prompt": 287,
+          "completion": 399
+        },
+        "cost_usd": 0.0016978499999999999,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f537",
+      "right_id": "z9",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The records have completely different names, addresses, cities, phone numbers, and restaurant types, indicating they are entirely different establishments.",
+      "provenance": {
+        "tokens": {
+          "prompt": 292,
+          "completion": 421
+        },
+        "cost_usd": 0.0017801,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f537",
+      "right_id": "z10",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The records have completely different names (Cafe Bizou vs. Bristol Farms Market Cafe), addresses (14016 Ventura Blvd. vs. 1570 Rosecrans Ave. S.), cities (Sherman Oaks vs. Pasadena), and phone numbers. These are clearly two different restaurants.",
+      "provenance": {
+        "tokens": {
+          "prompt": 295,
+          "completion": 127
+        },
+        "cost_usd": 0.00075425,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f963",
+      "right_id": "z11",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The two records have completely different names, addresses, cities, phone numbers, and restaurant types. There is no overlap in any of the identifying attributes, indicating they refer to completely different restaurants.",
+      "provenance": {
+        "tokens": {
+          "prompt": 283,
+          "completion": 164
+        },
+        "cost_usd": 0.00087115,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f685",
+      "right_id": "z11",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The records have completely different names, addresses, phone numbers, and restaurant types, indicating they refer to entirely different real-world restaurants.",
+      "provenance": {
+        "tokens": {
+          "prompt": 281,
+          "completion": 182
+        },
+        "cost_usd": 0.00093205,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f967",
+      "right_id": "z12",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The two records have completely different names, addresses, cities, phone numbers, and restaurant types. There is no overlap in any field to suggest these refer to the same real-world restaurant.",
+      "provenance": {
+        "tokens": {
+          "prompt": 290,
+          "completion": 127
+        },
+        "cost_usd": 0.0007490000000000001,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f921",
+      "right_id": "z12",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The names, addresses, cities, and phone numbers are all completely different, indicating these are distinct restaurants.",
+      "provenance": {
+        "tokens": {
+          "prompt": 297,
+          "completion": 53
+        },
+        "cost_usd": 0.00049735,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f537",
+      "right_id": "z12",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The two records have entirely different names (\"cafe bizou\" vs \"cafe '50s\"), addresses, cities, phone numbers, and cuisine types. There is no overlap in any identifying attributes, making it certain they refer to different restaurants.",
+      "provenance": {
+        "tokens": {
+          "prompt": 288,
+          "completion": 200
+        },
+        "cost_usd": 0.0010024,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f573",
+      "right_id": "z14",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The restaurants have completely different names, addresses, cities, phone numbers, and types. There is no overlap in any identifying information.",
+      "provenance": {
+        "tokens": {
+          "prompt": 285,
+          "completion": 111
+        },
+        "cost_usd": 0.00068775,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f989",
+      "right_id": "z14",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The two records have completely different names (bardelli's vs. cassell's), addresses (243 o'farrell st. vs. 3266 w. sixth st.), cities (san francisco vs. la), phone numbers, and restaurant types. There is no overlap in any identifying information, so they are definitively different restaurants.",
+      "provenance": {
+        "tokens": {
+          "prompt": 288,
+          "completion": 125
+        },
+        "cost_usd": 0.0007399,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f870",
+      "right_id": "z14",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The records have completely different names, cities (New York vs. Los Angeles), addresses, phone numbers, and restaurant types. They are definitively different restaurants.",
+      "provenance": {
+        "tokens": {
+          "prompt": 312,
+          "completion": 344
+        },
+        "cost_usd": 0.0015316,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f633",
+      "right_id": "z15",
+      "label": true,
+      "source": "teacher",
+      "confidence": 1.0,
+      "reasoning": "The records have completely different names, addresses, cities, and phone numbers. They are clearly two different restaurants in different locations (San Francisco vs. Redondo Beach).",
+      "provenance": {
+        "tokens": {
+          "prompt": 275,
+          "completion": 171
+        },
+        "cost_usd": 0.0008872500000000001,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f1065",
+      "right_id": "z15",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The records have completely different names (zarzuela vs. chez melange), cities (san francisco vs. redondo beach), addresses, and phone numbers, makingit certain they are not the same restaurant.",
+      "provenance": {
+        "tokens": {
+          "prompt": 283,
+          "completion": 520
+        },
+        "cost_usd": 0.00211715,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f639",
+      "right_id": "z17",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The records have completely different names, addresses, cities, phone numbers, and cuisine types. They are clearly two different restaurants in different states (California, but different cities - San Francisco vs Westwood/Los Angeles).",
+      "provenance": {
+        "tokens": {
+          "prompt": 281,
+          "completion": 173
+        },
+        "cost_usd": 0.00090055,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f680",
+      "right_id": "z18",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The records have completely different names, addresses, phone numbers, and restaurant types, indicating they refer to different real-world restaurants.",
+      "provenance": {
+        "tokens": {
+          "prompt": 281,
+          "completion": 133
+        },
+        "cost_usd": 0.00076055,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f639",
+      "right_id": "z19",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The records have completely different names, addresses, cities, and phone numbers. They are clearly two distinct restaurants in different locations.",
+      "provenance": {
+        "tokens": {
+          "prompt": 282,
+          "completion": 98
+        },
+        "cost_usd": 0.0006391000000000001,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f685",
+      "right_id": "z19",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The two records have entirely different names (morton's vs falafel king), addresses (8764 melrose ave. vs 1059 broxton ave.), cities (los angeles vs westwood), phone numbers, and cuisine types (american vs middle eastern). There is no overlap to suggest they are the same restaurant.",
+      "provenance": {
+        "tokens": {
+          "prompt": 280,
+          "completion": 91
+        },
+        "cost_usd": 0.0006125,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f931",
+      "right_id": "z19",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The records have completely different names, addresses, phone numbers, cities, and restaurant types. There is no indication they refer to the same restaurant.",
+      "provenance": {
+        "tokens": {
+          "prompt": 317,
+          "completion": 127
+        },
+        "cost_usd": 0.00077735,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f973",
+      "right_id": "z20",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The two records have different names, addresses, cities, phone numbers, and restaurant types. Record A is a buffet in Las Vegas, while Record B is a Chinese restaurant in West LA.",
+      "provenance": {
+        "tokens": {
+          "prompt": 288,
+          "completion": 162
+        },
+        "cost_usd": 0.0008694,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f682",
+      "right_id": "z20",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The two records have completely different names, addresses, phone numbers, cities, and restaurant types. There is no overlap in any field, clearly indicating they refer to two different restaurants.",
+      "provenance": {
+        "tokens": {
+          "prompt": 285,
+          "completion": 262
+        },
+        "cost_usd": 0.00121625,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f894",
+      "right_id": "z21",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The records have completely different names (the coffee pot vs. gumbo pot the), addresses(350 9th ave. vs. 6333 w. third st.), cities (new york vs. la), phone numbers, and restaurant types. They are definitively different restaurants.",
+      "provenance": {
+        "tokens": {
+          "prompt": 296,
+          "completion": 92
+        },
+        "cost_usd": 0.0006328,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f657",
+      "right_id": "z21",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The records have completely different names (cafe pinot vs gumbo pot the), addresses (700 w. fifth st. vs 6333 w. third st.), phone numbers, and cuisine types, indicating they are clearly different restaurants.",
+      "provenance": {
+        "tokens": {
+          "prompt": 288,
+          "completion": 189
+        },
+        "cost_usd": 0.0009639000000000002,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f911",
+      "right_id": "z21",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The records have completely different names, addresses, cities, phone numbers, and cuisine types. Record A is an Asian restaurant in New York, while Record B is a Cajun/Creole restaurant in LA.",
+      "provenance": {
+        "tokens": {
+          "prompt": 301,
+          "completion": 195
+        },
+        "cost_usd": 0.00099855,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f776",
+      "right_id": "z22",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The two records have entirely different names, addresses, cities (New York vs Hollywood), and phone numbers. There is no overlap in any identifying attributes, so they are definitely different restaurants.",
+      "provenance": {
+        "tokens": {
+          "prompt": 305,
+          "completion": 89
+        },
+        "cost_usd": 0.0006317499999999999,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f962",
+      "right_id": "z22",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The records have entirely different names, addresses, cities (Las Vegas vs. Hollywood), and phone numbers, indicating they are clearly distinct restaurants.",
+      "provenance": {
+        "tokens": {
+          "prompt": 285,
+          "completion": 61
+        },
+        "cost_usd": 0.00051275,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f930",
+      "right_id": "z22",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The records have completely different names, addresses, cities (Atlanta vs. Hollywood), and phone numbers. There is no overlap in any identifying information, so these are clearly different restaurants.",
+      "provenance": {
+        "tokens": {
+          "prompt": 300,
+          "completion": 73
+        },
+        "cost_usd": 0.0005704999999999999,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f560",
+      "right_id": "z23",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The records have different names, addresses, cities, phone numbers, and restaurant types, indicating they refer to completely different restaurants.",
+      "provenance": {
+        "tokens": {
+          "prompt": 285,
+          "completion": 58
+        },
+        "cost_usd": 0.00050225,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f657",
+      "right_id": "z23",
+      "label": true,
+      "source": "teacher",
+      "confidence": 1.0,
+      "reasoning": "The two records have completely different names, addresses, phone numbers, and cuisine types. There is no overlap in any identifying information.",
+      "provenance": {
+        "tokens": {
+          "prompt": 283,
+          "completion": 160
+        },
+        "cost_usd": 0.0008571500000000001,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f537",
+      "right_id": "z23",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The two records have completely different names, addresses, phone numbers, cities, and restaurant types. There is no overlapping information to suggest they refer to the same restaurant.",
+      "provenance": {
+        "tokens": {
+          "prompt": 288,
+          "completion": 188
+        },
+        "cost_usd": 0.0009603999999999999,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f649",
+      "right_id": "z24",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The records have entirely different names (adriano's ristorante vs. jan's family restaurant), addresses (2930 beverly glen circle vs. 8424 beverly blvd.), phone numbers, and cuisine types (italian vs. coffee shops). There is no indication these refer to the same real-world restaurant.",
+      "provenance": {
+        "tokens": {
+          "prompt": 299,
+          "completion": 105
+        },
+        "cost_usd": 0.00068145,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f555",
+      "right_id": "z25",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The restaurant names, addresses, phone numbers, and food types are completely different, clearly indicating two distinct restaurants in Santa Monica.",
+      "provenance": {
+        "tokens": {
+          "prompt": 288,
+          "completion": 164
+        },
+        "cost_usd": 0.0008764,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f666",
+      "right_id": "z25",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The records have completely different names (\"drago\" vs \"jiraffe\"), addresses, phone numbers, and cuisine types. They share only the city (Santa Monica), which is insufficient to indicate they refer to the same restaurant.",
+      "provenance": {
+        "tokens": {
+          "prompt": 287,
+          "completion": 80
+        },
+        "cost_usd": 0.00058135,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f884",
+      "right_id": "z26",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The records have entirely different names, addresses, cities (New York vs. Venice), phone numbers, and cuisine types (Italian pizza vs. hot dogs). There is no overlap in any field, indicating these are definitely different restaurants.",
+      "provenance": {
+        "tokens": {
+          "prompt": 297,
+          "completion": 102
+        },
+        "cost_usd": 0.00066885,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f708",
+      "right_id": "z26",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The records have completely different restaurant names, addresses, phone numbers, and cuisine types. There is no indication that these refer to the same restaurant.",
+      "provenance": {
+        "tokens": {
+          "prompt": 286,
+          "completion": 110
+        },
+        "cost_usd": 0.0006853,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f980",
+      "right_id": "z27",
+      "label": true,
+      "source": "teacher",
+      "confidence": 1.0,
+      "reasoning": "The records have different names, addresses, cities, phone numbers, and cuisine types, clearly referring to completely different restaurants.",
+      "provenance": {
+        "tokens": {
+          "prompt": 289,
+          "completion": 184
+        },
+        "cost_usd": 0.0009474500000000001,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f708",
+      "right_id": "z27",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The records have completely different names, addresses, phone numbers, and cities. There is no overlap in any identifying information, indicating these are two distinct restaurants.",
+      "provenance": {
+        "tokens": {
+          "prompt": 287,
+          "completion": 107
+        },
+        "cost_usd": 0.00067585,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f685",
+      "right_id": "z27",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The records have completely different names (morton's vs. joe's), addresses, cities (los angeles vs. venice), and phone numbers. There is no overlap in any identifying information.",
+      "provenance": {
+        "tokens": {
+          "prompt": 284,
+          "completion": 72
+        },
+        "cost_usd": 0.0005502,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f984",
+      "right_id": "z27",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The records have completely different names, addresses, cities (Las Vegas vs. Venice), phone numbers, and cuisine types. They clearly refer to different restaurants.",
+      "provenance": {
+        "tokens": {
+          "prompt": 289,
+          "completion": 396
+        },
+        "cost_usd": 0.00168945,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f677",
+      "right_id": "z28",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The names (\"jack sprat's grill\" vs \"john o'groats\"), addresses, phone numbers, and types of cuisine are all completely different. These are distinct restaurants located on the same street.",
+      "provenance": {
+        "tokens": {
+          "prompt": 296,
+          "completion": 166
+        },
+        "cost_usd": 0.0008918000000000001,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f555",
+      "right_id": "z28",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The two records have completely different names, addresses, phone numbers, cities, and restaurant types. There are no matching attributes to suggest they refer to the same real-world restaurant.",
+      "provenance": {
+        "tokens": {
+          "prompt": 289,
+          "completion": 136
+        },
+        "cost_usd": 0.0007794499999999999,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f671",
+      "right_id": "z28",
+      "label": true,
+      "source": "teacher",
+      "confidence": 1.0,
+      "reasoning": "The restaurants have completely different names, addresses, phone numbers, and types, indicating they are distinctly different establishments.",
+      "provenance": {
+        "tokens": {
+          "prompt": 289,
+          "completion": 134
+        },
+        "cost_usd": 0.00077245,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f726",
+      "right_id": "z29",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The records have completely different names (billy's vs johnnie's pastrami), addresses, cities (new york vs culver city), phone numbers, and restaurant types. There is no overlap in any identifying information.",
+      "provenance": {
+        "tokens": {
+          "prompt": 317,
+          "completion": 78
+        },
+        "cost_usd": 0.00060585,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f961",
+      "right_id": "z29",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The records have completely different names (bertolini's vs johnnie's pastrami), addresses, cities (las vegas vs culver city), phone numbers, and cuisine types (italian vs delis). There is no overlap indicating they are the same restaurant.",
+      "provenance": {
+        "tokens": {
+          "prompt": 304,
+          "completion": 94
+        },
+        "cost_usd": 0.0006482,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f708",
+      "right_id": "z30",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The names, addresses, cities, phone numbers, and restaurant types are all completely different. There is no indication these records refer to the same restaurant.",
+      "provenance": {
+        "tokens": {
+          "prompt": 294,
+          "completion": 50
+        },
+        "cost_usd": 0.0004837,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f958",
+      "right_id": "z30",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The records have completely different names, addresses, cities, phone numbers, and cuisine types. They are located in different states (Las Vegas, NV vs. Long Beach, CA) and share no common attributes indicating they could be the same restaurant.",
+      "provenance": {
+        "tokens": {
+          "prompt": 302,
+          "completion": 111
+        },
+        "cost_usd": 0.0007056,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f606",
+      "right_id": "z30",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The records have entirely different names, addresses, cities, phone numbers, and restaurant types. They are clearly two different establishments.",
+      "provenance": {
+        "tokens": {
+          "prompt": 299,
+          "completion": 63
+        },
+        "cost_usd": 0.00053445,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f623",
+      "right_id": "z30",
+      "label": true,
+      "source": "teacher",
+      "confidence": 1.0,
+      "reasoning": "The two records have completely different names, addresses, cities (Atlanta vs. Long Beach), and phone numbers, indicating they are entirely different restaurants.",
+      "provenance": {
+        "tokens": {
+          "prompt": 311,
+          "completion": 161
+        },
+        "cost_usd": 0.0008900500000000001,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f550",
+      "right_id": "z31",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The two records have completely different names, addresses, phone numbers, and cuisines, clearly indicating they are different restaurants.",
+      "provenance": {
+        "tokens": {
+          "prompt": 278,
+          "completion": 127
+        },
+        "cost_usd": 0.0007364,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f685",
+      "right_id": "z31",
+      "label": true,
+      "source": "teacher",
+      "confidence": 1.0,
+      "reasoning": "The restaurant names are completely different (\"morton's\" vs \"johnny rockets\"), and they have different street addresses and phone numbers, indicating they are different establishments on Melrose Ave.",
+      "provenance": {
+        "tokens": {
+          "prompt": 279,
+          "completion": 148
+        },
+        "cost_usd": 0.00081095,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f669",
+      "right_id": "z31",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The records have completely different names (eclipse vs. johnny rockets), addresses (8800 melrose ave. vs. 7507 melrose ave.), phone numbers, and restaurant types. They are clearly different restaurants on the same street.",
+      "provenance": {
+        "tokens": {
+          "prompt": 280,
+          "completion": 179
+        },
+        "cost_usd": 0.0009205,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f951",
+      "right_id": "z32",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The two records have completely different names (south city kitchen vs killer shrimp), cities (atlanta vs studio city), addresses, and phone numbers. There is no indication they refer to the same restaurant.",
+      "provenance": {
+        "tokens": {
+          "prompt": 274,
+          "completion": 96
+        },
+        "cost_usd": 0.0006237,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f1012",
+      "right_id": "z32",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The records have different names, addresses, cities, and phone numbers. They are clearly two distinct restaurants.",
+      "provenance": {
+        "tokens": {
+          "prompt": 276,
+          "completion": 57
+        },
+        "cost_usd": 0.0004893,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f584",
+      "right_id": "z32",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The two records have completely different names (oceana vs killer shrimp), addresses, cities, and phone numbers. They only share the same cuisine type (seafood), which is insufficient to indicate a match.",
+      "provenance": {
+        "tokens": {
+          "prompt": 275,
+          "completion": 75
+        },
+        "cost_usd": 0.0005512500000000001,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f560",
+      "right_id": "z33",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The restaurants have completely different names (cafe lalo vs kokomo cafe), addresses (201 w. 83rd st. vs 6333 w. third st.), and cities (new york vs la). They are definitively different real-world restaurants.",
+      "provenance": {
+        "tokens": {
+          "prompt": 282,
+          "completion": 153
+        },
+        "cost_usd": 0.0008316,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f759",
+      "right_id": "z33",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The two records have completely different names, addresses, phone numbers, and are located in different cities (new york vs la). They are definitively different restaurants.",
+      "provenance": {
+        "tokens": {
+          "prompt": 300,
+          "completion": 147
+        },
+        "cost_usd": 0.0008294999999999999,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f737",
+      "right_id": "z33",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The two records have completely different names, addresses, phone numbers, and are located in different cities (New York vs. Los Angeles), so they clearly refer to different real-world restaurants.",
+      "provenance": {
+        "tokens": {
+          "prompt": 284,
+          "completion": 109
+        },
+        "cost_usd": 0.0006797000000000001,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f555",
+      "right_id": "z34",
+      "label": true,
+      "source": "teacher",
+      "confidence": 1.0,
+      "reasoning": "The two records have completely different names (valentino vs. koo koo roo), addresses, cities, phone numbers, and types. They are definitely different restaurants.",
+      "provenance": {
+        "tokens": {
+          "prompt": 294,
+          "completion": 72
+        },
+        "cost_usd": 0.0005607,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f548",
+      "right_id": "z34",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The two records have completely different names (matsuhisa vs koo koo roo), addresses (129 n. la cienega blvd. vs 8393 w. beverly blvd.), phone numbers, and restaurant types (asian vs chicken). They clearly refer to different real-world restaurants.",
+      "provenance": {
+        "tokens": {
+          "prompt": 303,
+          "completion": 162
+        },
+        "cost_usd": 0.00088515,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f555",
+      "right_id": "z35",
+      "label": true,
+      "source": "teacher",
+      "confidence": 1.0,
+      "reasoning": "The records have completely different names (valentino vs. la cachette), addresses (3115 pico blvd. vs. 10506 little santa monica blvd.), cities (santa monica vs. century city), phone numbers, and cuisines (italian vs. french). There is no overlap in any identifying information, so they are definitely different restaurants.",
+      "provenance": {
+        "tokens": {
+          "prompt": 289,
+          "completion": 157
+        },
+        "cost_usd": 0.0008529499999999999,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f1053",
+      "right_id": "z36",
+      "label": true,
+      "source": "teacher",
+      "confidence": 1.0,
+      "reasoning": "The records refer to completely different restaurants: \"tadich grill\" is a seafood restaurant in San Francisco, while \"la salsa (la)\" is a Mexican restaurant in Malibu. The names, addresses, cities, and phone numbers all differ.",
+      "provenance": {
+        "tokens": {
+          "prompt": 276,
+          "completion": 98
+        },
+        "cost_usd": 0.0006328,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f651",
+      "right_id": "z36",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The names, addresses, phone numbers, and cuisine types of the two restaurants are completely different.",
+      "provenance": {
+        "tokens": {
+          "prompt": 283,
+          "completion": 148
+        },
+        "cost_usd": 0.00081515,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f658",
+      "right_id": "z36",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The restaurants have completely different names (California Pizza Kitchen vs. La Salsa), addresses, cities, phone numbers, and cuisine types, indicating they are distinct establishments.",
+      "provenance": {
+        "tokens": {
+          "prompt": 285,
+          "completion": 152
+        },
+        "cost_usd": 0.00083125,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f573",
+      "right_id": "z37",
+      "label": true,
+      "source": "teacher",
+      "confidence": 1.0,
+      "reasoning": "The records have completely different names, addresses, cities, phone numbers, and cuisines. Record A is a French restaurant in New York, while Record B is a Mexican restaurant in St. Boyle Heights. There is no overlap in any attributes.",
+      "provenance": {
+        "tokens": {
+          "prompt": 305,
+          "completion": 127
+        },
+        "cost_usd": 0.00076475,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f818",
+      "right_id": "z37",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The names, addresses, cities, phone numbers, and cuisines are all completely different. Record A is an Italian restaurant in New York, while Record B is a Mexican/Tex-Mex restaurant in St. Boyle Hts. There is no overlap in any fields, indicating they are clearly different restaurants.",
+      "provenance": {
+        "tokens": {
+          "prompt": 310,
+          "completion": 256
+        },
+        "cost_usd": 0.0012215,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f913",
+      "right_id": "z37",
+      "label": true,
+      "source": "teacher",
+      "confidence": 1.0,
+      "reasoning": "The names, addresses, cities, phone numbers, and types are completely different. These records refer to two distinct restaurants.",
+      "provenance": {
+        "tokens": {
+          "prompt": 301,
+          "completion": 154
+        },
+        "cost_usd": 0.00085505,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f687",
+      "right_id": "z38",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The restaurant names (nicola vs langer's), addresses, phone numbers, and types are all completely different. There is no indication these refer to the same establishment.",
+      "provenance": {
+        "tokens": {
+          "prompt": 286,
+          "completion": 175
+        },
+        "cost_usd": 0.0009128000000000001,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f573",
+      "right_id": "z38",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The two records have entirely different restaurant names (la caravelle vs. langer's), different cities (new york vs. la), different addresses, different phone numbers, and different restaurant types (french vs. delis). There is no overlap in any identifying information, so these are definitely not the same real-world restaurant.",
+      "provenance": {
+        "tokens": {
+          "prompt": 285,
+          "completion": 125
+        },
+        "cost_usd": 0.00073675,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f989",
+      "right_id": "z38",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The records have completely different names (bardelli's vs langer's), addresses, cities (san francisco vs la), and phone numbers. There is no overlap in any identifying information.",
+      "provenance": {
+        "tokens": {
+          "prompt": 288,
+          "completion": 180
+        },
+        "cost_usd": 0.0009324000000000001,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f693",
+      "right_id": "z39",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The records have completely different names (posto vs. local nochol), addresses (14928 ventura blvd. vs. 30869 thousand oaks blvd.), cities (sherman oaks vs. westlake village), phone numbers, and cuisine types (italian vs. health food). There are no matching attributes between the two records.",
+      "provenance": {
+        "tokens": {
+          "prompt": 285,
+          "completion": 177
+        },
+        "cost_usd": 0.0009187499999999999,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f931",
+      "right_id": "z39",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The two records have completely different names, addresses, cities, phone numbers, and restaurant types. There is no overlap in any identifying field.",
+      "provenance": {
+        "tokens": {
+          "prompt": 321,
+          "completion": 58
+        },
+        "cost_usd": 0.00054005,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f693",
+      "right_id": "z40",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The records have completely different names (\"posto\" vs \"main course the\"), addresses (ventura blvd vs w. pico blvd), cities (sherman oaks vs rancho park), phone numbers, and cuisine types (italian vs american). There is no overlap in any identifying information.",
+      "provenance": {
+        "tokens": {
+          "prompt": 287,
+          "completion": 138
+        },
+        "cost_usd": 0.00078435,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f537",
+      "right_id": "z40",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The restaurant names, addresses, cities, and phone numbers are completely different, indicating they are distinct restaurants.",
+      "provenance": {
+        "tokens": {
+          "prompt": 293,
+          "completion": 152
+        },
+        "cost_usd": 0.00083965,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f760",
+      "right_id": "z41",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The records have entirely different names, addresses, phone numbers, and are located in different cities (New York vs Los Angeles). There is no overlap in any identifying information.",
+      "provenance": {
+        "tokens": {
+          "prompt": 296,
+          "completion": 75
+        },
+        "cost_usd": 0.0005733,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f1012",
+      "right_id": "z42",
+      "label": true,
+      "source": "teacher",
+      "confidence": 1.0,
+      "reasoning": "The records have completely different names, addresses, cities, phone numbers, and cuisine types. There is no overlap in any identifying information.",
+      "provenance": {
+        "tokens": {
+          "prompt": 291,
+          "completion": 394
+        },
+        "cost_usd": 0.00168455,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f653",
+      "right_id": "z42",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The two records have completely different names (border grill vs. martha's), cities, phone numbers, addresses, and cuisine types, making it clear they refer to different restaurants.",
+      "provenance": {
+        "tokens": {
+          "prompt": 284,
+          "completion": 127
+        },
+        "cost_usd": 0.0007427,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f708",
+      "right_id": "z43",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The two records have completely different names (west beach cafe vs. maxwell's cafe), addresses (60 n. venice blvd. vs. 13329 washington blvd.), phone numbers (310/823-5396 vs. 310-306-7829), and cities (los angeles vs. marina del rey). There are no matching attributes indicating they are the same restaurant.",
+      "provenance": {
+        "tokens": {
+          "prompt": 286,
+          "completion": 241
+        },
+        "cost_usd": 0.0011438000000000002,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f555",
+      "right_id": "z44",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The restaurants have completely different names (\"valentino\" vs \"michael's (los angeles)\"), addresses (\"3115 pico blvd.\" vs \"1147 third st.\"), phone numbers, and cuisine types. They do not refer to the same real-world restaurant.",
+      "provenance": {
+        "tokens": {
+          "prompt": 291,
+          "completion": 164
+        },
+        "cost_usd": 0.00087955,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f549",
+      "right_id": "z44",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The records have completely different names (\"the palm\" vs \"michael's (los angeles)\"), addresses, cities, phone numbers, and cuisine types. There are no shared attributes to suggest these refer to the same restaurant.",
+      "provenance": {
+        "tokens": {
+          "prompt": 288,
+          "completion": 85
+        },
+        "cost_usd": 0.0005999,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f818",
+      "right_id": "z45",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The records have completely different names, addresses, cities, phone numbers, and cuisine types. They refer to entirely different restaurants.",
+      "provenance": {
+        "tokens": {
+          "prompt": 289,
+          "completion": 105
+        },
+        "cost_usd": 0.00067095,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f853",
+      "right_id": "z45",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The records have completely different names (otabe vs mishima), addresses, cities (New York vs LA), and phone numbers, indicating they are clearly distinct restaurants.",
+      "provenance": {
+        "tokens": {
+          "prompt": 280,
+          "completion": 109
+        },
+        "cost_usd": 0.0006755,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f702",
+      "right_id": "z46",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The records have completely different names (\"tavola calda\" vs \"mo better meatty meat\"), different street numbers (7371 vs 7261 Melrose Ave), different phone numbers, and different cuisine types (italian vs hamburgers). They are clearly distinct establishments on the same street.",
+      "provenance": {
+        "tokens": {
+          "prompt": 288,
+          "completion": 180
+        },
+        "cost_usd": 0.0009324000000000001,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f546",
+      "right_id": "z46",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The restaurant names are completely different, the street addresses have different numbers (8284 vs 7261), the phone numbers do not match, and the cuisine types differ (French vs. hamburgers). These are two distinct restaurants on Melrose Avenue.",
+      "provenance": {
+        "tokens": {
+          "prompt": 287,
+          "completion": 206
+        },
+        "cost_usd": 0.00102235,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f940",
+      "right_id": "z46",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The two records have completely different names, are located in different cities (Atlanta vs LA), have different addresses, phone numbers, and cuisine types. They are clearly not the same restaurant.",
+      "provenance": {
+        "tokens": {
+          "prompt": 289,
+          "completion": 149
+        },
+        "cost_usd": 0.0008249499999999999,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f666",
+      "right_id": "z47",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The two records have completely different names, addresses, cities, phone numbers, and restaurant types, indicating they are clearly distinct restaurants.",
+      "provenance": {
+        "tokens": {
+          "prompt": 281,
+          "completion": 116
+        },
+        "cost_usd": 0.0007010499999999999,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f537",
+      "right_id": "z47",
+      "label": true,
+      "source": "teacher",
+      "confidence": 1.0,
+      "reasoning": "The records have completely different names (\"cafe bizou\" vs \"mulberry st.\"), addresses (\"14016 ventura blvd.\" vs \"17040 ventura blvd.\"), phone numbers, cities, and cuisines. These are clearly distinct restaurants.",
+      "provenance": {
+        "tokens": {
+          "prompt": 286,
+          "completion": 164
+        },
+        "cost_usd": 0.0008743,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f708",
+      "right_id": "z48",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The two records have completely different names, addresses, phone numbers, and cities, indicating they refer to different real-world restaurants.",
+      "provenance": {
+        "tokens": {
+          "prompt": 288,
+          "completion": 158
+        },
+        "cost_usd": 0.0008554000000000001,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f688",
+      "right_id": "z49",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The records have completely different names, addresses, cities, phone numbers, and cuisine types, indicating they are entirely different restaurants.",
+      "provenance": {
+        "tokens": {
+          "prompt": 282,
+          "completion": 67
+        },
+        "cost_usd": 0.0005306,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f579",
+      "right_id": "z49",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The records have completely different names (\"manhattan ocean club\" vs \"ocean star\"), addresses, cities (\"new york\" vs \"monterey park\"), and phone numbers. There is no indication they refer to the same restaurant.",
+      "provenance": {
+        "tokens": {
+          "prompt": 289,
+          "completion": 118
+        },
+        "cost_usd": 0.00071645,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f584",
+      "right_id": "z49",
+      "label": true,
+      "source": "teacher",
+      "confidence": 1.0,
+      "reasoning": "The two records have different names (oceana vs ocean star), different addresses, different cities (new york vs monterey park), and different phone numbers. They are clearly distinct restaurants.",
+      "provenance": {
+        "tokens": {
+          "prompt": 284,
+          "completion": 189
+        },
+        "cost_usd": 0.0009597000000000002,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f930",
+      "right_id": "z50",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The records have completely different names, cities, addresses, phone numbers, and types. There are no shared attributes indicating they refer to the same restaurant.",
+      "provenance": {
+        "tokens": {
+          "prompt": 304,
+          "completion": 205
+        },
+        "cost_usd": 0.0010367,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f758",
+      "right_id": "z50",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The two records have completely different names, cities (New York vs. LA), addresses, and phone numbers. They clearly refer to different restaurants.",
+      "provenance": {
+        "tokens": {
+          "prompt": 283,
+          "completion": 138
+        },
+        "cost_usd": 0.00078015,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f618",
+      "right_id": "z51",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The restaurant names, cities, addresses, and phone numbers are all completely different, indicating these are two distinct restaurants.",
+      "provenance": {
+        "tokens": {
+          "prompt": 290,
+          "completion": 183
+        },
+        "cost_usd": 0.0009450000000000001,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f1002",
+      "right_id": "z52",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The records have completely different names, addresses, phone numbers, and cuisine types. There is no evidence to suggest these refer to the same restaurant.",
+      "provenance": {
+        "tokens": {
+          "prompt": 275,
+          "completion": 210
+        },
+        "cost_usd": 0.00102375,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f713",
+      "right_id": "z52",
+      "label": true,
+      "source": "teacher",
+      "confidence": 1.0,
+      "reasoning": "The records have completely different names, addresses, phone numbers, and cuisine types. They are clearly different restaurants.",
+      "provenance": {
+        "tokens": {
+          "prompt": 277,
+          "completion": 140
+        },
+        "cost_usd": 0.00078085,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f545",
+      "right_id": "z53",
+      "label": true,
+      "source": "teacher",
+      "confidence": 1.0,
+      "reasoning": "The names, addresses, phone numbers, and types of food are completely different. Record A is a French restaurant called \"l'orangerie\" and Record B is a hot dog stand called \"pink's famous chili dogs\". They are clearly not the same restaurant.",
+      "provenance": {
+        "tokens": {
+          "prompt": 299,
+          "completion": 176
+        },
+        "cost_usd": 0.00092995,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f655",
+      "right_id": "z53",
+      "label": true,
+      "source": "teacher",
+      "confidence": 1.0,
+      "reasoning": "The records have entirely different names (ca'brea vs. pink's famous chili dogs), addresses (346 s. la brea vs. 709 n. la brea), phone numbers, and cuisine types (italian vs. hot dogs). These clearly refer to two different real-world restaurants.",
+      "provenance": {
+        "tokens": {
+          "prompt": 291,
+          "completion": 229
+        },
+        "cost_usd": 0.00110705,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f667",
+      "right_id": "z53",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The records have completely different names, addresses, phone numbers, and restaurant types, indicating they are clearly distinct establishments in Los Angeles.",
+      "provenance": {
+        "tokens": {
+          "prompt": 295,
+          "completion": 515
+        },
+        "cost_usd": 0.0021122500000000004,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f704",
+      "right_id": "z53",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The two records have completely different restaurant names (\"tommy tang's\" vs \"pink's famous chili dogs\"), addresses (\"7313 melrose ave.\" vs \"709 n. la brea ave.\"), phone numbers, and cuisine types (\"asian\" vs \"hot dogs\"). There is no indication they refer to the same real-world restaurant.",
+      "provenance": {
+        "tokens": {
+          "prompt": 289,
+          "completion": 148
+        },
+        "cost_usd": 0.00082145,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f940",
+      "right_id": "z54",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The two records have completely different names, addresses, cities, phone numbers, and restaurant types. Record A is a Caribbean restaurant in Atlanta, while Record B is a Mexican restaurant in Burbank. There is no overlap in any identifying information.",
+      "provenance": {
+        "tokens": {
+          "prompt": 290,
+          "completion": 85
+        },
+        "cost_usd": 0.0006020000000000001,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f1024",
+      "right_id": "z54",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The records have completely different names, addresses, cities, phone numbers, and restaurant types. One is an Italian restaurant in San Francisco, while the other is a Mexican restaurant in Burbank.",
+      "provenance": {
+        "tokens": {
+          "prompt": 291,
+          "completion": 111
+        },
+        "cost_usd": 0.0006940500000000001,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f718",
+      "right_id": "z54",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The records have completely different names, addresses, cities, phone numbers, and cuisines. Record A is an Italian restaurant in New York, while Record B is a Mexican restaurant in Burbank. There is no overlap in any identifying information.",
+      "provenance": {
+        "tokens": {
+          "prompt": 308,
+          "completion": 100
+        },
+        "cost_usd": 0.0006734,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f685",
+      "right_id": "z55",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The records have completely different names (morton's vs r-23), addresses (8764 melrose ave. vs 923 e. third st.), phone numbers, and cuisine types (american vs japanese). These are clearly two different restaurants in Los Angeles.",
+      "provenance": {
+        "tokens": {
+          "prompt": 281,
+          "completion": 201
+        },
+        "cost_usd": 0.00099855,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f545",
+      "right_id": "z55",
+      "label": true,
+      "source": "teacher",
+      "confidence": 1.0,
+      "reasoning": "The records have completely different names, addresses, phone numbers, and cuisine types. There is no overlap in any identifying information, making it certain these refer to different restaurants.",
+      "provenance": {
+        "tokens": {
+          "prompt": 295,
+          "completion": 188
+        },
+        "cost_usd": 0.00096775,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f667",
+      "right_id": "z55",
+      "label": true,
+      "source": "teacher",
+      "confidence": 1.0,
+      "reasoning": "The records have completely different names, addresses, phone numbers, and cuisine types, clearly indicating they refer to different real-world restaurants.",
+      "provenance": {
+        "tokens": {
+          "prompt": 291,
+          "completion": 126
+        },
+        "cost_usd": 0.00074655,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f963",
+      "right_id": "z57",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The records have entirely different names, addresses, cities, phone numbers, and cuisine types. Record A is a continental bistro on the Las Vegas Strip, while Record B is a hot dog restaurant in Encino, CA. There is no overlap in any field, so they are definitively different restaurants.",
+      "provenance": {
+        "tokens": {
+          "prompt": 288,
+          "completion": 127
+        },
+        "cost_usd": 0.0007469,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f684",
+      "right_id": "z59",
+      "label": true,
+      "source": "teacher",
+      "confidence": 1.0,
+      "reasoning": "The two records have completely different names, addresses, cities, phone numbers, and restaurant types, indicating they are completely different restaurants.",
+      "provenance": {
+        "tokens": {
+          "prompt": 287,
+          "completion": 114
+        },
+        "cost_usd": 0.00070035,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f606",
+      "right_id": "z60",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The records are in different cities (Las Vegas vs. Beverly Hills) with different addresses and phone numbers, and the names do not indicate the same specific restaurant.",
+      "provenance": {
+        "tokens": {
+          "prompt": 313,
+          "completion": 84
+        },
+        "cost_usd": 0.00062265,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f658",
+      "right_id": "z60",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The records have completely different restaurant names (california pizza kitchen vs ruth's chris steak house), different addresses (207 vs 224 s. beverly dr.), different phone numbers, and different cuisine types. They are clearly two distinct businesses.",
+      "provenance": {
+        "tokens": {
+          "prompt": 311,
+          "completion": 164
+        },
+        "cost_usd": 0.00090055,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f630",
+      "right_id": "z61",
+      "label": true,
+      "source": "teacher",
+      "confidence": 1.0,
+      "reasoning": "The records have different names, cities, addresses, phone numbers, and types. There is no indication they refer to the same restaurant.",
+      "provenance": {
+        "tokens": {
+          "prompt": 274,
+          "completion": 95
+        },
+        "cost_usd": 0.0006202,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f1028",
+      "right_id": "z61",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The records have completely different names, addresses, cities, phone numbers, and restaurant types. They are clearly two different restaurants.",
+      "provenance": {
+        "tokens": {
+          "prompt": 279,
+          "completion": 122
+        },
+        "cost_usd": 0.00071995,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f540",
+      "right_id": "z63",
+      "label": true,
+      "source": "teacher",
+      "confidence": 1.0,
+      "reasoning": "The restaurants have completely different names, addresses, phone numbers, and types.",
+      "provenance": {
+        "tokens": {
+          "prompt": 278,
+          "completion": 129
+        },
+        "cost_usd": 0.0007434,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f685",
+      "right_id": "z63",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The restaurant names, street addresses, phone numbers, and food types are all completely different, indicating they are distinct establishments on Melrose Ave.",
+      "provenance": {
+        "tokens": {
+          "prompt": 277,
+          "completion": 199
+        },
+        "cost_usd": 0.0009873500000000001,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f1025",
+      "right_id": "z64",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The records have completely different names (le central vs. taiko), addresses, cities (san francisco vs. brentwood), and phone numbers. They clearly refer to different restaurants.",
+      "provenance": {
+        "tokens": {
+          "prompt": 278,
+          "completion": 160
+        },
+        "cost_usd": 0.0008519,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f993",
+      "right_id": "z64",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The two records have completely different names (bizou vs. taiko), addresses, cities (San Francisco vs. Brentwood), phone numbers, and cuisine types. They clearly refer to two distinct restaurants.",
+      "provenance": {
+        "tokens": {
+          "prompt": 277,
+          "completion": 383
+        },
+        "cost_usd": 0.00163135,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f552",
+      "right_id": "z64",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The two records have completely different names, addresses, phone numbers, and restaurant types, indicating they are definitively not the same restaurant.",
+      "provenance": {
+        "tokens": {
+          "prompt": 286,
+          "completion": 136
+        },
+        "cost_usd": 0.0007763,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f598",
+      "right_id": "z66",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The records have different restaurant names (\"uncle nick's\" vs \"uncle bill's pancake house\"), different addresses, different cities (\"new york\" vs \"manhattan beach\"), different phone numbers, and different cuisine types. They clearly refer to different restaurants.",
+      "provenance": {
+        "tokens": {
+          "prompt": 310,
+          "completion": 157
+        },
+        "cost_usd": 0.0008749999999999999,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f760",
+      "right_id": "z66",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The records have completely different names, addresses, phone numbers, and cities (New York vs. Manhattan Beach). They are clearly different restaurants.",
+      "provenance": {
+        "tokens": {
+          "prompt": 298,
+          "completion": 115
+        },
+        "cost_usd": 0.0007154,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f606",
+      "right_id": "z66",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The two records have completely different names, addresses, cities, phone numbers, and restaurant types. One is a steak house in Las Vegas, while the other is a pancake house/diner in Manhattan Beach. There is no overlap in any identifying fields.",
+      "provenance": {
+        "tokens": {
+          "prompt": 295,
+          "completion": 112
+        },
+        "cost_usd": 0.00070175,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f1065",
+      "right_id": "z68",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The records have entirely different names (Zarzuela vs Zankou Chicken), addresses, cities (San Francisco vs Glendale), phone numbers, and cuisine types. There is no overlap in any identifying information.",
+      "provenance": {
+        "tokens": {
+          "prompt": 291,
+          "completion": 87
+        },
+        "cost_usd": 0.00061005,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f966",
+      "right_id": "z68",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The recordshave completely different names, addresses, cities, phone numbers, and restaurant types. There is no overlap in any identifying information.",
+      "provenance": {
+        "tokens": {
+          "prompt": 288,
+          "completion": 129
+        },
+        "cost_usd": 0.0007539000000000001,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f847",
+      "right_id": "z69",
+      "label": true,
+      "source": "teacher",
+      "confidence": 1.0,
+      "reasoning": "The restaurant names, addresses, phone numbers, and cuisines are completely different. Record A is a Korean BBQ spot on W. 32nd St., while Record B is an Afghan restaurant on Ninth Ave.",
+      "provenance": {
+        "tokens": {
+          "prompt": 293,
+          "completion": 86
+        },
+        "cost_usd": 0.0006086500000000001,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f866",
+      "right_id": "z69",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The records have completely different names (post house vs. afghan kebab house), addresses, phone numbers, and cuisine types (american vs. afghan). These are clearly two different restaurants.",
+      "provenance": {
+        "tokens": {
+          "prompt": 279,
+          "completion": 71
+        },
+        "cost_usd": 0.00054145,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f901",
+      "right_id": "z69",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The records have different names, addresses, phone numbers, and cuisine types. There is no overlap in any identifying fields, indicating they are different restaurants.",
+      "provenance": {
+        "tokens": {
+          "prompt": 301,
+          "completion": 108
+        },
+        "cost_usd": 0.00069405,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f789",
+      "right_id": "z70",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The records have completely different names (gabriela's vs arcadia), addresses, phone numbers, and cuisine types. They are clearly different restaurants.",
+      "provenance": {
+        "tokens": {
+          "prompt": 294,
+          "completion": 65
+        },
+        "cost_usd": 0.0005362,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f880",
+      "right_id": "z70",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The records have completely different restaurant names (serendipity vs. arcadia), different addresses (225 e. 60th st. vs. 21 e. 62nd st.), and different phone numbers. There is no indication these refer to the same real-world restaurant.",
+      "provenance": {
+        "tokens": {
+          "prompt": 288,
+          "completion": 84
+        },
+        "cost_usd": 0.0005964,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f570",
+      "right_id": "z70",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The records have completely different names (Gramercy Tavern vs Arcadia), addresses (42 E. 20th St vs 21 E. 62nd St), and phone numbers. They are clearly distinct restaurants in New York.",
+      "provenance": {
+        "tokens": {
+          "prompt": 304,
+          "completion": 200
+        },
+        "cost_usd": 0.0010192,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f726",
+      "right_id": "z71",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The two records refer to different restaurants. They have different names (\"billy's\" vs \"benny's burritos\"), different addresses (948 1st ave. vs 93 ave. a), different phone numbers, and different food types (American vs Mexican).",
+      "provenance": {
+        "tokens": {
+          "prompt": 301,
+          "completion": 143
+        },
+        "cost_usd": 0.0008165500000000001,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f741",
+      "right_id": "z71",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The records have completely different names, addresses, phone numbers, and cuisine types, indicating they are distinct restaurants.",
+      "provenance": {
+        "tokens": {
+          "prompt": 298,
+          "completion": 172
+        },
+        "cost_usd": 0.0009149,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f759",
+      "right_id": "z71",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The records have completely different restaurant names, addresses, phone numbers, and cuisine types. There is no overlap in any identifying information, indicating they are distinct restaurants in New York.",
+      "provenance": {
+        "tokens": {
+          "prompt": 303,
+          "completion": 70
+        },
+        "cost_usd": 0.00056315,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f739",
+      "right_id": "z72",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The restaurant names, addresses, phone numbers, and cuisine types are all completely different, indicating these are two distinct restaurants in New York.",
+      "provenance": {
+        "tokens": {
+          "prompt": 280,
+          "completion": 161
+        },
+        "cost_usd": 0.0008575,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f561",
+      "right_id": "z72",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The restaurant names, addresses, phone numbers, and types are all completely different, indicating these are two distinct real-world restaurants.",
+      "provenance": {
+        "tokens": {
+          "prompt": 282,
+          "completion": 107
+        },
+        "cost_usd": 0.0006706,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f741",
+      "right_id": "z73",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The records have completely different names (\"cafe fes\" vs \"corner bistro\"), different addresses (246 vs 331 w. 4th st.), different phone numbers, and different cuisine types (mediterranean vs hamburgers). They are clearly distinct restaurants.",
+      "provenance": {
+        "tokens": {
+          "prompt": 299,
+          "completion": 221
+        },
+        "cost_usd": 0.00108745,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f837",
+      "right_id": "z73",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The records have completely different names, addresses, phone numbers, and cuisine types. They are definitively different restaurants.",
+      "provenance": {
+        "tokens": {
+          "prompt": 308,
+          "completion": 159
+        },
+        "cost_usd": 0.0008798999999999999,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f726",
+      "right_id": "z73",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The restaurant names, addresses, and phone numbers are completely different. \"billy's\" is on 1st ave with phone 212-753-1870, while \"corner bistro\" is on w. fourth st with phone 212-242-9502. They are clearly two different restaurants in New York.",
+      "provenance": {
+        "tokens": {
+          "prompt": 302,
+          "completion": 166
+        },
+        "cost_usd": 0.0008981,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f735",
+      "right_id": "z73",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The records have completely different names (cafe bianco vs corner bistro), addresses (1486 2nd ave vs 331 w. fourth st), phone numbers, and restaurant types (coffee bar vs hamburgers). They are clearly different restaurants.",
+      "provenance": {
+        "tokens": {
+          "prompt": 306,
+          "completion": 149
+        },
+        "cost_usd": 0.0008427999999999999,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f587",
+      "right_id": "z73",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The two records have completely different names, addresses, phone numbers, and restaurant types, clearly indicating they refer to different restaurants.",
+      "provenance": {
+        "tokens": {
+          "prompt": 285,
+          "completion": 158
+        },
+        "cost_usd": 0.0008522499999999999,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f876",
+      "right_id": "z74",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The records have completely different names, addresses, and phone numbers, indicating they are definitely different restaurants.",
+      "provenance": {
+        "tokens": {
+          "prompt": 291,
+          "completion": 407
+        },
+        "cost_usd": 0.00173005,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f857",
+      "right_id": "z74",
+      "label": true,
+      "source": "teacher",
+      "confidence": 1.0,
+      "reasoning": "The two records have completely different names, addresses, and phone numbers, indicating they refer to different real-world restaurants.",
+      "provenance": {
+        "tokens": {
+          "prompt": 293,
+          "completion": 157
+        },
+        "cost_usd": 0.00085715,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f559",
+      "right_id": "z75",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The names, addresses, and phone numbers of the two restaurants are completely different.Record A is \"aureole\" at \"34 e. 61st st.\" while Record B is \"cucina di pesce\" at \"87 e. fourth st.\". There is no overlap in any identifying information.",
+      "provenance": {
+        "tokens": {
+          "prompt": 285,
+          "completion": 151
+        },
+        "cost_usd": 0.0008277499999999999,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f883",
+      "right_id": "z76",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The two records have completely different names (shaan vs. darbar), addresses (57 w. 48th st. vs. 44 w. 56th st.), and phone numbers. There is no overlapping information to suggest they are the same restaurant.",
+      "provenance": {
+        "tokens": {
+          "prompt": 282,
+          "completion": 174
+        },
+        "cost_usd": 0.0009051,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f593",
+      "right_id": "z76",
+      "label": true,
+      "source": "teacher",
+      "confidence": 1.0,
+      "reasoning": "The records have completely different names (seryna vs darbar), addresses (11 e. 53rd st. vs 44 w. 56th st.), phone numbers, and cuisine types. There is no evidence to suggest these refer to the same real-world restaurant.",
+      "provenance": {
+        "tokens": {
+          "prompt": 283,
+          "completion": 143
+        },
+        "cost_usd": 0.00079765,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f592",
+      "right_id": "z77",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The records have completely different restaurant names (Second Avenue Deli vs. EJ's Luncheonette), addresses (156 2nd Ave vs. 432 Sixth Ave), phone numbers, and types (delicatessen vs. diners). There is no indication these refer to the same real-world restaurant.",
+      "provenance": {
+        "tokens": {
+          "prompt": 293,
+          "completion": 145
+        },
+        "cost_usd": 0.0008151500000000001,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f805",
+      "right_id": "z77",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The records have entirely different names (\"internet cafe\" vs \"ej's luncheonette\"), addresses (82 e. 3rd st. vs 432 sixth ave.), phone numbers, and restaurant types. They clearly refer to different establishments.",
+      "provenance": {
+        "tokens": {
+          "prompt": 306,
+          "completion": 196
+        },
+        "cost_usd": 0.0010073,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f805",
+      "right_id": "z78",
+      "label": true,
+      "source": "teacher",
+      "confidence": 1.0,
+      "reasoning": "The two records have completely different names (\"internet cafe\" vs \"edison cafe\"), addresses (82 e. 3rd st. vs 228 w. 47th st.), and phone numbers (212/ 614-0747 vs 212-840-5000). They are clearly distinct restaurants.",
+      "provenance": {
+        "tokens": {
+          "prompt": 307,
+          "completion": 212
+        },
+        "cost_usd": 0.00106435,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f835",
+      "right_id": "z78",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The records have entirely different names, addresses, and phone numbers, indicating they are different restaurants.",
+      "provenance": {
+        "tokens": {
+          "prompt": 302,
+          "completion": 107
+        },
+        "cost_usd": 0.0006916,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f799",
+      "right_id": "z79",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The records have completely different names (\"home\" vs \"elias corner\"), addresses (\"20 cornelia st.\" vs \"24-02 31st st.\"), cities (New York vs Queens), phone numbers, and cuisine types (American vs Greek). There is no overlap in any identifying information.",
+      "provenance": {
+        "tokens": {
+          "prompt": 297,
+          "completion": 129
+        },
+        "cost_usd": 0.00076335,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f730",
+      "right_id": "z79",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The names, addresses, phone numbers, and types are all completely different, indicating that these are two distinct restaurants in different locations.",
+      "provenance": {
+        "tokens": {
+          "prompt": 291,
+          "completion": 183
+        },
+        "cost_usd": 0.00094605,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f828",
+      "right_id": "z79",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The records have entirely different names (Les Halles vs Elias Corner), addresses (411 Park Ave. S vs 24-02 31st St.), cities (New York vs Queens), phone numbers, and restaurant types (French vs Greek). There is no overlap in any attribute.",
+      "provenance": {
+        "tokens": {
+          "prompt": 300,
+          "completion": 145
+        },
+        "cost_usd": 0.0008225,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f872",
+      "right_id": "z79",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The restaurant names, addresses, phone numbers, and cuisines are completely different. Record A refers to a Ruth's Chris Steak House in Manhattan, while Record B refers to Elias Corner, a Greek restaurant in Queens.",
+      "provenance": {
+        "tokens": {
+          "prompt": 284,
+          "completion": 202
+        },
+        "cost_usd": 0.0010052000000000001,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f878",
+      "right_id": "z80",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The records have different restaurant names (\"sarabeth's kitchen\" vs \"good enough to eat\"), different street addresses (423 vs 483 Amsterdam Ave), and different phone numbers. These are clearly two distinct restaurants.",
+      "provenance": {
+        "tokens": {
+          "prompt": 297,
+          "completion": 135
+        },
+        "cost_usd": 0.0007843500000000001,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f789",
+      "right_id": "z80",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The two records have completely different names (gabriela's vs. good enough to eat), different addresses (685 amsterdam ave vs. 483 amsterdam ave), different phone numbers, and different cuisines. They are clearly two distinct restaurants.",
+      "provenance": {
+        "tokens": {
+          "prompt": 291,
+          "completion": 143
+        },
+        "cost_usd": 0.0008060500000000001,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f865",
+      "right_id": "z80",
+      "label": true,
+      "source": "teacher",
+      "confidence": 1.0,
+      "reasoning": "The restaurants have completely different names (\"popover cafe\" vs \"good enough to eat\"), addresses (551 Amsterdam Ave vs 483 Amsterdam Ave), and phone numbers. Therefore, they refer to different real-world restaurants.",
+      "provenance": {
+        "tokens": {
+          "prompt": 293,
+          "completion": 203
+        },
+        "cost_usd": 0.00101815,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f773",
+      "right_id": "z81",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The restaurant names, addresses, phone numbers, and types are all completely different. There is no evidence suggesting these refer to the same real-world restaurant.",
+      "provenance": {
+        "tokens": {
+          "prompt": 280,
+          "completion": 130
+        },
+        "cost_usd": 0.0007489999999999999,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f763",
+      "right_id": "z81",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The records have completely different names (\"diva\" vs \"gray's papaya\"), addresses (\"341 w. broadway\" vs \"2090 broadway\"), phone numbers, and restaurant types (\"italian\" vs \"hot dogs\"). There is no indication these are the same restaurant.",
+      "provenance": {
+        "tokens": {
+          "prompt": 285,
+          "completion": 160
+        },
+        "cost_usd": 0.00085925,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f803",
+      "right_id": "z81",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The records have completely different names, addresses, phone numbers, and cuisine types. They are clearly different restaurants.",
+      "provenance": {
+        "tokens": {
+          "prompt": 291,
+          "completion": 173
+        },
+        "cost_usd": 0.0009110500000000001,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f818",
+      "right_id": "z82",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The two records have completely different names (lattanzi ristorante vs il mulino), different street addresses (361 w. 46th st. vs 86 w. third st.), and different phone numbers. There is no evidence to suggest they refer to the same real-world restaurant.",
+      "provenance": {
+        "tokens": {
+          "prompt": 288,
+          "completion": 202
+        },
+        "cost_usd": 0.0010094000000000001,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f876",
+      "right_id": "z82",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The two records have completely different names (\"san pietro\" vs \"il mulino\"), different addresses, and different phone numbers. The only common attributes are city (broadly) and cuisine type, which are far too generic to indicate they are the same restaurant.",
+      "provenance": {
+        "tokens": {
+          "prompt": 283,
+          "completion": 133
+        },
+        "cost_usd": 0.00076265,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f853",
+      "right_id": "z82",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The records have completely different names (\"otabe\" vs \"il mulino\"), addresses (\"68 e. 56th st.\" vs \"86 w. third st.\"), phone numbers, and cuisine types (\"asian\" vs \"italian\"). They are definitively different restaurants.",
+      "provenance": {
+        "tokens": {
+          "prompt": 279,
+          "completion": 127
+        },
+        "cost_usd": 0.00073745,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f979",
+      "right_id": "z83",
+      "label": true,
+      "source": "teacher",
+      "confidence": 1.0,
+      "reasoning": "The records have entirely different names, addresses, cities, phone numbers, and cuisines. Mary's Diner is in Las Vegas, while Jackson Diner is in Queens, making it impossible for them to be the same restaurant.",
+      "provenance": {
+        "tokens": {
+          "prompt": 289,
+          "completion": 155
+        },
+        "cost_usd": 0.00084595,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f612",
+      "right_id": "z83",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The two records have completely different names, addresses, cities, phone numbers, and restaurant types, indicating they refer to entirely different restaurants.",
+      "provenance": {
+        "tokens": {
+          "prompt": 281,
+          "completion": 192
+        },
+        "cost_usd": 0.0009670500000000001,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f921",
+      "right_id": "z83",
+      "label": true,
+      "source": "teacher",
+      "confidence": 1.0,
+      "reasoning": "The names (cafe renaissance vs jackson diner), addresses, cities (atlanta vs queens), phone numbers, and restaurant types (american vs indian) are completely different, indicating these are clearly two distinct restaurants.",
+      "provenance": {
+        "tokens": {
+          "prompt": 296,
+          "completion": 183
+        },
+        "cost_usd": 0.0009513,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f601",
+      "right_id": "z84",
+      "label": true,
+      "source": "teacher",
+      "confidence": 1.0,
+      "reasoning": "The records have completely different names, addresses, cities, and phone numbers. Record A is \"chin's\" in Las Vegas, while Record B is\"joe's shanghai\" in Queens, making it certain they are different restaurants.",
+      "provenance": {
+        "tokens": {
+          "prompt": 282,
+          "completion": 122
+        },
+        "cost_usd": 0.0007231,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f1023",
+      "right_id": "z84",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The records have completely different names, addresses, cities (San Francisco vs. Queens), and phone numbers, clearly referring to different restaurants.",
+      "provenance": {
+        "tokens": {
+          "prompt": 301,
+          "completion": 177
+        },
+        "cost_usd": 0.0009355499999999999,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f1021",
+      "right_id": "z84",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The records have entirely different names, addresses, cities, and phone numbers. There is no overlap in any attributes to suggest they refer to the same restaurant.",
+      "provenance": {
+        "tokens": {
+          "prompt": 278,
+          "completion": 207
+        },
+        "cost_usd": 0.0010164,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f842",
+      "right_id": "z85",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The records have completely different names (milan cafe and coffee bar vs. john's pizzeria), addresses (120 w. 23rd st.vs. 48 w. 65th st.), phone numbers, and restaurant types (coffee bar vs. pizza). There is no overlap indicating they are the same restaurant.",
+      "provenance": {
+        "tokens": {
+          "prompt": 292,
+          "completion": 139
+        },
+        "cost_usd": 0.0007930999999999999,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f837",
+      "right_id": "z86",
+      "label": true,
+      "source": "teacher",
+      "confidence": 1.0,
+      "reasoning": "The records have completely different names, addresses, phone numbers, and restaurant types, clearly referring to two different restaurants.",
+      "provenance": {
+        "tokens": {
+          "prompt": 304,
+          "completion": 109
+        },
+        "cost_usd": 0.0007007000000000001,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f565",
+      "right_id": "z86",
+      "label": true,
+      "source": "teacher",
+      "confidence": 1.0,
+      "reasoning": "The restaurant names (\"daniel\" vs \"kelley & ping\"), addresses (\"20 e. 76th st.\" vs \"127 greene st.\"), phone numbers (\"212/288-0033\" vs \"212-228-1212\"), and cuisine types (\"french\" vs \"pan-asian\") are completely different, indicating these are two distinct restaurants in New York.",
+      "provenance": {
+        "tokens": {
+          "prompt": 278,
+          "completion": 211
+        },
+        "cost_usd": 0.0010304,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f862",
+      "right_id": "z87",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The records have completely different names (persepolis vs kiev), addresses (1423 2nd ave vs 117 second ave), phone numbers (212/535-1100 vs 212-674-4040), and cuisine types (middle eastern vs ukrainian). They are clearly two different restaurants in New York City.",
+      "provenance": {
+        "tokens": {
+          "prompt": 295,
+          "completion": 287
+        },
+        "cost_usd": 0.0013142499999999999,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f728",
+      "right_id": "z87",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The restaurants have completely different names (boonthai vs. kiev), different addresses (1393a 2nd ave vs. 117 second ave), different phone numbers, and different cuisine types (asian vs. ukrainian). There is no overlap in any identifying information.",
+      "provenance": {
+        "tokens": {
+          "prompt": 298,
+          "completion": 143
+        },
+        "cost_usd": 0.0008134000000000001,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f1020",
+      "right_id": "z88",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The two records have completely different names (\"kabuto sushi\" vs \"kuruma zushi\"), are located in different cities (\"san francisco\" vs \"new york city\"), and have different addresses and phone numbers. They clearly refer to different restaurants.",
+      "provenance": {
+        "tokens": {
+          "prompt": 283,
+          "completion": 147
+        },
+        "cost_usd": 0.0008116499999999999,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f618",
+      "right_id": "z91",
+      "label": true,
+      "source": "teacher",
+      "confidence": 1.0,
+      "reasoning": "The records have completely different names (\"indigo coastal grill\" vs. \"lemongrass grill\"), cities (Atlanta vs. Brooklyn), addresses, phone numbers, and cuisine types (Caribbean vs. Thai). There is no overlap in any field, making it certain these are different restaurants.",
+      "provenance": {
+        "tokens": {
+          "prompt": 284,
+          "completion": 122
+        },
+        "cost_usd": 0.0007252000000000001,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f543",
+      "right_id": "z91",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The records have completely different names, addresses, cities, phone numbers, and types. One is an American restaurant in Los Angeles, while the other is a Thai restaurant in Brooklyn. There is no overlap in any identifying information.",
+      "provenance": {
+        "tokens": {
+          "prompt": 285,
+          "completion": 101
+        },
+        "cost_usd": 0.00065275,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f882",
+      "right_id": "z92",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The two records have completely different names, addresses, phone numbers, and restaurant types. They are clearly different restaurants.",
+      "provenance": {
+        "tokens": {
+          "prompt": 274,
+          "completion": 106
+        },
+        "cost_usd": 0.0006587,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f848",
+      "right_id": "z93",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The names, addresses, and phone numbers are all completely different between the two records, indicating they are distinct restaurants.",
+      "provenance": {
+        "tokens": {
+          "prompt": 301,
+          "completion": 117
+        },
+        "cost_usd": 0.0007255499999999999,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f787",
+      "right_id": "z93",
+      "label": true,
+      "source": "teacher",
+      "confidence": 1.0,
+      "reasoning": "The records have completely different names, addresses, phone numbers, and cuisine types. There is no overlap in any identifying information, making it certain they refer to different restaurants.",
+      "provenance": {
+        "tokens": {
+          "prompt": 305,
+          "completion": 215
+        },
+        "cost_usd": 0.00107275,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f853",
+      "right_id": "z94",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The records have completely different names (\"otabe\" vs \"menchanko-tei\"), different addresses (\"68 e. 56th st.\" vs \"39 w. 55th st.\"), and different phone numbers. There is no indication these refer to the same restaurant.",
+      "provenance": {
+        "tokens": {
+          "prompt": 286,
+          "completion": 119
+        },
+        "cost_usd": 0.0007168000000000001,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f818",
+      "right_id": "z94",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The records have completely different names, addresses, phone numbers, and cuisine types, clearly indicating they refer to different restaurants.",
+      "provenance": {
+        "tokens": {
+          "prompt": 295,
+          "completion": 156
+        },
+        "cost_usd": 0.0008557500000000001,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f883",
+      "right_id": "z94",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The two records have completely different names, addresses, phone numbers, and restaurant types. There is no overlap in any identifying fields, so they clearly refer to different restaurants.",
+      "provenance": {
+        "tokens": {
+          "prompt": 287,
+          "completion": 70
+        },
+        "cost_usd": 0.0005463499999999999,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f578",
+      "right_id": "z95",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The records have completely different names (lutece vs mitali east-west), addresses (249 e. 50th st. vs 296 bleecker st.), phone numbers, and cuisine types (french vs indian). They are definitively different restaurants.",
+      "provenance": {
+        "tokens": {
+          "prompt": 285,
+          "completion": 138
+        },
+        "cost_usd": 0.00078225,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f882",
+      "right_id": "z95",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The restaurants have completely different names, addresses, phone",
+      "provenance": {
+        "tokens": {
+          "prompt": 280,
+          "completion": 112
+        },
+        "cost_usd": 0.000686,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f867",
+      "right_id": "z96",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The records have completely different names, addresses, and phone numbers. There is no overlap in the identifying fields to suggest these refer to the same restaurant.",
+      "provenance": {
+        "tokens": {
+          "prompt": 278,
+          "completion": 592
+        },
+        "cost_usd": 0.0023639,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f893",
+      "right_id": "z96",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The two records have completely different restaurant names, phone numbers, cuisines (continental vs. thai), and addresses (400 w. 119th st. vs 435 amsterdam ave.). Therefore, they do not refer to the same real-world restaurant.",
+      "provenance": {
+        "tokens": {
+          "prompt": 297,
+          "completion": 193
+        },
+        "cost_usd": 0.0009873500000000001,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f558",
+      "right_id": "z96",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The restaurants have completely different names, addresses, phone numbers, and cuisines. There is no overlap in any identifying information.",
+      "provenance": {
+        "tokens": {
+          "prompt": 279,
+          "completion": 88
+        },
+        "cost_usd": 0.00060095,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f584",
+      "right_id": "z97",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The records have completely different names (\"oceana\" vs \"moustache\"), addresses, cities (New York vs Brooklyn), phone numbers, and restaurant types (seafood vs middle eastern). There is no overlap in any identifying information.",
+      "provenance": {
+        "tokens": {
+          "prompt": 278,
+          "completion": 196
+        },
+        "cost_usd": 0.0009778999999999999,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f568",
+      "right_id": "z97",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The names, addresses, cities, phone numbers, and cuisine types are all completely different. There is no overlap in any identifying information, indicating these are two distinct restaurants.",
+      "provenance": {
+        "tokens": {
+          "prompt": 281,
+          "completion": 121
+        },
+        "cost_usd": 0.00071855,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f851",
+      "right_id": "z98",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The records have completely different names (Orso vs Nobu), addresses (322 w. 46th st. vs 105 hudson st.), phone numbers, and cuisine types (Italian vs Japanese). These are clearly two different restaurants in New York.",
+      "provenance": {
+        "tokens": {
+          "prompt": 275,
+          "completion": 116
+        },
+        "cost_usd": 0.0006947500000000001,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f728",
+      "right_id": "z99",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The restaurant names, addresses, phone numbers, and types are all completely different, indicating they are separate establishments.",
+      "provenance": {
+        "tokens": {
+          "prompt": 307,
+          "completion": 435
+        },
+        "cost_usd": 0.0018448499999999999,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f729",
+      "right_id": "z99",
+      "label": true,
+      "source": "teacher",
+      "confidence": 1.0,
+      "reasoning": "The records have completely different names, addresses, phone numbers, and restaurant types, indicating they refer to different restaurants.",
+      "provenance": {
+        "tokens": {
+          "prompt": 299,
+          "completion": 163
+        },
+        "cost_usd": 0.0008844500000000001,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f799",
+      "right_id": "z99",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The records have completely different restaurant names, addresses, and phone numbers, indicating they refer to different establishments in New York.",
+      "provenance": {
+        "tokens": {
+          "prompt": 300,
+          "completion": 103
+        },
+        "cost_usd": 0.0006754999999999999,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f837",
+      "right_id": "z99",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The records have completely different names (\"marichu\" vs \"one if by land tibs\"), addresses (\"342 e. 46th st.\" vs \"17 barrow st.\"), phone numbers, and cuisine types. There is no indication these refer to the same restaurant.",
+      "provenance": {
+        "tokens": {
+          "prompt": 309,
+          "completion": 95
+        },
+        "cost_usd": 0.00065695,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f843",
+      "right_id": "z100",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The records refer to entirely different restaurants. The names (monkey bar vs. oyster bar), addresses (60 e. 54th st. vs. lower level), phone numbers, and cuisine types (american vs. seafood) are all completely different.",
+      "provenance": {
+        "tokens": {
+          "prompt": 270,
+          "completion": 122
+        },
+        "cost_usd": 0.0007105,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f723",
+      "right_id": "z100",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The records have entirely different names (\"barbetta\" vs \"oyster bar\"), addresses (\"321 w. 46th st.\" vs \"lower level\"), phone numbers, and cuisines (\"italian\" vs \"seafood\"). They are clearly different restaurants.",
+      "provenance": {
+        "tokens": {
+          "prompt": 276,
+          "completion": 125
+        },
+        "cost_usd": 0.0007273,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f787",
+      "right_id": "z100",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The records have completely different names, addresses, phone numbers, and cuisine types. Record A is an Italian restaurant called \"frico bar\" on W. 43rd St., while Record B is a seafood restaurant called \"oyster bar\" located at \"lower level\" (likely Grand Central Terminal). There is no overlap in any identifying information.",
+      "provenance": {
+        "tokens": {
+          "prompt": 290,
+          "completion": 244
+        },
+        "cost_usd": 0.0011585,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f549",
+      "right_id": "z101",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "Although both records refer to \"The Palm\" (a restaurant chain), they are located in entirely different cities (Los Angeles vs. New York City) with distinct addresses and phone numbers. Therefore, they refer to different branches of the chain, not the same real-world restaurant.",
+      "provenance": {
+        "tokens": {
+          "prompt": 276,
+          "completion": 259
+        },
+        "cost_usd": 0.0011963,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f592",
+      "right_id": "z102",
+      "label": true,
+      "source": "teacher",
+      "confidence": 1.0,
+      "reasoning": "The records have completely different names (second avenue deli vs. palm too), addresses (156 2nd ave. vs. 840 second ave.), phone numbers, and restaurant types (delicatessen vs. steakhouses). They clearly refer to different restaurants.",
+      "provenance": {
+        "tokens": {
+          "prompt": 290,
+          "completion": 175
+        },
+        "cost_usd": 0.0009170000000000001,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f549",
+      "right_id": "z102",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The restaurants are in different cities (Los Angeles vs. New York City), have different addresses, different phone numbers, and slightly different names (\"the palm\" vs \"palm too\").",
+      "provenance": {
+        "tokens": {
+          "prompt": 278,
+          "completion": 102
+        },
+        "cost_usd": 0.0006489,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f884",
+      "right_id": "z103",
+      "label": true,
+      "source": "teacher",
+      "confidence": 1.0,
+      "reasoning": "The records have different names (\"sofia fabulous pizza\" vs \"patsy's pizza\"), different addresses (\"1022 madison ave.\" vs \"19 old fulton st.\"), different cities (\"new york\" vs \"brooklyn\"), and different phone numbers. There is no overlap to suggest they are the same restaurant.",
+      "provenance": {
+        "tokens": {
+          "prompt": 294,
+          "completion": 137
+        },
+        "cost_usd": 0.0007882,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f819",
+      "right_id": "z103",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The two records have entirely different names, addresses, phone numbers, cities, and restaurant types. There is no overlap in any fields, indicating they are completely different restaurants.",
+      "provenance": {
+        "tokens": {
+          "prompt": 284,
+          "completion": 211
+        },
+        "cost_usd": 0.0010367,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f791",
+      "right_id": "z103",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The two records have entirely different names (gianni's vs. patsy's pizza), addresses (15 fulton st. vs. 19 old fulton st.), cities (new york vs. brooklyn), phone numbers (212/608-7300 vs. 718-858-4300), and cuisine types (seafood vs. pizza). They are definitively different restaurants.",
+      "provenance": {
+        "tokens": {
+          "prompt": 276,
+          "completion": 459
+        },
+        "cost_usd": 0.0018962999999999999,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f763",
+      "right_id": "z103",
+      "label": true,
+      "source": "teacher",
+      "confidence": 1.0,
+      "reasoning": "The records have completely different names (diva vs patsy's pizza), addresses, cities (new york vs brooklyn), phone numbers, and restaurant types. They clearly refer to different real-world restaurants.",
+      "provenance": {
+        "tokens": {
+          "prompt": 286,
+          "completion": 208
+        },
+        "cost_usd": 0.0010283,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f909",
+      "right_id": "z104",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The records have completely different names, addresses, cities, and phone numbers. Record A refers to a restaurant in Manhattan (63rd St), while Record B refers to Peter Luger Steak House in Brooklyn.",
+      "provenance": {
+        "tokens": {
+          "prompt": 290,
+          "completion": 209
+        },
+        "cost_usd": 0.001036,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f875",
+      "right_id": "z104",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The records have completely different names, addresses, cities, and phone numbers. They refer to two distinct, well-known steakhouses in New York City.",
+      "provenance": {
+        "tokens": {
+          "prompt": 301,
+          "completion": 447
+        },
+        "cost_usd": 0.0018805500000000001,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f606",
+      "right_id": "z104",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "These records clearly refer to different restaurants. Record A is a steak house in Las Vegas (phone area code 702) at 2880 Las Vegas Blvd. S, while Record B is Peter Luger Steak House in Brooklyn (phone area code 718) at 178 Broadway. Different cities, addresses, phone numbers, and names — no overlap beyond the generic restaurant type.",
+      "provenance": {
+        "tokens": {
+          "prompt": 289,
+          "completion": 333
+        },
+        "cost_usd": 0.0014689500000000001,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f895",
+      "right_id": "z104",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "Thetwo records have completely different names (\"the savannah club\" vs \"peter luger steak house\"), addresses, cities, phone numbers, and cuisine types. There is no overlap in any identifying information.",
+      "provenance": {
+        "tokens": {
+          "prompt": 289,
+          "completion": 146
+        },
+        "cost_usd": 0.00081445,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f868",
+      "right_id": "z105",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The records have completely different names (red tulip vs. rose of india), addresses (439 e. 75th st. vs. 308 e. sixth st.), phone numbers, and cuisine types (eastern european vs. indian). There is no overlap to suggest they are the same restaurant.",
+      "provenance": {
+        "tokens": {
+          "prompt": 284,
+          "completion": 520
+        },
+        "cost_usd": 0.0021181999999999998,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f566",
+      "right_id": "z105",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The restaurants have completely different names (\"dawat\" vs \"rose of india\"), addresses (\"210 e. 58th st.\" vs \"308 e. sixth st.\"), and phone numbers (\"212/355-7555\" vs \"212-533-5011\"). These are clearly two distinct restaurants.",
+      "provenance": {
+        "tokens": {
+          "prompt": 279,
+          "completion": 226
+        },
+        "cost_usd": 0.00108395,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f782",
+      "right_id": "z105",
+      "label": true,
+      "source": "teacher",
+      "confidence": 0.5,
+      "reasoning": "",
+      "provenance": {
+        "tokens": {
+          "prompt": 297,
+          "completion": 97
+        },
+        "cost_usd": 0.00065135,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f848",
+      "right_id": "z106",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The two records have completely different names, addresses, and phone numbers, indicating they refer to different restaurants.",
+      "provenance": {
+        "tokens": {
+          "prompt": 293,
+          "completion": 88
+        },
+        "cost_usd": 0.00061565,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f787",
+      "right_id": "z106",
+      "label": true,
+      "source": "teacher",
+      "confidence": 1.0,
+      "reasoning": "The records have completely different names (frico bar vs. sam's noodle shop), addresses, phone numbers, and cuisine types (Italian vs. Chinese). They are clearly different restaurants.",
+      "provenance": {
+        "tokens": {
+          "prompt": 297,
+          "completion": 151
+        },
+        "cost_usd": 0.00084035,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f592",
+      "right_id": "z107",
+      "label": true,
+      "source": "teacher",
+      "confidence": 1.0,
+      "reasoning": "The records have completely different names, addresses, phone numbers, and cuisine types, indicating they are distinct restaurants.",
+      "provenance": {
+        "tokens": {
+          "prompt": 290,
+          "completion": 137
+        },
+        "cost_usd": 0.000784,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f811",
+      "right_id": "z108",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The restaurant names (\"judson grill\" vs \"sparks steak house\"), addresses (\"152 w. 52nd st.\" vs \"210 e. 46th st.\"), and phone numbers are completely different. These refer to distinctly different restaurants.",
+      "provenance": {
+        "tokens": {
+          "prompt": 287,
+          "completion": 420
+        },
+        "cost_usd": 0.0017713499999999999,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f948",
+      "right_id": "z109",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The records have entirely different names, addresses, cities, and phone numbers, indicating they are distinct restaurants.",
+      "provenance": {
+        "tokens": {
+          "prompt": 277,
+          "completion": 110
+        },
+        "cost_usd": 0.0006758500000000001,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f569",
+      "right_id": "z109",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The records have completely different names, addresses, cities, phone numbers, and cuisine types, clearly indicating they are different restaurants.",
+      "provenance": {
+        "tokens": {
+          "prompt": 289,
+          "completion": 62
+        },
+        "cost_usd": 0.00052045,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f929",
+      "right_id": "z109",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The records have completely different names, addresses, cities, and phone numbers. One is located in Atlanta, GA, while the other is in Queens, NY. There is no overlap in any identifying information.",
+      "provenance": {
+        "tokens": {
+          "prompt": 298,
+          "completion": 222
+        },
+        "cost_usd": 0.0010899,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f729",
+      "right_id": "z109",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The records have completely different names, addresses, cities, phone numbers, and restaurant types. There is no overlap in any of the identifying fields, indicating they are distinct restaurants.",
+      "provenance": {
+        "tokens": {
+          "prompt": 298,
+          "completion": 199
+        },
+        "cost_usd": 0.0010094000000000001,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f775",
+      "right_id": "z110",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The records have entirely different names, addresses, phone numbers, and cuisine types. There is no overlap or similarity that would suggest they refer to the same restaurant.",
+      "provenance": {
+        "tokens": {
+          "prompt": 289,
+          "completion": 110
+        },
+        "cost_usd": 0.00068845,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f892",
+      "right_id": "z111",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The records have completely different names (Teresa's vs Sylvia's), addresses, phone numbers, and cuisine types. They are clearly distinct restaurants in New York.",
+      "provenance": {
+        "tokens": {
+          "prompt": 302,
+          "completion": 74
+        },
+        "cost_usd": 0.0005761,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f768",
+      "right_id": "z111",
+      "label": true,
+      "source": "teacher",
+      "confidence": 1.0,
+      "reasoning": "The records have completely different names (emily's vs. sylvia's), addresses (1325 5th ave. vs. 328 lenox ave.), phone numbers, and cuisine types, clearly indicating they are different restaurants.",
+      "provenance": {
+        "tokens": {
+          "prompt": 293,
+          "completion": 83
+        },
+        "cost_usd": 0.00059815,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f789",
+      "right_id": "z111",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The records have completely different restaurant names (gabriela's vs. sylvia's), addresses, phone numbers, and cuisine types, indicating they are definitely different restaurants.",
+      "provenance": {
+        "tokens": {
+          "prompt": 296,
+          "completion": 121
+        },
+        "cost_usd": 0.0007343,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f830",
+      "right_id": "z111",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The restaurant names, addresses, phone numbers, and cuisine types are all completely different. Lola is an American restaurant at 30 West 22nd St., while Sylvia's is a Southern/soul food restaurant at 328 Lenox Ave.",
+      "provenance": {
+        "tokens": {
+          "prompt": 302,
+          "completion": 270
+        },
+        "cost_usd": 0.0012621,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f937",
+      "right_id": "z112",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The restaurants are located in completely different cities (Atlanta vs. New York City), have different phone numbers, different addresses, and different names. Although both mention \"szechuan\", they clearly refer to different establishments.",
+      "provenance": {
+        "tokens": {
+          "prompt": 301,
+          "completion": 192
+        },
+        "cost_usd": 0.00098805,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f900",
+      "right_id": "z112",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The two records have different names, different addresses, and different phone numbers. There are no overlapping attributes other than the city (New York), which is insufficient to conclude they are the same restaurant.",
+      "provenance": {
+        "tokens": {
+          "prompt": 284,
+          "completion": 91
+        },
+        "cost_usd": 0.0006167,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f755",
+      "right_id": "z112",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The two records have completely different names, addresses, phone numbers, and restaurant types. The only similarity is that they are both located in New York, which is insufficient to consider them the same restaurant.",
+      "provenance": {
+        "tokens": {
+          "prompt": 281,
+          "completion": 158
+        },
+        "cost_usd": 0.0008480499999999999,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f878",
+      "right_id": "z113",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The two records have entirely different names, addresses, phonenumbers, and cuisine types. There is no overlap in any identifying information, indicating they are completely different restaurants.",
+      "provenance": {
+        "tokens": {
+          "prompt": 298,
+          "completion": 127
+        },
+        "cost_usd": 0.0007574000000000001,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f892",
+      "right_id": "z114",
+      "label": true,
+      "source": "teacher",
+      "confidence": 0.95,
+      "reasoning": "Both records share the name \"teresa's\" and similar cuisine types (East European vs. Polish), but they have completely different addresses, phone numbers, and cities. Record A is at 103 1st Ave in Manhattan (area code 212), while Record B is at 80 Montague St in Queens (area code 718). These represent different restaurant locations.",
+      "provenance": {
+        "tokens": {
+          "prompt": 293,
+          "completion": 239
+        },
+        "cost_usd": 0.00114415,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f639",
+      "right_id": "z114",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The records have completely different names, addresses, cities, phone numbers, and cuisine types, clearly indicating they are different restaurants.",
+      "provenance": {
+        "tokens": {
+          "prompt": 276,
+          "completion": 464
+        },
+        "cost_usd": 0.0019138,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f870",
+      "right_id": "z114",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The records have different names (roettelle a. g vs teresa's), addresses (126 e. 7th st. vs 80 montague st.), cities (new york vs queens), phone numbers, and types (continental vs polish). There is no indication these refer to the same restaurant.",
+      "provenance": {
+        "tokens": {
+          "prompt": 305,
+          "completion": 100
+        },
+        "cost_usd": 0.0006702500000000001,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f560",
+      "right_id": "z115",
+      "label": true,
+      "source": "teacher",
+      "confidence": 1.0,
+      "reasoning": "The records have completely different names (cafe lalo vs thai house cafe), addresses (201 w. 83rd st. vs 151 hudson st.), phone numbers, and restaurant types (coffee bar vs thai). There is no overlap in any identifying information.",
+      "provenance": {
+        "tokens": {
+          "prompt": 282,
+          "completion": 137
+        },
+        "cost_usd": 0.0007756,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f739",
+      "right_id": "z115",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The two records have entirely different names (\"cafe pierre\" vs \"thai house cafe\"), addresses, phone numbers, and cuisine types (\"french\" vs \"thai\"). There is no overlap in any identifying information.",
+      "provenance": {
+        "tokens": {
+          "prompt": 280,
+          "completion": 187
+        },
+        "cost_usd": 0.0009484999999999999,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f798",
+      "right_id": "z116",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The restaurant names, addresses, phone numbers, and cuisine types are all completely different. There is no overlap in any identifying information to suggest these are the same restaurant.",
+      "provenance": {
+        "tokens": {
+          "prompt": 291,
+          "completion": 70
+        },
+        "cost_usd": 0.00055055,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f862",
+      "right_id": "z117",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The records have completely different restaurant names (persepolis vs veselka), addresses (1423 2nd ave vs 144 second ave), phone numbers, and cuisine types (middle eastern vs ukrainian), indicating they are clearly distinct establishments.",
+      "provenance": {
+        "tokens": {
+          "prompt": 296,
+          "completion": 283
+        },
+        "cost_usd": 0.0013013,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f864",
+      "right_id": "z118",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The two records have completely different names (Pomaire vs. Westside Cottage), different addresses (371 W. 46th St. vs. 689 Ninth Ave.), different phone numbers, and different cuisine types (Latin American vs. Chinese). There is no indication these refer to the same restaurant.",
+      "provenance": {
+        "tokens": {
+          "prompt": 294,
+          "completion": 96
+        },
+        "cost_usd": 0.0006447,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f909",
+      "right_id": "z118",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The records have completely different addresses, phone numbers, names, and cuisine types (American vs. Chinese). They are clearly different restaurants.",
+      "provenance": {
+        "tokens": {
+          "prompt": 285,
+          "completion": 456
+        },
+        "cost_usd": 0.0018952500000000002,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f893",
+      "right_id": "z118",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The records have completely different names (terrace vs westside cottage), addresses (400 w. 119th st. vs 689 ninth ave.), phone numbers (212/666-9490 vs 212-245-0800), and cuisine types (continental vs chinese). There is no evidence suggesting these refer to the same restaurant.",
+      "provenance": {
+        "tokens": {
+          "prompt": 293,
+          "completion": 115
+        },
+        "cost_usd": 0.0007101500000000001,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f830",
+      "right_id": "z118",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The two records have completely different names, addresses, phone numbers, and cuisine types (American vs. Chinese), making it clear they refer to different restaurants.",
+      "provenance": {
+        "tokens": {
+          "prompt": 295,
+          "completion": 162
+        },
+        "cost_usd": 0.00087675,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f783",
+      "right_id": "z119",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The restaurant names (\"follonico\" vs \"windows on the world\"), addresses (\"6 w. 24th st.\" vs \"107th fl.\"), phone numbers, and types are all completely different. There is no overlap indicating these refer to the same restaurant.",
+      "provenance": {
+        "tokens": {
+          "prompt": 280,
+          "completion": 242
+        },
+        "cost_usd": 0.001141,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f867",
+      "right_id": "z119",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The restaurants have completely different names, addresses, and phone numbers. \"Rain\" is located on 82nd St. while \"Windows on the World\" was located on the 107th floor of the World Trade Center, making them definitively different establishments.",
+      "provenance": {
+        "tokens": {
+          "prompt": 274,
+          "completion": 245
+        },
+        "cost_usd": 0.0011451999999999999,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f849",
+      "right_id": "z119",
+      "label": true,
+      "source": "teacher",
+      "confidence": 1.0,
+      "reasoning": "The records have entirely different names (newsbar vs windows on the world), addresses, phone numbers, and restaurant types. They clearly refer to different restaurants.",
+      "provenance": {
+        "tokens": {
+          "prompt": 275,
+          "completion": 68
+        },
+        "cost_usd": 0.0005267500000000001,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f793",
+      "right_id": "z119",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The restaurant names, addresses, phone numbers, and types are all completely different. \"Global\" on 2nd Ave is an entirely different establishment from \"Windows on the World\" on the 107th floor.",
+      "provenance": {
+        "tokens": {
+          "prompt": 295,
+          "completion": 131
+        },
+        "cost_usd": 0.00076825,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f806",
+      "right_id": "z121",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The two records have completely different names, addresses, phone numbers, and cuisine types (Latin American vs Japanese). There are no matching attributes indicating they refer to the same real-world restaurant.",
+      "provenance": {
+        "tokens": {
+          "prompt": 283,
+          "completion": 108
+        },
+        "cost_usd": 0.00067515,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f853",
+      "right_id": "z121",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The records have completely different names, addresses, and phone numbers, indicating they are two distinct restaurants.",
+      "provenance": {
+        "tokens": {
+          "prompt": 281,
+          "completion": 449
+        },
+        "cost_usd": 0.00186655,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f592",
+      "right_id": "z122",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The two records have completely different names (second avenue deli vs. zarela), addresses (156 2nd ave. vs. 953 second ave.), phone numbers, and restaurant types (delicatessen vs. mexican). There is no overlap in any identifying details.",
+      "provenance": {
+        "tokens": {
+          "prompt": 288,
+          "completion": 196
+        },
+        "cost_usd": 0.0009884,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f967",
+      "right_id": "z123",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The records have completely different names (cafe roma vs. andre's french restaurant), addresses (3570 las vegas blvd. s vs. 401 s. 6th st.), phone numbers, and types. There is no overlap indicating these refer to the same restaurant.",
+      "provenance": {
+        "tokens": {
+          "prompt": 297,
+          "completion": 87
+        },
+        "cost_usd": 0.00061635,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f979",
+      "right_id": "z123",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The records have completely different names, addresses, phone numbers, and restaurant types, indicating they are two distinct restaurants in Las Vegas.",
+      "provenance": {
+        "tokens": {
+          "prompt": 297,
+          "completion": 156
+        },
+        "cost_usd": 0.0008578500000000001,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f966",
+      "right_id": "z123",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The records have completely different names (\"cafe michelle\" vs \"andre's french restaurant\"), addresses, phone numbers, and cuisine types. There is no overlap in any identifying attributes.",
+      "provenance": {
+        "tokens": {
+          "prompt": 292,
+          "completion": 72
+        },
+        "cost_usd": 0.0005586,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f963",
+      "right_id": "z124",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.1,
+      "reasoning": "The records have different names (bistro vs buccaneer bay club), different addresses (3400 vs 3300 Las Vegas Blvd S), and different phone numbers. These are almost certainly different restaurants.",
+      "provenance": {
+        "tokens": {
+          "prompt": 291,
+          "completion": 143
+        },
+        "cost_usd": 0.0008060500000000001,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f601",
+      "right_id": "z124",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The restaurant names, phone numbers, and cuisine types are completely different. While the addresses are close (3200 vs 3300 Las Vegas Blvd. S), on the Las Vegas Strip these numbers correspond to different large resort properties. Therefore, these are definitely different restaurants.",
+      "provenance": {
+        "tokens": {
+          "prompt": 292,
+          "completion": 198
+        },
+        "cost_usd": 0.0009996,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f983",
+      "right_id": "z124",
+      "label": true,
+      "source": "teacher",
+      "confidence": 1.0,
+      "reasoning": "The records have completely different names, addresses, phone numbers, and types. \"The Bacchanal\" is at Caesars Palace (3570 Las Vegas Blvd. S) while \"Buccaneer Bay Club\" is at Treasure Island (3300 Las Vegas Blvd. S.). There is no overlap in any identifying information.",
+      "provenance": {
+        "tokens": {
+          "prompt": 300,
+          "completion": 234
+        },
+        "cost_usd": 0.001134,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f967",
+      "right_id": "z124",
+      "label": true,
+      "source": "teacher",
+      "confidence": 1.0,
+      "reasoning": "The restaurants have completely different names, addresses",
+      "provenance": {
+        "tokens": {
+          "prompt": 298,
+          "completion": 191
+        },
+        "cost_usd": 0.0009814000000000001,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f985",
+      "right_id": "z125",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The records have different restaurant names, different street numbers on the same road, different phone numbers, and different cuisine types, indicating they are clearly different establishments.",
+      "provenance": {
+        "tokens": {
+          "prompt": 295,
+          "completion": 440
+        },
+        "cost_usd": 0.0018497500000000003,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f969",
+      "right_id": "z125",
+      "label": true,
+      "source": "teacher",
+      "confidence": 0.95,
+      "reasoning": "Both records share the same address (3700 W. Flamingo Rd. in Las Vegas, which is the Rio Hotel), but they represent two different restaurants locatedwithin the same hotel. \"Carnival World\" is a buffet, while \"Buzio's in the Rio\" is a seafood restaurant. The names, phone numbers, and types are all distinctly different.",
+      "provenance": {
+        "tokens": {
+          "prompt": 295,
+          "completion": 248
+        },
+        "cost_usd": 0.00117775,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f967",
+      "right_id": "z125",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The restaurants have completely different names, addresses, and phone numbers. Cafe Roma is a coffee shop/diner on Las Vegas Blvd, while Buzio's in the Rio is a seafood restaurant on Flamingo Rd. There is no overlap in any identifying information.",
+      "provenance": {
+        "tokens": {
+          "prompt": 299,
+          "completion": 215
+        },
+        "cost_usd": 0.00106645,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f606",
+      "right_id": "z126",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The two records have completely different names (\"steak house\" vs \"emeril's new orleans fish house\"), different addresses (2880 vs 3799 Las Vegas Blvd. S), different phone numbers, and different cuisine types (steak houses vs seafood). They are clearly distinct restaurants.",
+      "provenance": {
+        "tokens": {
+          "prompt": 304,
+          "completion": 327
+        },
+        "cost_usd": 0.0014636999999999999,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f689",
+      "right_id": "z126",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The records differ in name, address, city, phone number, and cuisine type. Record A is \"orleans\" in Los Angeles, while Record B is \"emeril's new orleans fish house\" in Las Vegas. There is no evidence suggesting these are the same real-world restaurant.",
+      "provenance": {
+        "tokens": {
+          "prompt": 294,
+          "completion": 101
+        },
+        "cost_usd": 0.0006622,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f985",
+      "right_id": "z127",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The two records have completely different restaurant names, addresses (different block on the same street), phone numbers, and cuisine types (Mexican vs. Italian), indicating they are distinct restaurants.",
+      "provenance": {
+        "tokens": {
+          "prompt": 295,
+          "completion": 150
+        },
+        "cost_usd": 0.00083475,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f966",
+      "right_id": "z127",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The records have completely different names (\"cafe michelle\" vs \"fiore rotisserie & grille\"), different addresses (\"1350 e. flamingo rd.\" vs \"3700 w. flamingo rd.\"), different phone numbers, and different cuisine types (american vs italian). There is no evidence suggesting these refer to the same real-world restaurant.",
+      "provenance": {
+        "tokens": {
+          "prompt": 294,
+          "completion": 183
+        },
+        "cost_usd": 0.0009492000000000001,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f957",
+      "right_id": "z127",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.05,
+      "reasoning": "While the two records share the same street address and city, the restaurant names (\"antonio's\" vs. \"fiore rotisserie & grille\") and phone numbers (702/252-7737 vs. 702-252-7702) are completely different. This suggests they are likely different restaurants located in the same building or shopping plaza.",
+      "provenance": {
+        "tokens": {
+          "prompt": 291,
+          "completion": 311
+        },
+        "cost_usd": 0.00139405,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f605",
+      "right_id": "z128",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The restaurantshave completely different names (\"second street grille\" vs \"hugo's cellar\"), different phone numbers, and slightly different street numbers. They are located on the same street but are distinct entities.",
+      "provenance": {
+        "tokens": {
+          "prompt": 282,
+          "completion": 295
+        },
+        "cost_usd": 0.0013286,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f985",
+      "right_id": "z128",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The records have completely different names (viva mercado's vs hugo's cellar), addresses (6182 w. flamingo rd. vs 202 e. fremont st.), phone numbers, and cuisines (mexican vs continental), indicating they are two different restaurants in Las Vegas.",
+      "provenance": {
+        "tokens": {
+          "prompt": 286,
+          "completion": 148
+        },
+        "cost_usd": 0.0008183000000000001,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f963",
+      "right_id": "z129",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The restaurant names (\"bistro\" vs \"madame ching's\"), types (\"continental\" vs \"asian\"), addresses (3400 vs 3300), and phone number prefixes (791 vs 894) are all different, indicating these are distinct restaurants.",
+      "provenance": {
+        "tokens": {
+          "prompt": 290,
+          "completion": 293
+        },
+        "cost_usd": 0.0013300000000000002,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f981",
+      "right_id": "z130",
+      "label": true,
+      "source": "teacher",
+      "confidence": 1.0,
+      "reasoning": "The records have completely different names, addresses (400 E. Sahara vs 4750 W. Sahara), phone numbers, and cuisines (continental vs chinese), indicating they are entirely different restaurants.",
+      "provenance": {
+        "tokens": {
+          "prompt": 289,
+          "completion": 214
+        },
+        "cost_usd": 0.00105245,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f975",
+      "right_id": "z130",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The records have completely different names, addresses, phone numbers, and restaurant types. They only share the same city and street name (Sahara Ave), but at different addresses.",
+      "provenance": {
+        "tokens": {
+          "prompt": 288,
+          "completion": 69
+        },
+        "cost_usd": 0.0005439,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f986",
+      "right_id": "z130",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The records have completely different names (\"yolie's\" vs \"mayflower cuisinier\"), addresses, phone numbers, and cuisine types. They are definitively different restaurants.",
+      "provenance": {
+        "tokens": {
+          "prompt": 288,
+          "completion": 197
+        },
+        "cost_usd": 0.0009919,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f959",
+      "right_id": "z130",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The records have completely different restaurant names, street addresses, and phone numbers. There is no evidence suggesting they refer to the same real-world restaurant.",
+      "provenance": {
+        "tokens": {
+          "prompt": 289,
+          "completion": 59
+        },
+        "cost_usd": 0.0005099499999999999,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f983",
+      "right_id": "z131",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.05,
+      "reasoning": "The records have completely different restaurant names (\"the bacchanal\" vs \"michael's\"), different addresses (3570 vs 3595 Las Vegas Blvd. S), and different phone numbers. These are distinct restaurants in Las Vegas.",
+      "provenance": {
+        "tokens": {
+          "prompt": 303,
+          "completion": 153
+        },
+        "cost_usd": 0.0008536500000000001,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f963",
+      "right_id": "z131",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The records have completely different names (\"bistro\" vs \"michael's (las vegas)\"), different street numbers on the same street (3400 vs 3595), and different phone numbers (791-7111 vs 737-7111). These refer to different restaurants.",
+      "provenance": {
+        "tokens": {
+          "prompt": 294,
+          "completion": 297
+        },
+        "cost_usd": 0.0013482000000000001,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f961",
+      "right_id": "z131",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The restaurants have completely different names, phone numbers, and cuisine types. Although they are located on the same street in Las Vegas, their street numbers are different (3570 vs. 3595), indicating they are separate establishments.",
+      "provenance": {
+        "tokens": {
+          "prompt": 299,
+          "completion": 183
+        },
+        "cost_usd": 0.00095445,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f980",
+      "right_id": "z131",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The restaurant names are entirely different (mikado vs michael's), the addresses are different (3400 vs 3595 Las Vegas Blvd. S), the phone numbers are different, and the cuisine types do not match (asian vs continental). These are distinct restaurants.",
+      "provenance": {
+        "tokens": {
+          "prompt": 297,
+          "completion": 188
+        },
+        "cost_usd": 0.00096985,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f963",
+      "right_id": "z132",
+      "label": true,
+      "source": "teacher",
+      "confidence": 0.95,
+      "reasoning": "The records have different names (\"bistro\" vs \"monte carlo\"), different addresses (3400 vs 3145 Las Vegas Blvd. S), and different phone numbers. These are clearly two distinct restaurants in Las Vegas.",
+      "provenance": {
+        "tokens": {
+          "prompt": 292,
+          "completion": 138
+        },
+        "cost_usd": 0.0007896,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f983",
+      "right_id": "z132",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The records have completely different names (\"the bacchanal\" vs \"monte carlo\"), different addresses (3570 vs 3145 Las Vegas Blvd. S), and different phone numbers. There is no overlap in any key identifying fields.",
+      "provenance": {
+        "tokens": {
+          "prompt": 301,
+          "completion": 193
+        },
+        "cost_usd": 0.00099155,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f972",
+      "right_id": "z132",
+      "label": true,
+      "source": "teacher",
+      "confidence": 1.0,
+      "reasoning": "The names, addresses, phone numbers, and cuisine types are all different. Empress Court at 3570 Las Vegas Blvd. S (Asian) and Monte Carlo at 3145 Las Vegas Blvd. S (French) are clearly distinct restaurants.",
+      "provenance": {
+        "tokens": {
+          "prompt": 297,
+          "completion": 197
+        },
+        "cost_usd": 0.00100135,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f963",
+      "right_id": "z133",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "Although the records share the same street address (likely a large hotel/casino on the Las Vegas strip that houses multiple restaurants), the restaurant names (\"bistro\" vs \"moongate\"), phone numbers, and cuisine types (\"continental\" vs \"chinese\") are completely different. These are distinct restaurants located at the same address.",
+      "provenance": {
+        "tokens": {
+          "prompt": 286,
+          "completion": 218
+        },
+        "cost_usd": 0.0010633,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f983",
+      "right_id": "z133",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The records have completely different names (the bacchanal vs. moongate), addresses (3570 vs 3400 Las Vegas Blvd. S), and phone numbers, indicating they are distinct restaurants.",
+      "provenance": {
+        "tokens": {
+          "prompt": 295,
+          "completion": 155
+        },
+        "cost_usd": 0.00085225,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f601",
+      "right_id": "z133",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The restaurant names (\"chin's\" vs \"moongate\"), addresses (\"3200\" vs \"3400\" Las Vegas Blvd S), and phone numbers are all completely different. These are distinct restaurants on the Las Vegas Strip.",
+      "provenance": {
+        "tokens": {
+          "prompt": 287,
+          "completion": 233
+        },
+        "cost_usd": 0.00111685,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f601",
+      "right_id": "z134",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The records have completely different restaurant names (\"chin's\" vs \"morton's of chicago\"), different phone numbers, and different cuisine types (asian vs steakhouses). While they share the same address, this is likely because they are located in the same large resort/casino complex on the Las Vegas Strip. They are clearly different restaurants.",
+      "provenance": {
+        "tokens": {
+          "prompt": 299,
+          "completion": 150
+        },
+        "cost_usd": 0.00083895,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f983",
+      "right_id": "z134",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The records have completely different names, addresses, phone numbers, and restaurant types, clearly indicating they refer to two different real-world restaurants.",
+      "provenance": {
+        "tokens": {
+          "prompt": 307,
+          "completion": 101
+        },
+        "cost_usd": 0.00067585,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f963",
+      "right_id": "z134",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The records have different names, different street addresses (3400 vs 3200 Las Vegas Blvd), different phone numbers, and different restaurant types. There is no evidence to suggest these are the same restaurant.",
+      "provenance": {
+        "tokens": {
+          "prompt": 298,
+          "completion": 212
+        },
+        "cost_usd": 0.0010549000000000001,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f969",
+      "right_id": "z135",
+      "label": true,
+      "source": "teacher",
+      "confidence": 1.0,
+      "reasoning": "The two records have entirely different names (\"carnival world\" vs \"nicky blair's\"), addresses (\"3700 w. flamingo rd.\" vs \"3925 paradise rd.\"), phone numbers, and restaurant types (\"buffets\" vs \"italian\"). They clearly refer to different restaurants in Las Vegas.",
+      "provenance": {
+        "tokens": {
+          "prompt": 287,
+          "completion": 198
+        },
+        "cost_usd": 0.00099435,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f966",
+      "right_id": "z135",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The records have completely different names, addresses, phone numbers, and cuisine types. There is no overlap in any identifying fields other than the city.",
+      "provenance": {
+        "tokens": {
+          "prompt": 286,
+          "completion": 404
+        },
+        "cost_usd": 0.0017143000000000002,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f958",
+      "right_id": "z135",
+      "label": true,
+      "source": "teacher",
+      "confidence": 1.0,
+      "reasoning": "The records have completely different names, addresses, phone numbers, and restaurant types, indicating they are distinct restaurants in Las Vegas.",
+      "provenance": {
+        "tokens": {
+          "prompt": 293,
+          "completion": 182
+        },
+        "cost_usd": 0.00094465,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f984",
+      "right_id": "z135",
+      "label": true,
+      "source": "teacher",
+      "confidence": 1.0,
+      "reasoning": "The two records have completely different names, addresses, and phone numbers. They are clearly different Italian restaurants in Las Vegas.",
+      "provenance": {
+        "tokens": {
+          "prompt": 287,
+          "completion": 161
+        },
+        "cost_usd": 0.0008648499999999999,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f966",
+      "right_id": "z136",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The records have entirely different names (cafe michelle vs. piero's restaurant), addresses (1350 e. flamingo rd. vs. 355 convention center dr.), phone numbers, and cuisine types (american vs. italian). There are no matching attributes indicating they are the same restaurant.",
+      "provenance": {
+        "tokens": {
+          "prompt": 283,
+          "completion": 100
+        },
+        "cost_usd": 0.00064715,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f967",
+      "right_id": "z136",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The two records have completely different names (cafe roma vs. piero's restaurant), addresses (3570 las vegas blvd. s vs. 355 convention center dr.), phone numbers, and cuisine types (coffee shops/diners vs. italian). There is no evidence linking these two records to the same real-world restaurant.",
+      "provenance": {
+        "tokens": {
+          "prompt": 288,
+          "completion": 120
+        },
+        "cost_usd": 0.0007224,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f969",
+      "right_id": "z136",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The restaurants have completely different names (\"carnival world\" vs \"piero's restaurant\"), addresses (\"3700 w. flamingo rd.\" vs \"355 convention center dr.\"), phone numbers, and types (\"buffets\" vs \"italian\"). There is no overlap in any identifying information.",
+      "provenance": {
+        "tokens": {
+          "prompt": 284,
+          "completion": 183
+        },
+        "cost_usd": 0.0009387,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f982",
+      "right_id": "z136",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The two records have completely different restaurant names, addresses, phone numbers, and cuisine types. There is no evidence to suggest they refer to the same real-world restaurant.",
+      "provenance": {
+        "tokens": {
+          "prompt": 288,
+          "completion": 131
+        },
+        "cost_usd": 0.0007609000000000001,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f963",
+      "right_id": "z137",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The two records have completely different names (\"bistro\" vs \"spago (las vegas)\"), different phone numbers, and slightly different street numbers (3400 vs 3500 Las Vegas Blvd. S), indicating they are distinct restaurants.",
+      "provenance": {
+        "tokens": {
+          "prompt": 292,
+          "completion": 417
+        },
+        "cost_usd": 0.0017661,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f983",
+      "right_id": "z137",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The records have completely different names, addresses, phone numbers, and types. \"The Bacchanal\" and \"Spago\" are distinct restaurants located at different addresses on Las Vegas Blvd.",
+      "provenance": {
+        "tokens": {
+          "prompt": 301,
+          "completion": 154
+        },
+        "cost_usd": 0.00085505,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f980",
+      "right_id": "z137",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The records have completely different restaurant names (mikado vs. spago), different street addresses (3400 vs. 3500 las vegas blvd. s), different phone numbers, and different cuisine types.",
+      "provenance": {
+        "tokens": {
+          "prompt": 295,
+          "completion": 477
+        },
+        "cost_usd": 0.00197925,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f983",
+      "right_id": "z139",
+      "label": true,
+      "source": "teacher",
+      "confidence": 1.0,
+      "reasoning": "The records have completely different names, addresses, and phone numbers, clearly indicating they refer to different restaurants in Las Vegas.",
+      "provenance": {
+        "tokens": {
+          "prompt": 289,
+          "completion": 131
+        },
+        "cost_usd": 0.00076195,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f963",
+      "right_id": "z140",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The two records have different names (\"bistro\" vs \"sterling brunch\"), different addresses (3400 vs 3645 las vegas blvd. s), different phone numbers, and different cuisine types. There are no overlapping attributes that suggest these refer to the same restaurant.",
+      "provenance": {
+        "tokens": {
+          "prompt": 288,
+          "completion": 183
+        },
+        "cost_usd": 0.0009429,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f601",
+      "right_id": "z140",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The records have completely different names, addresses, phone numbers, and cuisine types, indicating they are distinct restaurants.",
+      "provenance": {
+        "tokens": {
+          "prompt": 289,
+          "completion": 176
+        },
+        "cost_usd": 0.00091945,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f958",
+      "right_id": "z140",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.1,
+      "reasoning": "Both records share the same address because they are located within the same hotel (Bally's Las Vegas), but \"Bally's Big Kitchen\" (a buffet) and \"Sterling Brunch\" (an eclectic brunch spot) are distinct restaurants with different names, phone numbers, and types.",
+      "provenance": {
+        "tokens": {
+          "prompt": 297,
+          "completion": 312
+        },
+        "cost_usd": 0.00140385,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f983",
+      "right_id": "z141",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The restaurant names (\"the bacchanal\" vs \"tre visi\"), phone numbers, street addresses (3570 vs 3799 Las Vegas Blvd. S), and types are completely different. They refer to distinct real-world restaurants in Las Vegas.",
+      "provenance": {
+        "tokens": {
+          "prompt": 297,
+          "completion": 199
+        },
+        "cost_usd": 0.00100835,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f601",
+      "right_id": "z141",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The restaurants have completely different names (\"chin's\" vs \"tre visi\"), addresses (3200 vs 3799 Las Vegas Blvd S), phone numbers, and cuisine types (Asian vs Italian). These are clearly two different establishments.",
+      "provenance": {
+        "tokens": {
+          "prompt": 289,
+          "completion": 174
+        },
+        "cost_usd": 0.00091245,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f920",
+      "right_id": "z143",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The two records have completely different names (bistango vs. alon's at the terrace), different street addresses (1100 vs. 659 peachtree st.), different phone numbers, and different cuisine types (mediterranean vs. sandwiches). They are clearly distinct restaurants on the same street in Atlanta.",
+      "provenance": {
+        "tokens": {
+          "prompt": 283,
+          "completion": 97
+        },
+        "cost_usd": 0.00063665,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f610",
+      "right_id": "z143",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The two records have completely different names, addresses, phone numbers, and restaurant types. They are clearly distinct restaurants in Atlanta.",
+      "provenance": {
+        "tokens": {
+          "prompt": 281,
+          "completion": 169
+        },
+        "cost_usd": 0.0008865500000000001,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f608",
+      "right_id": "z143",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The records have completely different names (abruzzi vs. alon's at the terrace), addresses (2355 peachtree rd. vs. 659 peachtree st.), phone numbers, and cuisine types (italian vs. sandwiches). There is no evidence these refer to the same restaurant.",
+      "provenance": {
+        "tokens": {
+          "prompt": 296,
+          "completion": 91
+        },
+        "cost_usd": 0.0006293,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f615",
+      "right_id": "z143",
+      "label": true,
+      "source": "teacher",
+      "confidence": 1.0,
+      "reasoning": "The restaurants have completely different names, addresses, phone numbers, and types. There is no overlap in any identifying information.",
+      "provenance": {
+        "tokens": {
+          "prompt": 297,
+          "completion": 191
+        },
+        "cost_usd": 0.00098035,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f920",
+      "right_id": "z146",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The records have completely different names, addresses, and phone numbers. They are clearly two different restaurants in Atlanta.",
+      "provenance": {
+        "tokens": {
+          "prompt": 290,
+          "completion": 181
+        },
+        "cost_usd": 0.000938,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f951",
+      "right_id": "z147",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The restaurant names, addresses, and phone numbers are completely different. There are no overlapping identifiers to suggest these refer to the same real-world restaurant.",
+      "provenance": {
+        "tokens": {
+          "prompt": 293,
+          "completion": 145
+        },
+        "cost_usd": 0.0008151500000000001,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f947",
+      "right_id": "z147",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The records have completely different names, addresses, and phone numbers, indicating they refer to different restaurants.",
+      "provenance": {
+        "tokens": {
+          "prompt": 310,
+          "completion": 162
+        },
+        "cost_usd": 0.0008925000000000001,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f926",
+      "right_id": "z148",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The two records have entirely different names, addresses, and phone numbers. There are no common identifiers or overlapping attributes to suggest they refer to the same restaurant.",
+      "provenance": {
+        "tokens": {
+          "prompt": 293,
+          "completion": 72
+        },
+        "cost_usd": 0.0005596500000000001,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f625",
+      "right_id": "z148",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The restaurants have completely different names, addresses, phone numbers, and cuisine types. They are clearly distinct real-world restaurants.",
+      "provenance": {
+        "tokens": {
+          "prompt": 300,
+          "completion": 90
+        },
+        "cost_usd": 0.0006299999999999999,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f623",
+      "right_id": "z149",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The records have different names (\"cafe ritz-carlton buckhead\" vs \"brookhaven cafe\"), different addresses (3443 vs 4274 peachtree rd.), and different phone numbers. These are clearly different restaurants.",
+      "provenance": {
+        "tokens": {
+          "prompt": 300,
+          "completion": 115
+        },
+        "cost_usd": 0.0007175,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f623",
+      "right_id": "z150",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The records have completely different names (\"cafe ritz-carlton buckhead\" vs \"cafe sunflower\"), addresses (3434 peachtree rd. vs 5975 roswell rd.), and phone numbers. They are definitely different restaurants in Atlanta.",
+      "provenance": {
+        "tokens": {
+          "prompt": 302,
+          "completion": 167
+        },
+        "cost_usd": 0.0009016,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f871",
+      "right_id": "z152",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The records have entirely different names, addresses, cities, phone numbers, and cuisine types, indicating they are clearly different restaurants.",
+      "provenance": {
+        "tokens": {
+          "prompt": 301,
+          "completion": 62
+        },
+        "cost_usd": 0.00053305,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f979",
+      "right_id": "z152",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The records have completely different names (\"mary's diner\" vs \"carey's\"), addresses, cities (Las Vegas vs Marietta), and phone numbers. They are clearly distinct restaurants.",
+      "provenance": {
+        "tokens": {
+          "prompt": 295,
+          "completion": 75
+        },
+        "cost_usd": 0.0005722500000000001,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f932",
+      "right_id": "z153",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The records have completely different names, addresses (different street numbers and cities), phone numbers, and cuisine types. There is no evidence to suggest these refer to the same restaurant.",
+      "provenance": {
+        "tokens": {
+          "prompt": 286,
+          "completion": 235
+        },
+        "cost_usd": 0.0011228,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f622",
+      "right_id": "z153",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The restaurant names,",
+      "provenance": {
+        "tokens": {
+          "prompt": 292,
+          "completion": 100
+        },
+        "cost_usd": 0.0006566,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f618",
+      "right_id": "z156",
+      "label": true,
+      "source": "teacher",
+      "confidence": 1.0,
+      "reasoning": "The restaurant names, addresses, phone numbers, and cuisine types are all completely different, indicating they are distinct restaurants in Atlanta.",
+      "provenance": {
+        "tokens": {
+          "prompt": 299,
+          "completion": 188
+        },
+        "cost_usd": 0.00097195,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f613",
+      "right_id": "z157",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The records have different names (Ciboulette vs. Eats), different addresses (1529 Piedmont Ave vs. 600 Ponce de Leon Ave), different phone numbers, and different cuisine types (French vs. Italian). There is no evidence to suggest these refer to the same restaurant.",
+      "provenance": {
+        "tokens": {
+          "prompt": 280,
+          "completion": 153
+        },
+        "cost_usd": 0.0008295,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f913",
+      "right_id": "z157",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The records have completely different names (\"abbey\" vs \"eats\"), different street numbers (163 vs 600), and different phone numbers. They are clearly different restaurants that happen to be on the same street in Atlanta.",
+      "provenance": {
+        "tokens": {
+          "prompt": 279,
+          "completion": 174
+        },
+        "cost_usd": 0.0009019499999999999,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f613",
+      "right_id": "z158",
+      "label": true,
+      "source": "teacher",
+      "confidence": 1.0,
+      "reasoning": "The records have completely different names, addresses, phone numbers, and restaurant types. They are clearly two distinct restaurants in Atlanta.",
+      "provenance": {
+        "tokens": {
+          "prompt": 286,
+          "completion": 127
+        },
+        "cost_usd": 0.0007448000000000001,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f920",
+      "right_id": "z158",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The records have completely different names (\"bistango\" vs \"flying biscuit the\"), addresses (\"1100 peachtree st.\" vs \"1655 mclendon ave.\"), and phone numbers (\"404/724-0901\" vs \"404-687-8888\"). They clearly refer to different restaurants.",
+      "provenance": {
+        "tokens": {
+          "prompt": 285,
+          "completion": 192
+        },
+        "cost_usd": 0.0009712500000000001,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f926",
+      "right_id": "z158",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The records have completely different names, addresses, phone numbers, and restaurant types, indicating they are distinct restaurants in Atlanta.",
+      "provenance": {
+        "tokens": {
+          "prompt": 288,
+          "completion": 122
+        },
+        "cost_usd": 0.0007294000000000001,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f941",
+      "right_id": "z158",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The two records have completely different restaurant names (mckinnon's louisiane vs. flying biscuit), different addresses (3209 maple dr. vs. 1655 mclendon ave.), different phone numbers, and different cuisine types. There is no indication these refer to the same real-world restaurant.",
+      "provenance": {
+        "tokens": {
+          "prompt": 289,
+          "completion": 168
+        },
+        "cost_usd": 0.00089145,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f920",
+      "right_id": "z159",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The records have completely different names (bistango vs. frijoleros), addresses (1100 vs. 1031 peachtree st.), phone numbers, and cuisine types (mediterranean vs. tex-mex). There is no evidence these refer to the same real-world restaurant.",
+      "provenance": {
+        "tokens": {
+          "prompt": 285,
+          "completion": 95
+        },
+        "cost_usd": 0.0006317499999999999,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f635",
+      "right_id": "z159",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The records differ across all key attributes—name, address, city, phone number, and cuisine type—with no overlap, indicating they are clearly distinct restaurants in different cities.",
+      "provenance": {
+        "tokens": {
+          "prompt": 288,
+          "completion": 72
+        },
+        "cost_usd": 0.0005544,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f693",
+      "right_id": "z160",
+      "label": true,
+      "source": "teacher",
+      "confidence": 1.0,
+      "reasoning": "The records have completely different names, addresses, cities, phone numbers, and cuisine types. They are clearly distinct restaurants.",
+      "provenance": {
+        "tokens": {
+          "prompt": 281,
+          "completion": 54
+        },
+        "cost_usd": 0.00048405,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f941",
+      "right_id": "z160",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The records have completely different names, addresses, cities, and phone numbers. There is no evidence to suggest these refer to the same restaurant.",
+      "provenance": {
+        "tokens": {
+          "prompt": 284,
+          "completion": 152
+        },
+        "cost_usd": 0.0008302000000000001,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f685",
+      "right_id": "z160",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The records have completely different names, addresses, cities, and phone numbers, indicating they are entirely different restaurants in different locations.",
+      "provenance": {
+        "tokens": {
+          "prompt": 280,
+          "completion": 161
+        },
+        "cost_usd": 0.0008575,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f618",
+      "right_id": "z161",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The records have completely different names, addresses, phone numbers, and restaurant types. They only share the same city, making it certain they are different restaurants.",
+      "provenance": {
+        "tokens": {
+          "prompt": 288,
+          "completion": 412
+        },
+        "cost_usd": 0.0017444,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f625",
+      "right_id": "z162",
+      "label": true,
+      "source": "teacher",
+      "confidence": 1.0,
+      "reasoning": "The records have completely different names, addresses, phone numbers, and restaurant types. There is no overlap in any identifying fields, indicating they are distinct restaurants in Atlanta.",
+      "provenance": {
+        "tokens": {
+          "prompt": 292,
+          "completion": 78
+        },
+        "cost_usd": 0.0005796,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f615",
+      "right_id": "z162",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The records have completely different names, addresses, phone numbers, and restaurant types, clearly indicating they are two different restaurants in Atlanta.",
+      "provenance": {
+        "tokens": {
+          "prompt": 296,
+          "completion": 135
+        },
+        "cost_usd": 0.0007833,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f930",
+      "right_id": "z162",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The two records have entirely different names, addresses, phone numbers, and cuisine types. There is no indication they refer to the same restaurant.",
+      "provenance": {
+        "tokens": {
+          "prompt": 299,
+          "completion": 55
+        },
+        "cost_usd": 0.0005064500000000001,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f662",
+      "right_id": "z163",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The two records have entirely different names (\"chan dara\" vs \"house of chan\"), different cities (los angeles vs smyrna), and different addresses. There is no overlap in any identifying attributes, indicating they are completely separate restaurants.",
+      "provenance": {
+        "tokens": {
+          "prompt": 287,
+          "completion": 118
+        },
+        "cost_usd": 0.0007143499999999999,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f637",
+      "right_id": "z163",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The two records have completely different names, addresses, cities, and phone numbers. They are located in different states and have no matching attributes.",
+      "provenance": {
+        "tokens": {
+          "prompt": 295,
+          "completion": 260
+        },
+        "cost_usd": 0.00121975,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f847",
+      "right_id": "z163",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The records have entirely different names, addresses, cities, phone numbers, and cuisine types. There are no matching attributes to suggest these refer to the same restaurant.",
+      "provenance": {
+        "tokens": {
+          "prompt": 297,
+          "completion": 76
+        },
+        "cost_usd": 0.00057785,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f581",
+      "right_id": "z164",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The records have completely different names, addresses, cities, phone numbers, and cuisine types, indicating they refer to entirely different restaurants.",
+      "provenance": {
+        "tokens": {
+          "prompt": 299,
+          "completion": 59
+        },
+        "cost_usd": 0.00052045,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f898",
+      "right_id": "z164",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The records have entirely different names, addresses, cities, phone numbers, and cuisine types, indicating they refer to completely different restaurants.",
+      "provenance": {
+        "tokens": {
+          "prompt": 289,
+          "completion": 187
+        },
+        "cost_usd": 0.00095795,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f683",
+      "right_id": "z164",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The records have completely different names, addresses, cities, phone numbers, and restaurant types. They clearly refer to different restaurants.",
+      "provenance": {
+        "tokens": {
+          "prompt": 286,
+          "completion": 429
+        },
+        "cost_usd": 0.0018018,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f913",
+      "right_id": "z165",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The two records have completely different names (\"abbey\" vs \"java jive\"), addresses (\"163 ponce de leon ave.\" vs \"790 ponce de leon ave.\"), phone numbers, and types. Although they are on the same street in the same city, all key identifying attributes indicate they are distinct restaurants.",
+      "provenance": {
+        "tokens": {
+          "prompt": 284,
+          "completion": 171
+        },
+        "cost_usd": 0.0008967000000000001,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f919",
+      "right_id": "z166",
+      "label": true,
+      "source": "teacher",
+      "confidence": 1.0,
+      "reasoning": "The records have completely different names (\"bertolini's\" vs \"johnny rockets\"), addresses, phone numbers, and cuisines (Italian vs American). There is no overlap in any field, so these are definitively different restaurants.",
+      "provenance": {
+        "tokens": {
+          "prompt": 297,
+          "completion": 134
+        },
+        "cost_usd": 0.00078085,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f946",
+      "right_id": "z166",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The two records have completely different names, addresses, phone numbers, and cuisine types. One is an Italian restaurant on Pharr Rd., while the other is an American restaurant on Cobb Pkwy. There is no overlap in any identifying fields.",
+      "provenance": {
+        "tokens": {
+          "prompt": 283,
+          "completion": 71
+        },
+        "cost_usd": 0.00054565,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f931",
+      "right_id": "z166",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The restaurants have completely different names (holt bros. bar-b-q vs johnny rockets), different addresses (Jimmy Carter Blvd in Norcross vs Cobb Pkwy), different phone numbers, and different cuisine types (barbecue vs american). These are clearly different real-world restaurants.",
+      "provenance": {
+        "tokens": {
+          "prompt": 323,
+          "completion": 117
+        },
+        "cost_usd": 0.00074865,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f623",
+      "right_id": "z167",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The two records have completely different names, addresses, phone numbers, and cities. They clearly refer to different restaurants.",
+      "provenance": {
+        "tokens": {
+          "prompt": 304,
+          "completion": 183
+        },
+        "cost_usd": 0.0009597,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f545",
+      "right_id": "z168",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The records have completely different names (l'orangerie vs la fonda latina), cities (los angeles vs atlanta), addresses, phone numbers, and cuisines. They are clearly two different restaurants.",
+      "provenance": {
+        "tokens": {
+          "prompt": 297,
+          "completion": 108
+        },
+        "cost_usd": 0.00068985,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f667",
+      "right_id": "z168",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The records have entirely different names (drai's vs la fonda latina), cities (Los Angeles vs Atlanta), addresses, and cuisines (french vs spanish). There is no overlap in any identifying information.",
+      "provenance": {
+        "tokens": {
+          "prompt": 293,
+          "completion": 121
+        },
+        "cost_usd": 0.0007311500000000001,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f930",
+      "right_id": "z169",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The records have completely different names, addresses, cities, phone numbers, and restaurant types, indicating they refer to entirely different establishments.",
+      "provenance": {
+        "tokens": {
+          "prompt": 308,
+          "completion": 446
+        },
+        "cost_usd": 0.0018843999999999998,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f1063",
+      "right_id": "z169",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The records have completely different names, addresses, cities, phone numbers, and cuisine types. There is no overlap in any identifying information, indicating they are clearly different restaurants.",
+      "provenance": {
+        "tokens": {
+          "prompt": 297,
+          "completion": 69
+        },
+        "cost_usd": 0.00055335,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f613",
+      "right_id": "z170",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The two records have different names, addresses, phone numbers, and restaurant types. There are no overlapping identifiers or similarities that would suggest they refer to the same real-world restaurant.",
+      "provenance": {
+        "tokens": {
+          "prompt": 283,
+          "completion": 239
+        },
+        "cost_usd": 0.00113365,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f920",
+      "right_id": "z170",
+      "label": true,
+      "source": "teacher",
+      "confidence": 1.0,
+      "reasoning": "The records have completely different names (\"bistango\" vs \"majestic\"), addresses (\"1100 peachtree st.\" vs \"1031 ponce de leon ave.\"), phone numbers, and restaurant types (\"mediterranean\" vs \"diners\"). There is no overlap in any identifying attributes other than the city.",
+      "provenance": {
+        "tokens": {
+          "prompt": 282,
+          "completion": 227
+        },
+        "cost_usd": 0.0010906,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f921",
+      "right_id": "z170",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The records have completely different names (cafe renaissance vs majestic), addresses, phone numbers, and cuisine types. They are clearly different restaurants.",
+      "provenance": {
+        "tokens": {
+          "prompt": 298,
+          "completion": 64
+        },
+        "cost_usd": 0.0005369,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f685",
+      "right_id": "z171",
+      "label": true,
+      "source": "teacher",
+      "confidence": 1.0,
+      "reasoning": "The records refer to different locations of the Morton's chain. Record A is in Los Angeles (8764 Melrose Ave, phone 310/276-5205), while Record B is in Atlanta (303 Peachtree St. NE, phone 404-577-4366). Different addresses, cities, and phone numbers indicate these are separate restaurant locations.",
+      "provenance": {
+        "tokens": {
+          "prompt": 292,
+          "completion": 181
+        },
+        "cost_usd": 0.0009401000000000001,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f935",
+      "right_id": "z172",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The records have completely different names (\"kamogawa\" vs \"my thai\"), addresses (\"3300 peachtree rd.\" vs \"1248 clairmont rd.\"), and phone numbers. There are no matching fields other than city.",
+      "provenance": {
+        "tokens": {
+          "prompt": 287,
+          "completion": 137
+        },
+        "cost_usd": 0.00078085,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f935",
+      "right_id": "z174",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The two records have entirely different names, addresses, phone numbers, and cuisine types (Asian vs. Mexican). They are clearly two different restaurants in Atlanta.",
+      "provenance": {
+        "tokens": {
+          "prompt": 303,
+          "completion": 198
+        },
+        "cost_usd": 0.00101115,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f919",
+      "right_id": "z175",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The restaurants have completely different names (bertolini's vs original pancake house), different street addresses (3500 vs 4330 peachtree rd.), different phone numbers, and different cuisine types. They clearly refer to different businesses.",
+      "provenance": {
+        "tokens": {
+          "prompt": 297,
+          "completion": 185
+        },
+        "cost_usd": 0.00095935,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f626",
+      "right_id": "z175",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.05,
+      "reasoning": "The records have completely different names (\"toulouse\" vs \"original pancake house\"), different phone numbers, and different cuisine types (french vs american). While both are on Peachtree Rd in Atlanta, the street addresses differ and there is no overlap in any identifying information.",
+      "provenance": {
+        "tokens": {
+          "prompt": 280,
+          "completion": 329
+        },
+        "cost_usd": 0.0014455,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f956",
+      "right_id": "z176",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The restaurant names (\"tomtom\" vs \"palm the (atlanta)\"), phone numbers (404/264-1163 vs 404-814-1955), and food types (continental vs steakhouses) are completely different. While the street addresses are similar (3393 vs 3391 peachtree rd), the discrepancy in all other key identifiers confirms these are distinct restaurants.",
+      "provenance": {
+        "tokens": {
+          "prompt": 289,
+          "completion": 387
+        },
+        "cost_usd": 0.0016579499999999998,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f625",
+      "right_id": "z177",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The records have completely different names, addresses, phone numbers, cities, and cuisine types, indicating they refer to entirely different restaurants.",
+      "provenance": {
+        "tokens": {
+          "prompt": 292,
+          "completion": 167
+        },
+        "cost_usd": 0.0008910999999999999,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f624",
+      "right_id": "z177",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The records have completely different names, addresses, cities, phone numbers, and restaurant types. There is no overlap in any fields indicating they are entirely different restaurants.",
+      "provenance": {
+        "tokens": {
+          "prompt": 299,
+          "completion": 187
+        },
+        "cost_usd": 0.0009684499999999999,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f623",
+      "right_id": "z177",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The records have completely different names (\"cafe ritz-carlton buckhead\" vs \"rainbow restaurant\"), addresses, cities (atlanta vs decatur), phone numbers, and types. There is no overlap in any identifying information.",
+      "provenance": {
+        "tokens": {
+          "prompt": 302,
+          "completion": 82
+        },
+        "cost_usd": 0.0006041,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f941",
+      "right_id": "z179",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The restaurant names, addresses, and phone numbers are all completely different, indicating these are two distinct restaurants in Atlanta.",
+      "provenance": {
+        "tokens": {
+          "prompt": 287,
+          "completion": 157
+        },
+        "cost_usd": 0.00085085,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f618",
+      "right_id": "z179",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The restaurants have completely different names, addresses, phone numbers, and types, indicating they are entirely distinct establishments in Atlanta.",
+      "provenance": {
+        "tokens": {
+          "prompt": 287,
+          "completion": 191
+        },
+        "cost_usd": 0.00096985,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f916",
+      "right_id": "z180",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The two records have different names (anthonys vs soto), different phone numbers, different street addresses (3109 vs 3330 piedmont rd.), and different cuisine types (american vs japanese). There is no evidence these are the same restaurant.",
+      "provenance": {
+        "tokens": {
+          "prompt": 289,
+          "completion": 116
+        },
+        "cost_usd": 0.0007094499999999999,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f609",
+      "right_id": "z180",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The two records have completely different names (\"bacchanalia\" vs \"soto\"), different addresses (3125 vs 3330 Piedmont Rd), different phone numbers, and different cuisine types (international vs Japanese). They are clearly two distinct restaurants on the same road in Atlanta.",
+      "provenance": {
+        "tokens": {
+          "prompt": 286,
+          "completion": 151
+        },
+        "cost_usd": 0.0008288,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f947",
+      "right_id": "z181",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The two records have completely different names, addresses, phone numbers, and restaurant types. There is no evidence suggesting they refer to the same restaurant.",
+      "provenance": {
+        "tokens": {
+          "prompt": 303,
+          "completion": 128
+        },
+        "cost_usd": 0.00076615,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f958",
+      "right_id": "z181",
+      "label": true,
+      "source": "teacher",
+      "confidence": 1.0,
+      "reasoning": "The records refer to completely different restaurants located in different cities (Las Vegas vs. Atlanta), with entirely different names, addresses, phone numbers, and types.",
+      "provenance": {
+        "tokens": {
+          "prompt": 298,
+          "completion": 95
+        },
+        "cost_usd": 0.0006454,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f613",
+      "right_id": "z182",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The records have completely different names (ciboulette vs. tortillas), addresses, phone numbers, and cuisine types (french vs. tex-mex). There is no overlap in any identifying information, indicating these are distinct restaurants.",
+      "provenance": {
+        "tokens": {
+          "prompt": 290,
+          "completion": 150
+        },
+        "cost_usd": 0.0008294999999999999,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f644",
+      "right_id": "z183",
+      "label": true,
+      "source": "teacher",
+      "confidence": 1.0,
+      "reasoning": "The two records have completely different names, addresses, cities, and phone numbers, indicating they are entirely different restaurants.",
+      "provenance": {
+        "tokens": {
+          "prompt": 298,
+          "completion": 68
+        },
+        "cost_usd": 0.0005509,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f537",
+      "right_id": "z183",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The records have completely different names, addresses, cities, and phone numbers. Cafe Bizou is in Sherman Oaks, CA, while Van Gogh's is in Roswell, GA. They are definitively different restaurants.",
+      "provenance": {
+        "tokens": {
+          "prompt": 297,
+          "completion": 169
+        },
+        "cost_usd": 0.00090335,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f920",
+      "right_id": "z184",
+      "label": true,
+      "source": "teacher",
+      "confidence": 1.0,
+      "reasoning": "The restaurants have different names (\"bistango\" vs \"veggieland\"), addresses (\"1100 peachtree st.\" vs \"220 sandy springs circle\"), phone numbers, and cuisine types. They are completely different establishments.",
+      "provenance": {
+        "tokens": {
+          "prompt": 276,
+          "completion": 229
+        },
+        "cost_usd": 0.0010913,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f613",
+      "right_id": "z184",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The two records have completely different names, addresses, phone numbers, and restaurant types. There is no overlap in any identifying attributes.",
+      "provenance": {
+        "tokens": {
+          "prompt": 277,
+          "completion": 151
+        },
+        "cost_usd": 0.00081935,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f938",
+      "right_id": "z184",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The restaurants have entirely different names (\"lowcountry barbecue\" vs \"veggieland\"), addresses, phone numbers, and cuisine types. There is no overlap in any identifying information, indicating they are distinct businesses.",
+      "provenance": {
+        "tokens": {
+          "prompt": 294,
+          "completion": 233
+        },
+        "cost_usd": 0.0011242000000000001,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f941",
+      "right_id": "z184",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The records have completely different names, addresses, phone numbers, and restaurant types. There is no indication these refer to the same real-world restaurant.",
+      "provenance": {
+        "tokens": {
+          "prompt": 280,
+          "completion": 62
+        },
+        "cost_usd": 0.000511,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f625",
+      "right_id": "z185",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The records have completely different restaurant names (\"ritz-carlton atlanta\" vs \"white house restaurant\"), addresses (\"181 peachtree st.\" vs \"3172 peachtree rd. ne\"), phone numbers, and cuisine types. There is no evidence they refer to the same real-world restaurant.",
+      "provenance": {
+        "tokens": {
+          "prompt": 294,
+          "completion": 154
+        },
+        "cost_usd": 0.0008477000000000001,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f615",
+      "right_id": "z185",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The records have completely different restaurant names, addresses, phone numbers, and types. There is no overlap in any identifying information beyond being on Peachtree Rd in Atlanta.",
+      "provenance": {
+        "tokens": {
+          "prompt": 298,
+          "completion": 113
+        },
+        "cost_usd": 0.0007084,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f610",
+      "right_id": "z186",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The two records have completely different names, addresses, cities, phone numbers, and cuisine types. There is no overlap in any field, indicating they refer to entirely different real-world restaurants.",
+      "provenance": {
+        "tokens": {
+          "prompt": 283,
+          "completion": 75
+        },
+        "cost_usd": 0.00055965,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f608",
+      "right_id": "z186",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The records have completely different names, addresses, cities, phone numbers, and cuisine types (Italian vs. Thai). There is no indication these refer to the same restaurant.",
+      "provenance": {
+        "tokens": {
+          "prompt": 298,
+          "completion": 70
+        },
+        "cost_usd": 0.0005579000000000001,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f613",
+      "right_id": "z186",
+      "label": true,
+      "source": "teacher",
+      "confidence": 1.0,
+      "reasoning": "The two records have completely different names, addresses, phone numbers, cities, and cuisine types. There is no overlap in any identifying information, indicating they are definitively different restaurants.",
+      "provenance": {
+        "tokens": {
+          "prompt": 286,
+          "completion": 188
+        },
+        "cost_usd": 0.0009583,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f920",
+      "right_id": "z186",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The records have completely different names (bistango vs. zab-e-lee), addresses, cities (atlanta vs. college park), phone numbers, and cuisine types (mediterranean vs. thai). There is no overlap in any identifying attributes.",
+      "provenance": {
+        "tokens": {
+          "prompt": 285,
+          "completion": 87
+        },
+        "cost_usd": 0.0006037499999999999,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f630",
+      "right_id": "z187",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The two records have entirely different names, addresses, phone numbers, and cuisine types, clearly referring to different restaurants in San Francisco.",
+      "provenance": {
+        "tokens": {
+          "prompt": 277,
+          "completion": 114
+        },
+        "cost_usd": 0.0006898500000000001,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f1025",
+      "right_id": "z187",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The records have completely different names, addresses, phone numbers, and restaurant types. There are no matching attributes to indicate they refer to the same real-world restaurant.",
+      "provenance": {
+        "tokens": {
+          "prompt": 280,
+          "completion": 117
+        },
+        "cost_usd": 0.0007034999999999999,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f1026",
+      "right_id": "z187",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The records have completely different names (\"le soleil\" vs \"bill's place\"), different addresses (133 clement st vs 2315 clement st), different phone numbers, and different restaurant types (asian vs hamburgers). They are simply located on the same street.",
+      "provenance": {
+        "tokens": {
+          "prompt": 280,
+          "completion": 148
+        },
+        "cost_usd": 0.000812,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f741",
+      "right_id": "z188",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The records refer to different restaurants in different cities (New York vs. San Francisco), with different names (cafe fes vs. cafe flore), addresses, phone numbers, and cuisine types. There is no overlap to suggest they are the same entity.",
+      "provenance": {
+        "tokens": {
+          "prompt": 300,
+          "completion": 95
+        },
+        "cost_usd": 0.0006475,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f745",
+      "right_id": "z189",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The two records refer to completely different restaurants in different cities (New York vs. San Francisco) with different names, addresses, and phone numbers.",
+      "provenance": {
+        "tokens": {
+          "prompt": 299,
+          "completion": 162
+        },
+        "cost_usd": 0.00088095,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f742",
+      "right_id": "z189",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The records refer to completely different restaurants in different cities (Caffe Dante in New York vs. Caffe Greco in San Francisco) with distinct addresses and phone numbers.",
+      "provenance": {
+        "tokens": {
+          "prompt": 295,
+          "completion": 421
+        },
+        "cost_usd": 0.0017832500000000001,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f1045",
+      "right_id": "z189",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The records have completely different names (scala's bistro vs caffe greco), addresses (432 powell st vs 423 columbus ave), phone numbers, and restaurant types. There is no evidence to suggest these refer to the same restaurant.",
+      "provenance": {
+        "tokens": {
+          "prompt": 282,
+          "completion": 134
+        },
+        "cost_usd": 0.0007651000000000001,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f1010",
+      "right_id": "z190",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The two records have completely different names, addresses, phone numbers, and cuisine types. There is no overlap in any identifying information other than being located in San Francisco.",
+      "provenance": {
+        "tokens": {
+          "prompt": 279,
+          "completion": 179
+        },
+        "cost_usd": 0.00091945,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f1016",
+      "right_id": "z191",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The two records have completely different names (hyde street bistro vs. cha cha cha's), addresses (1521 hyde st. vs. 1805 haight st.), phone numbers, and cuisine types (italian vs. caribbean). There is no overlap in any identifying attributes, so they clearly refer to different restaurants.",
+      "provenance": {
+        "tokens": {
+          "prompt": 288,
+          "completion": 150
+        },
+        "cost_usd": 0.0008274,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f1044",
+      "right_id": "z191",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The records have completely different names (\"sanppo\" vs \"cha cha cha's\"), addresses (1702 post st. vs 1805 haight st.), phone numbers, and cuisine types (asian vs caribbean). These are clearly two different restaurants.",
+      "provenance": {
+        "tokens": {
+          "prompt": 280,
+          "completion": 91
+        },
+        "cost_usd": 0.0006125,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f1031",
+      "right_id": "z191",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The restaurant names, addresses, phone numbers, and cuisine types are all completely different, indicating these are two distinct restaurants in San Francisco.",
+      "provenance": {
+        "tokens": {
+          "prompt": 286,
+          "completion": 168
+        },
+        "cost_usd": 0.0008883000000000001,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f1025",
+      "right_id": "z192",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The records have completely different names, addresses, phone numbers, and cuisines. There are no overlapping attributes to suggest these are the same restaurant.",
+      "provenance": {
+        "tokens": {
+          "prompt": 277,
+          "completion": 138
+        },
+        "cost_usd": 0.00077385,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f642",
+      "right_id": "z193",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The restaurant names, addresses, and phone numbers are completely different, indicating they are two distinct restaurants in San Francisco.",
+      "provenance": {
+        "tokens": {
+          "prompt": 291,
+          "completion": 139
+        },
+        "cost_usd": 0.00079205,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f663",
+      "right_id": "z193",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The records have completely different names, addresses, cities, and phone numbers.",
+      "provenance": {
+        "tokens": {
+          "prompt": 292,
+          "completion": 125
+        },
+        "cost_usd": 0.0007441,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f630",
+      "right_id": "z194",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The two records have completely different names (boulevard vs. dusit thai), addresses (1 mission st. vs. 3221 mission st.), phone numbers, and cuisine types (american vs. thai). They are clearly different restaurants.",
+      "provenance": {
+        "tokens": {
+          "prompt": 277,
+          "completion": 87
+        },
+        "cost_usd": 0.00059535,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f1025",
+      "right_id": "z195",
+      "label": true,
+      "source": "teacher",
+      "confidence": 1.0,
+      "reasoning": "The records have completely different names, addresses, phone numbers, and cuisine types (Frenchvs. Japanese), indicating they are entirely different restaurants in San Francisco.",
+      "provenance": {
+        "tokens": {
+          "prompt": 272,
+          "completion": 172
+        },
+        "cost_usd": 0.0008876,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f1031",
+      "right_id": "z195",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The two records have completely different names (millennium vs. ebisu), addresses (246 mcallister st. vs. 1283 ninth ave.), phone numbers, and restaurant types (vegetarian vs. japanese). They clearly refer to different real-world restaurants.",
+      "provenance": {
+        "tokens": {
+          "prompt": 278,
+          "completion": 112
+        },
+        "cost_usd": 0.0006839,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f644",
+      "right_id": "z196",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The records have completely different names, addresses, phone numbers, and cuisines. There is no overlap in any field except city, indicating these are two distinct restaurants in San Francisco.",
+      "provenance": {
+        "tokens": {
+          "prompt": 288,
+          "completion": 116
+        },
+        "cost_usd": 0.0007084000000000001,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f625",
+      "right_id": "z196",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The records have no matching attributes. They differ in name (Ritz-Carlton Atlanta vs. Emerald Garden), city (Atlanta vs. San Francisco), address, phone number, and restaurant type (Continental vs. Vietnamese). They clearly refer to different real-world restaurants.",
+      "provenance": {
+        "tokens": {
+          "prompt": 290,
+          "completion": 143
+        },
+        "cost_usd": 0.0008050000000000002,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f1066",
+      "right_id": "z196",
+      "label": true,
+      "source": "teacher",
+      "confidence": 0.5,
+      "reasoning": "",
+      "provenance": {
+        "tokens": {
+          "prompt": 284,
+          "completion": 75
+        },
+        "cost_usd": 0.0005607,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f644",
+      "right_id": "z197",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The records have completely different names (ritz-carlton restaurant and dining room vs eric's chinese restaurant), addresses (600 stockton st vs 1500 church st), phone numbers, and cuisine types (american vs chinese). They are clearly different restaurants in San Francisco.",
+      "provenance": {
+        "tokens": {
+          "prompt": 289,
+          "completion": 89
+        },
+        "cost_usd": 0.00061495,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f697",
+      "right_id": "z197",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The records have completely different names, addresses, cities (Los Angeles vs San Francisco), and phone numbers. There is no indication they refer to the same real-world restaurant.",
+      "provenance": {
+        "tokens": {
+          "prompt": 287,
+          "completion": 67
+        },
+        "cost_usd": 0.00053585,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f1003",
+      "right_id": "z198",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The records have completely different names, addresses, phone numbers, and restaurant types. They are clearly two different establishments in San Francisco.",
+      "provenance": {
+        "tokens": {
+          "prompt": 284,
+          "completion": 176
+        },
+        "cost_usd": 0.0009142,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f1044",
+      "right_id": "z198",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The restaurant names, addresses, phone numbers, and types are all completely different, indicating these are two distinct restaurants in San Francisco.",
+      "provenance": {
+        "tokens": {
+          "prompt": 281,
+          "completion": 113
+        },
+        "cost_usd": 0.00069055,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f1025",
+      "right_id": "z199",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The records have completely different names, phone numbers, addresses (453 vs 333 Bush St), and cuisine types, indicating they are distinct restaurants.",
+      "provenance": {
+        "tokens": {
+          "prompt": 280,
+          "completion": 486
+        },
+        "cost_usd": 0.0019950000000000002,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f1031",
+      "right_id": "z199",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The two records have completely different names, addresses, phone numbers, and restaurant types, indicating they are entirely different establishments.",
+      "provenance": {
+        "tokens": {
+          "prompt": 286,
+          "completion": 204
+        },
+        "cost_usd": 0.0010143,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f1010",
+      "right_id": "z199",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The records have completely different names (\"harris'\" vs \"kelly's on trinity\"), addresses (\"2100 van ness ave.\" vs \"333 bush st.\"), phone numbers, and restaurant types. These are clearly different restaurants.",
+      "provenance": {
+        "tokens": {
+          "prompt": 283,
+          "completion": 141
+        },
+        "cost_usd": 0.00079065,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f1025",
+      "right_id": "z200",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The records have completely different names",
+      "provenance": {
+        "tokens": {
+          "prompt": 280,
+          "completion": 45
+        },
+        "cost_usd": 0.00045149999999999997,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f643",
+      "right_id": "z200",
+      "label": true,
+      "source": "teacher",
+      "confidence": 1.0,
+      "reasoning": "The two records have completely different restaurant names (\"postrio\" vs \"la cumbre\"), addresses (\"545 post st.\" vs \"515 valencia st.\"), phone numbers, and cuisine types. They are clearly distinct restaurants.",
+      "provenance": {
+        "tokens": {
+          "prompt": 279,
+          "completion": 152
+        },
+        "cost_usd": 0.0008249500000000001,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f1031",
+      "right_id": "z202",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The records have completely different names, addresses, phone numbers, and cuisine types. There is no overlap in any identifying information, clearly indicating two different restaurants in San Francisco.",
+      "provenance": {
+        "tokens": {
+          "prompt": 286,
+          "completion": 124
+        },
+        "cost_usd": 0.0007343,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f708",
+      "right_id": "z203",
+      "label": true,
+      "source": "teacher",
+      "confidence": 1.0,
+      "reasoning": "The records have completely different names, addresses, phone numbers, and cities (Los Angeles vs. San Francisco). They are clearly two different restaurants.",
+      "provenance": {
+        "tokens": {
+          "prompt": 295,
+          "completion": 170
+        },
+        "cost_usd": 0.0009047500000000001,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f1031",
+      "right_id": "z204",
+      "label": true,
+      "source": "teacher",
+      "confidence": 1.0,
+      "reasoning": "The records have completely different names (millennium vs. marnee thai), addresses, phone numbers, and restaurant types. They clearly refer to different restaurants in San Francisco.",
+      "provenance": {
+        "tokens": {
+          "prompt": 283,
+          "completion": 150
+        },
+        "cost_usd": 0.00082215,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f1051",
+      "right_id": "z205",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The restaurant names (\"straits cafe\" vs \"mel's drive-in\"), addresses (3300 vs 3355 Geary), phone numbers, and cuisine types (asian vs hamburgers) are all completely different, indicating these are distinct businesses.",
+      "provenance": {
+        "tokens": {
+          "prompt": 287,
+          "completion": 221
+        },
+        "cost_usd": 0.00107485,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f1010",
+      "right_id": "z205",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The records have completely different names (harris' vs mel's drive-in), addresses (2100 van ness ave. vs 3355 geary st.), phone numbers, and restaurant types (steak houses vs hamburgers), indicating they are clearly different establishments.",
+      "provenance": {
+        "tokens": {
+          "prompt": 285,
+          "completion": 113
+        },
+        "cost_usd": 0.00069475,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f1021",
+      "right_id": "z205",
+      "label": true,
+      "source": "teacher",
+      "confidence": 1.0,
+      "reasoning": "The records have completely different names (\"katia's\" vs \"mel's drive-in\"), addresses (\"600 5th ave.\" vs \"3355 geary st.\"), and phone numbers. There is no overlap in any identifying fields to suggest these refer to the same restaurant.",
+      "provenance": {
+        "tokens": {
+          "prompt": 284,
+          "completion": 107
+        },
+        "cost_usd": 0.0006727,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f1045",
+      "right_id": "z205",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The records have completely different names (scala's bistro vs. mel's drive-in), addresses (432 powell st. vs. 3355 geary st.), phone numbers, and restaurant types (italian vs. hamburgers). There is no overlap indicating they are the same restaurant.",
+      "provenance": {
+        "tokens": {
+          "prompt": 288,
+          "completion": 95
+        },
+        "cost_usd": 0.0006349000000000001,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f640",
+      "right_id": "z206",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The records have completely different names (masa's vs mo's burgers), different addresses (648 bush st. vs 1322 grant st.), different phone numbers, and different cuisine types (french vs hamburgers). There is no overlap to suggest these are the same restaurant.",
+      "provenance": {
+        "tokens": {
+          "prompt": 278,
+          "completion": 92
+        },
+        "cost_usd": 0.0006139,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f697",
+      "right_id": "z207",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The two records refer to different restaurants with completely different names, addresses, cities (Los Angeles vs San Francisco), phone numbers, and restaurant types (Asian vs Cambodian). There is no overlap in any identifying information.",
+      "provenance": {
+        "tokens": {
+          "prompt": 295,
+          "completion": 57
+        },
+        "cost_usd": 0.00050925,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f644",
+      "right_id": "z207",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The records have completely different names, addresses, phone numbers, and cuisine types. There is no overlap in any identifying information.",
+      "provenance": {
+        "tokens": {
+          "prompt": 297,
+          "completion": 181
+        },
+        "cost_usd": 0.0009453500000000001,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f1031",
+      "right_id": "z208",
+      "label": true,
+      "source": "teacher",
+      "confidence": 1.0,
+      "reasoning": "The records have completely different restaurant names (\"millennium\" vs \"roosevelt tamale parlor\"), different addresses (246 mcallister st. vs 2817 24th st.), different phone numbers, and different cuisine types (vegetarian vs mexican). These are clearly two distinct restaurants in San Francisco.",
+      "provenance": {
+        "tokens": {
+          "prompt": 295,
+          "completion": 101
+        },
+        "cost_usd": 0.00066325,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f1050",
+      "right_id": "z209",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The records have completely different names (stoyanof's cafe vs. sally's cafe & bakery), addresses (1240 9th ave. vs. 300 de haro st.), phone numbers, and cuisine types. There is no overlap in any identifying information.",
+      "provenance": {
+        "tokens": {
+          "prompt": 296,
+          "completion": 168
+        },
+        "cost_usd": 0.0008988,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f996",
+      "right_id": "z209",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The records have completely different names, addresses, phone numbers, and restaurant types, with no overlap indicating they are the same restaurant.",
+      "provenance": {
+        "tokens": {
+          "prompt": 296,
+          "completion": 58
+        },
+        "cost_usd": 0.0005138,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f1066",
+      "right_id": "z209",
+      "label": true,
+      "source": "teacher",
+      "confidence": 1.0,
+      "reasoning": "The records have completely different names, addresses, phone numbers, and restaurant types. Record A is \"zuni cafe & grill\" at 1658 market st, while Record B is \"sally's cafe & bakery\" at 300 de haro st. These are clearly distinct restaurants.",
+      "provenance": {
+        "tokens": {
+          "prompt": 288,
+          "completion": 166
+        },
+        "cost_usd": 0.0008834000000000001,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f1031",
+      "right_id": "z211",
+      "label": true,
+      "source": "teacher",
+      "confidence": 1.0,
+      "reasoning": "The records have entirely different names (millennium vs slanted door), addresses, phone numbers, and cuisine types. They are clearly distinct restaurants that merely share the same city.",
+      "provenance": {
+        "tokens": {
+          "prompt": 284,
+          "completion": 86
+        },
+        "cost_usd": 0.0005992,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f991",
+      "right_id": "z211",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The records have completely different names (bistro roti vs slanted door), addresses (155 steuart st. vs 584 valencia st.), phone numbers, and cuisine types (french vs vietnamese). They are clearly different restaurants.",
+      "provenance": {
+        "tokens": {
+          "prompt": 281,
+          "completion": 92
+        },
+        "cost_usd": 0.0006170500000000001,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f1021",
+      "right_id": "z211",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The restaurant names (\"katia's\" vs \"slanted door\"), addresses (\"600 5th ave.\" vs \"584 valencia st.\"), and phone numbers (\"415/668-9292\" vs \"415-861-8032\") are completely different. There is no evidence suggesting these records refer to the same restaurant.",
+      "provenance": {
+        "tokens": {
+          "prompt": 280,
+          "completion": 194
+        },
+        "cost_usd": 0.000973,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f1051",
+      "right_id": "z212",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The two records have completely different names (straits cafe vs. swan oyster depot), addresses (3300 geary blvd. vs. 1517 polk st.), and phone numbers, despite being in the same city. They clearly refer to different restaurants.",
+      "provenance": {
+        "tokens": {
+          "prompt": 285,
+          "completion": 155
+        },
+        "cost_usd": 0.00084175,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f629",
+      "right_id": "z212",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The two records have completely different names (\"aqua\" vs \"swan oyster depot\"), addresses (252 california st. vs 1517 polk st.), and phone numbers. They are distinctly different seafood restaurants in San Francisco.",
+      "provenance": {
+        "tokens": {
+          "prompt": 280,
+          "completion": 134
+        },
+        "cost_usd": 0.000763,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f1031",
+      "right_id": "z213",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The records have entirely different names, addresses, phone numbers, and cuisine types (vegetarian vs. thai), indicating they refer to completely different restaurants.",
+      "provenance": {
+        "tokens": {
+          "prompt": 285,
+          "completion": 181
+        },
+        "cost_usd": 0.00093275,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f993",
+      "right_id": "z213",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The records have completely different names (bizou vs. thep phanom), addresses (598 fourth st. vs. 400 waller st.), phone numbers, and cuisines (french vs. thai). They clearly refer to two different restaurants in San Francisco.",
+      "provenance": {
+        "tokens": {
+          "prompt": 278,
+          "completion": 170
+        },
+        "cost_usd": 0.0008869,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f1025",
+      "right_id": "z214",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The names (\"le central\" vs \"ti couz\"), addresses (\"453 bush st.\" vs \"3108 16th st.\"), and phone numbers (\"415/391-2233\" vs \"415-252-7373\") are all completely different. These are clearly two different French restaurants in San Francisco.",
+      "provenance": {
+        "tokens": {
+          "prompt": 279,
+          "completion": 251
+        },
+        "cost_usd": 0.0011714499999999999,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f993",
+      "right_id": "z214",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The two records have entirely different names (\"bizou\" vs \"ti couz\"), addresses (\"598 fourth st.\" vs \"3108 16th st.\"), and phone numbers (\"415/543-2222\" vs \"415-252-7373\"). Although they are both French restaurants in San Francisco, there is no overlap in any identifying information, indicating they are distinct restaurants.",
+      "provenance": {
+        "tokens": {
+          "prompt": 278,
+          "completion": 313
+        },
+        "cost_usd": 0.0013874,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f1050",
+      "right_id": "z215",
+      "label": true,
+      "source": "teacher",
+      "confidence": 1.0,
+      "reasoning": "The records have completely different names, addresses, phone numbers, and cuisine types. They are clearly two different restaurants in San Francisco.",
+      "provenance": {
+        "tokens": {
+          "prompt": 291,
+          "completion": 169
+        },
+        "cost_usd": 0.00089705,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f993",
+      "right_id": "z216",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The records have completely different names (bizou vs tu lan), addresses, phone numbers, and cuisine types (frenchvs vietnamese), indicating they are distinct restaurants.",
+      "provenance": {
+        "tokens": {
+          "prompt": 271,
+          "completion": 117
+        },
+        "cost_usd": 0.00069405,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f643",
+      "right_id": "z216",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The two records have completely different names (postrio vs. tu lan), addresses (545 post st. vs. 8 sixth st.), phone numbers, and cuisine types (american vs. vietnamese). They clearly refer to different restaurants in San Francisco.",
+      "provenance": {
+        "tokens": {
+          "prompt": 271,
+          "completion": 110
+        },
+        "cost_usd": 0.0006695500000000001,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f1003",
+      "right_id": "z216",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The two records have different names (\"faz\" vs \"tu lan\"), different addresses (\"161 sutter st.\" vs \"8 sixth st.\"), different phone numbers, and different cuisine types (Greek/Middle Eastern vs Vietnamese). These are clearly distinct restaurants in San Francisco.",
+      "provenance": {
+        "tokens": {
+          "prompt": 275,
+          "completion": 151
+        },
+        "cost_usd": 0.00081725,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f996",
+      "right_id": "z217",
+      "label": true,
+      "source": "teacher",
+      "confidence": 1.0,
+      "reasoning": "The records have completely different names (cafe marimba vs vicolo pizzeria), addresses (2317 chestnut st. vs 201 ivy st.), phone numbers, and cuisine types (mexican vs pizza), indicating they are definitely not the same restaurant.",
+      "provenance": {
+        "tokens": {
+          "prompt": 293,
+          "completion": 175
+        },
+        "cost_usd": 0.00092015,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f1031",
+      "right_id": "z217",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The two records have completely different names, addresses, phone numbers, and restaurant types. They are clearly different restaurants in San Francisco.",
+      "provenance": {
+        "tokens": {
+          "prompt": 284,
+          "completion": 198
+        },
+        "cost_usd": 0.0009912,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f653",
+      "right_id": "z218",
+      "label": true,
+      "source": "teacher",
+      "confidence": 1.0,
+      "reasoning": "The two records are located in completely different cities (los angeles vs. san francisco), have different names, different addresses, and different phone numbers. There is no evidence to suggest they refer to the same restaurant.",
+      "provenance": {
+        "tokens": {
+          "prompt": 290,
+          "completion": 151
+        },
+        "cost_usd": 0.000833,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f1012",
+      "right_id": "z218",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The records have completely different names, addresses, phone numbers, and cuisine types (seafood vs. mexican), indicating they are distinct restaurants in San Francisco.",
+      "provenance": {
+        "tokens": {
+          "prompt": 297,
+          "completion": 122
+        },
+        "cost_usd": 0.00073885,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f1066",
+      "right_id": "z218",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The two records have completely different names, addresses, phone numbers, and restaurant types. They are clearly two different restaurants in San Francisco.",
+      "provenance": {
+        "tokens": {
+          "prompt": 300,
+          "completion": 117
+        },
+        "cost_usd": 0.0007244999999999999,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f693",
+      "right_id": "z220",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The records have completely different names (posto vs. art's deli), addresses (14928 vs. 12224 ventura blvd.), cities (sherman oaks vs. studio city), phone numbers, and restaurant types. There is no overlap to suggest they are the same restaurant.",
+      "provenance": {
+        "tokens": {
+          "prompt": 280,
+          "completion": 190
+        },
+        "cost_usd": 0.000959,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f555",
+      "right_id": "z220",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The records have completely different names, addresses, cities, phone numbers, and types, indicating they refer to two distinct real-world restaurants.",
+      "provenance": {
+        "tokens": {
+          "prompt": 282,
+          "completion": 72
+        },
+        "cost_usd": 0.0005481,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f963",
+      "right_id": "z221",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The records have completely different names, addresses, cities, phone numbers, and restaurant types. They are located in different states and clearly refer to completely different establishments.",
+      "provenance": {
+        "tokens": {
+          "prompt": 280,
+          "completion": 380
+        },
+        "cost_usd": 0.001624,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f1041",
+      "right_id": "z221",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The records have entirely different names (\"r&g lounge\" vs \"bel-air hotel\"), addresses, cities (San Francisco vs Bel Air), and phone numbers. They clearly refer to two different restaurants.",
+      "provenance": {
+        "tokens": {
+          "prompt": 295,
+          "completion": 102
+        },
+        "cost_usd": 0.00066675,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f663",
+      "right_id": "z221",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The two records have completely different names (clearwater cafe vs. bel-air hotel), addresses (168 w. colorado blvd. vs. 701 stone canyon rd.), cities (los angeles vs. bel air), and phone numbers. They clearly refer to different establishments.",
+      "provenance": {
+        "tokens": {
+          "prompt": 283,
+          "completion": 213
+        },
+        "cost_usd": 0.00104265,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f537",
+      "right_id": "z222",
+      "label": true,
+      "source": "teacher",
+      "confidence": 1.0,
+      "reasoning": "The records have identical restaurant names, addresses, cities, and phone numbers (with only minor formatting differences in the phone number). The cuisine type is also consistent (\"french\" vs \"french bistro\"), and the embedded text matches exactly. These clearly refer to the same real-world restaurant.",
+      "provenance": {
+        "tokens": {
+          "prompt": 295,
+          "completion": 93
+        },
+        "cost_usd": 0.00063525,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f967",
+      "right_id": "z222",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The records have completely different names, addresses, cities, and phone numbers. They are clearly two distinct restaurants in different locations (Las Vegas vs. Sherman Oaks).",
+      "provenance": {
+        "tokens": {
+          "prompt": 297,
+          "completion": 198
+        },
+        "cost_usd": 0.0010048499999999998,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f538",
+      "right_id": "z223",
+      "label": true,
+      "source": "teacher",
+      "confidence": 1.0,
+      "reasoning": "Both records share identical names, addresses, cities, and phone numbers (differing only in formatting). The differing cuisine labels and sources are expected when comparing across guides like Fodor's and Zagat.",
+      "provenance": {
+        "tokens": {
+          "prompt": 290,
+          "completion": 98
+        },
+        "cost_usd": 0.0006475000000000001,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f671",
+      "right_id": "z223",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The restaurant names, addresses, phone numbers, and cuisine types are completely different, indicating these are two distinct restaurants in Los Angeles.",
+      "provenance": {
+        "tokens": {
+          "prompt": 289,
+          "completion": 426
+        },
+        "cost_usd": 0.00179445,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f667",
+      "right_id": "z223",
+      "label": true,
+      "source": "teacher",
+      "confidence": 1.0,
+      "reasoning": "The two records have completely different names, addresses, phone numbers, and restaurant types. They clearly refer to two different restaurants in Los Angeles.",
+      "provenance": {
+        "tokens": {
+          "prompt": 296,
+          "completion": 125
+        },
+        "cost_usd": 0.0007483,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f662",
+      "right_id": "z223",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The two records have completely different names (\"chan dara\" vs \"campanile\"), addresses, phone numbers, and restaurant types. They are clearly distinct restaurants.",
+      "provenance": {
+        "tokens": {
+          "prompt": 289,
+          "completion": 123
+        },
+        "cost_usd": 0.0007339499999999999,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f539",
+      "right_id": "z224",
+      "label": true,
+      "source": "teacher",
+      "confidence": 1.0,
+      "reasoning": "The name, address, and city are identical. The phone numbers match exactly except for minor formatting differences (slash vs. dash). The differing cuisine types are simply due to different categorizations by the two restaurant guides (Fodors vs. Zagat), and both \"French\" and \"Pacific New Wave\" accurately describe the fusion cuisine of this well-known restaurant.",
+      "provenance": {
+        "tokens": {
+          "prompt": 284,
+          "completion": 268
+        },
+        "cost_usd": 0.0012362,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f540",
+      "right_id": "z225",
+      "label": true,
+      "source": "teacher",
+      "confidence": 1.0,
+      "reasoning": "Both records have identical restaurant names (\"citrus\"), addresses (\"6703 melrose ave.\"), cities (\"los angeles\"), and types (\"californian\"). The phone numbers are functionally identical, differing only in formatting (\"213/857-0034\" vs \"213-857-0034\"). The different sources (fodors vs zagat) are expected for duplicate listings.",
+      "provenance": {
+        "tokens": {
+          "prompt": 281,
+          "completion": 155
+        },
+        "cost_usd": 0.0008375500000000001,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f685",
+      "right_id": "z225",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The restaurants have completely different names (\"morton's\" vs \"citrus\"), addresses (\"8764 melrose ave.\" vs \"6703 melrose ave.\"), phone numbers, and cuisine types. They are clearly two different establishments.",
+      "provenance": {
+        "tokens": {
+          "prompt": 280,
+          "completion": 194
+        },
+        "cost_usd": 0.000973,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f550",
+      "right_id": "z225",
+      "label": true,
+      "source": "teacher",
+      "confidence": 0.99,
+      "reasoning": "The two records refer to different restaurants with different names (\"patina\" vs \"citrus\"), different addresses on Melrose Ave (5955 vs 6703), and different phone numbers. These are clearly distinct establishments.",
+      "provenance": {
+        "tokens": {
+          "prompt": 279,
+          "completion": 110
+        },
+        "cost_usd": 0.0006779500000000001,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f682",
+      "right_id": "z226",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The records have completely different names, addresses, and phone numbers. Le Dome and Fenix at the Argyle are distinct restaurants located at different addresses on Sunset Blvd.",
+      "provenance": {
+        "tokens": {
+          "prompt": 292,
+          "completion": 231
+        },
+        "cost_usd": 0.0011151,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f680",
+      "right_id": "z226",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The records have completely different names (joss vs fenix at the argyle), addresses (9255 vs 8358 sunset blvd.), phone numbers, cities, and cuisine types. There is no evidence to suggest these refer to the same restaurant.",
+      "provenance": {
+        "tokens": {
+          "prompt": 291,
+          "completion": 219
+        },
+        "cost_usd": 0.0010720500000000002,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f828",
+      "right_id": "z226",
+      "label": true,
+      "source": "teacher",
+      "confidence": 1.0,
+      "reasoning": "The records have completely different names (\"les halles\" vs \"fenix at the argyle\"), different cities (\"new york\" vs \"w. hollywood\"), and different addresses, making it certain they refer to different restaurants.",
+      "provenance": {
+        "tokens": {
+          "prompt": 312,
+          "completion": 120
+        },
+        "cost_usd": 0.0007476,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f669",
+      "right_id": "z226",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The records have completely different names, addresses, phone numbers, cities, and restaurant types with no overlapping information, clearly indicating they refer to different restaurants.",
+      "provenance": {
+        "tokens": {
+          "prompt": 293,
+          "completion": 193
+        },
+        "cost_usd": 0.00098315,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f669",
+      "right_id": "z227",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The two records have completely different names, addresses, cities, and phone numbers. There are no matching attributes that would suggest they refer to the same restaurant.",
+      "provenance": {
+        "tokens": {
+          "prompt": 284,
+          "completion": 171
+        },
+        "cost_usd": 0.0008967000000000001,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f618",
+      "right_id": "z228",
+      "label": true,
+      "source": "teacher",
+      "confidence": 1.0,
+      "reasoning": "The records have entirely different names, addresses, cities, and phone numbers. They are clearly two different restaurants located in Atlanta and Beverly Hills.",
+      "provenance": {
+        "tokens": {
+          "prompt": 290,
+          "completion": 217
+        },
+        "cost_usd": 0.001064,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f1065",
+      "right_id": "z229",
+      "label": true,
+      "source": "teacher",
+      "confidence": 1.0,
+      "reasoning": "The records have completely different names (Zarzuela vs. Katsu), different addresses (2000 Hyde St vs. 1972 Hillhurst Ave), different cities (San Francisco vs. Los Feliz), different phone numbers, and different cuisine types (Spanish/Mexican/Latin American vs. Japanese). There is zero overlap in identifying information.",
+      "provenance": {
+        "tokens": {
+          "prompt": 284,
+          "completion": 142
+        },
+        "cost_usd": 0.0007952,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f702",
+      "right_id": "z229",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The restaurants have entirely different names (tavola calda vs katsu), addresses (7371 melrose ave. vs 1972 hillhurst ave.), phone numbers, and cuisine types (italian vs japanese). They are clearly different restaurants.",
+      "provenance": {
+        "tokens": {
+          "prompt": 283,
+          "completion": 152
+        },
+        "cost_usd": 0.0008291500000000001,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f1021",
+      "right_id": "z229",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The records have different names, addresses, phone numbers, and cities. There is no overlap in any identifying information.",
+      "provenance": {
+        "tokens": {
+          "prompt": 276,
+          "completion": 61
+        },
+        "cost_usd": 0.0005032999999999999,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f656",
+      "right_id": "z230",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The records have entirely different names (ca'del sol vs. l'orangerie), addresses, phone numbers, cuisines (italian vs. french), and even slightly different cities (los angeles vs. w. hollywood). There are no overlapping attributes to suggest these are the same restaurant.",
+      "provenance": {
+        "tokens": {
+          "prompt": 305,
+          "completion": 103
+        },
+        "cost_usd": 0.0006807499999999999,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f656",
+      "right_id": "z231",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The names (\"ca'del sol\" vs \"le chardonnay\"), addresses (\"4100 cahuenga blvd.\" vs \"8284 melrose ave.\"), phone numbers, and cuisine types (italian vs french bistro) are completely different, clearly indicating two distinct restaurants.",
+      "provenance": {
+        "tokens": {
+          "prompt": 304,
+          "completion": 82
+        },
+        "cost_usd": 0.0006062,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f656",
+      "right_id": "z232",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The restaurant names, addresses, and phone numbers are all completely different. While both are Italian restaurants in Los Angeles, there is no evidence to suggest they refer to the same real-world entity.",
+      "provenance": {
+        "tokens": {
+          "prompt": 292,
+          "completion": 153
+        },
+        "cost_usd": 0.0008421000000000001,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f545",
+      "right_id": "z232",
+      "label": true,
+      "source": "teacher",
+      "confidence": 1.0,
+      "reasoning": "The records have entirely different names (l'orangerie vs. locanda veneta), addresses (903 n. la cienega blvd. vs. 8638 w. third st.), phone numbers, and cuisine types (French vs. Italian). There is no overlap in any field, so these are clearly different restaurants.",
+      "provenance": {
+        "tokens": {
+          "prompt": 298,
+          "completion": 131
+        },
+        "cost_usd": 0.0007714,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f702",
+      "right_id": "z232",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The records have completely different names, addresses, and phone numbers, indicating they are distinct restaurants despite both being Italian establishments in Los Angeles.",
+      "provenance": {
+        "tokens": {
+          "prompt": 290,
+          "completion": 112
+        },
+        "cost_usd": 0.0006965000000000001,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f548",
+      "right_id": "z233",
+      "label": true,
+      "source": "teacher",
+      "confidence": 1.0,
+      "reasoning": "The name, address, city, and phone number are identical, with only minor formatting differences in the phone number (slashes vs. dashes). The different sources (Fodors vs. Zagat) and complementary types (asian vs. seafood) are expected when comparing records across different datasets.",
+      "provenance": {
+        "tokens": {
+          "prompt": 304,
+          "completion": 528
+        },
+        "cost_usd": 0.0021672,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f662",
+      "right_id": "z233",
+      "label": true,
+      "source": "teacher",
+      "confidence": 1.0,
+      "reasoning": "The records have completely different names (chan dara vs. matsuhisa), addresses, cities, and phone numbers, indicating they are distinct restaurants.",
+      "provenance": {
+        "tokens": {
+          "prompt": 295,
+          "completion": 155
+        },
+        "cost_usd": 0.00085225,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f550",
+      "right_id": "z235",
+      "label": true,
+      "source": "teacher",
+      "confidence": 1.0,
+      "reasoning": "All fields match perfectly, including the exact name, address, city, and cuisine type. The phone numbers match after accounting for a trivial formatting difference (\"/\" vs \"-\"). The records simply originate from different data sources (Fodors vs Zagat) describing the same establishment.",
+      "provenance": {
+        "tokens": {
+          "prompt": 278,
+          "completion": 209
+        },
+        "cost_usd": 0.0010234,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f655",
+      "right_id": "z235",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The records have completely different names (\"ca'brea\" vs \"patina\"), addresses (\"346 s. la brea ave.\" vs \"5955 melrose ave.\"), phone numbers, and cuisine types. There is no overlap in any field, indicating they are distinct real-world restaurants.",
+      "provenance": {
+        "tokens": {
+          "prompt": 285,
+          "completion": 126
+        },
+        "cost_usd": 0.00074025,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f739",
+      "right_id": "z236",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The records have completely different names, addresses, cities, phone numbers, and restaurant types, indicating they are entirely different restaurants.",
+      "provenance": {
+        "tokens": {
+          "prompt": 289,
+          "completion": 62
+        },
+        "cost_usd": 0.00052045,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f537",
+      "right_id": "z237",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The records have completely different names, addresses, phone numbers, and cities, indicating they are clearly two different restaurants on Ventura Blvd.",
+      "provenance": {
+        "tokens": {
+          "prompt": 292,
+          "completion": 228
+        },
+        "cost_usd": 0.0011046,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f553",
+      "right_id": "z238",
+      "label": true,
+      "source": "teacher",
+      "confidence": 0.99,
+      "reasoning": "The records have identical names, addresses, cities, and phone numbers (with minor formatting differences). The cuisine types are also closely related (\"italian\" vs \"nuova cucina italian\"). The different sources (fodors vs zagat) are expected for duplicate restaurant listings.",
+      "provenance": {
+        "tokens": {
+          "prompt": 292,
+          "completion": 127
+        },
+        "cost_usd": 0.0007511,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f545",
+      "right_id": "z238",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The records have completely different names (l'orangerie vs. rex il ristorante), addresses (903 n. la cienega blvd. vs. 617 s. olive st.), phone numbers, and cuisine types (french vs. nuova cucina italian). There is no overlap to suggest these are the same restaurant.",
+      "provenance": {
+        "tokens": {
+          "prompt": 301,
+          "completion": 102
+        },
+        "cost_usd": 0.00067305,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f656",
+      "right_id": "z238",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The two records have completely different names (\"ca'del sol\" vs \"rex il ristorante\"), different addresses (\"4100 cahuenga blvd.\" vs \"617 s. olive st.\"), and different phone numbers. There is no overlap in any identifying information, so they are definitely different restaurants.",
+      "provenance": {
+        "tokens": {
+          "prompt": 295,
+          "completion": 198
+        },
+        "cost_usd": 0.00100275,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f555",
+      "right_id": "z240",
+      "label": true,
+      "source": "teacher",
+      "confidence": 1.0,
+      "reasoning": "The records have identical names (\"valentino\"), addresses (\"3115 pico blvd.\"), cities (\"santa monica\"), and cuisine types (\"italian\"). The phone numbers differ only in formatting (\"310/829-4313\" vs \"310-829-4313\") but represent the same number. The different sources (fodors vs zagat) are expected for the same real-world restaurant.",
+      "provenance": {
+        "tokens": {
+          "prompt": 285,
+          "completion": 175
+        },
+        "cost_usd": 0.00091175,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f579",
+      "right_id": "z242",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The restaurant names, addresses, phone numbers, and types are all completely different. They are clearly two distinct restaurants in New York City.",
+      "provenance": {
+        "tokens": {
+          "prompt": 287,
+          "completion": 182
+        },
+        "cost_usd": 0.0009383499999999999,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f573",
+      "right_id": "z244",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The records have entirely different names (la caravelle vs. aureole), different addresses (33 w. 55th st. vs. 34 e. 61st st.), different phone numbers, and different cuisine types. There is no overlap in any identifying fields, indicating these are clearly distinct restaurants.",
+      "provenance": {
+        "tokens": {
+          "prompt": 288,
+          "completion": 106
+        },
+        "cost_usd": 0.0006734,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f718",
+      "right_id": "z244",
+      "label": true,
+      "source": "teacher",
+      "confidence": 1.0,
+      "reasoning": "The records have completely different names (\"anche vivolo\" vs \"aureole\"), addresses, phone numbers, and cuisine types. They are clearly distinct restaurants.",
+      "provenance": {
+        "tokens": {
+          "prompt": 309,
+          "completion": 71
+        },
+        "cost_usd": 0.00057295,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f585",
+      "right_id": "z245",
+      "label": true,
+      "source": "teacher",
+      "confidence": 1.0,
+      "reasoning": "The records have different names (\"park avenue cafe\" vs \"cafe lalo\") and completely different addresses (\"100 e. 63rd st.\" vs \"201 w. 83rd st.\"), indicating they are distinct restaurants.",
+      "provenance": {
+        "tokens": {
+          "prompt": 285,
+          "completion": 126
+        },
+        "cost_usd": 0.00074025,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f739",
+      "right_id": "z245",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The two records have different names (cafe pierre vs cafe lalo), different addresses (2 e. 61st st. vs 201 w. 83rd st.), different phone numbers, and different types (french vs coffeehouses). They are clearly different restaurants.",
+      "provenance": {
+        "tokens": {
+          "prompt": 287,
+          "completion": 131
+        },
+        "cost_usd": 0.0007598500000000001,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f739",
+      "right_id": "z246",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The two records have completely different names (\"cafe pierre\" vs \"cafe des artistes\"), different addresses (\"2 e. 61st st.\" vs \"1 w. 67th st.\"), and different phone numbers. Despite both being French restaurants in New York, these details clearly identify them as distinct establishments.",
+      "provenance": {
+        "tokens": {
+          "prompt": 291,
+          "completion": 209
+        },
+        "cost_usd": 0.00103705,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f737",
+      "right_id": "z246",
+      "label": true,
+      "source": "teacher",
+      "confidence": 1.0,
+      "reasoning": "The records have different names (\"cafe la fortuna\" vs \"cafe des artistes\"), different addresses (69 w. 71st st vs 1 w. 67th st), different phone numbers, and different restaurant types (coffee bar vs french classic). These are clearly two distinct restaurants.",
+      "provenance": {
+        "tokens": {
+          "prompt": 295,
+          "completion": 105
+        },
+        "cost_usd": 0.00067725,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f592",
+      "right_id": "z248",
+      "label": true,
+      "source": "teacher",
+      "confidence": 1.0,
+      "reasoning": "The records have completely different names (Second Avenue Deli vs Carnegie Deli), different addresses (156 2nd Ave vs 854 Seventh Ave), and different phone numbers. These are two well-known but distinct delicatessens in New York City.",
+      "provenance": {
+        "tokens": {
+          "prompt": 292,
+          "completion": 240
+        },
+        "cost_usd": 0.0011466,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f886",
+      "right_id": "z248",
+      "label": true,
+      "source": "teacher",
+      "confidence": 1.0,
+      "reasoning": "The Stage Deli and Carnegie Deli are two distinct, famous delicatessens in New York City locatednear each other on 7th Avenue (at 834 and 854, respectively), with different names, addresses, and phone numbers.",
+      "provenance": {
+        "tokens": {
+          "prompt": 301,
+          "completion": 132
+        },
+        "cost_usd": 0.0007780500000000001,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f577",
+      "right_id": "z249",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The restaurant names, addresses, and phone numbers are completely different. They are distinct restaurants in New York.",
+      "provenance": {
+        "tokens": {
+          "prompt": 281,
+          "completion": 98
+        },
+        "cost_usd": 0.00063805,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f853",
+      "right_id": "z250",
+      "label": true,
+      "source": "teacher",
+      "confidence": 1.0,
+      "reasoning": "The records have completely different names (\"otabe\" vs \"daniel\"), addresses (\"68 e. 56th st.\" vs \"20 e. 76th st.\"), phone numbers, and cuisine types. There is no overlap in any identifying attributes, clearly indicating they are two different restaurants.",
+      "provenance": {
+        "tokens": {
+          "prompt": 283,
+          "completion": 261
+        },
+        "cost_usd": 0.00121065,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f864",
+      "right_id": "z251",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The records have entirely different names (pomaire vs. dawat), addresses (371 w. 46th st. vs. 210 e. 58th st.), phone numbers, and cuisines (latin american vs. indian). These are clearly different restaurants.",
+      "provenance": {
+        "tokens": {
+          "prompt": 300,
+          "completion": 138
+        },
+        "cost_usd": 0.0007979999999999999,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f853",
+      "right_id": "z251",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The restaurants have different names (\"otabe\" vs \"dawat\"), different addresses (\"68 e. 56th st.\" vs \"210 e. 58th st.\"), and different phone numbers (\"212/223-7575\" vs \"212-355-7555\"). There is no evidence to suggest these refer to the same real-world restaurant.",
+      "provenance": {
+        "tokens": {
+          "prompt": 282,
+          "completion": 152
+        },
+        "cost_usd": 0.0008281,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f790",
+      "right_id": "z253",
+      "label": true,
+      "source": "teacher",
+      "confidence": 1.0,
+      "reasoning": "The records have different restaurant names (gallagher's vs four seasons), different street addresses (228 w. 52nd st. vs 99 e. 52nd st.), and different phone numbers. These are clearly two different restaurants in New York.",
+      "provenance": {
+        "tokens": {
+          "prompt": 285,
+          "completion": 80
+        },
+        "cost_usd": 0.00057925,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f842",
+      "right_id": "z254",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The records have completely different names, addresses, and phone numbers, indicating they are distinct restaurants in New York.",
+      "provenance": {
+        "tokens": {
+          "prompt": 298,
+          "completion": 99
+        },
+        "cost_usd": 0.0006594,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f879",
+      "right_id": "z254",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The records have entirely different names (\"sea grill\" vs \"gotham bar & grill\"), addresses (19 w. 49th st. vs 12 e. 12th st.), phone numbers (212/332-7610 vs 212-620-4020), and cuisine types (seafood vs american (new)). Only the city matches loosely (new york vs new york city), which is insufficient to suggest these are the same restaurant.",
+      "provenance": {
+        "tokens": {
+          "prompt": 291,
+          "completion": 140
+        },
+        "cost_usd": 0.00079555,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f584",
+      "right_id": "z256",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The two records have completely different names (oceana vs. island spice), addresses (55 e. 54th st. vs. 402 w. 44th st.), phone numbers, and cuisine types (seafood vs. caribbean). There is no indication these refer to the same restaurant.",
+      "provenance": {
+        "tokens": {
+          "prompt": 284,
+          "completion": 96
+        },
+        "cost_usd": 0.0006342000000000001,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f573",
+      "right_id": "z259",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The restaurants have completely different names (\"la caravelle\" vs \"la cote basque\"), different addresses (33 w. 55th st. vs 60 w. 55th st.), and different phone numbers. While they are both French restaurants in New York, they are clearly distinct establishments.",
+      "provenance": {
+        "tokens": {
+          "prompt": 294,
+          "completion": 156
+        },
+        "cost_usd": 0.0008547000000000001,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f825",
+      "right_id": "z260",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The records have different names (\"le marais\" vs \"le bernardin\"), different addresses (150 w. 46th st. vs 155 w. 51st st.), different phone numbers, and different cuisine types (american vs seafood). These are clearly two distinct restaurants in New York.",
+      "provenance": {
+        "tokens": {
+          "prompt": 283,
+          "completion": 101
+        },
+        "cost_usd": 0.00065065,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f756",
+      "right_id": "z260",
+      "label": true,
+      "source": "teacher",
+      "confidence": 1.0,
+      "reasoning": "The two records have completely different names, addresses, phone numbers, and cuisines. They are distinctly different restaurants located on the same street in New York.",
+      "provenance": {
+        "tokens": {
+          "prompt": 280,
+          "completion": 146
+        },
+        "cost_usd": 0.0008049999999999999,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f821",
+      "right_id": "z260",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The records have completely different names (Le Colonial vs. Le Bernardin), addresses (149 e. 57th st vs. 155 w. 51st st), phone numbers, and cuisine types (asian vs. seafood). These are clearly two distinct well-known restaurants in New York.",
+      "provenance": {
+        "tokens": {
+          "prompt": 283,
+          "completion": 98
+        },
+        "cost_usd": 0.0006401499999999999,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f573",
+      "right_id": "z261",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The two records have completely different names (\"la caravelle\" vs \"les celebrites\"), different addresses (\"33 w. 55th st.\" vs \"155 w. 58th st.\"), and different phone numbers. While both are French restaurants in New York, the specific identifying details do not match at all.",
+      "provenance": {
+        "tokens": {
+          "prompt": 290,
+          "completion": 168
+        },
+        "cost_usd": 0.0008925000000000001,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f825",
+      "right_id": "z262",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The restaurants have completely different names, addresses, phone numbers, and cuisine types. There is no overlap in identifying information.",
+      "provenance": {
+        "tokens": {
+          "prompt": 294,
+          "completion": 85
+        },
+        "cost_usd": 0.0006062000000000001,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f573",
+      "right_id": "z262",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The restaurant names (\"la caravelle\" vs \"lespinasse\"), street addresses (\"33 w. 55th st.\" vs \"2 e. 55th st.\"), and phone numbers are all completely different, indicating these are two distinct restaurants.",
+      "provenance": {
+        "tokens": {
+          "prompt": 297,
+          "completion": 207
+        },
+        "cost_usd": 0.0010363500000000001,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f723",
+      "right_id": "z263",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The records have completely different names, addresses, phone numbers, and cuisine types. There is no evidence to suggest these refer to the same restaurant.",
+      "provenance": {
+        "tokens": {
+          "prompt": 291,
+          "completion": 108
+        },
+        "cost_usd": 0.00068355,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f729",
+      "right_id": "z265",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The restaurants have completely different names (bouterin vs. march), addresses (420 e. 59th st. vs. 405 e. 58th st.), phone numbers, and cuisines (french vs. american (new)). There is no indication they refer to the same real-world restaurant.",
+      "provenance": {
+        "tokens": {
+          "prompt": 301,
+          "completion": 149
+        },
+        "cost_usd": 0.00083755,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f853",
+      "right_id": "z265",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The records have completely different names, addresses, phone numbers, and restaurant types. There is no evidence to suggest they refer to the same real-world restaurant.",
+      "provenance": {
+        "tokens": {
+          "prompt": 285,
+          "completion": 217
+        },
+        "cost_usd": 0.00105875,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f773",
+      "right_id": "z268",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The restaurant names (\"felix\" vs \"montrachet\"), addresses (\"340 w. broadway\" vs \"239 w. broadway\"), and phone numbers are all completely different, indicating these are two separate French restaurants in New York.",
+      "provenance": {
+        "tokens": {
+          "prompt": 287,
+          "completion": 374
+        },
+        "cost_usd": 0.0016103499999999998,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f587",
+      "right_id": "z271",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The records have completely different restaurant names (picholine vs petrossian), addresses (35 w. 64th st. vs 182 w. 58th st.), phone numbers, and cuisine types (mediterranean vs russian). They are clearly distinct restaurants.",
+      "provenance": {
+        "tokens": {
+          "prompt": 286,
+          "completion": 198
+        },
+        "cost_usd": 0.0009933,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f837",
+      "right_id": "z272",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The restaurants have completely different names (\"marichu\" vs \"picholine\"), addresses (\"342 e. 46th st.\" vs \"35 w. 64th st.\"), phone numbers, and cuisines (\"french\" vs \"mediterranean\"). They are definitively different restaurants.",
+      "provenance": {
+        "tokens": {
+          "prompt": 311,
+          "completion": 210
+        },
+        "cost_usd": 0.00106155,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f783",
+      "right_id": "z273",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The records have completely different names (\"follonico\" vs \"pisces\"), addresses (\"6 w. 24th st.\" vs \"95 ave. a\"), phone numbers, and cuisine types. There is no indication these refer to the same restaurant.",
+      "provenance": {
+        "tokens": {
+          "prompt": 279,
+          "completion": 181
+        },
+        "cost_usd": 0.0009264500000000001,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f558",
+      "right_id": "z274",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The records have completely different names (aquavit vs. rainbow room), addresses (13 w. 54th st. vs. 30 rockefeller plaza), phone numbers, and cuisine types. These are clearly two distinct restaurants in New York.",
+      "provenance": {
+        "tokens": {
+          "prompt": 277,
+          "completion": 163
+        },
+        "cost_usd": 0.0008613500000000001,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f796",
+      "right_id": "z274",
+      "label": true,
+      "source": "teacher",
+      "confidence": 1.0,
+      "reasoning": "The records have completely different names (\"halcyon\" vs \"rainbow room\"), addresses (\"151 w. 54th st.\" vs \"30 rockefeller plaza\"), and phone numbers. They are clearly different restaurants.",
+      "provenance": {
+        "tokens": {
+          "prompt": 296,
+          "completion": 131
+        },
+        "cost_usd": 0.0007693000000000001,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f776",
+      "right_id": "z274",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The restaurants have completely different names (\"film center cafe\" vs \"rainbow room\"), different addresses (635 9th Ave vs 30 Rockefeller Plaza), and different phone numbers. They are distinct establishments in New York.",
+      "provenance": {
+        "tokens": {
+          "prompt": 300,
+          "completion": 101
+        },
+        "cost_usd": 0.0006685,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f741",
+      "right_id": "z275",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The restaurant names, addresses, phone numbers, cities, and cuisine types are completely different, indicating these are two distinct restaurants.",
+      "provenance": {
+        "tokens": {
+          "prompt": 290,
+          "completion": 238
+        },
+        "cost_usd": 0.0011375,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f888",
+      "right_id": "z275",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The records have completely different names, addresses, cities, phone numbers, and cuisine types. There is no overlap in any identifying information.",
+      "provenance": {
+        "tokens": {
+          "prompt": 280,
+          "completion": 213
+        },
+        "cost_usd": 0.0010395,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f908",
+      "right_id": "z275",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The two records have completely different names (water club vs river cafe), addresses (500 e. 30th st. vs 1 water st.), cities (new york vs brooklyn), and phone numbers. They clearly refer to two distinct restaurants.",
+      "provenance": {
+        "tokens": {
+          "prompt": 271,
+          "completion": 181
+        },
+        "cost_usd": 0.0009180500000000001,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f739",
+      "right_id": "z275",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The names, addresses, cities (Manhattan vs Brooklyn), phone numbers, and cuisines are all completely different. There is no overlap or similarity suggesting these are the same restaurant.",
+      "provenance": {
+        "tokens": {
+          "prompt": 275,
+          "completion": 113
+        },
+        "cost_usd": 0.00068425,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f736",
+      "right_id": "z276",
+      "label": true,
+      "source": "teacher",
+      "confidence": 1.0,
+      "reasoning": "The restaurant names, street addresses, phone numbers, and cuisines are all completely different. There is no indication these refer to the same real-world restaurant.",
+      "provenance": {
+        "tokens": {
+          "prompt": 277,
+          "completion": 203
+        },
+        "cost_usd": 0.00100135,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f876",
+      "right_id": "z276",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The names (\"san pietro\" vs \"san domenico\"), addresses (\"18 e. 54th st.\" vs \"240 central park s.\"), and phone numbers (\"212/753-9015\" vs \"212-265-5959\") are completely different. These are clearly two distinct Italian restaurants in New York.",
+      "provenance": {
+        "tokens": {
+          "prompt": 282,
+          "completion": 308
+        },
+        "cost_usd": 0.0013741,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f563",
+      "right_id": "z277",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The records have completely different restaurant names (Carnegie Deli vs. Second Avenue Deli), different addresses (854 7th Ave vs. 156 Second Ave), and different phone numbers. Despite both being delicatessens in New York City, these are clearly two distinct real-world restaurants.",
+      "provenance": {
+        "tokens": {
+          "prompt": 302,
+          "completion": 128
+        },
+        "cost_usd": 0.0007651,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f862",
+      "right_id": "z277",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The records have completely different restaurant names (persepolis vs. second avenue deli), addresses (1423 2nd ave. vs. 156 second ave.), phone numbers (212/535-1100 vs. 212-677-0606), and cuisine types (middle eastern vs. delis). There is no indication these refer to the same restaurant.",
+      "provenance": {
+        "tokens": {
+          "prompt": 297,
+          "completion": 167
+        },
+        "cost_usd": 0.00089635,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f573",
+      "right_id": "z279",
+      "label": true,
+      "source": "teacher",
+      "confidence": 1.0,
+      "reasoning": "The restaurants have completely different names (\"la caravelle\" vs \"shun lee palace\"), different addresses (33 w. 55th st. vs 155 e. 55th st.), different phone numbers, and different cuisine types (french vs chinese).",
+      "provenance": {
+        "tokens": {
+          "prompt": 290,
+          "completion": 158
+        },
+        "cost_usd": 0.0008575,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f592",
+      "right_id": "z280",
+      "label": true,
+      "source": "teacher",
+      "confidence": 1.0,
+      "reasoning": "The records have completely different names (\"second avenue deli\" vs \"sign of the dove\"), addresses (156 2ndave vs 1110 third ave), phone numbers, and cuisine types. They are definitively different restaurants.",
+      "provenance": {
+        "tokens": {
+          "prompt": 292,
+          "completion": 180
+        },
+        "cost_usd": 0.0009366000000000001,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f864",
+      "right_id": "z280",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The restaurants have completely different names (pomaire vs. sign of the dove), addresses (371 w. 46th st. vs. 1110 third ave.), and phone numbers. They are clearly distinct entities.",
+      "provenance": {
+        "tokens": {
+          "prompt": 298,
+          "completion": 399
+        },
+        "cost_usd": 0.0017094,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f868",
+      "right_id": "z280",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The records have completely different names, addresses, phone numbers, and cuisine types, indicating they are clearly different restaurants.",
+      "provenance": {
+        "tokens": {
+          "prompt": 285,
+          "completion": 154
+        },
+        "cost_usd": 0.00083825,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f724",
+      "right_id": "z281",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The two records refer to completely different restaurants in New York City, with different names (\"ben benson's\" vs. \"smith & wollensky\"), different addresses (\"123 w. 52nd st.\" vs. \"797 third ave.\"), and different phone numbers.",
+      "provenance": {
+        "tokens": {
+          "prompt": 284,
+          "completion": 98
+        },
+        "cost_usd": 0.0006412,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f726",
+      "right_id": "z283",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The two records have entirely different restaurant names (\"billy's\" vs \"uncle nick's\"), addresses (\"948 1st ave.\" vs \"747 ninth ave.\"), phone numbers, and cuisine types (\"american\" vs \"greek\"). There are no matching attributes indicating these could be the same real-world restaurant.",
+      "provenance": {
+        "tokens": {
+          "prompt": 299,
+          "completion": 159
+        },
+        "cost_usd": 0.0008704499999999999,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f592",
+      "right_id": "z283",
+      "label": true,
+      "source": "teacher",
+      "confidence": 1.0,
+      "reasoning": "The two records have completely different names (second avenue deli vs. uncle nick's), addresses (156 2nd ave. vs. 747 ninth ave.), phone numbers, and cuisine types (delicatessen vs. greek). There is no overlap in any identifying fields, so they are clearly different restaurants.",
+      "provenance": {
+        "tokens": {
+          "prompt": 291,
+          "completion": 138
+        },
+        "cost_usd": 0.0007885500000000001,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f864",
+      "right_id": "z283",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The two records have completely different names (pomaire vs uncle nick's), addresses (371 w. 46th st vs 747 ninth ave), phone numbers, and cuisine types (latin american vs greek). There is no overlap in any identifying attributes.",
+      "provenance": {
+        "tokens": {
+          "prompt": 297,
+          "completion": 324
+        },
+        "cost_usd": 0.00144585,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f760",
+      "right_id": "z284",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The recordshave entirely different names (cupcake cafe vs union square cafe), addresses (522 9th ave. vs 21 e. 16th st.), and phone numbers, indicating they are distinct restaurants in New York.",
+      "provenance": {
+        "tokens": {
+          "prompt": 296,
+          "completion": 147
+        },
+        "cost_usd": 0.0008253,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f739",
+      "right_id": "z284",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The records have completely different restaurant names (cafe pierre vs. union square cafe), different addresses (2 e. 61st st. vs. 21 e. 16th st.), and different phone numbers. There is no indication they refer to the same restaurant.",
+      "provenance": {
+        "tokens": {
+          "prompt": 287,
+          "completion": 120
+        },
+        "cost_usd": 0.0007213499999999999,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f741",
+      "right_id": "z284",
+      "label": true,
+      "source": "teacher",
+      "confidence": 1.0,
+      "reasoning": "The restaurant names, addresses, phone numbers, and cuisine types are entirely different, indicating these are two distinct restaurants in New York.",
+      "provenance": {
+        "tokens": {
+          "prompt": 302,
+          "completion": 104
+        },
+        "cost_usd": 0.0006811,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f569",
+      "right_id": "z285",
+      "label": true,
+      "source": "teacher",
+      "confidence": 1.0,
+      "reasoning": "The two records have completely different names, addresses, phone numbers, and restaurant types (Gotham Bar & Grill vs. Virgil's Real BBQ), clearly referring to two different restaurants.",
+      "provenance": {
+        "tokens": {
+          "prompt": 297,
+          "completion": 73
+        },
+        "cost_usd": 0.00056735,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f963",
+      "right_id": "z287",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The restaurant names, addresses, phone numbers, and food types are all completely different, indicating they are two separate establishments.",
+      "provenance": {
+        "tokens": {
+          "prompt": 298,
+          "completion": 212
+        },
+        "cost_usd": 0.0010549000000000001,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f963",
+      "right_id": "z288",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The two records have different names, addresses, and phone numbers. Record A is \"bistro\" on Las Vegas Blvd. S with phone 702-791-7111, while Record B is \"le montrachet bistro\" on Paradise Rd. with phone 702-732-5651. These indicate two distinct restaurants.",
+      "provenance": {
+        "tokens": {
+          "prompt": 287,
+          "completion": 225
+        },
+        "cost_usd": 0.00108885,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f967",
+      "right_id": "z288",
+      "label": true,
+      "source": "teacher",
+      "confidence": 1.0,
+      "reasoning": "The two records have entirely different names, addresses, phone numbers, and restaurant types. There is no overlap in the identifying information to suggest these refer to the same real-world restaurant.",
+      "provenance": {
+        "tokens": {
+          "prompt": 294,
+          "completion": 75
+        },
+        "cost_usd": 0.0005712,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f986",
+      "right_id": "z288",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The restaurants have completely different names (Yolie's vs Le Montrachet Bistro), different addresses (3900 Paradise Rd vs 3000 Paradise Rd), different phone numbers, and different cuisine types (Steak houses vs French bistro). There is no evidence to suggest they are the same restaurant.",
+      "provenance": {
+        "tokens": {
+          "prompt": 285,
+          "completion": 184
+        },
+        "cost_usd": 0.0009432500000000001,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f983",
+      "right_id": "z289",
+      "label": true,
+      "source": "teacher",
+      "confidence": 0.9,
+      "reasoning": "Although both records share the exact same address (likely Caesars Palace), the restaurant names (\"the bacchanal\" vs \"palace court\"), phone numbers, and types are completely different, indicating they are separate restaurants within the same location.",
+      "provenance": {
+        "tokens": {
+          "prompt": 300,
+          "completion": 218
+        },
+        "cost_usd": 0.001078,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f963",
+      "right_id": "z290",
+      "label": true,
+      "source": "teacher",
+      "confidence": 1.0,
+      "reasoning": "The two records have different names, addresses, phone numbers, and restaurant types. There is no overlap in the identifying attributes, so they definitely refer to different restaurants.",
+      "provenance": {
+        "tokens": {
+          "prompt": 283,
+          "completion": 156
+        },
+        "cost_usd": 0.00084315,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f958",
+      "right_id": "z291",
+      "label": true,
+      "source": "teacher",
+      "confidence": 1.0,
+      "reasoning": "The records have different names (\"bally's big kitchen\" vs \"steak house the\"), different addresses (3645 vs 2880 las vegas blvd. s), different phone numbers, and different restaurant types (buffets vs steakhouses).",
+      "provenance": {
+        "tokens": {
+          "prompt": 303,
+          "completion": 156
+        },
+        "cost_usd": 0.00086415,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f983",
+      "right_id": "z291",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The names, addresses, and phone numbers are completely different. \"The Bacchanal\" is located at 3570 Las Vegas Blvd S (Caesars Palace), while \"Steak House The\" is located at 2880 Las Vegas Blvd S (Circus Circus), making them definitively different restaurants.",
+      "provenance": {
+        "tokens": {
+          "prompt": 303,
+          "completion": 225
+        },
+        "cost_usd": 0.0011056500000000001,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f969",
+      "right_id": "z292",
+      "label": true,
+      "source": "teacher",
+      "confidence": 1.0,
+      "reasoning": "The records have completely different names, addresses, phone numbers, and restaurant types, indicating they are distinct establishments.",
+      "provenance": {
+        "tokens": {
+          "prompt": 293,
+          "completion": 151
+        },
+        "cost_usd": 0.00083615,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f957",
+      "right_id": "z292",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The records have completely different names, addresses (3700 w. flamingo vs 2245 e. flamingo rd.), phone numbers, and cuisine types (italian vs steakhouses). These are clearly two different restaurants.",
+      "provenance": {
+        "tokens": {
+          "prompt": 289,
+          "completion": 118
+        },
+        "cost_usd": 0.00071645,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f625",
+      "right_id": "z295",
+      "label": true,
+      "source": "teacher",
+      "confidence": 1.0,
+      "reasoning": "The records have completely different names, addresses, and phone numbers. There is no overlap in any identifying information, indicating they are distinct restaurants.",
+      "provenance": {
+        "tokens": {
+          "prompt": 296,
+          "completion": 176
+        },
+        "cost_usd": 0.0009268,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f626",
+      "right_id": "z296",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The restaurant names (\"toulouse\" vs \"brasserie le coze\"), addresses (\"b peachtree rd.\" vs \"3393 peachtree rd.\"), and phone numbers are all different. These are clearly distinct French restaurants in Atlanta.",
+      "provenance": {
+        "tokens": {
+          "prompt": 282,
+          "completion": 139
+        },
+        "cost_usd": 0.0007826,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f956",
+      "right_id": "z296",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The restaurants have completely different names (\"tomtom\" vs \"brasserie le coze\"), different phone numbers, and different types. Although they share the same address, these are clearly two different establishments.",
+      "provenance": {
+        "tokens": {
+          "prompt": 284,
+          "completion": 371
+        },
+        "cost_usd": 0.0015967000000000002,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f623",
+      "right_id": "z297",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The two records have different restaurant names, different street addresses (3434 peachtree rd. vs 3073 piedmont rd.), and different phone numbers. They are clearly distinct establishments in Atlanta.",
+      "provenance": {
+        "tokens": {
+          "prompt": 303,
+          "completion": 175
+        },
+        "cost_usd": 0.00093065,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f624",
+      "right_id": "z297",
+      "label": true,
+      "source": "teacher",
+      "confidence": 1.0,
+      "reasoning": "The records have completely different names, addresses, phone numbers, and cuisine types. Record A refers to the fine dining restaurant inside the Ritz-Carlton Buckhead, while Record B refers to a separate American diner located on Piedmont Rd.",
+      "provenance": {
+        "tokens": {
+          "prompt": 300,
+          "completion": 234
+        },
+        "cost_usd": 0.001134,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f625",
+      "right_id": "z298",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The records have different names (Ritz-Carlton Atlanta vs Ciboulette restaurant), different addresses (181 Peachtree St. vs 1529 Piedmont Ave.), different phone numbers, and different cuisine types. They clearly refer to two different restaurants in Atlanta.",
+      "provenance": {
+        "tokens": {
+          "prompt": 295,
+          "completion": 118
+        },
+        "cost_usd": 0.00072275,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f614",
+      "right_id": "z299",
+      "label": true,
+      "source": "teacher",
+      "confidence": 0.98,
+      "reasoning": "The records have identical names, addresses, cities, and matching phone numbers (differing only in formatting). The type and source differ, but this is expected from different data sources describing the same restaurant.",
+      "provenance": {
+        "tokens": {
+          "prompt": 284,
+          "completion": 137
+        },
+        "cost_usd": 0.0007777000000000001,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f610",
+      "right_id": "z299",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The tworecords have completely different names (\"bone's\" vs \"delectables\"), addresses, phone numbers, and restaurant types, indicating they are completely different establishments in Atlanta.",
+      "provenance": {
+        "tokens": {
+          "prompt": 281,
+          "completion": 389
+        },
+        "cost_usd": 0.0016565500000000001,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f613",
+      "right_id": "z299",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The records have completely different names, addresses, phone numbers, and cuisine types, with no overlapping information to suggest they refer to the same restaurant.",
+      "provenance": {
+        "tokens": {
+          "prompt": 284,
+          "completion": 57
+        },
+        "cost_usd": 0.0004977,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f920",
+      "right_id": "z300",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The two records have completely different names (\"bistango\" vs \"georgia grille\"), street addresses (\"1100 peachtree st.\" vs \"2290 peachtree rd.\"), phone numbers, and cuisine types, making it clear they are different restaurants.",
+      "provenance": {
+        "tokens": {
+          "prompt": 280,
+          "completion": 452
+        },
+        "cost_usd": 0.0018759999999999998,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f934",
+      "right_id": "z300",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The restaurant names, phone numbers, and exact addresses are completely different, indicating these are distinct restaurants located near each other on Peachtree Rd. in Atlanta.",
+      "provenance": {
+        "tokens": {
+          "prompt": 292,
+          "completion": 222
+        },
+        "cost_usd": 0.0010836,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f622",
+      "right_id": "z301",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The records have completely different restaurant names, addresses (1232 W. Paces Ferry Rd. vs 490 E. Paces Ferry Rd. NE), and phone numbers. These are clearly two different restaurants in Atlanta.",
+      "provenance": {
+        "tokens": {
+          "prompt": 305,
+          "completion": 151
+        },
+        "cost_usd": 0.00084875,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f618",
+      "right_id": "z303",
+      "label": true,
+      "source": "teacher",
+      "confidence": 0.99,
+      "reasoning": "The restaurant name, street address, and city are identical. The phone numbers are functionally identical, differing only in formatting (slash vs. hyphen). The slight difference in the restaurant \"type\" (caribbean vs. eclectic) is typical when comparing different review sources like Fodors and Zagat, and does not outweigh the exact name and location matches.",
+      "provenance": {
+        "tokens": {
+          "prompt": 288,
+          "completion": 294
+        },
+        "cost_usd": 0.0013314,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f956",
+      "right_id": "z304",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The restaurant names are completely different (\"tomtom\" vs \"la grotta\"), the phone numbers do not match, the street numbers are different (3393 vs 2637), and the cuisine types differ (continental vs italian). They are clearly distinct restaurants on the same road in Atlanta.",
+      "provenance": {
+        "tokens": {
+          "prompt": 281,
+          "completion": 240
+        },
+        "cost_usd": 0.00113505,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f916",
+      "right_id": "z304",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The records have completely different names, addresses, phone numbers, and cuisine types. The only shared attribute is the city (Atlanta). These are clearly two distinct restaurants.",
+      "provenance": {
+        "tokens": {
+          "prompt": 299,
+          "completion": 123
+        },
+        "cost_usd": 0.00074445,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f620",
+      "right_id": "z305",
+      "label": true,
+      "source": "teacher",
+      "confidence": 1.0,
+      "reasoning": "Both records have the exact same name, address, city, and embed_text. The phone numbers are identical aside from formatting differences (slash vs hyphen). The types are also highly similar (\"southern\" vs \"southern/soul\"). These clearly refer to the same real-world restaurant.",
+      "provenance": {
+        "tokens": {
+          "prompt": 297,
+          "completion": 160
+        },
+        "cost_usd": 0.0008718500000000001,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f624",
+      "right_id": "z305",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The two records have entirely different names, addresses, phone numbers, and restaurant types. Record A refers to the dining room at the Ritz-Carlton Buckhead, while Record B refers to Mary Mac's Tea Room, which are distinct restaurants in Atlanta.",
+      "provenance": {
+        "tokens": {
+          "prompt": 306,
+          "completion": 159
+        },
+        "cost_usd": 0.0008778,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f610",
+      "right_id": "z306",
+      "label": true,
+      "source": "teacher",
+      "confidence": 1.0,
+      "reasoning": "The records have completely different names, addresses, and phone numbers. They are clearly distinct restaurants in Atlanta.",
+      "provenance": {
+        "tokens": {
+          "prompt": 277,
+          "completion": 104
+        },
+        "cost_usd": 0.00065485,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f935",
+      "right_id": "z306",
+      "label": true,
+      "source": "teacher",
+      "confidence": 1.0,
+      "reasoning": "The records have completely different names, addresses, phone numbers, and cuisine types. There is no overlap in any identifying information, indicating they are distinct restaurants.",
+      "provenance": {
+        "tokens": {
+          "prompt": 288,
+          "completion": 179
+        },
+        "cost_usd": 0.0009289000000000001,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f945",
+      "right_id": "z306",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The two records have completely different names (\"pleasant peasant\" vs \"nikolai's roof\"), addresses (\"555 peachtree st.\" vs \"255 courtland st.\"), phone numbers, and restaurant types. There is no overlap in any identifying attributes, indicating they are distinct restaurants.",
+      "provenance": {
+        "tokens": {
+          "prompt": 287,
+          "completion": 94
+        },
+        "cost_usd": 0.00063035,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f625",
+      "right_id": "z308",
+      "label": true,
+      "source": "teacher",
+      "confidence": 0.9,
+      "reasoning": "While both records refer to restaurants associated with the Ritz-Carlton in Atlanta, they are at different locations (Downtown vs. Buckhead) with different addresses, phone numbers, and restaurant types. Record B explicitly specifies \"buckhead\" and \"cafe\", distinguishing it from the main Ritz-Carlton Atlanta restaurant in Record A.",
+      "provenance": {
+        "tokens": {
+          "prompt": 307,
+          "completion": 210
+        },
+        "cost_usd": 0.0010573499999999999,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f623",
+      "right_id": "z310",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.05,
+      "reasoning": "The restaurants have different names, addresses (3434 Peachtree Rd. vs 181 Peachtree St.), and phone numbers. While both are associated with the Ritz-Carlton brand in Atlanta, they are located in different parts of the city (Buckhead vs. Downtown) and refer to distinct dining establishments.",
+      "provenance": {
+        "tokens": {
+          "prompt": 302,
+          "completion": 221
+        },
+        "cost_usd": 0.0010906,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f920",
+      "right_id": "z311",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The records have completely different names, addresses, phone numbers, and cuisine types. They only share the city and the street name (Peachtree), which is a very long street in Atlanta, making it insufficient to consider them the same restaurant.",
+      "provenance": {
+        "tokens": {
+          "prompt": 281,
+          "completion": 197
+        },
+        "cost_usd": 0.00098455,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f923",
+      "right_id": "z311",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The records have different names (cassis vs. toulouse), different addresses (3300 peachtree rd vs 293-b peachtree rd), different phone numbers, and different cuisine types. They are distinct restaurants.",
+      "provenance": {
+        "tokens": {
+          "prompt": 288,
+          "completion": 154
+        },
+        "cost_usd": 0.0008414,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f627",
+      "right_id": "z312",
+      "label": true,
+      "source": "teacher",
+      "confidence": 1.0,
+      "reasoning": "Both records have the identical name, address, city, and phone number (formatting difference only: \"/\" vs \"-\"). They also share the same type, confirming they refer to the same restaurant.",
+      "provenance": {
+        "tokens": {
+          "prompt": 290,
+          "completion": 54
+        },
+        "cost_usd": 0.0004935,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f660",
+      "right_id": "z312",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The two records have completely different names, cities, addresses, phone numbers, and restaurant types, indicating they refer to entirely different establishments.",
+      "provenance": {
+        "tokens": {
+          "prompt": 280,
+          "completion": 159
+        },
+        "cost_usd": 0.0008504999999999999,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f547",
+      "right_id": "z312",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The records have different names (locanda veneta vs. veni vidi vici), different cities (los angeles vs. atlanta), different addresses, and different phone numbers. They clearly refer to different restaurants.",
+      "provenance": {
+        "tokens": {
+          "prompt": 282,
+          "completion": 144
+        },
+        "cost_usd": 0.0008001,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f628",
+      "right_id": "z313",
+      "label": true,
+      "source": "teacher",
+      "confidence": 1.0,
+      "reasoning": "The records have identical names, addresses, cities, and embed text. The phone numbers are the same, just formatted differently (415/387-0408 vs 415-387-0408). The type is a close match (\"french\" vs \"french (new)\"). These factors overwhelmingly indicate they refer to the same real-world restaurant.",
+      "provenance": {
+        "tokens": {
+          "prompt": 284,
+          "completion": 242
+        },
+        "cost_usd": 0.0011452,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f634",
+      "right_id": "z313",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The two records have completely different restaurant names, addresses, and phone numbers. They are clearly distinct restaurants in San Francisco.",
+      "provenance": {
+        "tokens": {
+          "prompt": 286,
+          "completion": 71
+        },
+        "cost_usd": 0.0005488000000000001,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f1026",
+      "right_id": "z313",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The records have completely different restaurant names (\"le soleil\" vs \"alain rondelli\"), different addresses (133 vs 126 Clement St.), different phone numbers, and different cuisine types. There is no evidence to suggest these are the same restaurant.",
+      "provenance": {
+        "tokens": {
+          "prompt": 280,
+          "completion": 91
+        },
+        "cost_usd": 0.0006125,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f629",
+      "right_id": "z314",
+      "label": true,
+      "source": "teacher",
+      "confidence": 1.0,
+      "reasoning": "Both records have the same restaurant name (\"aqua\"), identical address (\"252 california st.\"), same city (\"san francisco\"), and matching phone numbers (formatting differs slightly). The different cuisine types and sources are expected cross-platform variations.",
+      "provenance": {
+        "tokens": {
+          "prompt": 275,
+          "completion": 109
+        },
+        "cost_usd": 0.0006702500000000001,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f1045",
+      "right_id": "z314",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The records have different names (scala's bistro vs. aqua), different addresses (432 powell st. vs. 252 california st.), different phone numbers, and different cuisine types. These are clearly two different restaurants in San Francisco.",
+      "provenance": {
+        "tokens": {
+          "prompt": 281,
+          "completion": 116
+        },
+        "cost_usd": 0.0007010499999999999,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f1031",
+      "right_id": "z314",
+      "label": true,
+      "source": "teacher",
+      "confidence": 1.0,
+      "reasoning": "The two records have completely different names (millennium vs. aqua), addresses (246 mcallister st. vs. 252 california st.), phone numbers, and restaurant types. They clearly refer to different restaurants in San Francisco.",
+      "provenance": {
+        "tokens": {
+          "prompt": 281,
+          "completion": 174
+        },
+        "cost_usd": 0.00090405,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f996",
+      "right_id": "z314",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The records have different names (cafe marimba vs aqua), different addresses (2317 chestnut st. vs 252 california st.), and different phone numbers. These are clearly two different restaurants.",
+      "provenance": {
+        "tokens": {
+          "prompt": 290,
+          "completion": 128
+        },
+        "cost_usd": 0.0007525,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f630",
+      "right_id": "z315",
+      "label": true,
+      "source": "teacher",
+      "confidence": 1.0,
+      "reasoning": "Both records have identical names (\"boulevard\"), addresses (\"1 mission st.\"), and cities (\"san francisco\"). The phone numbers match exactly despite minor formatting differences (slashes vs hyphens). The cuisine types are compatible (\"american\" vs \"american (new)\"). The different sources (Fodors vs Zagat) further support that these are two listings for the same well-known San Francisco restaurant.",
+      "provenance": {
+        "tokens": {
+          "prompt": 269,
+          "completion": 150
+        },
+        "cost_usd": 0.0008074499999999999,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f1025",
+      "right_id": "z315",
+      "label": true,
+      "source": "teacher",
+      "confidence": 1.0,
+      "reasoning": "The records have completely different names (le central vs. boulevard), addresses (453 bush st. vs. 1 mission st.), phone numbers, and cuisine types, clearly indicating they are two different restaurants in San Francisco.",
+      "provenance": {
+        "tokens": {
+          "prompt": 272,
+          "completion": 142
+        },
+        "cost_usd": 0.0007826,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f996",
+      "right_id": "z316",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The two records have completely different names (cafe marimba vs. cafe claude), addresses (2317 chestnut st. vs. 7 claude ln.), phone numbers (415/776-1506 vs. 415-392-3505), and cuisines (mexican/latin american/spanish vs. french bistro). There is no overlap in any identifying information other than the city.",
+      "provenance": {
+        "tokens": {
+          "prompt": 294,
+          "completion": 192
+        },
+        "cost_usd": 0.0009807000000000001,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f657",
+      "right_id": "z316",
+      "label": true,
+      "source": "teacher",
+      "confidence": 1.0,
+      "reasoning": "The records have completely different names, cities, addresses, phone numbers, and cuisine types, making it certain they refer to different restaurants.",
+      "provenance": {
+        "tokens": {
+          "prompt": 284,
+          "completion": 496
+        },
+        "cost_usd": 0.0020342000000000003,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f1050",
+      "right_id": "z316",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The records have completely different names, addresses, phone numbers, and cuisine types. They are definitely distinct restaurants in San Francisco.",
+      "provenance": {
+        "tokens": {
+          "prompt": 294,
+          "completion": 178
+        },
+        "cost_usd": 0.0009316999999999999,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f632",
+      "right_id": "z317",
+      "label": true,
+      "source": "teacher",
+      "confidence": 0.99,
+      "reasoning": "Both records share the same name, address, city, and phone number (with only minor formatting differences in the phone number). The restaurant type is also closely related (\"american\" vs \"american (new)\"). They come from different sources (fodors and zagat), which is expected for the same real-world restaurant listed in different guides.",
+      "provenance": {
+        "tokens": {
+          "prompt": 278,
+          "completion": 117
+        },
+        "cost_usd": 0.0007014,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f1021",
+      "right_id": "z317",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The records have completely different names, addresses, and phone numbers, with no overlap beyond being located in San Francisco. There is no evidence suggesting these refer to the same restaurant.",
+      "provenance": {
+        "tokens": {
+          "prompt": 279,
+          "completion": 115
+        },
+        "cost_usd": 0.00069545,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f1045",
+      "right_id": "z317",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The records have completely different names (scala's bistro vs. campton place), different addresses (432 powell st. vs. 340 stockton st.), different phone numbers, and different cuisine types. These are clearly distinct restaurants in San Francisco.",
+      "provenance": {
+        "tokens": {
+          "prompt": 283,
+          "completion": 86
+        },
+        "cost_usd": 0.00059815,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f634",
+      "right_id": "z319",
+      "label": true,
+      "source": "teacher",
+      "confidence": 1.0,
+      "reasoning": "The records have identical names, addresses, and cities. The phone numbers are the same but formatted differently. The restaurant types are very similar (\"french\" vs \"french (new)\"). All evidence strongly indicates these are the same restaurant.",
+      "provenance": {
+        "tokens": {
+          "prompt": 288,
+          "completion": 268
+        },
+        "cost_usd": 0.0012404,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f1025",
+      "right_id": "z320",
+      "label": true,
+      "source": "teacher",
+      "confidence": 1.0,
+      "reasoning": "The names (\"le central\" vs \"fringale\"), addresses (\"453 bush st.\" vs \"570 fourth st.\"), and phone numbers (\"415/391-2233\" vs \"415-543-0573\") are completely different, indicating these are two distinct restaurants in San Francisco.",
+      "provenance": {
+        "tokens": {
+          "prompt": 277,
+          "completion": 256
+        },
+        "cost_usd": 0.0011868500000000001,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f993",
+      "right_id": "z320",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The records have different names (bizou vs fringale), different street addresses (598 vs 570), and different phone line numbers (2222 vs 0573). They are distinct restaurants on the same street in San Francisco.",
+      "provenance": {
+        "tokens": {
+          "prompt": 276,
+          "completion": 259
+        },
+        "cost_usd": 0.0011963,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f636",
+      "right_id": "z321",
+      "label": true,
+      "source": "teacher",
+      "confidence": 0.99,
+      "reasoning": "The records have identical names, addresses, and cities. The phone numbers are identical except for formatting (slash vs hyphen). The cuisine types (american vs californian) are highly related and often used interchangeably in restaurant guides. The slight differences are consistent with different data sources (Fodors vs Zagat) describing the same restaurant.",
+      "provenance": {
+        "tokens": {
+          "prompt": 294,
+          "completion": 132
+        },
+        "cost_usd": 0.0007707,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f1031",
+      "right_id": "z321",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The records have completely different names, addresses, phone numbers, and restaurant types. They are clearly distinct restaurants in San Francisco.",
+      "provenance": {
+        "tokens": {
+          "prompt": 291,
+          "completion": 385
+        },
+        "cost_usd": 0.00165305,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f630",
+      "right_id": "z321",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The restaurant names, addresses, and phone numbers are completely different, indicating they refer to two distinct restaurants in San Francisco.",
+      "provenance": {
+        "tokens": {
+          "prompt": 282,
+          "completion": 123
+        },
+        "cost_usd": 0.0007266,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f637",
+      "right_id": "z322",
+      "label": true,
+      "source": "teacher",
+      "confidence": 1.0,
+      "reasoning": "The records have identical restaurant names, addresses, and cities. The phone numbers are the same but formatted differently (slashes vs dashes). The cuisine types are closely related (asian vs thai), and the different sources (fodors vs zagat) simply indicate the records were aggregated from different guides. These definitively refer to the same real-world restaurant.",
+      "provenance": {
+        "tokens": {
+          "prompt": 302,
+          "completion": 156
+        },
+        "cost_usd": 0.0008631000000000001,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f1003",
+      "right_id": "z323",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The records have completely different names (faz vs la folie), addresses (161 sutter st. vs 2316 polk st.), phone numbers, and restaurant types. They are definitively different restaurants.",
+      "provenance": {
+        "tokens": {
+          "prompt": 285,
+          "completion": 181
+        },
+        "cost_usd": 0.00093275,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f1050",
+      "right_id": "z324",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The records have completely different names (\"stoyanof's cafe\" vs \"lulu restaurant-bis-cafe\"), different addresses (\"1240 9th ave.\" vs \"816 folsom st.\"), and different phone numbers. There is no overlap in any identifying information.",
+      "provenance": {
+        "tokens": {
+          "prompt": 304,
+          "completion": 91
+        },
+        "cost_usd": 0.0006376999999999999,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f1051",
+      "right_id": "z324",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The records have completely different names (straits cafe vs. lulu restaurant-bis-cafe), different addresses (3300 geary blvd. vs. 816 folsom st.), different phone numbers (415/668-1783 vs. 415-495-5775), and different cuisine types (asian vs. mediterranean). There is no evidence these refer to the same restaurant.",
+      "provenance": {
+        "tokens": {
+          "prompt": 294,
+          "completion": 219
+        },
+        "cost_usd": 0.0010752000000000001,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f708",
+      "right_id": "z324",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The two records have completely different names, addresses, cities, phone numbers, and cuisine types. There is no overlap in any identifying information, clearly indicating they are different restaurants.",
+      "provenance": {
+        "tokens": {
+          "prompt": 295,
+          "completion": 71
+        },
+        "cost_usd": 0.00055825,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f1031",
+      "right_id": "z325",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The records have different names (millennium vs masa's), addresses (246 mcallister st. vs 648 bush st.), phone numbers, and cuisine types. They are clearly distinct restaurants in San Francisco.",
+      "provenance": {
+        "tokens": {
+          "prompt": 284,
+          "completion": 251
+        },
+        "cost_usd": 0.0011767,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f643",
+      "right_id": "z326",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The restaurants have completely different names (postrio vs. mifune), addresses (545 post st. vs. 1737 postst.), phone numbers, and cuisine types (american vs. japanese). They are clearly two distinct establishments.",
+      "provenance": {
+        "tokens": {
+          "prompt": 275,
+          "completion": 225
+        },
+        "cost_usd": 0.00107625,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f643",
+      "right_id": "z328",
+      "label": true,
+      "source": "teacher",
+      "confidence": 0.99,
+      "reasoning": "The records share the exact same name (\"postrio\"), address (\"545 post st.\"), city (\"san francisco\"), and phone number (differing only in formatting). The cuisine types (\"american\" vs \"californian\") are closely related, and the differing sources (fodors vs zagat) are expected for duplicate listings.",
+      "provenance": {
+        "tokens": {
+          "prompt": 274,
+          "completion": 182
+        },
+        "cost_usd": 0.0009247,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f1025",
+      "right_id": "z328",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The records have different names (\"le central\" vs \"postrio\"), different addresses (453 bush st vs 545 post st), different phone numbers, and different cuisine types (french vs californian). There is no evidence to suggest these refer to the same restaurant.",
+      "provenance": {
+        "tokens": {
+          "prompt": 275,
+          "completion": 155
+        },
+        "cost_usd": 0.0008312500000000001,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f624",
+      "right_id": "z329",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The two records refer to restaurants in completely different cities (Atlanta vs. San Francisco) with different addresses and phone numbers, indicating they are distinct locations of the Ritz-Carlton brand.",
+      "provenance": {
+        "tokens": {
+          "prompt": 313,
+          "completion": 138
+        },
+        "cost_usd": 0.00081165,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f625",
+      "right_id": "z329",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The two records refer to restaurants in completely different cities (Atlanta vs. San Francisco) with different addresses, phone numbers, and names. They are different branches of the Ritz-Carlton hotel chain.",
+      "provenance": {
+        "tokens": {
+          "prompt": 306,
+          "completion": 147
+        },
+        "cost_usd": 0.0008358,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f645",
+      "right_id": "z330",
+      "label": true,
+      "source": "teacher",
+      "confidence": 1.0,
+      "reasoning": "The records have identical names, addresses, cities, types, and embed_text. The phone numbers match exactly when formatting differences are normalized (slash vs. hyphen separator). The only difference is the source (fodors vs. zagat), which is expected in entity resolution tasks.",
+      "provenance": {
+        "tokens": {
+          "prompt": 281,
+          "completion": 130
+        },
+        "cost_usd": 0.0007500499999999999,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f1021",
+      "right_id": "z330",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The records have completely different names, addresses, and phone numbers. There is no evidence to suggest they refer to the same restaurant.",
+      "provenance": {
+        "tokens": {
+          "prompt": 279,
+          "completion": 210
+        },
+        "cost_usd": 0.00102795,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f1058",
+      "right_id": "z330",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.0,
+      "reasoning": "The restaurant names, addresses, and phone numbers are completely different between the two records. While they are both Italian restaurants in San Francisco, there is no overlap in any identifying information.",
+      "provenance": {
+        "tokens": {
+          "prompt": 283,
+          "completion": 230
+        },
+        "cost_usd": 0.00110215,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    },
+    {
+      "left_id": "f624",
+      "right_id": "z331",
+      "label": false,
+      "source": "teacher",
+      "confidence": 0.1,
+      "reasoning": "While both records are associated with the Ritz-Carlton in Atlanta, they are at completelydifferent addresses (3434 Peachtree Rd. in Buckhead vs. 181 Peachtree St. downtown), have different phone numbers, and different restaurant names (\"dining room\" vs \"cafe\"). These are two distinct restaurants.",
+      "provenance": {
+        "tokens": {
+          "prompt": 306,
+          "completion": 200
+        },
+        "cost_usd": 0.0010213,
+        "model": "openrouter/z-ai/glm-5.2"
+      }
+    }
+  ],
+  "metadata": {
+    "blocker": "VectorBlocker",
+    "k_neighbors": 5,
+    "labeler": "TeacherLabeler",
+    "total_cost_usd": 1.2848156999999987,
+    "corpus_size": 864,
+    "total_candidates": 3490,
+    "filtered_candidates": 1382,
+    "mined": 1382,
+    "labeled": 1382,
+    "matches": 382,
+    "non_matches": 1000
+  }
+}

--- a/data/gold_sets/fodors_zagat/report.md
+++ b/data/gold_sets/fodors_zagat/report.md
@@ -15,13 +15,13 @@
 - Cohen's kappa: 0.6954
 - MCC: 0.7256
 
-## Calibration (teacher confidence vs. correctness)
+## Calibration (P(match) score vs. is-match)
 - Evaluated pairs: 213
-- Brier score (primary): 0.4741
-- ECE (equal-mass, 8 bins): 0.4635
+- Brier score (primary): 0.1469
+- ECE (equal-mass, 8 bins): 0.1363
 - Reliability bins (mean_conf -> observed_freq, count):
-  - 0.0000 -> 1.0000 (n=67)
-  - 0.0500 -> 1.0000 (n=3)
+  - 0.0000 -> 0.0000 (n=67)
+  - 0.0500 -> 0.0000 (n=3)
   - 0.8180 -> 0.7333 (n=15)
   - 0.9882 -> 0.9697 (n=33)
   - 1.0000 -> 0.7158 (n=95)

--- a/data/gold_sets/fodors_zagat/report.md
+++ b/data/gold_sets/fodors_zagat/report.md
@@ -1,0 +1,39 @@
+# Bootstrap Report
+
+## Blocking (pair-completeness)
+- Pair-completeness (candidate recall): 0.9911
+- Candidate precision: 0.0803
+- Total candidates: 1382
+- Missed matches: 1
+
+## Teacher-vs-truth agreement
+- Evaluated pairs: 213
+- Accuracy: 0.8498
+- Precision: 0.7801
+- Recall: 0.9910
+- F1: 0.8730
+- Cohen's kappa: 0.6954
+- MCC: 0.7256
+
+## Calibration (teacher confidence vs. correctness)
+- Evaluated pairs: 213
+- Brier score (primary): 0.4741
+- ECE (equal-mass, 8 bins): 0.4635
+- Reliability bins (mean_conf -> observed_freq, count):
+  - 0.0000 -> 1.0000 (n=67)
+  - 0.0500 -> 1.0000 (n=3)
+  - 0.8180 -> 0.7333 (n=15)
+  - 0.9882 -> 0.9697 (n=33)
+  - 1.0000 -> 0.7158 (n=95)
+
+## Routing / coverage
+- Total candidates: 1382
+- Mined: 1382
+- Labeled: 1382
+- Skipped: 0
+- With ground truth: 213
+- Total cost (USD): 1.2848
+
+## Agreement convergence
+- Points: 213
+- Final F1 @ 213 labels: 0.8730

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -6,6 +6,30 @@
 - Implemented core primitives (`Module`, `Blocker`, `Clusterer`) with Pydantic data contracts and 100% test coverage
 - Completed Approach 1 (classical baseline): `AllPairsBlocker` + `RapidfuzzModule` end-to-end pipeline
 
+### M1: Cold-start gold-set bootstrapping (LLM-teacher)
+
+Reusable, entity-type-agnostic `langres.bootstrap` package that mines hard-negative
+candidate pairs from a blocker, labels them with a budget-capped LLM teacher, and
+emits a versioned gold set + coverage/calibration report. Validated on the
+**Fodors-Zagat** restaurant benchmark (864 records / 112 cross-source matches).
+
+- **Data contract + adapter**: `GoldPair`/`GoldSet` (versioned Pydantic, JSON
+  save/load), `RestaurantSchema` (computed `embed_text`), `load_fodors_zagat`,
+  and a blocking k-sweep that pins `DEFAULT_BLOCKING_K=5` (Pair-Completeness 0.9911).
+- **Mining + labeling**: `HardNegativeMiner` (three-stratum similarity sampling),
+  `TeacherLabeler` (hard $20 budget cap via pre-flight pair cap + per-pair token
+  tally + blind-cost abort, `enable_langfuse=False` client), plus `GroundTruth`/`Fake`
+  labelers for deterministic, zero-spend CI runs.
+- **Metrics + report**: added `cohens_kappa`, `matthews_corrcoef`, `brier_score`,
+  `expected_calibration_error` (equal-mass bins), `reliability_bins` to `core.metrics`;
+  `BootstrapReport` covers Pair-Completeness, teacher-vs-truth agreement (F1/kappa/MCC),
+  calibration (Brier/ECE of P(match) vs is-match), and an agreement-convergence curve.
+- **`Bootstrapper`** orchestrator wires blocker → cross-source filter → miner → labeler
+  → gold set + report; deterministic real-embedding example + slow CI test.
+- **EXIT (real GLM-5.2 teacher run, $1.28)**: 1382-pair gold set committed at
+  `data/gold_sets/fodors_zagat/`; Pair-Completeness 0.9911, teacher-vs-truth (n=213)
+  F1 0.873 / kappa 0.695 / MCC 0.726, calibration Brier 0.147 / ECE 0.136.
+
 ### Component Inspection Methods (Progressive Pipeline Building)
 
 **Added exploratory analysis capabilities to core components** - enables parameter tuning WITHOUT ground truth labels:

--- a/examples/run_m1_gold_set.py
+++ b/examples/run_m1_gold_set.py
@@ -20,8 +20,9 @@ blind" lesson):
         --worst-case-tokens 1500 --budget 20 --budget-soft 15
 
 The teacher client is built with ``enable_langfuse=False`` (B4), so no Langfuse
-creds are needed. ``OPENROUTER_API_KEY`` is read from ``.env`` via pydantic-settings.
-Run with the sandbox disabled — openrouter.ai is a network call.
+creds are needed. ``OPENROUTER_API_KEY`` is loaded from ``.env`` into the process
+environment (via ``load_dotenv``) so LiteLLM picks it up — it is NOT a declared
+``Settings`` field. Run with the sandbox disabled — openrouter.ai is a network call.
 
 ``print`` is allowed in examples (this is an operator tool, not library code).
 """
@@ -32,6 +33,8 @@ import argparse
 import logging
 from pathlib import Path
 from typing import Any
+
+from dotenv import load_dotenv
 
 from langres.bootstrap import Bootstrapper, GoldSet, HardNegativeMiner, TeacherLabeler
 from langres.core.blockers.vector import VectorBlocker
@@ -175,6 +178,10 @@ def run(
 
 
 def main() -> int:
+    # Load .env into the process environment so LiteLLM sees OPENROUTER_API_KEY
+    # (it is not a declared Settings field). Explicit, not reliant on import side
+    # effects.
+    load_dotenv()
     logging.basicConfig(level=logging.INFO, format="%(levelname)s %(name)s: %(message)s")
     logging.getLogger("langres").setLevel(logging.INFO)
 

--- a/examples/run_m1_gold_set.py
+++ b/examples/run_m1_gold_set.py
@@ -1,0 +1,208 @@
+"""M1 Wave 5 — the paid EXIT run: label the Fodors-Zagat cross-source band with a
+real budget-capped GLM teacher, then commit the gold set + report.
+
+This is the one script in the repo that spends money. It is intentionally a
+two-step tool so the price/token assumptions behind the budget cap are *verified*
+before any band-sized spend (design-review B1/W1, and the "never burn a paid run
+blind" lesson):
+
+    # 1. Smoke-test: ONE real call. Prints the model id, token usage, and the
+    #    cost litellm/OpenRouter reports, so we can pin honest prices + a safe
+    #    worst-case token count. Costs a fraction of a cent.
+    OMP_NUM_THREADS=1 KMP_DUPLICATE_LIB_OK=1 uv run python examples/run_m1_gold_set.py \
+        --smoke --model openrouter/z-ai/glm-5.2
+
+    # 2. Full run: labels the whole cross-source band under a hard $20 cap, using
+    #    the prices pinned from step 1, and writes data/gold_sets/fodors_zagat/.
+    OMP_NUM_THREADS=1 KMP_DUPLICATE_LIB_OK=1 uv run python examples/run_m1_gold_set.py \
+        --model openrouter/z-ai/glm-5.2 \
+        --price-prompt 0.95 --price-completion 3.00 \
+        --worst-case-tokens 1500 --budget 20 --budget-soft 15
+
+The teacher client is built with ``enable_langfuse=False`` (B4), so no Langfuse
+creds are needed. ``OPENROUTER_API_KEY`` is read from ``.env`` via pydantic-settings.
+Run with the sandbox disabled — openrouter.ai is a network call.
+
+``print`` is allowed in examples (this is an operator tool, not library code).
+"""
+
+from __future__ import annotations
+
+import argparse
+import logging
+from pathlib import Path
+from typing import Any
+
+from langres.bootstrap import Bootstrapper, GoldSet, HardNegativeMiner, TeacherLabeler
+from langres.core.blockers.vector import VectorBlocker
+from langres.core.embeddings import SentenceTransformerEmbedder
+from langres.core.indexes.vector_index import FAISSIndex
+from langres.core.models import ERCandidate
+from langres.data.er_benchmarks import (
+    DEFAULT_BLOCKING_K,
+    RestaurantSchema,
+    load_fodors_zagat,
+)
+
+logger = logging.getLogger(__name__)
+
+OUT_DIR = Path("data/gold_sets/fodors_zagat")
+
+
+def _cross_source(candidate: ERCandidate[RestaurantSchema]) -> bool:
+    """Keep only cross-source candidate pairs (Fodors x Zagat) — design-review B2."""
+    return bool(candidate.left.source != candidate.right.source)
+
+
+def _make_blocker(k_neighbors: int) -> VectorBlocker[RestaurantSchema]:
+    """Real-embedding vector blocker (MiniLM + FAISS, cosine) — same wiring as the
+    deterministic example, so blocking pair-completeness is honest."""
+    return VectorBlocker(
+        vector_index=FAISSIndex(
+            embedder=SentenceTransformerEmbedder("all-MiniLM-L6-v2"),
+            metric="cosine",
+        ),
+        schema=RestaurantSchema,
+        text_field="embed_text",
+        k_neighbors=k_neighbors,
+    )
+
+
+def smoke(model: str) -> int:
+    """Make ONE real teacher call on a real cross-source pair and print diagnostics.
+
+    Prints token usage and the cost litellm reports, so the operator can pin
+    honest ``--price-prompt``/``--price-completion`` and a safe ``--worst-case-tokens``
+    for the full run. Returns a process exit code.
+    """
+    from langres.clients import Settings, create_llm_client
+    from langres.core.modules.llm_judge import LLMJudge
+
+    corpus_records, _ = load_fodors_zagat()
+    fodors = next(r for r in corpus_records if r.source == "fodors")
+    zagat = next(r for r in corpus_records if r.source == "zagat")
+    candidate: ERCandidate[RestaurantSchema] = ERCandidate(
+        left=fodors, right=zagat, blocker_name="smoke"
+    )
+
+    client = create_llm_client(Settings(), enable_langfuse=False)
+    judge: LLMJudge[Any] = LLMJudge(client=client, model=model, entity_noun="restaurant")
+
+    print(f"[smoke] model={model}")
+    print(f"[smoke] pair: {fodors.name!r} (fodors)  vs  {zagat.name!r} (zagat)")
+    judgements = list(judge.forward(iter([candidate])))
+    if not judgements:
+        print("[smoke] FAIL: judge yielded no judgement.")
+        return 1
+    j = judgements[0]
+    prov = j.provenance
+    pt = int(prov.get("prompt_tokens", 0) or 0)
+    ct = int(prov.get("completion_tokens", 0) or 0)
+    cost = float(prov.get("cost_usd", 0.0) or 0.0)
+    print(f"[smoke] score={j.score:.3f}  prompt_tokens={pt}  completion_tokens={ct}")
+    print(f"[smoke] litellm reported cost_usd={cost:.6f}")
+    if pt == 0 and ct == 0:
+        print("[smoke] WARN: no token usage reported — the budget tally would be blind.")
+        return 1
+    suggested = max(1000, (pt + ct) * 2)
+    print(
+        f"[smoke] OK. Suggested --worst-case-tokens >= {suggested} "
+        f"(2x measured {pt + ct}). If reported cost_usd is 0, pin prices from the "
+        "provider's published per-1M rates; the tally then uses those pinned prices."
+    )
+    return 0
+
+
+def run(
+    *,
+    model: str,
+    price_prompt: float,
+    price_completion: float,
+    worst_case_tokens: int,
+    budget: float,
+    budget_soft: float,
+    k_neighbors: int,
+) -> int:
+    """Run the full paid band-labeling and write the gold set + report. Returns an exit code."""
+    corpus_records, gold_clusters = load_fodors_zagat()
+    corpus = [r.model_dump() for r in corpus_records]
+
+    teacher = TeacherLabeler.from_env(
+        price_per_1m_prompt_tokens=price_prompt,
+        price_per_1m_completion_tokens=price_completion,
+        worst_case_tokens_per_pair=worst_case_tokens,
+        model=model,
+        entity_noun="restaurant",
+        budget_usd=budget,
+        budget_soft_usd=budget_soft,
+    )
+    bootstrapper = Bootstrapper(_make_blocker(k_neighbors), HardNegativeMiner(seed=0), teacher)
+
+    print(f"[run] model={model}  budget=${budget:.2f} (soft ${budget_soft:.2f})")
+    gold, report = bootstrapper.build(
+        corpus, candidate_filter=_cross_source, gold_clusters=gold_clusters
+    )
+
+    OUT_DIR.mkdir(parents=True, exist_ok=True)
+    gold_path = OUT_DIR / "gold_set.json"
+    report_path = OUT_DIR / "report.md"
+    gold.save(gold_path)
+    report_path.write_text(report.to_markdown(), encoding="utf-8")
+    # Round-trip proof on the artifact we just wrote.
+    assert GoldSet.load(gold_path).model_dump() == gold.model_dump(), "gold-set round-trip differs"
+
+    cov = report.coverage
+    print(
+        f"[run] labeled={cov.labeled} skipped={teacher.skipped_count} "
+        f"dropped_by_cap={teacher.dropped_by_cap_count}"
+    )
+    print(f"[run] honest cost=${teacher.total_spent_usd:.4f}  (cap ${budget:.2f})")
+    print(f"[run] Pair-Completeness={report.blocking.pair_completeness:.4f}")
+    if report.agreement is not None:
+        a = report.agreement
+        print(
+            f"[run] teacher-vs-truth: acc={a.accuracy:.4f} F1={a.f1:.4f} "
+            f"kappa={a.cohens_kappa:.4f} MCC={a.mcc:.4f} (n={a.n_evaluated})"
+        )
+    if report.calibration is not None:
+        c = report.calibration
+        print(f"[run] calibration: Brier={c.brier:.4f} ECE={c.ece:.4f} (n={c.n_evaluated})")
+    print(f"[run] wrote {gold_path} and {report_path}")
+    if cov.labeled == 0:
+        print("[run] FAIL: 0 labeled — check the model id / API key.")
+        return 1
+    return 0
+
+
+def main() -> int:
+    logging.basicConfig(level=logging.INFO, format="%(levelname)s %(name)s: %(message)s")
+    logging.getLogger("langres").setLevel(logging.INFO)
+
+    p = argparse.ArgumentParser(description="M1 Wave 5 paid GLM-teacher gold-set run.")
+    p.add_argument("--smoke", action="store_true", help="One real call + diagnostics, then exit.")
+    p.add_argument("--model", default="openrouter/z-ai/glm-5.2")
+    p.add_argument("--price-prompt", type=float, default=0.95, help="USD per 1M prompt tokens.")
+    p.add_argument(
+        "--price-completion", type=float, default=3.00, help="USD per 1M completion tokens."
+    )
+    p.add_argument("--worst-case-tokens", type=int, default=1500)
+    p.add_argument("--budget", type=float, default=20.0)
+    p.add_argument("--budget-soft", type=float, default=15.0)
+    p.add_argument("--k-neighbors", type=int, default=DEFAULT_BLOCKING_K)
+    args = p.parse_args()
+
+    if args.smoke:
+        return smoke(args.model)
+    return run(
+        model=args.model,
+        price_prompt=args.price_prompt,
+        price_completion=args.price_completion,
+        worst_case_tokens=args.worst_case_tokens,
+        budget=args.budget,
+        budget_soft=args.budget_soft,
+        k_neighbors=args.k_neighbors,
+    )
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/langres/bootstrap/labelers.py
+++ b/src/langres/bootstrap/labelers.py
@@ -76,7 +76,10 @@ class GroundTruthLabeler(Labeler):
             candidates: Candidate pairs to label.
 
         Returns:
-            One :class:`GoldPair` per candidate, ``source="ground_truth"`` and
+            One :class:`GoldPair` per candidate, ``source="ground_truth"``. Since
+            ``confidence`` is canonically **P(match)**, a known match gets ``1.0``
+            and a known non-match ``0.0`` -- so this perfect labeler also reads as
+            perfectly calibrated, instead of looking miscalibrated under a flat
             ``confidence=1.0``.
         """
         labels: list[GoldPair] = []
@@ -90,7 +93,7 @@ class GroundTruthLabeler(Labeler):
                     right_id=right_id,
                     label=is_match,
                     source="ground_truth",
-                    confidence=1.0,
+                    confidence=1.0 if is_match else 0.0,
                 )
             )
         return labels
@@ -129,17 +132,21 @@ class FakeLabeler(Labeler):
         # ``total_spent_usd`` off whatever labeler it holds).
         self.total_spent_usd: float = 0.0
 
-    def _confidence(self, score: float) -> float:
-        """Deterministic, over-confident self-confidence for one label.
+    def _p_match(self, score: float, is_match: bool) -> float:
+        """Deterministic, over-confident **P(match)** for one label.
 
-        Grows with the margin ``|score - threshold|`` but starts at a ``0.7``
-        floor even for near-threshold pairs, so the labeler is systematically
-        over-confident on the ambiguous band -- a realistic miscalibration that
-        keeps ECE / Brier non-degenerate. The result lies in ``[0.7, 0.99]``
-        (floor ``0.7`` at the threshold, capped at ``0.99``).
+        ``confidence`` is canonically P(match) (matching :class:`TeacherLabeler`).
+        The labeler is over-confident *toward its predicted class*: starting from
+        a ``0.7`` self-confidence floor that grows with the margin
+        ``|score - threshold|`` (capped ``0.99``), P(match) is that confidence for
+        a predicted match and its complement for a predicted non-match. So
+        predicted matches land in ``[0.7, 0.99]`` and predicted non-matches in
+        ``[0.01, 0.3]`` -- inflated on the ambiguous band, keeping Brier/ECE (now
+        P(match)-vs-is-match) non-degenerate.
         """
         margin = abs(score - self.threshold)
-        return round(min(0.99, 0.7 + 0.6 * margin), 4)
+        confidence = min(0.99, 0.7 + 0.6 * margin)
+        return round(confidence if is_match else 1.0 - confidence, 4)
 
     def label(self, candidates: list[ERCandidate[Any]]) -> list[GoldPair]:
         """Label each candidate by its similarity score.
@@ -162,13 +169,14 @@ class FakeLabeler(Labeler):
                     "FakeLabeler requires similarity_score on every candidate; "
                     f"pair {cand.left.id}/{cand.right.id} has none"
                 )
+            is_match = score >= self.threshold
             labels.append(
                 GoldPair(
                     left_id=cand.left.id,
                     right_id=cand.right.id,
-                    label=score >= self.threshold,
+                    label=is_match,
                     source="fake",
-                    confidence=self._confidence(score),
+                    confidence=self._p_match(score, is_match),
                 )
             )
         return labels

--- a/src/langres/bootstrap/models.py
+++ b/src/langres/bootstrap/models.py
@@ -35,8 +35,11 @@ class GoldPair(BaseModel):
         label: ``True`` if the pair is a match, ``False`` otherwise.
         source: Provenance of the label (``"teacher"``, ``"ground_truth"``,
             ``"human"``, or ``"fake"``).
-        confidence: Optional label confidence in ``[0, 1]`` (e.g. a teacher
-            model's probability). ``None`` when not applicable.
+        confidence: Optional **P(match)** score in ``[0, 1]`` -- the probability
+            the pair is a match (NOT confidence in the chosen label). ``label`` is
+            the thresholded ``confidence``. All labelers honor this convention so
+            the calibration report can treat it uniformly. ``None`` when not
+            applicable.
         reasoning: Optional free-text rationale for the label (e.g. a teacher
             model's explanation).
         provenance: Free-form metadata about how the label was produced

--- a/src/langres/bootstrap/report.py
+++ b/src/langres/bootstrap/report.py
@@ -100,12 +100,14 @@ class AgreementStats(BaseModel):
 
 
 class CalibrationStats(BaseModel):
-    """Calibration of teacher confidence against label-correctness.
+    """Calibration of the teacher's match-probability against the truth.
 
-    ``confidence`` is the teacher's verbalized self-confidence in its own label;
-    the outcome being calibrated is whether that label was actually correct
-    (``teacher_label == truth_label``). So this answers "when the teacher says it
-    is 80% sure, is it right 80% of the time?".
+    ``confidence`` is the teacher's verbalized P(match) score (the same value
+    that thresholds into its label); the outcome being calibrated is whether the
+    pair is *actually* a match. So this answers "when the teacher scores a pair
+    0.8, is it a true match 80% of the time?". (Calibrating P(match) against
+    label-*correctness* instead would mis-score a confident correct non-match --
+    P(match)~0 yet "correct" -- inflating Brier and inverting the diagram.)
 
     Attributes:
         n_evaluated: Number of teacher pairs with both a confidence and a
@@ -235,7 +237,7 @@ class BootstrapReport(BaseModel):
         teacher_labels: list[bool] = []
         truth_labels: list[bool] = []
         confidences: list[float] = []
-        correctness: list[bool] = []
+        confidence_is_match: list[bool] = []
         for pair in ordered_pairs:
             if pair.left_id not in truth_entities or pair.right_id not in truth_entities:
                 continue  # No ground truth for this pair -> excluded, honestly.
@@ -244,11 +246,16 @@ class BootstrapReport(BaseModel):
             teacher_labels.append(pair.label)
             truth_labels.append(truth_label)
             if pair.confidence is not None:
+                # ``confidence`` is the teacher's P(match) score, so calibration is
+                # against whether the pair is *actually* a match -- not against
+                # label-correctness (that would mis-score a confident correct
+                # non-match, since its P(match) is ~0 while it "happened" to be a
+                # correct non-match, inflating Brier and inverting the diagram).
                 confidences.append(pair.confidence)
-                correctness.append(pair.label == truth_label)
+                confidence_is_match.append(truth_label)
 
         agreement = cls._build_agreement(teacher_labels, truth_labels)
-        calibration = cls._build_calibration(confidences, correctness, n_bins)
+        calibration = cls._build_calibration(confidences, confidence_is_match, n_bins)
         convergence = cls._build_convergence(teacher_labels, truth_labels)
 
         # --- Routing / coverage + honest cost ----------------------------------
@@ -309,20 +316,23 @@ class BootstrapReport(BaseModel):
 
     @staticmethod
     def _build_calibration(
-        confidences: list[float], correctness: list[bool], n_bins: int
+        confidences: list[float], is_match: list[bool], n_bins: int
     ) -> CalibrationStats | None:
-        """Compute confidence calibration, or ``None`` if no pair has confidence + truth."""
+        """Calibrate P(match) scores against the true is-match outcome.
+
+        ``None`` if no pair has both a confidence and a ground-truth label.
+        """
         if not confidences:
             return None
         return CalibrationStats(
             n_evaluated=len(confidences),
-            brier=brier_score(confidences, correctness),
+            brier=brier_score(confidences, is_match),
             ece=expected_calibration_error(
-                confidences, correctness, n_bins=n_bins, strategy="quantile"
+                confidences, is_match, n_bins=n_bins, strategy="quantile"
             ),
             n_bins=n_bins,
             reliability=reliability_bins(
-                confidences, correctness, n_bins=n_bins, strategy="quantile"
+                confidences, is_match, n_bins=n_bins, strategy="quantile"
             ),
         )
 
@@ -388,7 +398,7 @@ class BootstrapReport(BaseModel):
             ]
         lines.append("")
 
-        lines.append("## Calibration (teacher confidence vs. correctness)")
+        lines.append("## Calibration (P(match) score vs. is-match)")
         if self.calibration is None:
             lines.append("- No labeled pair had both a confidence and a ground-truth label.")
         else:

--- a/src/langres/bootstrap/report.py
+++ b/src/langres/bootstrap/report.py
@@ -331,9 +331,7 @@ class BootstrapReport(BaseModel):
                 confidences, is_match, n_bins=n_bins, strategy="quantile"
             ),
             n_bins=n_bins,
-            reliability=reliability_bins(
-                confidences, is_match, n_bins=n_bins, strategy="quantile"
-            ),
+            reliability=reliability_bins(confidences, is_match, n_bins=n_bins, strategy="quantile"),
         )
 
     @staticmethod

--- a/tests/bootstrap/test_gold_set_artifact.py
+++ b/tests/bootstrap/test_gold_set_artifact.py
@@ -1,0 +1,39 @@
+"""Guard the committed M1 gold-set artifact (the Wave 5 paid deliverable).
+
+Deterministic, no network: loads ``data/gold_sets/fodors_zagat/gold_set.json``
+and asserts its structural invariants so an accidental truncation/corruption of
+the paid artifact is caught in CI.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from langres.bootstrap import GoldSet
+
+ARTIFACT = (
+    Path(__file__).resolve().parents[2] / "data" / "gold_sets" / "fodors_zagat" / "gold_set.json"
+)
+
+
+def test_gold_set_artifact_invariants() -> None:
+    gold = GoldSet.load(ARTIFACT)
+
+    # Round-trips through its own serializer.
+    assert GoldSet.model_validate_json(gold.model_dump_json()).model_dump() == gold.model_dump()
+
+    assert gold.schema_version == "1"
+    # The full Fodors-Zagat cross-source band (hundreds-low-thousands of pairs).
+    assert len(gold.pairs) >= 1000
+
+    meta = gold.metadata
+    assert meta["labeler"] == "TeacherLabeler"
+    assert float(meta["total_cost_usd"]) > 0.0  # a real, paid run
+    assert int(meta["matches"]) + int(meta["non_matches"]) == len(gold.pairs)
+
+    for pair in gold.pairs:
+        assert pair.source == "teacher"
+        assert isinstance(pair.label, bool)
+        assert pair.confidence is not None and 0.0 <= pair.confidence <= 1.0
+        # label is the thresholded confidence (default 0.5) -> internally consistent.
+        assert pair.label == (pair.confidence >= 0.5)

--- a/tests/bootstrap/test_labelers.py
+++ b/tests/bootstrap/test_labelers.py
@@ -33,7 +33,9 @@ def test_ground_truth_labels_match_and_non_match() -> None:
     labeler = GroundTruthLabeler.from_clusters([{"a", "b"}, {"c", "d"}])
     out = labeler.label([_cand("a", "b"), _cand("b", "a"), _cand("a", "c")])
     assert [p.label for p in out] == [True, True, False]
-    assert all(p.source == "ground_truth" and p.confidence == 1.0 for p in out)
+    assert all(p.source == "ground_truth" for p in out)
+    # confidence is P(match): 1.0 for known matches, 0.0 for known non-matches.
+    assert [p.confidence for p in out] == [1.0, 1.0, 0.0]
 
 
 def test_ground_truth_from_clusters_expands_multi_member_cluster() -> None:
@@ -330,12 +332,19 @@ def test_fake_labeler_thresholds_on_similarity() -> None:
     assert all(p.source == "fake" for p in out)
 
 
-def test_fake_labeler_confidence_is_in_range_and_overconfident() -> None:
-    out = FakeLabeler(threshold=0.5).label([_scored("a", "b", 0.5), _scored("c", "d", 1.0)])
-    # Near-threshold pair: floor of 0.7 (over-confident on the ambiguous band).
+def test_fake_labeler_confidence_is_p_match_and_overconfident() -> None:
+    # confidence is P(match): high for predicted matches, low (the complement)
+    # for predicted non-matches, over-confident on the near-threshold band.
+    out = FakeLabeler(threshold=0.5).label(
+        [_scored("a", "b", 0.5), _scored("c", "d", 1.0), _scored("e", "f", 0.0)]
+    )
+    # Predicted match at the threshold: floor P(match) of 0.7.
     assert out[0].confidence == pytest.approx(0.7)
-    # Far-from-threshold pair: higher, capped at 0.99.
+    # Far-from-threshold match: higher, capped at 0.99.
     assert out[1].confidence == pytest.approx(0.99)
+    # Confident predicted non-match: low P(match) = 1 - 0.99 = 0.01.
+    assert out[2].label is False
+    assert out[2].confidence == pytest.approx(0.01)
     assert all(p.confidence is not None and 0.0 <= p.confidence <= 1.0 for p in out)
 
 

--- a/tests/bootstrap/test_report.py
+++ b/tests/bootstrap/test_report.py
@@ -94,11 +94,12 @@ def test_calibration_hand_computed() -> None:
     report = BootstrapReport.build(_scenario_gold(), _scenario_candidates(), _TRUTH, n_bins=2)
     c = report.calibration
     assert c is not None
-    # confidences [0.9,0.8,0.4], correctness [True,True,False]
-    # Brier: (0.01 + 0.04 + 0.16)/3 = 0.07
+    # confidences=P(match) [0.9,0.8,0.4]; is_match outcomes [True,False,True]
+    # (a-b match, a-c non-match, c-d match). Brier calibrates P(match) vs is-match:
+    # ((0.9-1)^2 + (0.8-0)^2 + (0.4-1)^2)/3 = (0.01 + 0.64 + 0.36)/3 = 0.336667
     assert c.n_evaluated == 3
-    assert c.brier == pytest.approx(0.07)
-    # quantile 2 bins: [0.4,0.8] acc .5 conf .6; [0.9] acc 1 conf .9 -> ECE 0.1
+    assert c.brier == pytest.approx(0.336667, abs=1e-6)
+    # quantile 2 bins: [0.4,0.8] is-match .5 conf .6; [0.9] is-match 1 conf .9 -> ECE 0.1
     assert c.ece == pytest.approx(0.1)
     assert c.n_bins == 2
     assert len(c.reliability) == 2
@@ -209,7 +210,7 @@ def test_to_markdown_contains_key_numbers() -> None:
     assert "F1: 0.6667" in md
     assert "Cohen's kappa: 0.4000" in md
     assert "MCC: 0.5000" in md
-    assert "Brier score (primary): 0.0700" in md
+    assert "Brier score (primary): 0.3367" in md
     assert "ECE (equal-mass, 2 bins): 0.1000" in md
     assert "Total cost (USD): 1.2500" in md
     assert "Final F1 @ 3 labels: 0.6667" in md


### PR DESCRIPTION
The EXIT deliverable for M1: a real, budget-capped LLM-teacher run producing a committed, versioned Fodors-Zagat gold set + coverage/calibration report.

## What landed
- **Paid harness** `examples/run_m1_gold_set.py` (committed *before* spending — worktree/paid-run survival): two-step `--smoke` (verify model id + token usage + price) then capped full run.
- **Committed artifact** `data/gold_sets/fodors_zagat/{gold_set.json,report.md}` — 1382 cross-source pairs labeled by `openrouter/z-ai/glm-5.2`.
- **Calibration bug fix** in `bootstrap/report.py` (surfaced by the real report).
- **Deterministic artifact-invariant test** + CHANGELOG M1 entry.

## Measured results (real run, honest cost **$1.28**, well under the $20 cap)
| Gate | Result |
|---|---|
| Blocking Pair-Completeness | **0.9911** (≥0.95 ✓) |
| Teacher-vs-truth agreement (n=213) | acc 0.850 · P 0.780 · R 0.991 · **F1 0.873** · kappa 0.695 · **MCC 0.726** |
| Calibration | **Brier 0.147 · ECE 0.136** (P(match) vs is-match) |
| Labels | 1382 (382 match / 1000 non-match), 0 skipped, 0 dropped-by-cap |

All three M1 EXIT gates met: gold set serialized+versioned; teacher-vs-truth agreement measured on a 213-pair spot-check; Pair-Completeness ≥0.95 reported.

## Budget safety (design-review B1), verified live
The tight-cap validation run truncated 1382→38 pairs at a $0.20 soft budget (per-pair hard cap + token×pinned-price tally), proving the cap binds before spend. Full run used `--price-prompt 1.05 --price-completion 3.50` (litellm has no glm-5.2 entry; pinned at the nearest anchor, `openrouter/z-ai/glm-5.1`).

## Calibration fix (the one substantive change beyond the run)
The real report showed an **inverted reliability diagram** (score 0.0 → observed 1.0) and inflated Brier (0.474). Root cause: calibration paired the teacher's **P(match)** confidence with label-**correctness**, so a *confident correct non-match* (P(match)≈0, "correct") took a full Brier penalty. `GoldPair.confidence` is P(match), so the correct outcome to calibrate against is **is-match**. Fixed the wiring + docstrings + markdown header, updated the hand-computed test, and **regenerated `report.md` from the existing gold set (no re-spend)**: Brier 0.474→0.147, ECE 0.464→0.136, reliability now monotonic.

## Gates
mypy strict (53 files) ✓ · ruff ✓ · `pytest -m "not integration"` (slow tests run) **1080 passed, 98.87% coverage** ✓.

https://claude.ai/code/session_01Qik2ZVTbXtYt6rx2uLkYSd