### PR TITLE
M2 Wave 1: shared restaurant blocker/resolver factories + Fodors split

### DIFF
--- a/src/langres/data/er_benchmarks.py
+++ b/src/langres/data/er_benchmarks.py
@@ -12,16 +12,22 @@ therefore filters candidate pairs to cross-source ones before measuring recall
 
 import csv
 import logging
+import random
+from collections import defaultdict
 from importlib import resources
 from typing import Literal
 
 from pydantic import BaseModel, computed_field
 
 from langres.core.blockers.vector import VectorBlocker
+from langres.core.clusterer import Clusterer
+from langres.core.comparator import Comparator
 from langres.core.embeddings import SentenceTransformerEmbedder
 from langres.core.indexes.vector_index import FAISSIndex
+from langres.core.judges.weighted_average import WeightedAverageJudge
 from langres.core.metrics import evaluate_blocking
 from langres.core.models import ERCandidate
+from langres.core.resolver import Resolver
 
 logger = logging.getLogger(__name__)
 
@@ -187,6 +193,164 @@ def load_fodors_zagat() -> tuple[list[RestaurantSchema], list[set[str]]]:
         len(singletons),
     )
     return corpus, gold_clusters
+
+
+def build_restaurant_blocker(
+    k_neighbors: int = DEFAULT_BLOCKING_K,
+) -> VectorBlocker[RestaurantSchema]:
+    """Build the shared restaurant VectorBlocker (MiniLM + FAISS-cosine).
+
+    This is the one blocking config used across M1 and M2 — extracted here so
+    the gold-set run, the k-sweep, and the M2 Resolver all wire the *same*
+    candidate generator rather than each re-spelling it. Declarative
+    (``schema=`` + ``text_field=``) so the resulting blocker is
+    config-serializable: it round-trips through a saved Resolver artifact.
+
+    Each call constructs a *fresh* (unbuilt) :class:`FAISSIndex`; embedding only
+    happens when the index is later populated from a corpus (e.g. by
+    ``Resolver.resolve``). :func:`sweep_blocking_k` intentionally does **not**
+    use this factory: it shares one pre-built index across every ``k`` to embed
+    the corpus once, whereas this factory owns its own index per call.
+
+    Args:
+        k_neighbors: Nearest neighbours per record. Defaults to the pinned
+            :data:`DEFAULT_BLOCKING_K` (clears Pair-Completeness >= 0.95).
+
+    Returns:
+        A :class:`VectorBlocker` over ``RestaurantSchema.embed_text``.
+    """
+    return VectorBlocker(
+        vector_index=FAISSIndex(
+            embedder=SentenceTransformerEmbedder("all-MiniLM-L6-v2"),
+            metric="cosine",
+        ),
+        schema=RestaurantSchema,
+        text_field="embed_text",
+        k_neighbors=k_neighbors,
+    )
+
+
+def build_restaurant_resolver(threshold: float, k_neighbors: int = DEFAULT_BLOCKING_K) -> Resolver:
+    """Wire the M2 baseline restaurant Resolver (vector-blocked, zero-spend).
+
+    Composes the shared :func:`build_restaurant_blocker` with the missing-aware
+    :class:`~langres.core.comparator.StringComparator` (auto-derived from
+    ``RestaurantSchema``) and the registered, zero-spend
+    :class:`~langres.core.judges.weighted_average.WeightedAverageJudge` scoring
+    on the same FeatureSpecs, then a connected-components
+    :class:`~langres.core.clusterer.Clusterer` at ``threshold``. Mirrors
+    ``Resolver.from_schema``'s comparator+judge+clusterer wiring but swaps the
+    default all-pairs blocker for the vector blocker.
+
+    ``Comparator.from_schema`` derives one feature per ``str | None`` field and
+    already excludes ``id``, the computed ``embed_text``, and ``source`` (a
+    ``Literal``, not a string). Excluding ``source`` is essential: Fodors-Zagat's
+    true matches are all cross-source, so comparing ``source`` would penalise
+    every positive. The resulting Resolver is fully serializable (every slot is a
+    registered component), so ``save()`` does not raise.
+
+    Args:
+        threshold: Clusterer match threshold (tune on train, score on test).
+        k_neighbors: Blocking neighbours; defaults to :data:`DEFAULT_BLOCKING_K`.
+
+    Returns:
+        A ready-to-run, serializable :class:`Resolver`.
+    """
+    comparator: Comparator[RestaurantSchema] = Comparator.from_schema(RestaurantSchema)
+    return Resolver(
+        blocker=build_restaurant_blocker(k_neighbors),
+        comparator=comparator,
+        # The judge scores on the same FeatureSpecs the comparator compares on,
+        # so the comparison vector and the weights line up.
+        module=WeightedAverageJudge(feature_specs=comparator.feature_specs),
+        clusterer=Clusterer(threshold=threshold),
+    )
+
+
+def _split_stratum(
+    clusters: list[set[str]], test_size: float, rng: random.Random
+) -> tuple[list[set[str]], list[set[str]]]:
+    """Split one same-size cluster stratum into (train, test) whole clusters.
+
+    Clusters are sorted into a canonical order (by their sorted id tuple) before
+    shuffling so the split is deterministic given ``rng`` regardless of input
+    ordering. At least one cluster always goes to test (mirrors
+    :func:`stratified_dedup_split`).
+    """
+    ordered = sorted(clusters, key=lambda c: tuple(sorted(c)))
+    rng.shuffle(ordered)
+    n_test = max(1, int(len(ordered) * test_size))
+    return ordered[:-n_test], ordered[-n_test:]
+
+
+def split_restaurant_corpus(
+    corpus: list[RestaurantSchema],
+    gold_clusters: list[set[str]],
+    *,
+    test_size: float = 0.3,
+    seed: int = 0,
+) -> tuple[list[RestaurantSchema], list[RestaurantSchema], list[set[str]], list[set[str]]]:
+    """Stratified, leakage-free train/test split over full restaurant records.
+
+    Mirrors :func:`~langres.data.splitting.stratified_dedup_split`'s
+    cluster-size stratification (singletons distributed separately; matched
+    groups split within each size band, whole clusters kept together) but
+    operates on full :class:`RestaurantSchema` records — preserving ``source``
+    and the ``f``/``z`` ids — instead of the ``{id, name}``-only int-cast dicts
+    that function produces (which can't reconstruct ``RestaurantSchema``).
+
+    Because whole gold clusters are assigned to one side, no match pair ever
+    straddles the split (no test-set leakage), and each returned cluster list
+    partitions exactly its split's ids.
+
+    Args:
+        corpus: Records from :func:`load_fodors_zagat` (the complete corpus).
+        gold_clusters: The complete closed-world partition (match sets +
+            singletons) from :func:`load_fodors_zagat`.
+        test_size: Fraction of each stratum assigned to test (in ``(0, 1)``).
+        seed: Seed for the deterministic shuffle.
+
+    Returns:
+        ``(train_records, test_records, train_clusters, test_clusters)``.
+
+    Raises:
+        ValueError: If ``test_size`` is not in the open interval ``(0, 1)``.
+    """
+    if not 0.0 < test_size < 1.0:
+        raise ValueError(f"test_size must be in (0, 1); got {test_size}")
+
+    by_id = {r.id: r for r in corpus}
+    rng = random.Random(seed)
+
+    # Stratify: singletons in their own band, matched groups by cluster size.
+    singletons = [c for c in gold_clusters if len(c) == 1]
+    groups_by_size: dict[int, list[set[str]]] = defaultdict(list)
+    for cluster in gold_clusters:
+        if len(cluster) >= 2:
+            groups_by_size[len(cluster)].append(cluster)
+
+    train_clusters: list[set[str]] = []
+    test_clusters: list[set[str]] = []
+    # Process strata in a fixed order (singletons, then ascending size) so rng
+    # consumption — and thus the split — is reproducible.
+    strata = [singletons] + [groups_by_size[size] for size in sorted(groups_by_size)]
+    for stratum in strata:
+        train_part, test_part = _split_stratum(stratum, test_size, rng)
+        train_clusters.extend(train_part)
+        test_clusters.extend(test_part)
+
+    train_ids = {rid for cluster in train_clusters for rid in cluster}
+    test_ids = {rid for cluster in test_clusters for rid in cluster}
+    train_records = [by_id[rid] for rid in sorted(train_ids)]
+    test_records = [by_id[rid] for rid in sorted(test_ids)]
+    logger.info(
+        "split_restaurant_corpus: %d train records (%d clusters), %d test records (%d clusters)",
+        len(train_records),
+        len(train_clusters),
+        len(test_records),
+        len(test_clusters),
+    )
+    return train_records, test_records, train_clusters, test_clusters
 
 
 def _cross_source(

--- a/src/langres/data/er_benchmarks.py
+++ b/src/langres/data/er_benchmarks.py
@@ -341,8 +341,14 @@ def split_restaurant_corpus(
 
     train_ids = {rid for cluster in train_clusters for rid in cluster}
     test_ids = {rid for cluster in test_clusters for rid in cluster}
-    train_records = [by_id[rid] for rid in sorted(train_ids)]
-    test_records = [by_id[rid] for rid in sorted(test_ids)]
+
+    # Natural sort (f1, f2, f10 — not f1, f10, f2) so the returned record order
+    # is intuitive for callers; ids are always a source letter + integer.
+    def _natural(rid: str) -> tuple[str, int]:
+        return (rid[0], int(rid[1:]))
+
+    train_records = [by_id[rid] for rid in sorted(train_ids, key=_natural)]
+    test_records = [by_id[rid] for rid in sorted(test_ids, key=_natural)]
     logger.info(
         "split_restaurant_corpus: %d train records (%d clusters), %d test records (%d clusters)",
         len(train_records),

--- a/tests/data/test_m2_factories.py
+++ b/tests/data/test_m2_factories.py
@@ -40,10 +40,9 @@ def test_build_restaurant_blocker_defaults() -> None:
     blocker = build_restaurant_blocker()
     assert isinstance(blocker, VectorBlocker)
     assert blocker.k_neighbors == DEFAULT_BLOCKING_K
-    # Declarative (serializable) wiring: schema + text_field, not callables.
-    assert blocker._schema_type_name is not None
-    assert blocker._text_field == "embed_text"
-    # MiniLM + FAISS-cosine — the M1 config, reused.
+    # Declarative (serializable) wiring is asserted via the save() round-trip in
+    # test_build_restaurant_resolver_is_serializable; don't reach into private
+    # attrs here. MiniLM + FAISS-cosine — the M1 config, reused.
     assert isinstance(blocker.vector_index, FAISSIndex)
     assert blocker.vector_index.metric == "cosine"
     assert blocker.vector_index.embedder.model_name == "all-MiniLM-L6-v2"

--- a/tests/data/test_m2_factories.py
+++ b/tests/data/test_m2_factories.py
@@ -1,0 +1,209 @@
+"""M2 Wave 1 — shared restaurant blocker/resolver factories + Fodors split.
+
+Fast, network-free unit tests for the three public helpers that wire the M0/M1
+primitives into a reusable M2 baseline:
+
+- ``build_restaurant_blocker`` — the shared MiniLM + FAISS-cosine VectorBlocker.
+- ``build_restaurant_resolver`` — VectorBlocker + StringComparator + the
+  zero-spend WeightedAverageJudge + connected-components Clusterer, serializable.
+- ``split_restaurant_corpus`` — leakage-free stratified train/test split over
+  FULL ``RestaurantSchema`` records (preserving ``source`` + ``f``/``z`` ids).
+
+The wiring / type / split-shape assertions need no embeddings and stay fast; the
+one assertion that ``.save()`` writes an artifact runs on an unbuilt index (the
+blocker never embeds), so it is fast too.
+"""
+
+from pathlib import Path
+
+import pytest
+
+from langres.core.blockers.vector import VectorBlocker
+from langres.core.clusterer import Clusterer
+from langres.core.comparator import StringComparator
+from langres.core.indexes.vector_index import FAISSIndex
+from langres.core.judges.weighted_average import WeightedAverageJudge
+from langres.core.resolver import Resolver
+from langres.data.er_benchmarks import (
+    DEFAULT_BLOCKING_K,
+    RestaurantSchema,
+    build_restaurant_blocker,
+    build_restaurant_resolver,
+    load_fodors_zagat,
+    split_restaurant_corpus,
+)
+
+# --- build_restaurant_blocker ----------------------------------------------------
+
+
+def test_build_restaurant_blocker_defaults() -> None:
+    blocker = build_restaurant_blocker()
+    assert isinstance(blocker, VectorBlocker)
+    assert blocker.k_neighbors == DEFAULT_BLOCKING_K
+    # Declarative (serializable) wiring: schema + text_field, not callables.
+    assert blocker._schema_type_name is not None
+    assert blocker._text_field == "embed_text"
+    # MiniLM + FAISS-cosine — the M1 config, reused.
+    assert isinstance(blocker.vector_index, FAISSIndex)
+    assert blocker.vector_index.metric == "cosine"
+    assert blocker.vector_index.embedder.model_name == "all-MiniLM-L6-v2"
+
+
+def test_build_restaurant_blocker_custom_k() -> None:
+    blocker = build_restaurant_blocker(k_neighbors=17)
+    assert blocker.k_neighbors == 17
+
+
+# --- build_restaurant_resolver ---------------------------------------------------
+
+
+def test_build_restaurant_resolver_wires_expected_components() -> None:
+    resolver = build_restaurant_resolver(threshold=0.7)
+    assert isinstance(resolver, Resolver)
+    assert isinstance(resolver.blocker, VectorBlocker)
+    assert isinstance(resolver.comparator, StringComparator)
+    assert isinstance(resolver.module, WeightedAverageJudge)
+    assert isinstance(resolver.clusterer, Clusterer)
+    assert resolver.clusterer.threshold == 0.7
+    assert resolver.blocker.k_neighbors == DEFAULT_BLOCKING_K
+
+
+def test_build_restaurant_resolver_custom_k() -> None:
+    resolver = build_restaurant_resolver(threshold=0.5, k_neighbors=9)
+    assert isinstance(resolver.blocker, VectorBlocker)
+    assert resolver.blocker.k_neighbors == 9
+
+
+def test_build_restaurant_resolver_excludes_source_feature() -> None:
+    # Cross-source true matches mean comparing ``source`` would penalise every
+    # positive; the comparator (and the judge sharing its specs) must omit it.
+    resolver = build_restaurant_resolver(threshold=0.7)
+    assert resolver.comparator is not None
+    feature_names = {s.name for s in resolver.comparator.feature_specs}
+    assert "source" not in feature_names
+    assert "embed_text" not in feature_names
+    assert "id" not in feature_names
+    assert feature_names == {"name", "addr", "city", "phone", "type"}
+    # Judge scores on the SAME specs the comparator compares on.
+    assert {s.name for s in resolver.module.feature_specs} == feature_names
+
+
+def test_build_restaurant_resolver_is_serializable(tmp_path: Path) -> None:
+    # The whole point of the M2 artifact contract: save() must not raise. The
+    # blocker's index is never built here, so this stays fast (no embeddings).
+    resolver = build_restaurant_resolver(threshold=0.7)
+    resolver.save(tmp_path)
+    # round-trips through the registry (no pickle, no code execution).
+    reloaded = Resolver.load(tmp_path)
+    assert isinstance(reloaded.blocker, VectorBlocker)
+    assert isinstance(reloaded.module, WeightedAverageJudge)
+    assert isinstance(reloaded.comparator, StringComparator)
+    assert reloaded.clusterer.threshold == 0.7
+
+
+# --- split_restaurant_corpus -----------------------------------------------------
+
+
+def _synthetic_corpus() -> tuple[list[RestaurantSchema], list[set[str]]]:
+    """A small closed-world corpus: 4 cross-source match pairs + 4 singletons.
+
+    Mirrors ``load_fodors_zagat``'s shape (source-prefixed ids, complete
+    partition) without touching disk or embeddings.
+    """
+    corpus: list[RestaurantSchema] = []
+    clusters: list[set[str]] = []
+    for i in range(4):  # matched cross-source pairs f{i}/z{i}
+        corpus.append(RestaurantSchema(id=f"f{i}", name=f"resto {i}", source="fodors"))
+        corpus.append(RestaurantSchema(id=f"z{i}", name=f"resto {i}", source="zagat"))
+        clusters.append({f"f{i}", f"z{i}"})
+    for i in range(4):  # unmatched singletons
+        corpus.append(RestaurantSchema(id=f"f{100 + i}", name=f"solo {i}", source="fodors"))
+        clusters.append({f"f{100 + i}"})
+    return corpus, clusters
+
+
+def test_split_returns_full_records_with_source_and_ids() -> None:
+    corpus, clusters = _synthetic_corpus()
+    train, test, _, _ = split_restaurant_corpus(corpus, clusters, test_size=0.5, seed=0)
+    # Records survive as RestaurantSchema with source + f/z ids preserved.
+    for rec in train + test:
+        assert isinstance(rec, RestaurantSchema)
+        assert rec.source in ("fodors", "zagat")
+        assert rec.id[0] in ("f", "z")
+
+
+def test_split_is_disjoint_and_covers_corpus() -> None:
+    corpus, clusters = _synthetic_corpus()
+    train, test, _, _ = split_restaurant_corpus(corpus, clusters, test_size=0.5, seed=0)
+    train_ids = {r.id for r in train}
+    test_ids = {r.id for r in test}
+    assert train_ids.isdisjoint(test_ids)
+    assert train_ids | test_ids == {r.id for r in corpus}
+    assert len(train) + len(test) == len(corpus)
+
+
+def test_split_keeps_every_match_pair_in_one_side() -> None:
+    # The leakage guard: no gold match pair may straddle train/test.
+    corpus, clusters = _synthetic_corpus()
+    train, test, _, _ = split_restaurant_corpus(corpus, clusters, test_size=0.5, seed=0)
+    train_ids = {r.id for r in train}
+    test_ids = {r.id for r in test}
+    for cluster in clusters:
+        if len(cluster) < 2:
+            continue
+        in_train = cluster <= train_ids
+        in_test = cluster <= test_ids
+        assert in_train ^ in_test, f"match pair {cluster} leaked across the split"
+
+
+def test_split_clusters_restricted_to_each_side() -> None:
+    corpus, clusters = _synthetic_corpus()
+    train, test, train_cls, test_cls = split_restaurant_corpus(
+        corpus, clusters, test_size=0.5, seed=0
+    )
+    train_ids = {r.id for r in train}
+    test_ids = {r.id for r in test}
+    # Returned clusters partition exactly their own split's ids.
+    assert {rid for c in train_cls for rid in c} == train_ids
+    assert {rid for c in test_cls for rid in c} == test_ids
+    # Each returned cluster is a subset of its split (never mixes sides).
+    for c in train_cls:
+        assert c <= train_ids
+    for c in test_cls:
+        assert c <= test_ids
+
+
+def test_split_is_deterministic_under_fixed_seed() -> None:
+    corpus, clusters = _synthetic_corpus()
+    a = split_restaurant_corpus(corpus, clusters, test_size=0.5, seed=7)
+    b = split_restaurant_corpus(corpus, clusters, test_size=0.5, seed=7)
+    assert [r.id for r in a[0]] == [r.id for r in b[0]]
+    assert [r.id for r in a[1]] == [r.id for r in b[1]]
+    assert a[2] == b[2]
+    assert a[3] == b[3]
+
+
+def test_split_real_fodors_corpus_no_leakage_and_complete() -> None:
+    # The loader is fast (CSV only, no embeddings) — keep this in the fast suite.
+    corpus, gold = load_fodors_zagat()
+    train, test, train_cls, test_cls = split_restaurant_corpus(corpus, gold, test_size=0.3, seed=0)
+    train_ids = {r.id for r in train}
+    test_ids = {r.id for r in test}
+    assert train_ids.isdisjoint(test_ids)
+    assert train_ids | test_ids == {r.id for r in corpus}
+    # No cross-source match pair straddles the split (the leakage invariant).
+    for cluster in (c for c in gold if len(c) == 2):
+        in_train = cluster <= train_ids
+        in_test = cluster <= test_ids
+        assert in_train ^ in_test
+    # Roughly 30% of records land in test (stratified, so approximate).
+    assert 0.2 < len(test) / len(corpus) < 0.4
+    # Restricted clusters cover exactly their split.
+    assert {rid for c in train_cls for rid in c} == train_ids
+    assert {rid for c in test_cls for rid in c} == test_ids
+
+
+def test_split_rejects_out_of_range_test_size() -> None:
+    corpus, clusters = _synthetic_corpus()
+    with pytest.raises(ValueError, match="test_size"):
+        split_restaurant_corpus(corpus, clusters, test_size=1.5, seed=0)


### PR DESCRIPTION
## What

M2 Wave 1 (per `m2-walking-skeleton.md`): wire the M0/M1 primitives into three reusable public helpers in `langres.data.er_benchmarks` — the baseline the Wave 2 eval harness and Wave 3 artifact proof build on. **Composition only — no core Resolver/Comparator/Judge API changes.**

### Helpers (as implemented)
- `build_restaurant_blocker(k_neighbors: int = DEFAULT_BLOCKING_K) -> VectorBlocker[RestaurantSchema]` — the shared MiniLM + FAISS-cosine blocker. Extracts M1's example-private `_make_blocker` (review P3) so the gold-set run and the M2 Resolver wire the **same** candidate generator. Declarative (`schema=`/`text_field=`), so it round-trips through a saved artifact.
- `build_restaurant_resolver(threshold: float, k_neighbors: int = DEFAULT_BLOCKING_K) -> Resolver` — `build_restaurant_blocker(k)` + `Comparator.from_schema(RestaurantSchema)` + **`WeightedAverageJudge`** (zero-spend, registered, serializable — **not** `CascadeModule`, review P1-2) + connected-components `Clusterer`. The comparator auto-excludes `source` (a `Literal`), `embed_text` (computed), and `id`, so cross-source true matches aren't penalised (review P2). `save()` does not raise.
- `split_restaurant_corpus(corpus, gold_clusters, *, test_size=0.3, seed=0)` — stratified, leakage-free split over **full `RestaurantSchema` records** (preserves `source` + `f`/`z` ids). Mirrors `stratified_dedup_split`'s size stratification but keeps whole gold clusters on one side, so no match pair straddles train/test (review P1-4). Deterministic given seed.

### Notes / deviation
- `sweep_blocking_k` is **left as-is** (not refactored onto the factory): it shares one pre-built FAISS index across all `k` to embed the corpus once, which the per-call-fresh-index factory can't express without changing its cost behavior. Documented in the factory docstring. The factory still cleanly captures the M1 `_make_blocker` config for the non-sweep callers.

## Tests
`tests/data/test_m2_factories.py` (13 cases) — fast, network-free:
- blocker: type, `k`, declarative schema/`text_field`, MiniLM + cosine index;
- resolver: component types, **source/embed_text/id excluded**, judge specs == comparator specs, **save → load round-trip**;
- split: disjointness, corpus coverage, **no match-pair leakage**, restricted clusters, determinism under fixed seed, a real `load_fodors_zagat()` assertion (loader is embedding-free), and `test_size` range validation.

## Gates
- `uv run mypy src/` — clean (53 files)
- `uv run ruff check .` + `ruff format --check .` — clean
- `OMP_NUM_THREADS=1 KMP_DUPLICATE_LIB_OK=1 uv run pytest -q -m "not integration"` — **1099 passed**, coverage **98.88%** overall / **100%** on `er_benchmarks.py`

https://claude.ai/code/session_01Qik2ZVTbXtYt6rx2uLkYSd