### PR TITLE
M2 Wave 2: held-out BCubed eval harness + partition-safe metric + skeleton example

### DIFF
--- a/examples/m2_walking_skeleton_fodors_zagat.py
+++ b/examples/m2_walking_skeleton_fodors_zagat.py
@@ -1,0 +1,80 @@
+"""M2 walking skeleton — held-out BCubed baseline on Fodors-Zagat.
+
+Runs the full M2 pipeline end-to-end, deterministically and with ZERO spend
+(real MiniLM embeddings for blocking; the WeightedAverageJudge is a zero-cost
+feature-bag scorer — no LLM):
+
+    load -> split (seed=0) -> tune threshold on TRAIN -> build resolver at the
+    chosen threshold -> evaluate on the held-out TEST split.
+
+It reports the headline BCubed Precision/Recall/F1 against the dataset's TRUE
+closed-world ``perfectMapping`` ground truth (NOT the M1 teacher labels), plus
+three honesty diagnostics: the chosen threshold (tuned on train only — no test
+leakage), the all-singletons sanity floor (the score of merging nothing), and
+the test-split cross-source blocking Pair-Completeness (which caps recall).
+
+Run:
+    OMP_NUM_THREADS=1 KMP_DUPLICATE_LIB_OK=1 \\
+        uv run python examples/m2_walking_skeleton_fodors_zagat.py
+"""
+
+from langres.data.er_benchmarks import (
+    DEFAULT_THRESHOLD_GRID,
+    build_restaurant_resolver,
+    evaluate_resolver_bcubed,
+    load_fodors_zagat,
+    split_restaurant_corpus,
+    tune_threshold_on_train,
+)
+
+SEED = 0
+TEST_SIZE = 0.3
+
+
+def main() -> None:
+    """Run the deterministic, zero-spend M2 skeleton and print the baseline."""
+    print("=" * 64)
+    print("M2 walking skeleton — Fodors-Zagat held-out BCubed baseline")
+    print("=" * 64)
+
+    # 1. Load the complete closed-world corpus + true ground-truth partition.
+    corpus, gold_clusters = load_fodors_zagat()
+    print(f"\nCorpus: {len(corpus)} records, {len(gold_clusters)} gold clusters")
+
+    # 2. Leakage-free stratified split (whole match clusters kept on one side).
+    train_records, test_records, train_clusters, test_clusters = split_restaurant_corpus(
+        corpus, gold_clusters, test_size=TEST_SIZE, seed=SEED
+    )
+    print(
+        f"Split (seed={SEED}, test_size={TEST_SIZE}): "
+        f"{len(train_records)} train / {len(test_records)} test records"
+    )
+
+    # 3. Tune the Clusterer threshold on TRAIN only (test is never touched here).
+    print(f"\nTuning threshold on TRAIN over {list(DEFAULT_THRESHOLD_GRID)} …")
+    best_threshold = tune_threshold_on_train(train_records, train_clusters)
+    print(f"Chosen threshold (best TRAIN BCubed F1): {best_threshold}")
+
+    # 4. Build the resolver at the chosen threshold and score on held-out TEST.
+    resolver = build_restaurant_resolver(best_threshold)
+    result = evaluate_resolver_bcubed(resolver, test_records, test_clusters)
+
+    print("\n" + "-" * 64)
+    print("Held-out TEST BCubed (vs TRUE perfectMapping ground truth)")
+    print("-" * 64)
+    print(f"  BCubed Precision        : {result.precision:.4f}")
+    print(f"  BCubed Recall           : {result.recall:.4f}")
+    print(f"  BCubed F1               : {result.f1:.4f}")
+    print(f"  Sanity floor (F1)       : {result.sanity_floor_f1:.4f}  (merge nothing)")
+    print(f"  Blocking Pair-Complete. : {result.pair_completeness:.4f}  (caps recall)")
+    print(f"  Chosen threshold        : {best_threshold}")
+    print("-" * 64)
+
+    if result.f1 > result.sanity_floor_f1:
+        print("\nThe resolver beats the merge-nothing floor (baseline has signal).")
+    else:
+        print("\nThe resolver does NOT beat the floor — an honest, weak baseline (M3 improves).")
+
+
+if __name__ == "__main__":
+    main()

--- a/src/langres/core/metrics.py
+++ b/src/langres/core/metrics.py
@@ -47,7 +47,10 @@ def calculate_bcubed_precision(
         gold = [{"e1", "e2"}]
         precision = calculate_bcubed_precision(predicted, gold)  # 1.0
     """
-    # Build gold cluster lookup: entity_id -> cluster_id
+    # Build gold cluster lookup: entity_id (str) -> cluster_id (int). The str/int
+    # key-vs-value type split is load-bearing for the partition-safe fallback
+    # below: ``get(entity, entity)`` yields the str id for gold-absent entities,
+    # which can never equal an int cluster id, so two absent ids stay distinct.
     gold_lookup: dict[str, int] = {}
     for cluster_id, cluster in enumerate(gold_clusters):
         for entity_id in cluster:
@@ -99,7 +102,11 @@ def calculate_bcubed_recall(
         gold = [{"e1", "e2"}]  # Should be together
         recall = calculate_bcubed_recall(predicted, gold)  # 0.5
     """
-    # Build predicted cluster lookup: entity_id -> cluster_id
+    # Build predicted cluster lookup: entity_id (str) -> cluster_id (int). The
+    # str/int key-vs-value type split is load-bearing for the partition-safe
+    # fallback below: ``get(entity, entity)`` yields the str id for un-clustered
+    # entities, which can never equal an int cluster id, so two absent ids stay
+    # distinct (instead of colliding on a shared ``None``).
     pred_lookup: dict[str, int] = {}
     for cluster_id, cluster in enumerate(predicted_clusters):
         for entity_id in cluster:

--- a/src/langres/core/metrics.py
+++ b/src/langres/core/metrics.py
@@ -60,9 +60,14 @@ def calculate_bcubed_precision(
     for pred_cluster in predicted_clusters:
         for entity in pred_cluster:
             # Count how many entities in this predicted cluster share
-            # the same gold cluster as this entity
+            # the same gold cluster as this entity. Any entity absent from the
+            # gold partition falls back to its own id as a unique singleton key
+            # (ids are str, gold cluster keys are int, so no collision): two
+            # gold-absent ids must NOT compare equal via a shared ``None``.
             same_cluster_count = sum(
-                1 for other in pred_cluster if gold_lookup.get(entity) == gold_lookup.get(other)
+                1
+                for other in pred_cluster
+                if gold_lookup.get(entity, entity) == gold_lookup.get(other, other)
             )
 
             # Precision for this entity = same_cluster / predicted_cluster_size
@@ -106,10 +111,16 @@ def calculate_bcubed_recall(
 
     for gold_cluster in gold_clusters:
         for entity in gold_cluster:
-            # Count how many entities in this gold cluster are also
-            # in the same predicted cluster as this entity
+            # Count how many entities in this gold cluster are also in the same
+            # predicted cluster as this entity. Any entity absent from all
+            # predicted clusters (the Clusterer drops singletons) falls back to
+            # its own id as a unique singleton key (ids are str, predicted
+            # cluster keys are int, so no collision): two un-merged ids must NOT
+            # compare equal via a shared ``None`` and inflate recall.
             same_cluster_count = sum(
-                1 for other in gold_cluster if pred_lookup.get(entity) == pred_lookup.get(other)
+                1
+                for other in gold_cluster
+                if pred_lookup.get(entity, entity) == pred_lookup.get(other, other)
             )
 
             # Recall for this entity = same_cluster / gold_cluster_size

--- a/src/langres/data/er_benchmarks.py
+++ b/src/langres/data/er_benchmarks.py
@@ -14,18 +14,20 @@ import csv
 import logging
 import random
 from collections import defaultdict
+from collections.abc import Iterable, Sequence
 from importlib import resources
 from typing import Literal
 
 from pydantic import BaseModel, computed_field
 
+from langres.core.blocker import Blocker
 from langres.core.blockers.vector import VectorBlocker
 from langres.core.clusterer import Clusterer
 from langres.core.comparator import Comparator
 from langres.core.embeddings import SentenceTransformerEmbedder
 from langres.core.indexes.vector_index import FAISSIndex
 from langres.core.judges.weighted_average import WeightedAverageJudge
-from langres.core.metrics import evaluate_blocking
+from langres.core.metrics import calculate_bcubed_metrics, evaluate_blocking
 from langres.core.models import ERCandidate
 from langres.core.resolver import Resolver
 
@@ -59,6 +61,11 @@ DEFAULT_BLOCKING_K = 5
 
 #: Pair-Completeness gate the blocking k-sweep must clear (DESIGN-REVIEW W7).
 RECALL_GATE = 0.95
+
+#: Candidate Clusterer thresholds swept by :func:`tune_threshold_on_train`. The
+#: WeightedAverageJudge scores in ``[0, 1]``; this small grid brackets the
+#: useful range without an expensive fine sweep (tuned on TRAIN only).
+DEFAULT_THRESHOLD_GRID: tuple[float, ...] = (0.3, 0.4, 0.5, 0.6, 0.7, 0.8)
 
 
 class RestaurantSchema(BaseModel):
@@ -431,3 +438,164 @@ def pick_blocking_k(recalls: dict[int, float], threshold: float = RECALL_GATE) -
     if passing:
         return passing[0]
     return max(recalls, key=lambda k: recalls[k])
+
+
+# ---------------------------------------------------------------------------
+# Held-out BCubed evaluation (M2 Wave 2)
+# ---------------------------------------------------------------------------
+
+
+class BCubedEvalResult(BaseModel):
+    """BCubed scores of a resolver on one record split, plus two diagnostics.
+
+    Attributes:
+        precision: BCubed precision against the (closed-world) truth partition.
+        recall: BCubed recall against the truth partition.
+        f1: BCubed F1 (harmonic mean of precision and recall).
+        pair_completeness: Cross-source blocking recall on this split — the
+            fraction of true match pairs the resolver's blocker even surfaced as
+            candidates. It caps achievable recall, so it is reported every run.
+        sanity_floor_f1: BCubed F1 of the all-singletons prediction (the resolver
+            merging *nothing*). A meaningful run must clear this floor; a resolver
+            scoring at it has added no value over "every record is unique".
+    """
+
+    precision: float
+    recall: float
+    f1: float
+    pair_completeness: float
+    sanity_floor_f1: float
+
+
+def complete_partition(
+    predicted_clusters: list[set[str]], all_ids: Iterable[str]
+) -> list[set[str]]:
+    """Complete a predicted clustering into a full partition over ``all_ids``.
+
+    The :class:`~langres.core.clusterer.Clusterer` drops singletons, so a record
+    that was never merged is simply absent from ``predicted_clusters``. BCubed
+    must average over *every* item, so this appends a singleton ``{id}`` for each
+    id not already in a predicted cluster. Even with the partition-safe metric
+    fix, completing the partition is required so BCubed *precision* averages over
+    all items rather than only the merged ones.
+
+    Args:
+        predicted_clusters: Multi-record clusters from ``Resolver.resolve``.
+        all_ids: Every record id in the split (e.g. ``[r.id for r in records]``).
+
+    Returns:
+        ``predicted_clusters`` followed by one singleton per uncovered id (in
+        ``all_ids`` order, so the result is deterministic).
+    """
+    clustered = {rid for cluster in predicted_clusters for rid in cluster}
+    completed = list(predicted_clusters)
+    completed.extend({rid} for rid in all_ids if rid not in clustered)
+    return completed
+
+
+def _cross_source_pair_completeness(
+    blocker: Blocker[RestaurantSchema],
+    record_dicts: list[dict[str, object]],
+    truth_clusters: list[set[str]],
+) -> float:
+    """Cross-source blocking Pair-Completeness for one split.
+
+    Streams candidates from an already-built ``blocker``, filters to cross-source
+    pairs (Fodors-Zagat true matches are all cross-source; intra-source pairs are
+    noise — same rule as :func:`sweep_blocking_k`), and measures candidate recall
+    against ``truth_clusters``.
+    """
+    candidates: list[ERCandidate[RestaurantSchema]] = list(blocker.stream(record_dicts))
+    return evaluate_blocking(_cross_source(candidates), truth_clusters).candidate_recall
+
+
+def evaluate_resolver_bcubed(
+    resolver: Resolver,
+    test_records: list[RestaurantSchema],
+    test_truth_clusters: list[set[str]],
+) -> BCubedEvalResult:
+    """Score a built resolver on a held-out split with BCubed + diagnostics.
+
+    Pure function (no global state): it runs ``resolver.resolve`` on the records,
+    completes the predicted partition with singletons, and scores BCubed against
+    the closed-world ``test_truth_clusters``. It also reports the all-singletons
+    sanity floor and the resolver's own cross-source blocking Pair-Completeness —
+    the latter by reusing ``resolver.blocker`` (its index is already built by the
+    ``resolve`` call above, so no re-embedding), keeping the measured blocking
+    identical to the one used in resolution.
+
+    Args:
+        resolver: A built (serializable) Resolver, e.g. from
+            :func:`build_restaurant_resolver`.
+        test_records: The held-out records (full ``RestaurantSchema`` objects).
+        test_truth_clusters: The closed-world truth partition restricted to the
+            test split (match sets + singletons), from
+            :func:`split_restaurant_corpus`.
+
+    Returns:
+        A :class:`BCubedEvalResult` with precision/recall/F1, Pair-Completeness,
+        and the sanity floor.
+    """
+    record_dicts = [r.model_dump() for r in test_records]
+    all_ids = [r.id for r in test_records]
+
+    predicted = resolver.resolve(record_dicts)
+    completed = complete_partition(predicted, all_ids)
+    bcubed = calculate_bcubed_metrics(completed, test_truth_clusters)
+
+    # Sanity floor: the resolver merges nothing -> every record is a singleton.
+    floor = calculate_bcubed_metrics([{rid} for rid in all_ids], test_truth_clusters)
+
+    pair_completeness = _cross_source_pair_completeness(
+        resolver.blocker, record_dicts, test_truth_clusters
+    )
+
+    return BCubedEvalResult(
+        precision=bcubed["precision"],
+        recall=bcubed["recall"],
+        f1=bcubed["f1"],
+        pair_completeness=pair_completeness,
+        sanity_floor_f1=floor["f1"],
+    )
+
+
+def tune_threshold_on_train(
+    train_records: list[RestaurantSchema],
+    train_clusters: list[set[str]],
+    *,
+    thresholds: Sequence[float] = DEFAULT_THRESHOLD_GRID,
+    k_neighbors: int = DEFAULT_BLOCKING_K,
+) -> float:
+    """Select the Clusterer threshold maximizing BCubed F1 on the TRAIN split.
+
+    Builds a fresh :func:`build_restaurant_resolver` per candidate threshold,
+    scores it on ``train_records`` via :func:`evaluate_resolver_bcubed`, and
+    returns the threshold with the highest train F1. The **test split is never
+    touched here** — this is the no-leakage tuning step. Ties keep the first
+    (lowest) threshold in ``thresholds`` order.
+
+    Args:
+        train_records: Training records (full ``RestaurantSchema`` objects).
+        train_clusters: Closed-world truth partition for the train split.
+        thresholds: Candidate Clusterer thresholds to sweep.
+        k_neighbors: Blocking neighbours for the built resolvers.
+
+    Returns:
+        The best-performing threshold by train BCubed F1.
+
+    Raises:
+        ValueError: If ``thresholds`` is empty.
+    """
+    if not thresholds:
+        raise ValueError("thresholds is empty; nothing to tune over")
+
+    best_threshold = thresholds[0]
+    best_f1 = -1.0
+    for threshold in thresholds:
+        resolver = build_restaurant_resolver(threshold, k_neighbors=k_neighbors)
+        result = evaluate_resolver_bcubed(resolver, train_records, train_clusters)
+        logger.info("threshold=%.2f -> train BCubed F1=%.4f", threshold, result.f1)
+        if result.f1 > best_f1:
+            best_f1 = result.f1
+            best_threshold = threshold
+    return best_threshold

--- a/src/langres/data/er_benchmarks.py
+++ b/src/langres/data/er_benchmarks.py
@@ -18,7 +18,7 @@ from collections.abc import Iterable, Sequence
 from importlib import resources
 from typing import Literal
 
-from pydantic import BaseModel, computed_field
+from pydantic import BaseModel, Field, computed_field
 
 from langres.core.blocker import Blocker
 from langres.core.blockers.vector import VectorBlocker
@@ -457,14 +457,17 @@ class BCubedEvalResult(BaseModel):
             candidates. It caps achievable recall, so it is reported every run.
         sanity_floor_f1: BCubed F1 of the all-singletons prediction (the resolver
             merging *nothing*). A meaningful run must clear this floor; a resolver
-            scoring at it has added no value over "every record is unique".
+            scoring at it has added no value over "every record is unique". On a
+            sparse dataset with many true singletons this floor can be high (e.g.
+            ~0.93 on Fodors-Zagat, which is mostly singletons) — that's expected,
+            not a weak floor; what matters is that ``f1`` clears it.
     """
 
-    precision: float
-    recall: float
-    f1: float
-    pair_completeness: float
-    sanity_floor_f1: float
+    precision: float = Field(ge=0.0, le=1.0)
+    recall: float = Field(ge=0.0, le=1.0)
+    f1: float = Field(ge=0.0, le=1.0)
+    pair_completeness: float = Field(ge=0.0, le=1.0)
+    sanity_floor_f1: float = Field(ge=0.0, le=1.0)
 
 
 def complete_partition(
@@ -573,6 +576,12 @@ def tune_threshold_on_train(
     returns the threshold with the highest train F1. The **test split is never
     touched here** — this is the no-leakage tuning step. Ties keep the first
     (lowest) threshold in ``thresholds`` order.
+
+    Note: each candidate builds a fresh resolver and re-embeds the train corpus,
+    even though only ``Clusterer.threshold`` varies (the embeddings and candidate
+    pairs are identical across sweeps). At POC / Fodors-Zagat scale this is fine;
+    for larger corpora, share one built blocker across thresholds and vary only
+    the Clusterer.
 
     Args:
         train_records: Training records (full ``RestaurantSchema`` objects).

--- a/tests/core/test_metrics.py
+++ b/tests/core/test_metrics.py
@@ -187,6 +187,65 @@ def test_bcubed_metrics_return_type():
     assert all(0.0 <= v <= 1.0 for v in metrics.values())
 
 
+# --- Partition-safety regression (P1-5): unclustered ids are own singletons -------
+#
+# The Clusterer drops singletons, so a record with no merge is simply ABSENT from
+# the predicted clusters. The metric must treat each absent id as its own
+# singleton cluster, NOT as a shared implicit "None" cluster (which would make two
+# un-merged ids compare equal and inflate the score). These cases are hand-verified
+# below. The fix must be a no-op when the partition is already complete (every id
+# present), so all the tests above stay green.
+
+
+def test_bcubed_recall_unmerged_pair_not_scored_as_recalled():
+    """Hand-verified: an empty prediction must NOT score the {a,b} pair recall 1.0.
+
+    gold = [{a, b}, {c}], predicted = [] (the Clusterer merged nothing, so every
+    record is absent from the predicted clusters).
+
+    Correct per-item recall:
+      a: only a itself shares a's (absent) cluster -> 1/2
+      b: only b itself shares b's (absent) cluster -> 1/2
+      c: c is alone in its gold cluster            -> 1/1
+      mean = (0.5 + 0.5 + 1.0) / 3 = 2/3
+
+    The latent bug mapped every absent id to a single ``None`` cluster, so a and b
+    compared equal and scored 1.0 each -> overall recall 1.0 (wrong).
+    """
+    from langres.core.metrics import calculate_bcubed_recall
+
+    recall = calculate_bcubed_recall([], [{"a", "b"}, {"c"}])
+    assert recall == pytest.approx(2 / 3)
+    assert recall < 1.0
+
+
+def test_bcubed_recall_complete_partition_still_perfect():
+    """The fix is a no-op when nothing is unclustered: a correct prediction is 1.0."""
+    from langres.core.metrics import calculate_bcubed_recall
+
+    recall = calculate_bcubed_recall([{"a", "b"}, {"c"}], [{"a", "b"}, {"c"}])
+    assert recall == 1.0
+
+
+def test_bcubed_precision_absent_from_gold_not_scored_as_pure():
+    """Symmetric guard: ids absent from the gold partition are their own singletons.
+
+    predicted = [{x, y}], gold = [{z}] (x and y are not in any gold cluster).
+
+    Correct per-item precision:
+      x: only x itself shares x's (absent) gold cluster -> 1/2
+      y: only y itself shares y's (absent) gold cluster -> 1/2
+      mean = 0.5
+
+    The latent bug mapped both to a single ``None`` gold cluster -> precision 1.0.
+    """
+    from langres.core.metrics import calculate_bcubed_precision
+
+    precision = calculate_bcubed_precision([{"x", "y"}], [{"z"}])
+    assert precision == pytest.approx(0.5)
+    assert precision < 1.0
+
+
 def test_pairwise_metrics_perfect_clustering():
     """Test pairwise metrics with perfect clustering."""
     from langres.core.metrics import calculate_pairwise_metrics

--- a/tests/data/test_m2_eval.py
+++ b/tests/data/test_m2_eval.py
@@ -1,0 +1,188 @@
+"""M2 Wave 2 — held-out BCubed eval harness (fast, embedding-free unit tests).
+
+Covers the three pure helpers added for the M2 skeleton eval:
+
+- ``complete_partition`` — singleton-completes a predicted clustering so BCubed
+  averages over EVERY item (the Clusterer drops singletons).
+- ``evaluate_resolver_bcubed`` — resolve -> complete -> BCubed + Pair-Completeness
+  + sanity floor, as a :class:`BCubedEvalResult`.
+- ``tune_threshold_on_train`` — picks the best Clusterer threshold by TRAIN F1.
+
+These use an ``AllPairsBlocker`` resolver (``Resolver.from_schema``) or stub the
+eval, so no embeddings run — they stay in the fast suite. The real-embedding
+end-to-end assertion lives in ``tests/data/test_m2_skeleton_slow.py``.
+"""
+
+import pytest
+
+from langres.data import er_benchmarks
+from langres.data.er_benchmarks import (
+    DEFAULT_THRESHOLD_GRID,
+    BCubedEvalResult,
+    RestaurantSchema,
+    complete_partition,
+    evaluate_resolver_bcubed,
+    tune_threshold_on_train,
+)
+from langres.core.resolver import Resolver
+
+# --- complete_partition ----------------------------------------------------------
+
+
+def test_complete_partition_adds_singletons_for_uncovered_ids() -> None:
+    completed = complete_partition([{"a", "b"}], ["a", "b", "c", "d"])
+    assert completed == [{"a", "b"}, {"c"}, {"d"}]
+
+
+def test_complete_partition_empty_prediction_is_all_singletons() -> None:
+    # The Clusterer merged nothing -> every id becomes its own singleton.
+    assert complete_partition([], ["a", "b"]) == [{"a"}, {"b"}]
+
+
+def test_complete_partition_noop_when_already_complete() -> None:
+    predicted = [{"a", "b"}, {"c"}]
+    assert complete_partition(predicted, ["a", "b", "c"]) == predicted
+
+
+def test_complete_partition_is_deterministic_in_all_ids_order() -> None:
+    # Singletons are appended in all_ids order, not set-iteration order.
+    completed = complete_partition([{"a"}], ["a", "z", "m"])
+    assert completed == [{"a"}, {"z"}, {"m"}]
+
+
+# --- evaluate_resolver_bcubed (AllPairs resolver, no embeddings) ------------------
+
+
+def _tiny_corpus() -> tuple[list[RestaurantSchema], list[set[str]]]:
+    """Two cross-source identical-field match pairs + two singletons.
+
+    Identical fields make the equal-weight ``WeightedAverageJudge`` score the
+    matched pairs at ~1.0 (plenty of evidence: all five fields present), so they
+    merge at a low threshold; the distinct singletons never merge.
+    """
+    records = [
+        RestaurantSchema(
+            id="f0",
+            name="alpha pizza",
+            addr="1 main",
+            city="rome",
+            phone="111",
+            type="italian",
+            source="fodors",
+        ),
+        RestaurantSchema(
+            id="z0",
+            name="alpha pizza",
+            addr="1 main",
+            city="rome",
+            phone="111",
+            type="italian",
+            source="zagat",
+        ),
+        RestaurantSchema(
+            id="f1",
+            name="beta sushi",
+            addr="2 oak",
+            city="tokyo",
+            phone="222",
+            type="japanese",
+            source="fodors",
+        ),
+        RestaurantSchema(
+            id="z1",
+            name="beta sushi",
+            addr="2 oak",
+            city="tokyo",
+            phone="222",
+            type="japanese",
+            source="zagat",
+        ),
+        RestaurantSchema(id="f100", name="gamma diner", source="fodors"),
+        RestaurantSchema(id="z200", name="delta cafe", source="zagat"),
+    ]
+    truth = [{"f0", "z0"}, {"f1", "z1"}, {"f100"}, {"z200"}]
+    return records, truth
+
+
+def test_evaluate_resolver_bcubed_returns_expected_fields() -> None:
+    records, truth = _tiny_corpus()
+    # AllPairsBlocker -> no embeddings; threshold low enough to merge identical pairs.
+    resolver = Resolver.from_schema(RestaurantSchema, threshold=0.3)
+
+    result = evaluate_resolver_bcubed(resolver, records, truth)
+
+    assert isinstance(result, BCubedEvalResult)
+    for value in (result.precision, result.recall, result.f1, result.pair_completeness):
+        assert 0.0 <= value <= 1.0
+    # AllPairs surfaces every cross-source pair -> blocking captures all matches.
+    assert result.pair_completeness == 1.0
+    # The matched pairs are recovered, so the run beats "merge nothing".
+    assert result.f1 > result.sanity_floor_f1
+    # Identical-field matches + distinct singletons -> a perfect partition here.
+    assert result.f1 == 1.0
+    assert result.precision == 1.0
+    assert result.recall == 1.0
+
+
+def test_evaluate_resolver_bcubed_sanity_floor_is_all_singletons_score() -> None:
+    records, truth = _tiny_corpus()
+    resolver = Resolver.from_schema(RestaurantSchema, threshold=0.3)
+
+    result = evaluate_resolver_bcubed(resolver, records, truth)
+
+    # The floor is below 1.0 because all-singletons misses both true match pairs.
+    assert 0.0 < result.sanity_floor_f1 < 1.0
+
+
+# --- tune_threshold_on_train (stubbed eval, no embeddings) ------------------------
+
+
+def test_tune_threshold_picks_argmax_train_f1(monkeypatch: pytest.MonkeyPatch) -> None:
+    # Map each candidate threshold to a known train F1; tune must return the max.
+    f1_by_threshold = {0.3: 0.10, 0.4: 0.50, 0.5: 0.90, 0.6: 0.40, 0.7: 0.20, 0.8: 0.05}
+
+    def fake_eval(
+        resolver: Resolver,
+        records: list[RestaurantSchema],
+        clusters: list[set[str]],
+    ) -> BCubedEvalResult:
+        threshold = resolver.clusterer.threshold
+        return BCubedEvalResult(
+            precision=0.0,
+            recall=0.0,
+            f1=f1_by_threshold[threshold],
+            pair_completeness=1.0,
+            sanity_floor_f1=0.0,
+        )
+
+    monkeypatch.setattr(er_benchmarks, "evaluate_resolver_bcubed", fake_eval)
+
+    best = tune_threshold_on_train([], [], thresholds=tuple(f1_by_threshold))
+    assert best == 0.5
+
+
+def test_tune_threshold_breaks_ties_to_first(monkeypatch: pytest.MonkeyPatch) -> None:
+    def fake_eval(
+        resolver: Resolver,
+        records: list[RestaurantSchema],
+        clusters: list[set[str]],
+    ) -> BCubedEvalResult:
+        return BCubedEvalResult(
+            precision=0.0, recall=0.0, f1=0.5, pair_completeness=1.0, sanity_floor_f1=0.0
+        )
+
+    monkeypatch.setattr(er_benchmarks, "evaluate_resolver_bcubed", fake_eval)
+
+    # All equal F1 -> the first (lowest) threshold in order wins.
+    best = tune_threshold_on_train([], [], thresholds=(0.4, 0.5, 0.6))
+    assert best == 0.4
+
+
+def test_tune_threshold_rejects_empty_grid() -> None:
+    with pytest.raises(ValueError, match="thresholds is empty"):
+        tune_threshold_on_train([], [], thresholds=())
+
+
+def test_default_threshold_grid_is_ascending_in_unit_range() -> None:
+    assert DEFAULT_THRESHOLD_GRID == tuple(sorted(DEFAULT_THRESHOLD_GRID))
+    assert all(0.0 < t < 1.0 for t in DEFAULT_THRESHOLD_GRID)

--- a/tests/data/test_m2_skeleton_slow.py
+++ b/tests/data/test_m2_skeleton_slow.py
@@ -1,0 +1,52 @@
+"""M2 walking skeleton — full real-embedding end-to-end regression gate (slow).
+
+Runs the complete M2 pipeline on the real Fodors-Zagat corpus with real MiniLM
+embeddings and ZERO spend (no LLM): load -> split (seed=0) -> tune threshold on
+TRAIN -> evaluate on the held-out TEST split against the TRUE ``perfectMapping``
+ground truth.
+
+This mirrors ``examples/m2_walking_skeleton_fodors_zagat.py``. It is marked
+``slow`` (it embeds the corpus) but RUNS in CI. The F1 floor below is an
+INFORMATIONAL / regression gate pinned from the first real run (measured BCubed
+F1 = 0.9799), NOT a quality bar — it exists to catch a regression, not to assert
+the baseline is "good enough". M3 is what improves the baseline.
+"""
+
+import pytest
+
+from langres.data.er_benchmarks import (
+    RECALL_GATE,
+    build_restaurant_resolver,
+    evaluate_resolver_bcubed,
+    load_fodors_zagat,
+    split_restaurant_corpus,
+    tune_threshold_on_train,
+)
+
+# Pinned from the first real run (measured F1 = 0.9799), set ~3 points below as a
+# regression gate with margin for cross-machine embedding/FAISS nondeterminism.
+# This is informational only — it is NOT the M2 quality bar.
+F1_REGRESSION_FLOOR = 0.95
+
+
+@pytest.mark.slow
+def test_m2_skeleton_held_out_bcubed_regression_gate() -> None:
+    corpus, gold_clusters = load_fodors_zagat()
+    train_records, test_records, train_clusters, test_clusters = split_restaurant_corpus(
+        corpus, gold_clusters, test_size=0.3, seed=0
+    )
+
+    # Tune on TRAIN only (no test leakage), then score the held-out TEST split.
+    best_threshold = tune_threshold_on_train(train_records, train_clusters)
+    resolver = build_restaurant_resolver(best_threshold)
+    result = evaluate_resolver_bcubed(resolver, test_records, test_clusters)
+
+    # Regression gate (informational, not a quality bar).
+    assert result.f1 >= F1_REGRESSION_FLOOR
+    # The baseline must carry signal — beat the all-singletons floor.
+    assert result.f1 > result.sanity_floor_f1
+    # Blocking must surface the true matches it is asked to judge.
+    assert result.pair_completeness >= RECALL_GATE
+    # Sanity: all reported scores are valid probabilities.
+    for value in (result.precision, result.recall, result.f1):
+        assert 0.0 <= value <= 1.0


### PR DESCRIPTION
## M2 Wave 2 — held-out BCubed eval harness + partition-safe metric + skeleton example

Wires the Wave 1 factories into a deterministic, **zero-spend** held-out BCubed
evaluation on Fodors-Zagat, scored against the dataset's TRUE `perfectMapping`
ground truth (not the M1 teacher labels), and fixes a latent BCubed core bug.

### (A) Partition-safe BCubed metric (review P1-5)
`calculate_bcubed_recall`/`_precision` mapped any id absent from the predicted
(resp. gold) partition to a single implicit `None` cluster, so two un-merged ids
compared equal and were scored as co-clustered — inflating recall for every
unresolved gold-match pair. Since the Clusterer drops singletons, this fired for
every false negative. Fix: fall back to the id itself as the lookup key (ids are
`str`, cluster keys are `int` → no collision), giving each absent id a unique
singleton cluster. No-op when the partition is already complete. Hand-verified
tests: gold `[{a,b},{c}]` vs predicted `[]` → recall `2/3` (was `1.0`).

### (B) Reusable BCubed eval helper (`er_benchmarks.py`)
- `complete_partition(predicted, all_ids)` — singleton-completes a clustering so
  BCubed averages over **every** item.
- `evaluate_resolver_bcubed(resolver, test_records, test_truth) -> BCubedEvalResult`
  — resolve → complete → `calculate_bcubed_metrics`, plus the all-singletons
  **sanity floor** and the resolver's own cross-source blocking
  **Pair-Completeness** (reuses `resolver.blocker` post-resolve, no re-embedding).

### (C) Threshold tuning on TRAIN only (no leakage)
`tune_threshold_on_train(...)` sweeps `DEFAULT_THRESHOLD_GRID`, picks the best
TRAIN BCubed F1. The test split is never touched during tuning.

### (D) Deterministic example
`examples/m2_walking_skeleton_fodors_zagat.py`: load → split(seed=0) →
tune-on-train → eval-on-test → prints BCubed P/R/F1, sanity floor, chosen
threshold, and test-split Pair-Completeness. Real MiniLM embeddings, zero spend.

### (E) Slow CI regression gate
`tests/data/test_m2_skeleton_slow.py` (`@slow`, runs in CI) asserts the full
real-embedding pipeline clears an **informational** F1 regression floor (`0.95`,
pinned ~3 pts below the measured run), beats the sanity floor, and clears the
blocking Pair-Completeness gate.

### Measured first real run (seed=0, test_size=0.3, k=5)
| Metric | Value |
|---|---|
| BCubed Precision | 0.9910 |
| BCubed Recall | 0.9690 |
| **BCubed F1** | **0.9799** |
| Sanity floor (F1) | 0.9317 |
| Pair-Completeness | 1.0000 |
| Chosen threshold | 0.8 |

The baseline beats the merge-nothing floor (has signal). Note the floor is high
because most records are singletons — the honest framing the example prints.

### Gates
- `uv run mypy src/` — clean (53 files).
- `uv run ruff check .` + `ruff format --check .` — clean.
- `OMP_NUM_THREADS=1 KMP_DUPLICATE_LIB_OK=1 uv run pytest -q -m "not integration"` —
  **1113 passed**, 0 failed; coverage **98.89%** (gate 95%). `er_benchmarks.py`
  100%; the metric edits are covered (the two uncovered `metrics.py` lines are
  pre-existing, in `evaluate_blocking_with_ranking`).
- No `print()` in src/ or tests/ (example only). No new deps. No Resolver/
  Comparator/Judge API changes.

### Self-review
- Eval oracle = `load_fodors_zagat` `perfectMapping` ground truth (not teacher gold). ✓
- No train/test leakage (tune on train, score on test). ✓
- Predicted partition completed with singletons before scoring. ✓
- Metric fix is a no-op on complete partitions (existing tests stay green). ✓

https://claude.ai/code/session_01Qik2ZVTbXtYt6rx2uLkYSd