### PR TITLE
M2 Wave 3: fresh-process artifact proof + brainsquad consumption contract + docs

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -6,6 +6,44 @@
 - Implemented core primitives (`Module`, `Blocker`, `Clusterer`) with Pydantic data contracts and 100% test coverage
 - Completed Approach 1 (classical baseline): `AllPairsBlocker` + `RapidfuzzModule` end-to-end pipeline
 
+### M2: Walking skeleton end-to-end + baseline + artifact (Fodors-Zagat)
+
+Wired the existing M0/M1 primitives into one deterministic, zero-spend Resolver
+pipeline that reports a held-out BCubed baseline and proves the brainsquad
+**artifact consumption contract** end-to-end. This is mechanics + serialization,
+not Person-resolution quality (that is M5).
+
+- **Pipeline (compose, no new components)**: `build_restaurant_resolver` wires
+  the shared `VectorBlocker` (MiniLM + FAISS-cosine, `k=5`) with the missing-aware
+  `Comparator.from_schema(RestaurantSchema)` (auto-excludes `id`, computed
+  `embed_text`, and the `source` Literal — comparing `source` would penalise the
+  all-cross-source true matches), the registered zero-spend `WeightedAverageJudge`,
+  and a connected-components `Clusterer`. `split_restaurant_corpus` is a
+  leakage-free stratified split over full records; the threshold is tuned on TRAIN
+  only and BCubed is scored on the held-out TEST split against the dataset's TRUE
+  `perfectMapping` closed-world partition (NOT the M1 teacher labels). The
+  predicted partition is singleton-completed before scoring.
+- **Measured baseline (seed=0, test_size=0.3, threshold tuned to 0.8)**: held-out
+  TEST BCubed **P/R/F1 = 0.991 / 0.969 / 0.980** vs the merge-nothing sanity floor
+  **F1 = 0.932** (Fodors-Zagat is singleton-dominated, so the floor is high by
+  construction) — i.e. ~5 honest points of signal over "every record is unique".
+  Blocking **Pair-Completeness = 1.0** on the test split (it caps recall). The
+  slow CI gate pins F1 ≥ 0.95 as an informational regression floor, not a quality
+  bar — M3 is what improves the baseline.
+- **Artifact contract = `resolve()`-only**: `resolver.save(<dir>)` writes the
+  artifact **directory** (a `resolver.json` manifest + FAISS sidecar; no pickle,
+  no code execution) and `Resolver.load(<dir>).resolve(records)` is the entire
+  consumer call (`records: list[dict]` → `list[set[str]]` of multi-record
+  clusters). A fresh-process identity test imports `langres.data.er_benchmarks`
+  (which now registers `RestaurantSchema` at import time), reloads the artifact in
+  a subprocess, and asserts clusters identical to the in-process run. Bad-input
+  contract: empty corpus → `[]`; a record missing a required field → pydantic
+  `ValidationError` naming the field (before any embedding). The copy-paste
+  consumption snippet lives in `docs/DX_RESOLVER.md`.
+- **Deferred to M5**: `Resolver.link()` / `Resolver.stream_against()` (incremental
+  linking against a saved corpus) remain `NotImplementedError` stubs and are **not**
+  part of the M2 contract — batch dedup via `resolve()` is.
+
 ### M1: Cold-start gold-set bootstrapping (LLM-teacher)
 
 Reusable, entity-type-agnostic `langres.bootstrap` package that mines hard-negative

--- a/docs/DX_RESOLVER.md
+++ b/docs/DX_RESOLVER.md
@@ -129,3 +129,35 @@ Resolver(
 ```
 
 Runnable end-to-end: [`examples/resolver_company_dedup.py`](../examples/resolver_company_dedup.py).
+
+## Consuming a saved artifact (M2 — this is all brainsquad writes)
+
+The M2 walking skeleton (`examples/m2_walking_skeleton_fodors_zagat.py`) builds,
+tunes, and **saves** a Resolver artifact. The integrator who *consumes* that
+artifact writes none of the build code — only load + resolve:
+
+```python
+import langres.data.er_benchmarks  # registers RestaurantSchema (must precede load)
+from langres.core.resolver import Resolver
+
+# records: list[dict] — raw rows in the saved corpus's schema (e.g. RestaurantSchema).
+clusters = Resolver.load("artifacts/fodors_zagat").resolve(records)
+# -> list[set[str]] of multi-record clusters (singletons are dropped).
+```
+
+That is the entire consumer path: `save(<dir>)` writes the artifact **directory**
+(a human-readable `resolver.json` manifest plus any FAISS sidecar — no pickle, no
+code execution), and `Resolver.load(<dir>).resolve(records)` reconstructs the
+pipeline from the registry and runs it. The import line is load-bearing: a fresh
+process must register the record schema **before** `Resolver.load`, or the
+manifest's `schema_type_name` won't resolve. A fresh-process identity proof
+(`tests/data/test_m2_artifact_slow.py`) asserts the reloaded artifact produces
+clusters identical to the in-process run.
+
+**Two consumption modes, one line each:**
+
+- **Batch dedup of a corpus** (available now, M2): `resolver.resolve(records)` —
+  cluster a record list into entities.
+- **Incremental linking of new records against a saved corpus** (M5, not yet
+  available): `.link()` / `.stream_against()` raise `NotImplementedError` today;
+  the incremental contract lands in M5.

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -217,8 +217,12 @@ coverage report. Produce the brainsquad **People (board-members) gold set**.
 ### M2 — Walking skeleton end-to-end + baseline
 Person: feature bag → block → baseline judge (embedding cascade or
 `gliner-linker`) → cluster → eval → **artifact**. brainsquad loads & runs it.
-- **Exit:** **BCubed F1 baseline reported** on held-out gold; artifact runs a
-  brainsquad-style `.link()` / `.resolve()` call end-to-end.
+- **Exit (SHIPPED):** **BCubed F1 baseline reported** on held-out gold; the saved
+  artifact runs a brainsquad-style **`.resolve()`** call end-to-end in a fresh
+  process (identical clusters). Measured on Fodors-Zagat (seed=0, threshold 0.8):
+  held-out BCubed P/R/F1 = 0.991/0.969/0.980 vs merge-nothing floor 0.932,
+  Pair-Completeness 1.0. The M2 consumption contract is `resolve()`-only;
+  incremental `.link()` / `.stream_against()` are M5 stubs (below).
 
 ### M3 — The seam: multi-method benchmark
 Wrap ≥3 methods (rapidfuzz, embedding cascade, LLM judge, **GLinker**) behind the

--- a/src/langres/data/er_benchmarks.py
+++ b/src/langres/data/er_benchmarks.py
@@ -21,6 +21,7 @@ from typing import Literal
 from pydantic import BaseModel, Field, computed_field
 
 from langres.core.blocker import Blocker
+from langres.core.blockers.all_pairs import register_schema_idempotent
 from langres.core.blockers.vector import VectorBlocker
 from langres.core.clusterer import Clusterer
 from langres.core.comparator import Comparator
@@ -103,6 +104,15 @@ class RestaurantSchema(BaseModel):
         empty tokens.
         """
         return " ".join(p for p in [self.name, self.city, self.addr] if p)
+
+
+# Register RestaurantSchema at import time so a fresh process that only does
+# ``import langres.data.er_benchmarks`` (e.g. to ``Resolver.load`` a saved
+# artifact and ``resolve``) finds the schema in the registry without first
+# constructing a blocker. The declarative VectorBlocker re-registers idempotently
+# in :func:`build_restaurant_blocker`, so this is the single source of truth for
+# the registry key and round-trips the saved artifact's ``schema_type_name``.
+register_schema_idempotent(RestaurantSchema)
 
 
 def _unquote(value: str) -> str:

--- a/tests/data/test_m2_artifact_slow.py
+++ b/tests/data/test_m2_artifact_slow.py
@@ -91,8 +91,10 @@ def test_m2_artifact_resolve_identity_fresh_process(tmp_path: Path) -> None:
     records_path.write_text(json.dumps(test_dicts))
 
     # 3. Fresh subprocess: import the package, load the artifact, resolve.
+    #    timeout guards CI against a hung embed/load; capture stderr so a
+    #    failure surfaces the subprocess traceback instead of a bare exit code.
     out_path = tmp_path / "clusters_b.json"
-    subprocess.run(
+    result = subprocess.run(
         [
             sys.executable,
             "-c",
@@ -101,8 +103,15 @@ def test_m2_artifact_resolve_identity_fresh_process(tmp_path: Path) -> None:
             str(records_path),
             str(out_path),
         ],
-        check=True,
+        check=False,
+        capture_output=True,
+        text=True,
+        timeout=300,
     )
+    if result.returncode != 0:
+        raise AssertionError(
+            f"Artifact subprocess failed (exit {result.returncode}):\n{result.stderr}"
+        )
     clusters_b = [set(c) for c in json.loads(out_path.read_text())]
 
     # 4. Identical clusters, compared canonically (order-independent).

--- a/tests/data/test_m2_artifact_slow.py
+++ b/tests/data/test_m2_artifact_slow.py
@@ -28,6 +28,7 @@ import json
 import subprocess
 import sys
 from pathlib import Path
+from typing import TypeAlias
 
 import pytest
 
@@ -40,7 +41,7 @@ from langres.data.er_benchmarks import (
 
 # Canonical, order-independent form of a clustering: a sorted tuple of
 # sorted-id tuples. Used on both sides of the in-process vs fresh-process check.
-Canonical = tuple[tuple[str, ...], ...]
+Canonical: TypeAlias = tuple[tuple[str, ...], ...]
 
 
 def _canonical(clusters: list[set[str]]) -> Canonical:
@@ -57,10 +58,12 @@ import langres.data.er_benchmarks  # noqa: F401 — registers RestaurantSchema
 from langres.core.resolver import Resolver
 
 artifact_dir, records_path, out_path = sys.argv[1], sys.argv[2], sys.argv[3]
-records = json.loads(open(records_path).read())
+with open(records_path) as f:
+    records = json.loads(f.read())
 clusters = Resolver.load(artifact_dir).resolve(records)
 canonical = sorted(sorted(c) for c in clusters)
-open(out_path, "w").write(json.dumps(canonical))
+with open(out_path, "w") as f:
+    f.write(json.dumps(canonical))
 """
 
 

--- a/tests/data/test_m2_artifact_slow.py
+++ b/tests/data/test_m2_artifact_slow.py
@@ -1,0 +1,106 @@
+"""M2 EXIT — fresh-process artifact identity proof (the brainsquad contract).
+
+Proves the second half of the M2 exit criterion: a saved Resolver artifact runs
+a brainsquad-style ``.resolve()`` call end-to-end **in a fresh process** and
+yields *identical* clusters to the in-process run. ``resolve()`` is the ONLY M2
+consumption call — ``.link()`` / ``.stream_against()`` are M5 stubs and are never
+touched here.
+
+The proof, deterministically and with ZERO spend (real MiniLM embeddings for
+blocking; the WeightedAverageJudge is a zero-cost feature-bag scorer):
+
+1. load -> split (seed=0) -> tune threshold on TRAIN -> build the resolver ->
+   ``resolve`` the held-out TEST dicts IN-PROCESS -> clusters_A.
+2. ``resolver.save(<dir>)`` writes the artifact directory (manifest + FAISS
+   sidecar built over the test corpus).
+3. A FRESH subprocess that first ``import langres.data.er_benchmarks`` (so
+   ``RestaurantSchema`` is in the registry before ``Resolver.load``) reads the
+   exact same test dicts from a JSON file, calls
+   ``Resolver.load(<dir>).resolve(<dicts>)``, and writes its clusters as JSON.
+4. clusters_A is asserted equal to clusters_B **canonically** — each clustering
+   reduced to a sorted tuple of sorted-id tuples, so the check is independent of
+   cluster order and within-cluster id order.
+
+Marked ``slow`` (it embeds the corpus) but RUNS in CI.
+"""
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+from langres.data.er_benchmarks import (
+    build_restaurant_resolver,
+    load_fodors_zagat,
+    split_restaurant_corpus,
+    tune_threshold_on_train,
+)
+
+# Canonical, order-independent form of a clustering: a sorted tuple of
+# sorted-id tuples. Used on both sides of the in-process vs fresh-process check.
+Canonical = tuple[tuple[str, ...], ...]
+
+
+def _canonical(clusters: list[set[str]]) -> Canonical:
+    return tuple(sorted(tuple(sorted(c)) for c in clusters))
+
+
+# Run in a fresh interpreter: import the package (registers RestaurantSchema),
+# load the artifact, resolve the SAME test dicts, write canonical clusters out.
+_SUBPROCESS_SCRIPT = """
+import json
+import sys
+
+import langres.data.er_benchmarks  # noqa: F401 — registers RestaurantSchema
+from langres.core.resolver import Resolver
+
+artifact_dir, records_path, out_path = sys.argv[1], sys.argv[2], sys.argv[3]
+records = json.loads(open(records_path).read())
+clusters = Resolver.load(artifact_dir).resolve(records)
+canonical = sorted(sorted(c) for c in clusters)
+open(out_path, "w").write(json.dumps(canonical))
+"""
+
+
+@pytest.mark.slow
+def test_m2_artifact_resolve_identity_fresh_process(tmp_path: Path) -> None:
+    # 1. Build the M2 resolver exactly as the skeleton does (tune on TRAIN only).
+    corpus, gold_clusters = load_fodors_zagat()
+    train_records, test_records, train_clusters, _ = split_restaurant_corpus(
+        corpus, gold_clusters, test_size=0.3, seed=0
+    )
+    best_threshold = tune_threshold_on_train(train_records, train_clusters)
+    resolver = build_restaurant_resolver(best_threshold)
+
+    # In-process resolve over the held-out test dicts (the brainsquad call shape).
+    test_dicts = [r.model_dump() for r in test_records]
+    clusters_a = resolver.resolve(test_dicts)
+    assert clusters_a, "expected the baseline to find at least one multi-record cluster"
+
+    # 2. Persist the artifact directory and the exact dicts the subprocess reuses.
+    artifact_dir = tmp_path / "artifact"
+    resolver.save(artifact_dir)
+    assert (artifact_dir / "resolver.json").exists()
+
+    records_path = tmp_path / "test_records.json"
+    records_path.write_text(json.dumps(test_dicts))
+
+    # 3. Fresh subprocess: import the package, load the artifact, resolve.
+    out_path = tmp_path / "clusters_b.json"
+    subprocess.run(
+        [
+            sys.executable,
+            "-c",
+            _SUBPROCESS_SCRIPT,
+            str(artifact_dir),
+            str(records_path),
+            str(out_path),
+        ],
+        check=True,
+    )
+    clusters_b = [set(c) for c in json.loads(out_path.read_text())]
+
+    # 4. Identical clusters, compared canonically (order-independent).
+    assert _canonical(clusters_a) == _canonical(clusters_b)

--- a/tests/data/test_m2_bad_input.py
+++ b/tests/data/test_m2_bad_input.py
@@ -64,7 +64,9 @@ def test_resolve_record_missing_required_field_raises_naming_field() -> None:
     pydantic ``ValidationError`` whose message names the offending fields.
     """
     resolver = _fast_restaurant_resolver()
-    # Two records so the path reaches schema construction (one record short-circuits).
+    # resolve() reconstructs every record through the schema factory up front (in
+    # the index-build step, before any embedding/blocking), so the first malformed
+    # record raises. A small two-record corpus stands in for a realistic input.
     bad_records = [{"id": "f1"}, {"id": "z1"}]
 
     with pytest.raises(pydantic.ValidationError) as exc_info:

--- a/tests/data/test_m2_bad_input.py
+++ b/tests/data/test_m2_bad_input.py
@@ -1,0 +1,75 @@
+"""M2 bad-input contract — the resolver's documented behavior on degenerate input.
+
+These are the DX-hardening assertions from the Wave 3 review: a brainsquad
+integrator must know exactly what ``resolve`` does at the edges. They run FAST —
+the resolver here mirrors :func:`build_restaurant_resolver` (same
+``RestaurantSchema`` + ``Comparator.from_schema`` + ``WeightedAverageJudge`` +
+``Clusterer`` wiring) but swaps the MiniLM embedder for a ``FakeEmbedder`` so no
+model loads. The two contracts under test are embedder-independent:
+
+- **Empty corpus** -> ``resolve([])`` returns ``[]`` (no clusters). Verified
+  identical with the real MiniLM resolver.
+- **Missing required field** -> the schema factory raises ``pydantic.ValidationError``
+  naming the missing field, and it surfaces at schema-construction time (before
+  any embedding).
+"""
+
+import pydantic
+import pytest
+
+from langres.core import (
+    Clusterer,
+    Comparator,
+    FAISSIndex,
+    FakeEmbedder,
+    Resolver,
+    VectorBlocker,
+    WeightedAverageJudge,
+)
+from langres.data.er_benchmarks import RestaurantSchema
+
+
+def _fast_restaurant_resolver(threshold: float = 0.8) -> Resolver:
+    """A RestaurantSchema resolver with a FakeEmbedder (no MiniLM load).
+
+    Wired exactly like :func:`build_restaurant_resolver` apart from the embedder,
+    so the schema-factory and clusterer paths under test are identical.
+    """
+    index = FAISSIndex(embedder=FakeEmbedder(embedding_dim=16), metric="cosine")
+    blocker: VectorBlocker[RestaurantSchema] = VectorBlocker(
+        vector_index=index,
+        schema=RestaurantSchema,
+        text_field="embed_text",
+        k_neighbors=5,
+    )
+    comparator: Comparator[RestaurantSchema] = Comparator.from_schema(RestaurantSchema)
+    return Resolver(
+        blocker=blocker,
+        comparator=comparator,
+        module=WeightedAverageJudge(feature_specs=comparator.feature_specs),
+        clusterer=Clusterer(threshold=threshold),
+    )
+
+
+def test_resolve_empty_corpus_returns_no_clusters() -> None:
+    """An empty corpus resolves to an empty cluster list (not an error)."""
+    assert _fast_restaurant_resolver().resolve([]) == []
+
+
+def test_resolve_record_missing_required_field_raises_naming_field() -> None:
+    """A record missing required fields raises ValidationError naming them.
+
+    ``name`` (a required ``str``) and ``source`` (a required ``Literal``) are both
+    absent, so the schema factory fails fast — before any embedding — with a
+    pydantic ``ValidationError`` whose message names the offending fields.
+    """
+    resolver = _fast_restaurant_resolver()
+    # Two records so the path reaches schema construction (one record short-circuits).
+    bad_records = [{"id": "f1"}, {"id": "z1"}]
+
+    with pytest.raises(pydantic.ValidationError) as exc_info:
+        resolver.resolve(bad_records)
+
+    message = str(exc_info.value)
+    assert "name" in message
+    assert "source" in message


### PR DESCRIPTION
## M2 Wave 3 — fresh-process artifact proof + brainsquad consumption contract + docs

Final M2 build wave. Composes the Wave 1/2 primitives; **no Resolver/Comparator/Judge API changes**. The M2 consumption contract is **`resolve()`-only** — `.link()` / `.stream_against()` stay M5 stubs and are never referenced.

### What's in this PR

**(A) Fresh-process artifact identity proof** — `tests/data/test_m2_artifact_slow.py` (`@pytest.mark.slow`, zero spend):
load → split(seed=0) → tune-on-TRAIN → build → in-process `resolve()` → `save(<dir>)`; then a **fresh subprocess** that `import langres.data.er_benchmarks` + `Resolver.load(<dir>).resolve(<same dicts>)`; asserts clusters identical **canonically** (sorted tuple of sorted-id tuples). Test dicts written to JSON and reused by the subprocess for robustness.

**Schema-registration fix (src):** `register_schema_idempotent(RestaurantSchema)` now runs at **import time** of `er_benchmarks`, so a fresh process that only imports the module can `Resolver.load` a saved artifact (the manifest's `schema_type_name` resolves). Honors Lessons-Learned DoD #1 and the documented "import registers RestaurantSchema" contract. Idempotent with the blocker's own registration.

**(B) Bad-input contract** — `tests/data/test_m2_bad_input.py` (fast, `FakeEmbedder` — no MiniLM load; behavior verified identical to the real resolver):
empty corpus → `[]`; record missing a required field → `pydantic.ValidationError` naming `name`/`source` (surfaces at schema-factory time, before embedding).

**(C) Consumption snippet** — new section in `docs/DX_RESOLVER.md` ("this is all brainsquad writes"): `import er_benchmarks` → `Resolver.load(dir).resolve(records)`. Chosen over a guarded example file because the DX doc is always present (no CI guard for an absent artifact dir) and lives with the other Resolver DX content. States both modes: batch dedup = `resolve()` (now); incremental linking = M5.

**(D) Docs sync** — `docs/CHANGELOG.md` M2 entry (measured baseline below; `resolve()`-only artifact contract; `.link()`/`stream_against` = M5; `save(<dir>)` writes a directory, `Resolver.load(<dir>).resolve(records)` consumes it); `docs/ROADMAP.md` M2 exit marked SHIPPED with evidence.

### Measured baseline (verified by running the pipeline, not pasted)
Fodors-Zagat, seed=0, test_size=0.3, threshold tuned to 0.8 → held-out TEST BCubed **P/R/F1 = 0.991 / 0.969 / 0.980**, merge-nothing sanity floor **F1 = 0.932** (singleton-dominated dataset), Pair-Completeness **1.0**. ~5 honest points over the floor.

### Gates
- `uv run ruff check .` + `ruff format --check .` clean; `uv run mypy src/` strict clean.
- `OMP_NUM_THREADS=1 KMP_DUPLICATE_LIB_OK=1 uv run pytest -q -m "not integration"`: **1116 passed**, coverage **98.89%** (≥95%); `er_benchmarks.py` and `resolver.py` at **100%**.
- Slow artifact identity test run and **passing** in 43s.
- No `print()` in src/tests; no new deps; no core API changes.

Base = `feat/m2-skeleton` (not main).

https://claude.ai/code/session_01Qik2ZVTbXtYt6rx2uLkYSd
