### PR TITLE
docs: M2 post-merge audit follow-ups (north-star M5 exit, M3 harness extraction, PC caveat)

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -27,9 +27,15 @@ not Person-resolution quality (that is M5).
   TEST BCubed **P/R/F1 = 0.991 / 0.969 / 0.980** vs the merge-nothing sanity floor
   **F1 = 0.932** (Fodors-Zagat is singleton-dominated, so the floor is high by
   construction) — i.e. ~5 honest points of signal over "every record is unique".
-  Blocking **Pair-Completeness = 1.0** on the test split (it caps recall). The
-  slow CI gate pins F1 ≥ 0.95 as an informational regression floor, not a quality
-  bar — M3 is what improves the baseline.
+  Blocking **Pair-Completeness = 1.0** on the test split (it caps recall) — but
+  this is **seed-dependent**, not a system property: the blocker's full-corpus
+  Pair-Completeness is **0.9911** (one structurally-missed pair, `f640`/`z325`,
+  identical `embed_text` in both sources), and with `seed=0` that pair lands in
+  the *train* split, so the *test* split sees 1.0. A different seed would show
+  ~0.971 on test. The slow CI gate pins F1 ≥ 0.95 as an informational regression
+  floor, not a quality bar — M3 is what improves the baseline. NOTE: BCubed on a
+  singleton-heavy corpus over-weights trivially-correct singletons; M3 reports
+  **pairwise F1 on true matches** as the honest complement.
 - **Artifact contract = `resolve()`-only**: `resolver.save(<dir>)` writes the
   artifact **directory** (a `resolver.json` manifest + FAISS sidecar; no pickle,
   no code execution) and `Resolver.load(<dir>).resolve(records)` is the entire

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -227,13 +227,24 @@ Fodors-Zagat (Person artifact + brainsquad load-and-run is M5, see below).
   incremental `.link()` / `.stream_against()` are M5 stubs (below).
 
 ### M3 — The seam: multi-method benchmark
-Wrap ≥3 methods (rapidfuzz, embedding cascade, LLM judge, **GLinker**) behind the
-interfaces; benchmark harness emits BCubed / recall / cost / latency table on the
+**First task (carried from the M2 post-merge audit):** extract the general
+evaluation/split/threshold-tuning machinery (`evaluate_resolver_bcubed`,
+`BCubedEvalResult`, `complete_partition`, `tune_threshold_on_train`) out of the
+dataset-specific `data/er_benchmarks.py` (now a ~620-line god-module) into a
+reusable `core` benchmark/eval module, and collapse `split_restaurant_corpus`
+back onto a generalised `data/splitting.py`. The harness is a first-class
+component (§2.2), not benchmark glue — extract-then-extend so each new dataset
+reuses it instead of re-duplicating. Also report **pairwise F1 on true matches**
+alongside BCubed (BCubed is inflated on singleton-heavy corpora — see the M2
+sanity-floor caveat).
+
+Then wrap ≥3 methods (rapidfuzz, embedding cascade, LLM judge, **GLinker**) behind
+the interfaces; the harness emits BCubed / recall / cost / latency on the
 Person gold set (+ ≥1 standard benchmark dataset). These method families *are* the
 three `POC.md` approaches — 1 (classical/rapidfuzz), 2 (embedding ANN), 3 (hybrid
 LLM) — now raced head-to-head behind one interface instead of run in sequence.
-- **Exit:** a reproducible **method-comparison table**; a winner selected with
-  evidence.
+- **Exit:** a reproducible **method-comparison table** (Δ-above-floor reported
+  next to absolute BCubed); a winner selected with evidence.
 
 ### M4 — DSPy-distilled cheap judge (the differentiator)
 Compile a teacher→student judge (MIPROv2) against the gold set; the cheap student
@@ -252,6 +263,15 @@ golden record** (§2.4 flagship loop).
   incremental `.link(new_record)` returns the correct existing entity or "new";
   **a sparse new mention correctly links to a feature-rich golden record, and the
   golden record gains the mention's new features** (enrichment verified).
+- **Exit (north-star measurability — carried from the M2 audit):** **Person
+  resolution is *measurable*.** M0–M2 validate the machinery on Fodors-Zagat
+  restaurants because brainsquad Persons have ~0 duplicates and no ground truth;
+  M1's chartered Person gold set shipped as a restaurant one. Before M6 can gate
+  on "Person BCubed ≥ 0.85," M5 must establish an evaluable Person target —
+  either a real (even small) Person gold set via the bootstrapper, or a formally
+  defined measurable proxy (e.g. synthetic name-variant linking). Until this
+  exit is met, "validated on Fodors-Zagat" is explicitly *not* "validated on
+  Person."
 
 ### M6 — Hardening (post-proof)
 Blocking-funnel optimisation (recall-first Optuna objective), score calibration,


### PR DESCRIPTION
Docs-only. Records the decisions + truthfulness fixes from the M2 post-merge audit (two independent reviewers — claims/debt + vision-alignment — plus orchestrator verification).

- **ROADMAP M5** — explicit *'Person resolution is measurable'* exit. The north-star (brainsquad Person dedup) has never been measured (Persons have ~0 dupes, no ground truth; M1's chartered Person gold set shipped as a restaurant one). Decision: keep deferring to M5, but document it so it can't keep slipping — M6's `BCubed >= 0.85` gate presupposes a Person target that doesn't exist yet.
- **ROADMAP M3** — first task = extract the general eval/split/tune machinery out of the ~620-line `data/er_benchmarks.py` god-module into reusable `core`; report pairwise-F1 + Δ-above-floor next to BCubed.
- **CHANGELOG M2** — correct `Pair-Completeness = 1.0` to note it's **seed-dependent** (full-corpus PC is 0.9911; the one structurally-missed pair lands in train at seed=0), and flag BCubed's singleton inflation.

No code or behavior change.

https://claude.ai/code/session_01Qik2ZVTbXtYt6rx2uLkYSd