### PR TITLE
M3 W1: reusable benchmark harness in core (pair+pipeline tracks, budgeted runner)

### DIFF
--- a/src/langres/bootstrap/labelers.py
+++ b/src/langres/bootstrap/labelers.py
@@ -20,10 +20,21 @@ from typing import Any
 from langres.bootstrap._pairs import canonical_pair_key
 from langres.bootstrap.base import Labeler
 from langres.bootstrap.models import GoldPair
+from langres.core.benchmark import BlindCostError
 from langres.core.models import ERCandidate
 from langres.core.modules.llm_judge import LLMJudge
 
 logger = logging.getLogger(__name__)
+
+# ``BlindCostError`` moved to ``langres.core.benchmark`` (shared with the core
+# budgeted runner); imported here so ``langres.bootstrap`` keeps re-exporting it
+# and ``TeacherLabeler`` continues to raise the same type.
+__all__ = [
+    "BlindCostError",
+    "FakeLabeler",
+    "GroundTruthLabeler",
+    "TeacherLabeler",
+]
 
 
 class GroundTruthLabeler(Labeler):
@@ -180,25 +191,6 @@ class FakeLabeler(Labeler):
                 )
             )
         return labels
-
-
-class BlindCostError(RuntimeError):
-    """Raised when the teacher cannot observe its own spend.
-
-    If a judgement reports neither token counts nor a cost, the running tally
-    can no longer be trusted, so the cap is blind. Continuing would risk
-    unbounded spend, so :class:`TeacherLabeler` aborts instead.
-
-    The pairs already labeled (and paid for) before the abort are attached as
-    :attr:`partial` so a caller can recover them rather than discard paid work.
-    :attr:`partial` is populated by :meth:`TeacherLabeler.label` (the catcher)
-    immediately before it re-raises; the raise site does not set it.
-    """
-
-    def __init__(self, message: str) -> None:
-        super().__init__(message)
-        # Populated by TeacherLabeler.label() (the catcher), not at raise time.
-        self.partial: list[GoldPair] = []
 
 
 class TeacherLabeler(Labeler):

--- a/src/langres/core/__init__.py
+++ b/src/langres/core/__init__.py
@@ -5,7 +5,7 @@ This module provides the foundational primitives for building custom
 entity resolution pipelines.
 """
 
-from langres.core import metrics, optimizers
+from langres.core import benchmark, metrics, optimizers
 from langres.core.adapters.glinker import GLinkerAdapter
 from langres.core.blocker import Blocker
 from langres.core.blockers.all_pairs import AllPairsBlocker
@@ -69,6 +69,7 @@ __all__ = [
     "ARTIFACT_VERSION",
     "AllPairsBlocker",
     "ArtifactManifest",
+    "benchmark",
     "Blocker",
     "CandidateStats",
     "ClusterStats",

--- a/src/langres/core/benchmark.py
+++ b/src/langres/core/benchmark.py
@@ -64,11 +64,14 @@ class BlindCostError(RuntimeError):
     - (For :class:`~langres.bootstrap.labelers.TeacherLabeler`) a judgement
       reports neither token counts nor a cost, so the running tally is untrusted.
 
-    Any results already produced (and paid for) before the abort are attached as
-    :attr:`partial` so a caller can recover them rather than discard paid work.
-    Typed ``list[Any]`` so the same error serves both the bootstrap teacher
-    (``GoldPair`` results) and the core runner (``PairwiseJudgement`` results)
-    without coupling ``core`` to ``bootstrap``.
+    :attr:`partial` carries any results already produced (and paid for) before a
+    *mid-loop* abort, so a caller can recover them rather than discard paid work.
+    It is set by the catcher immediately before re-raising (e.g.
+    :meth:`~langres.bootstrap.labelers.TeacherLabeler.label`), not at the raise
+    site; for a *pre-flight* raise (``BudgetedModuleRunner`` rejecting a ``$0``
+    price before any work) it stays empty. Typed ``list[Any]`` so the same error
+    serves both the bootstrap teacher (``GoldPair`` results) and the core runner
+    (``PairwiseJudgement`` results) without coupling ``core`` to ``bootstrap``.
     """
 
     def __init__(self, message: str) -> None:
@@ -317,6 +320,31 @@ class Benchmark(Protocol[RecordT]):
 # ---------------------------------------------------------------------------
 
 
+def _pipeline_track(
+    predicted: list[set[str]],
+    all_ids: list[str],
+    truth_clusters: list[set[str]],
+) -> PipelineTrack:
+    """Score a predicted clustering into a :class:`PipelineTrack`.
+
+    Shared by :func:`evaluate_resolver_bcubed` (which resolves first) and
+    :func:`run_method` (which reuses an already-timed clustering), so the BCubed +
+    floor + Δ computation lives in one place and cannot drift.
+    """
+    completed = complete_partition(predicted, all_ids)
+    bcubed = calculate_bcubed_metrics(completed, truth_clusters)
+    pairwise = calculate_pairwise_metrics(completed, truth_clusters)
+    floor = calculate_bcubed_metrics([{rid} for rid in all_ids], truth_clusters)
+    return PipelineTrack(
+        bcubed_p=bcubed["precision"],
+        bcubed_r=bcubed["recall"],
+        bcubed_f1=bcubed["f1"],
+        cluster_pairwise_f1=pairwise["f1"],
+        delta_above_floor=bcubed["f1"] - floor["f1"],
+        sanity_floor_f1=floor["f1"],
+    )
+
+
 def evaluate_resolver_bcubed(
     resolver: Resolver,
     test_records: Sequence[_Resolvable],
@@ -340,21 +368,8 @@ def evaluate_resolver_bcubed(
     """
     record_dicts = [r.model_dump() for r in test_records]
     all_ids = [r.id for r in test_records]
-
     predicted = resolver.resolve(record_dicts)
-    completed = complete_partition(predicted, all_ids)
-    bcubed = calculate_bcubed_metrics(completed, test_truth_clusters)
-    pairwise = calculate_pairwise_metrics(completed, test_truth_clusters)
-    floor = calculate_bcubed_metrics([{rid} for rid in all_ids], test_truth_clusters)
-
-    return PipelineTrack(
-        bcubed_p=bcubed["precision"],
-        bcubed_r=bcubed["recall"],
-        bcubed_f1=bcubed["f1"],
-        cluster_pairwise_f1=pairwise["f1"],
-        delta_above_floor=bcubed["f1"] - floor["f1"],
-        sanity_floor_f1=floor["f1"],
-    )
+    return _pipeline_track(predicted, all_ids, test_truth_clusters)
 
 
 def tune_threshold_on_train(
@@ -494,20 +509,9 @@ def run_method(
     predicted = resolver.clusterer.cluster(iter(test_judgements))
     elapsed = time.perf_counter() - start
 
-    # (5a) Pipeline track.
+    # (5a) Pipeline track (reuses the already-timed clustering).
     all_ids = [r.id for r in test_records]
-    completed = complete_partition(predicted, all_ids)
-    bcubed = calculate_bcubed_metrics(completed, test_clusters)
-    pairwise = calculate_pairwise_metrics(completed, test_clusters)
-    floor = calculate_bcubed_metrics([{rid} for rid in all_ids], test_clusters)
-    pipeline = PipelineTrack(
-        bcubed_p=bcubed["precision"],
-        bcubed_r=bcubed["recall"],
-        bcubed_f1=bcubed["f1"],
-        cluster_pairwise_f1=pairwise["f1"],
-        delta_above_floor=bcubed["f1"] - floor["f1"],
-        sanity_floor_f1=floor["f1"],
-    )
+    pipeline = _pipeline_track(predicted, all_ids, test_clusters)
 
     # (5b) Pair track on TEST at the train-tuned pair threshold.
     test_gold_pairs = gold_pairs_from_clusters(test_clusters)
@@ -695,6 +699,11 @@ class BudgetedModuleRunner:
         """
         try:
             produced = list(self._module.forward(iter([candidate])))
+        except BlindCostError:
+            # Untrackable spend must abort the whole run, never be swallowed as a
+            # skip — otherwise the budget cap would keep accruing unknowable cost
+            # (mirrors TeacherLabeler, which re-raises BlindCostError).
+            raise
         except Exception as exc:  # noqa: BLE001 — one bad call must not abort the run
             self.skipped_count += 1
             logger.warning("Module call failed for a candidate: %s; skipping", exc)

--- a/src/langres/core/benchmark.py
+++ b/src/langres/core/benchmark.py
@@ -636,8 +636,11 @@ class BudgetedModuleRunner:
             per-pair budget stop fires.
 
         Raises:
-            BlindCostError: If the resolved worst-case per-pair price is ``$0``,
-                so the cap cannot bound spend.
+            BlindCostError: If the resolved worst-case per-pair price is ``$0``
+                (a pre-flight blind cap), or if a wrapped module reports
+                untrackable spend mid-run. In the mid-run case the judgements
+                already produced (and paid for) are attached to the exception's
+                ``partial`` so the caller can recover them.
         """
         self.total_spent_usd = 0.0
         self.labeled_count = 0
@@ -665,7 +668,13 @@ class BudgetedModuleRunner:
                     len(judgements),
                 )
                 break
-            judgement = self._score_one(candidate)
+            try:
+                judgement = self._score_one(candidate)
+            except BlindCostError as exc:
+                # Recover the already-paid judgements rather than discard them
+                # (mirrors TeacherLabeler.label); the catcher sets ``partial``.
+                exc.partial = judgements
+                raise
             if judgement is not None:
                 judgements.append(judgement)
         return judgements

--- a/src/langres/core/benchmark.py
+++ b/src/langres/core/benchmark.py
@@ -454,15 +454,16 @@ def run_method(
         resolver_factory: ``threshold -> Resolver`` for the method under test.
         seed: Split seed.
         budget: Optional hard ceiling on measured spend; if set and the run's
-            ``usd_total`` exceeds it, raises :class:`BlindCostError`. Zero-spend
-            methods (W1) pass ``budget=None`` (no spend to bound) or ``0.0`` to
-            assert they truly spent nothing.
+            ``usd_total`` exceeds it, raises ``ValueError``. Zero-spend methods
+            (W1) pass ``budget=None`` (no spend to bound) or ``0.0`` to assert
+            they truly spent nothing. Per-pair *enforcement* of a budget is the
+            job of :class:`BudgetedModuleRunner`; this is a post-run guard.
 
     Returns:
         A populated :class:`MethodResult`.
 
     Raises:
-        BlindCostError: If ``budget`` is set and measured ``usd_total`` exceeds it.
+        ValueError: If ``budget`` is set and measured ``usd_total`` exceeds it.
     """
     corpus, gold_clusters, _gold_pairs = benchmark.load()
     train_records, test_records, train_clusters, test_clusters = benchmark.split(
@@ -525,7 +526,7 @@ def run_method(
     latency = LatencyTrack(seconds_per_pair=elapsed / n_pairs if n_pairs > 0 else 0.0)
 
     if budget is not None and cost.usd_total > budget:
-        raise BlindCostError(
+        raise ValueError(
             f"run_method spent ${cost.usd_total:.4f}, exceeding budget ${budget:.4f}"
         )
 

--- a/src/langres/core/benchmark.py
+++ b/src/langres/core/benchmark.py
@@ -80,7 +80,9 @@ class BlindCostError(RuntimeError):
         self.partial: list[Any] = []
 
 
-def complete_partition(predicted_clusters: list[set[str]], all_ids: Sequence[str]) -> list[set[str]]:
+def complete_partition(
+    predicted_clusters: list[set[str]], all_ids: Sequence[str]
+) -> list[set[str]]:
     """Complete a predicted clustering into a full partition over ``all_ids``.
 
     The :class:`~langres.core.clusterer.Clusterer` drops singletons, so a record
@@ -495,9 +497,7 @@ def run_method(
     # (3) Pair threshold on TRAIN. The clusterer threshold is irrelevant to the
     # raw judgement scores, so any factory threshold yields the same judgements.
     train_gold_pairs = gold_pairs_from_clusters(train_clusters)
-    train_judgements = resolver_factory(threshold).predict(
-        [r.model_dump() for r in train_records]
-    )
+    train_judgements = resolver_factory(threshold).predict([r.model_dump() for r in train_records])
     train_curve = pair_pr_curve(train_judgements, train_gold_pairs, grid)
     best_pair = max(train_curve, key=lambda m: m.f1)
 
@@ -530,9 +530,7 @@ def run_method(
     latency = LatencyTrack(seconds_per_pair=elapsed / n_pairs if n_pairs > 0 else 0.0)
 
     if budget is not None and cost.usd_total > budget:
-        raise ValueError(
-            f"run_method spent ${cost.usd_total:.4f}, exceeding budget ${budget:.4f}"
-        )
+        raise ValueError(f"run_method spent ${cost.usd_total:.4f}, exceeding budget ${budget:.4f}")
 
     return MethodResult(
         method=getattr(resolver.module, "type_name", type(resolver.module).__name__),
@@ -672,16 +670,13 @@ class BudgetedModuleRunner:
                 judgements.append(judgement)
         return judgements
 
-    def _apply_preflight_cap(
-        self, candidates: list[Any], worst_case_per_pair: float
-    ) -> list[Any]:
+    def _apply_preflight_cap(self, candidates: list[Any], worst_case_per_pair: float) -> list[Any]:
         """Truncate the input so even worst-case spend stays under the soft budget."""
         max_pairs = math.floor(self.budget_soft_usd / worst_case_per_pair)
         if len(candidates) > max_pairs:
             self.dropped_by_cap_count = len(candidates) - max_pairs
             logger.info(
-                "Pre-flight cap: keeping %d of %d pairs (soft budget $%.2f, "
-                "worst-case $%.6f/pair)",
+                "Pre-flight cap: keeping %d of %d pairs (soft budget $%.2f, worst-case $%.6f/pair)",
                 max_pairs,
                 len(candidates),
                 self.budget_soft_usd,

--- a/src/langres/core/benchmark.py
+++ b/src/langres/core/benchmark.py
@@ -1,0 +1,710 @@
+"""Dataset-agnostic entity-resolution benchmark harness (M3 Wave 1).
+
+This module is the reusable spine for benchmarking resolution *methods* across
+*datasets* with a single, honest methodology. It is deliberately free of any
+domain or dataset import (no ``langres.data``): a dataset participates by
+conforming to the :class:`Benchmark` protocol, and a method participates as a
+``resolver_factory: Callable[[float], Resolver]``. Keeping the harness in
+``langres.core`` and depending only on a *factory* (never on
+``build_restaurant_resolver`` or any concrete loader) is what avoids the
+``core -> data.er_benchmarks -> core`` import cycle.
+
+Two evaluation tracks, computed for every method, are the core methodology fix:
+
+- **Pair-level (pre-clustering).** :func:`~langres.core.metrics.classify_pairs`
+  scores each candidate judgement against the gold pairs *before* clustering.
+  Ranking judges only by post-clustering pairwise F1 is biased: transitive
+  closure lets one false-positive edge chain-merge and tank precision, unfairly
+  punishing high-recall judges. The pair track isolates the scorer.
+- **Pipeline (post-clustering).** The familiar block -> judge -> cluster ->
+  BCubed flow, plus the all-singletons sanity floor and the Δ above it.
+
+The harness consumes a *full* :class:`~langres.core.resolver.Resolver` factory
+rather than a raw ``Module`` factory on purpose: comparison-aware judges (e.g.
+``WeightedAverageJudge``) require a ``Comparator`` upstream, so the only uniform
+contract across methods is a complete resolver.
+"""
+
+import logging
+import math
+import time
+from collections.abc import Callable, Sequence
+from typing import Any, Protocol, TypeVar, runtime_checkable
+
+from pydantic import BaseModel, Field
+
+from langres.core.metrics import (
+    PairMetrics,
+    calculate_bcubed_metrics,
+    calculate_pairwise_metrics,
+    classify_pairs,
+    pair_pr_curve,
+    pairs_from_clusters,
+)
+from langres.core.models import PairwiseJudgement
+from langres.core.module import Module
+from langres.core.resolver import Resolver
+
+logger = logging.getLogger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# Shared errors and partition helpers
+# ---------------------------------------------------------------------------
+
+
+class BlindCostError(RuntimeError):
+    """Raised when a budgeted runner cannot observe the cost of its work.
+
+    A budget cap is only safe while spend can be measured. Two situations make
+    the cap *blind* and so abort the run rather than risk unbounded spend:
+
+    - The resolved per-pair worst-case price is ``$0`` (e.g. a price of zero was
+      passed), so the pre-flight cap ``floor(budget / 0)`` is unbounded.
+    - (For :class:`~langres.bootstrap.labelers.TeacherLabeler`) a judgement
+      reports neither token counts nor a cost, so the running tally is untrusted.
+
+    Any results already produced (and paid for) before the abort are attached as
+    :attr:`partial` so a caller can recover them rather than discard paid work.
+    Typed ``list[Any]`` so the same error serves both the bootstrap teacher
+    (``GoldPair`` results) and the core runner (``PairwiseJudgement`` results)
+    without coupling ``core`` to ``bootstrap``.
+    """
+
+    def __init__(self, message: str) -> None:
+        super().__init__(message)
+        # Populated by the catcher immediately before re-raising, not at raise time.
+        self.partial: list[Any] = []
+
+
+def complete_partition(predicted_clusters: list[set[str]], all_ids: Sequence[str]) -> list[set[str]]:
+    """Complete a predicted clustering into a full partition over ``all_ids``.
+
+    The :class:`~langres.core.clusterer.Clusterer` drops singletons, so a record
+    that was never merged is simply absent from ``predicted_clusters``. BCubed
+    must average over *every* item, so this appends a singleton ``{id}`` for each
+    id not already in a predicted cluster. Even with the partition-safe metric
+    fix, completing the partition is required so BCubed *precision* averages over
+    all items rather than only the merged ones.
+
+    Args:
+        predicted_clusters: Multi-record clusters from ``Resolver.resolve``.
+        all_ids: Every record id in the split (e.g. ``[r.id for r in records]``).
+
+    Returns:
+        ``predicted_clusters`` followed by one singleton per uncovered id (in
+        ``all_ids`` order, so the result is deterministic).
+    """
+    clustered = {rid for cluster in predicted_clusters for rid in cluster}
+    completed = list(predicted_clusters)
+    completed.extend({rid} for rid in all_ids if rid not in clustered)
+    return completed
+
+
+def gold_pairs_from_clusters(clusters: list[set[str]]) -> set[frozenset[str]]:
+    """Derive the order-independent gold match pairs from a cluster partition.
+
+    Every within-cluster pair is a true match; singletons contribute none. Used
+    to build the pair-level ground truth for one split (leakage-free, since the
+    pairs come only from that split's clusters).
+
+    Args:
+        clusters: Gold clusters for one split (match sets + singletons).
+
+    Returns:
+        The set of true match pairs as ``frozenset`` pairs.
+    """
+    return {frozenset(pair) for pair in pairs_from_clusters(clusters)}
+
+
+# ---------------------------------------------------------------------------
+# Result models
+# ---------------------------------------------------------------------------
+
+
+class PairTrack(BaseModel):
+    """Pair-level (pre-clustering) scores at the tuned pair threshold.
+
+    Attributes:
+        precision: Pair-level precision on the test split.
+        recall: Pair-level recall on the test split.
+        f1: Pair-level F1 on the test split.
+        pr_curve: Optional precision/recall/F1 across the threshold grid (test
+            split), for plotting the trade-off. ``None`` when not requested.
+    """
+
+    precision: float
+    recall: float
+    f1: float
+    pr_curve: list[PairMetrics] | None = None
+
+
+class PipelineTrack(BaseModel):
+    """Post-clustering pipeline scores against the closed-world truth partition.
+
+    Attributes:
+        bcubed_p: BCubed precision.
+        bcubed_r: BCubed recall.
+        bcubed_f1: BCubed F1.
+        cluster_pairwise_f1: Pairwise F1 of the *completed* clustering (the
+            transitive-closure view the pair track deliberately avoids).
+        delta_above_floor: ``bcubed_f1 - sanity_floor_f1`` — value added over
+            merging nothing. Negative means the method is worse than no merges.
+        sanity_floor_f1: BCubed F1 of the all-singletons prediction.
+    """
+
+    bcubed_p: float
+    bcubed_r: float
+    bcubed_f1: float
+    cluster_pairwise_f1: float
+    delta_above_floor: float
+    sanity_floor_f1: float
+
+
+class CostTrack(BaseModel):
+    """Spend accounting for a method run. Zero-spend methods leave the optionals empty.
+
+    Attributes:
+        usd_total: Total measured spend across all judged test pairs.
+        usd_per_1k_pairs: Spend normalized per 1k candidate pairs.
+        est_usd_per_100k: Linear extrapolation to 100k pairs.
+        escalation_rate: Fraction of pairs escalated to the expensive stage
+            (cascade methods only); ``None`` for single-stage methods.
+        llm_calls_per_candidate: Mean LLM calls per candidate (cascade methods
+            only); ``None`` for zero-LLM methods.
+    """
+
+    usd_total: float = 0.0
+    usd_per_1k_pairs: float = 0.0
+    est_usd_per_100k: float = 0.0
+    escalation_rate: float | None = None
+    llm_calls_per_candidate: float | None = None
+
+
+class LatencyTrack(BaseModel):
+    """Wall-clock accounting for a method run.
+
+    Attributes:
+        seconds_per_pair: Mean seconds to score one candidate pair on the test
+            split (block -> compare -> score -> cluster, amortized).
+        throttle_seconds: Seconds spent sleeping on rate-limit throttles
+            (API methods only); ``None`` when not throttled.
+        embed_cache_hit_rate: Embedding cache hit rate in ``[0, 1]`` (embedding
+            methods with a cache only); ``None`` otherwise.
+    """
+
+    seconds_per_pair: float
+    throttle_seconds: float | None = None
+    embed_cache_hit_rate: float | None = None
+
+
+class MethodResult(BaseModel):
+    """One method's result on one dataset/seed: both tracks, cost, and latency.
+
+    Attributes:
+        method: Method label (e.g. ``"weighted_average"``).
+        dataset: Dataset label (e.g. ``"fodors_zagat"``).
+        seed: Split seed used.
+        threshold: Tuned pipeline (clusterer) threshold.
+        pair: Pair-level track.
+        pipeline: Post-clustering pipeline track.
+        cost: Spend accounting.
+        latency: Wall-clock accounting.
+    """
+
+    method: str
+    dataset: str
+    seed: int
+    threshold: float
+    pair: PairTrack
+    pipeline: PipelineTrack
+    cost: CostTrack = Field(default_factory=CostTrack)
+    latency: LatencyTrack
+
+
+class BenchmarkTable(BaseModel):
+    """Collects :class:`MethodResult`s and renders a method×dataset×seed table.
+
+    A thin, serializable accumulator: append results as runs complete, then call
+    :meth:`to_markdown` for a compact headline view (BCubed F1, pair F1, cost,
+    latency). Kept deliberately small — richer reporting (per-track breakdowns,
+    plots) composes on top of the stored ``results`` rather than bloating this.
+    """
+
+    results: list[MethodResult] = Field(default_factory=list)
+
+    def add(self, result: MethodResult) -> None:
+        """Append one method result."""
+        self.results.append(result)
+
+    def to_markdown(self) -> str:
+        """Render the collected results as a Markdown table.
+
+        Columns: method, dataset, seed, threshold, pipeline BCubed F1, pair F1,
+        total USD, and seconds/pair. Rows are emitted in insertion order.
+
+        Returns:
+            A Markdown table string (header + one row per result). With no
+            results, returns just the header row.
+        """
+        header = (
+            "| method | dataset | seed | threshold | bcubed_f1 | pair_f1 "
+            "| usd_total | s_per_pair |\n"
+            "| --- | --- | --- | --- | --- | --- | --- | --- |"
+        )
+        rows = [
+            f"| {r.method} | {r.dataset} | {r.seed} | {r.threshold:.2f} "
+            f"| {r.pipeline.bcubed_f1:.4f} | {r.pair.f1:.4f} "
+            f"| {r.cost.usd_total:.4f} | {r.latency.seconds_per_pair:.6f} |"
+            for r in self.results
+        ]
+        return "\n".join([header, *rows])
+
+
+# ---------------------------------------------------------------------------
+# Benchmark protocol
+# ---------------------------------------------------------------------------
+
+
+@runtime_checkable
+class _Resolvable(Protocol):
+    """Minimal record contract the harness needs: an id and a dict dump."""
+
+    id: str
+
+    def model_dump(self) -> dict[str, Any]:
+        """Return a JSON-able dict of the record (the resolver's raw input)."""
+        ...  # pragma: no cover
+
+
+RecordT = TypeVar("RecordT", bound=_Resolvable)
+"""The dataset's record type — any Pydantic schema exposing ``id`` + ``model_dump``."""
+
+
+@runtime_checkable
+class Benchmark(Protocol[RecordT]):
+    """A dataset adapter the harness can run any resolver factory against.
+
+    Conformers expose a stable ``name``, a ``load`` returning the corpus plus the
+    closed-world gold partition and gold pairs, a leakage-free ``split``, and the
+    ``threshold_grid`` to tune over. Generic over the dataset's record type so a
+    conformer (e.g. the Fodors-Zagat adapter) keeps its concrete schema typing. A
+    dataset's own schema and blocking config live behind its ``resolver_factory``
+    (passed separately to :func:`run_method`), so this protocol stays free of any
+    domain type.
+    """
+
+    name: str
+    threshold_grid: tuple[float, ...]
+
+    def load(self) -> tuple[list[RecordT], list[set[str]], set[frozenset[str]]]:
+        """Return ``(corpus, gold_clusters, gold_pairs)`` for the full dataset."""
+        ...  # pragma: no cover
+
+    def split(
+        self,
+        corpus: list[RecordT],
+        gold_clusters: list[set[str]],
+        *,
+        seed: int,
+    ) -> tuple[list[RecordT], list[RecordT], list[set[str]], list[set[str]]]:
+        """Split into ``(train_records, test_records, train_clusters, test_clusters)``."""
+        ...  # pragma: no cover
+
+
+# ---------------------------------------------------------------------------
+# Generic evaluation primitives (resolver-factory based, no dataset imports)
+# ---------------------------------------------------------------------------
+
+
+def evaluate_resolver_bcubed(
+    resolver: Resolver,
+    test_records: Sequence[_Resolvable],
+    test_truth_clusters: list[set[str]],
+) -> PipelineTrack:
+    """Score a built resolver on a held-out split (pipeline track).
+
+    Runs ``resolver.resolve`` on the records, completes the predicted partition
+    with singletons, and scores BCubed + pairwise against the closed-world
+    ``test_truth_clusters``, plus the all-singletons sanity floor and the Δ above
+    it. Dataset-agnostic: no cross-source / blocking diagnostics (those belong in
+    a dataset-specific wrapper).
+
+    Args:
+        resolver: A built resolver (its index, if any, is built by ``resolve``).
+        test_records: Held-out records (each exposing ``id`` and ``model_dump``).
+        test_truth_clusters: Closed-world truth partition for the test split.
+
+    Returns:
+        A :class:`PipelineTrack`.
+    """
+    record_dicts = [r.model_dump() for r in test_records]
+    all_ids = [r.id for r in test_records]
+
+    predicted = resolver.resolve(record_dicts)
+    completed = complete_partition(predicted, all_ids)
+    bcubed = calculate_bcubed_metrics(completed, test_truth_clusters)
+    pairwise = calculate_pairwise_metrics(completed, test_truth_clusters)
+    floor = calculate_bcubed_metrics([{rid} for rid in all_ids], test_truth_clusters)
+
+    return PipelineTrack(
+        bcubed_p=bcubed["precision"],
+        bcubed_r=bcubed["recall"],
+        bcubed_f1=bcubed["f1"],
+        cluster_pairwise_f1=pairwise["f1"],
+        delta_above_floor=bcubed["f1"] - floor["f1"],
+        sanity_floor_f1=floor["f1"],
+    )
+
+
+def tune_threshold_on_train(
+    resolver_factory: Callable[[float], Resolver],
+    train_records: Sequence[_Resolvable],
+    train_clusters: list[set[str]],
+    *,
+    thresholds: Sequence[float],
+) -> float:
+    """Select the clusterer threshold maximizing train BCubed F1 (no leakage).
+
+    Builds a fresh resolver per candidate threshold via ``resolver_factory``,
+    scores it on the TRAIN split, and returns the best threshold. The test split
+    is never touched. Ties keep the first (lowest-index) threshold in order.
+
+    Args:
+        resolver_factory: ``threshold -> Resolver`` (a dataset wrapper injects its
+            own builder, e.g. ``build_restaurant_resolver``).
+        train_records: Training records.
+        train_clusters: Closed-world truth partition for the train split.
+        thresholds: Candidate clusterer thresholds to sweep.
+
+    Returns:
+        The best-performing threshold by train BCubed F1.
+
+    Raises:
+        ValueError: If ``thresholds`` is empty.
+    """
+    if not thresholds:
+        raise ValueError("thresholds is empty; nothing to tune over")
+
+    best_threshold = thresholds[0]
+    best_f1 = -1.0
+    for threshold in thresholds:
+        resolver = resolver_factory(threshold)
+        track = evaluate_resolver_bcubed(resolver, train_records, train_clusters)
+        logger.info("threshold=%.2f -> train BCubed F1=%.4f", threshold, track.bcubed_f1)
+        if track.bcubed_f1 > best_f1:
+            best_f1 = track.bcubed_f1
+            best_threshold = threshold
+    return best_threshold
+
+
+def _judgement_cost(judgement: PairwiseJudgement) -> float:
+    """Measured USD cost of one judgement from its provenance.
+
+    Reads ``provenance["cost_usd"]`` first, falling back to
+    ``provenance["llm_cost_usd"]`` (the key ``CascadeModule`` writes). Zero-spend
+    judges set neither, so this returns ``0.0`` for them.
+    """
+    prov = judgement.provenance
+    if "cost_usd" in prov:
+        return float(prov["cost_usd"])
+    if "llm_cost_usd" in prov:
+        return float(prov["llm_cost_usd"])
+    return 0.0
+
+
+def _cost_track(judgements: list[PairwiseJudgement]) -> CostTrack:
+    """Aggregate per-judgement spend into a :class:`CostTrack`.
+
+    ``escalation_rate`` / ``llm_calls_per_candidate`` stay ``None`` here: they are
+    cascade-specific and not derivable from a flat judgement list.
+    """
+    n_pairs = len(judgements)
+    usd_total = sum(_judgement_cost(j) for j in judgements)
+    per_pair = usd_total / n_pairs if n_pairs > 0 else 0.0
+    return CostTrack(
+        usd_total=usd_total,
+        usd_per_1k_pairs=per_pair * 1_000.0,
+        est_usd_per_100k=per_pair * 100_000.0,
+    )
+
+
+def run_method(
+    benchmark: Benchmark[RecordT],
+    resolver_factory: Callable[[float], Resolver],
+    *,
+    seed: int,
+    budget: float | None = None,
+) -> MethodResult:
+    """Run one resolver factory against one benchmark, computing both tracks.
+
+    Pipeline:
+
+    1. ``benchmark.load`` + ``benchmark.split(seed=seed)`` (leakage-free).
+    2. Tune the clusterer threshold on TRAIN BCubed F1.
+    3. Tune the pair-level threshold on TRAIN pair-level F1 (independent of the
+       clusterer threshold — it classifies raw scores).
+    4. Score TEST once: predict judgements (timed), then cluster.
+    5. Compute the pipeline track (BCubed + floor) and the pair track (test
+       judgements at the tuned pair threshold, plus the full PR curve), and the
+       cost + latency tracks.
+
+    Args:
+        benchmark: A :class:`Benchmark` conformer.
+        resolver_factory: ``threshold -> Resolver`` for the method under test.
+        seed: Split seed.
+        budget: Optional hard ceiling on measured spend; if set and the run's
+            ``usd_total`` exceeds it, raises :class:`BlindCostError`. Zero-spend
+            methods (W1) pass ``budget=None`` (no spend to bound) or ``0.0`` to
+            assert they truly spent nothing.
+
+    Returns:
+        A populated :class:`MethodResult`.
+
+    Raises:
+        BlindCostError: If ``budget`` is set and measured ``usd_total`` exceeds it.
+    """
+    corpus, gold_clusters, _gold_pairs = benchmark.load()
+    train_records, test_records, train_clusters, test_clusters = benchmark.split(
+        corpus, gold_clusters, seed=seed
+    )
+
+    grid = benchmark.threshold_grid
+
+    # (2) Pipeline threshold on TRAIN.
+    threshold = tune_threshold_on_train(
+        resolver_factory, train_records, train_clusters, thresholds=grid
+    )
+
+    # (3) Pair threshold on TRAIN. The clusterer threshold is irrelevant to the
+    # raw judgement scores, so any factory threshold yields the same judgements.
+    train_gold_pairs = gold_pairs_from_clusters(train_clusters)
+    train_judgements = resolver_factory(threshold).predict(
+        [r.model_dump() for r in train_records]
+    )
+    train_curve = pair_pr_curve(train_judgements, train_gold_pairs, grid)
+    best_pair = max(train_curve, key=lambda m: m.f1)
+
+    # (4) Score TEST once (timed): judgements -> clusters.
+    resolver = resolver_factory(threshold)
+    test_dicts = [r.model_dump() for r in test_records]
+    start = time.perf_counter()
+    test_judgements = resolver.predict(test_dicts)
+    predicted = resolver.clusterer.cluster(iter(test_judgements))
+    elapsed = time.perf_counter() - start
+
+    # (5a) Pipeline track.
+    all_ids = [r.id for r in test_records]
+    completed = complete_partition(predicted, all_ids)
+    bcubed = calculate_bcubed_metrics(completed, test_clusters)
+    pairwise = calculate_pairwise_metrics(completed, test_clusters)
+    floor = calculate_bcubed_metrics([{rid} for rid in all_ids], test_clusters)
+    pipeline = PipelineTrack(
+        bcubed_p=bcubed["precision"],
+        bcubed_r=bcubed["recall"],
+        bcubed_f1=bcubed["f1"],
+        cluster_pairwise_f1=pairwise["f1"],
+        delta_above_floor=bcubed["f1"] - floor["f1"],
+        sanity_floor_f1=floor["f1"],
+    )
+
+    # (5b) Pair track on TEST at the train-tuned pair threshold.
+    test_gold_pairs = gold_pairs_from_clusters(test_clusters)
+    test_curve = pair_pr_curve(test_judgements, test_gold_pairs, grid)
+    test_pair = classify_pairs(test_judgements, test_gold_pairs, best_pair.threshold)
+    pair = PairTrack(
+        precision=test_pair.precision,
+        recall=test_pair.recall,
+        f1=test_pair.f1,
+        pr_curve=test_curve,
+    )
+
+    # (5c) Cost + latency.
+    cost = _cost_track(test_judgements)
+    n_pairs = len(test_judgements)
+    latency = LatencyTrack(seconds_per_pair=elapsed / n_pairs if n_pairs > 0 else 0.0)
+
+    if budget is not None and cost.usd_total > budget:
+        raise BlindCostError(
+            f"run_method spent ${cost.usd_total:.4f}, exceeding budget ${budget:.4f}"
+        )
+
+    return MethodResult(
+        method=getattr(resolver.module, "type_name", type(resolver.module).__name__),
+        dataset=benchmark.name,
+        seed=seed,
+        threshold=threshold,
+        pair=pair,
+        pipeline=pipeline,
+        cost=cost,
+        latency=latency,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Budgeted module runner
+# ---------------------------------------------------------------------------
+
+
+class BudgetedModuleRunner:
+    """Run any :class:`~langres.core.module.Module` under a hard spend cap.
+
+    Wraps a module and scores candidate pairs one at a time, never letting the
+    worst-case spend cross ``budget_usd``. The same three-layer guarantee proven
+    by :class:`~langres.bootstrap.labelers.TeacherLabeler`, but as a clean,
+    ``Module``-typed component returning :class:`PairwiseJudgement` (the teacher
+    is welded to ``LLMJudge`` and returns ``GoldPair``, so it cannot be reused
+    directly):
+
+    1. **Pre-flight hard cap.** Truncate the input to
+       ``floor(budget_soft_usd / worst_case_per_pair)`` pairs, where
+       ``worst_case_per_pair = worst_case_units_per_pair * price`` (``price`` is
+       per token or per pair, set ``worst_case_units_per_pair=1`` for a flat
+       per-pair price). A resolved ``price`` of ``$0`` makes the cap blind and
+       raises :class:`BlindCostError` before any work.
+    2. **Running tally + per-pair stop.** Spend is tallied from each judgement's
+       ``provenance["cost_usd"]`` (falling back to ``provenance["llm_cost_usd"]``).
+       Before scoring *each* pair, if the worst-case projected spend would cross
+       ``budget_usd`` the run stops and returns what was scored so far.
+    3. **Per-call resilience.** Each pair is scored in its own ``forward`` call
+       wrapped in ``try/except``; one failed call skips that pair and the loop
+       continues, so a single error never discards already-paid results.
+
+    Live run statistics are reset at the start of every :meth:`run` call and so
+    describe only the most recent call: :attr:`total_spent_usd`,
+    :attr:`labeled_count`, :attr:`skipped_count`, :attr:`dropped_by_cap_count`.
+    """
+
+    def __init__(
+        self,
+        module: Module[Any],
+        *,
+        budget_usd: float = 20.0,
+        budget_soft_usd: float = 15.0,
+        worst_case_units_per_pair: float = 1.0,
+    ) -> None:
+        """Initialize the runner.
+
+        Args:
+            module: The wrapped scorer.
+            budget_usd: Hard spend ceiling — the run stops before crossing it.
+            budget_soft_usd: Soft ceiling used to size the pre-flight cap, giving
+                headroom below ``budget_usd``.
+            worst_case_units_per_pair: Worst-case priced units (e.g. tokens) for
+                one pair; ``1.0`` means ``price`` is a flat per-pair price.
+
+        Raises:
+            ValueError: If any budget/unit value is non-positive, or
+                ``budget_soft_usd > budget_usd``.
+        """
+        if budget_usd <= 0.0 or budget_soft_usd <= 0.0:
+            raise ValueError("budgets must be positive")
+        if budget_soft_usd > budget_usd:
+            raise ValueError("budget_soft_usd must not exceed budget_usd")
+        if worst_case_units_per_pair <= 0.0:
+            raise ValueError("worst_case_units_per_pair must be positive")
+
+        self._module = module
+        self.budget_usd = budget_usd
+        self.budget_soft_usd = budget_soft_usd
+        self.worst_case_units_per_pair = worst_case_units_per_pair
+
+        self.total_spent_usd: float = 0.0
+        self.labeled_count: int = 0
+        self.skipped_count: int = 0
+        self.dropped_by_cap_count: int = 0
+
+    def run(
+        self,
+        candidates: Sequence[Any],
+        price_per_token_or_pair: float,
+    ) -> list[PairwiseJudgement]:
+        """Score candidates under the budget cap, returning the judgements made.
+
+        Args:
+            candidates: Candidate pairs to score (each scored via the module's
+                ``forward``).
+            price_per_token_or_pair: Price per worst-case unit (token, or pair
+                when ``worst_case_units_per_pair == 1``). Must be ``> 0``.
+
+        Returns:
+            The judgements produced. May be fewer than the input: dropped by the
+            pre-flight cap, skipped on a failed call, or truncated when the
+            per-pair budget stop fires.
+
+        Raises:
+            BlindCostError: If the resolved worst-case per-pair price is ``$0``,
+                so the cap cannot bound spend.
+        """
+        self.total_spent_usd = 0.0
+        self.labeled_count = 0
+        self.skipped_count = 0
+        self.dropped_by_cap_count = 0
+
+        worst_case_per_pair = self.worst_case_units_per_pair * price_per_token_or_pair
+        if worst_case_per_pair <= 0.0:
+            raise BlindCostError(
+                f"resolved worst-case price is ${worst_case_per_pair:.6f}/pair; "
+                "the budget cap would be blind"
+            )
+
+        capped = self._apply_preflight_cap(list(candidates), worst_case_per_pair)
+        judgements: list[PairwiseJudgement] = []
+        for candidate in capped:
+            projected = self.total_spent_usd + worst_case_per_pair
+            if projected > self.budget_usd:
+                logger.info(
+                    "Budget stop: spent=$%.4f + next worst-case $%.6f would exceed "
+                    "budget $%.2f; returning %d judgements",
+                    self.total_spent_usd,
+                    worst_case_per_pair,
+                    self.budget_usd,
+                    len(judgements),
+                )
+                break
+            judgement = self._score_one(candidate)
+            if judgement is not None:
+                judgements.append(judgement)
+        return judgements
+
+    def _apply_preflight_cap(
+        self, candidates: list[Any], worst_case_per_pair: float
+    ) -> list[Any]:
+        """Truncate the input so even worst-case spend stays under the soft budget."""
+        max_pairs = math.floor(self.budget_soft_usd / worst_case_per_pair)
+        if len(candidates) > max_pairs:
+            self.dropped_by_cap_count = len(candidates) - max_pairs
+            logger.info(
+                "Pre-flight cap: keeping %d of %d pairs (soft budget $%.2f, "
+                "worst-case $%.6f/pair)",
+                max_pairs,
+                len(candidates),
+                self.budget_soft_usd,
+                worst_case_per_pair,
+            )
+            return candidates[:max_pairs]
+        return candidates
+
+    def _score_one(self, candidate: Any) -> PairwiseJudgement | None:
+        """Score one pair, tally its spend, and return the judgement (or ``None``).
+
+        Returns ``None`` (incrementing :attr:`skipped_count`) when the module call
+        raises or yields nothing, so the caller's loop continues without losing
+        already-paid results.
+        """
+        try:
+            produced = list(self._module.forward(iter([candidate])))
+        except Exception as exc:  # noqa: BLE001 — one bad call must not abort the run
+            self.skipped_count += 1
+            logger.warning("Module call failed for a candidate: %s; skipping", exc)
+            return None
+
+        if not produced:
+            self.skipped_count += 1
+            logger.warning("Module yielded no judgement for a candidate; skipping")
+            return None
+
+        judgement = produced[0]
+        self.total_spent_usd += _judgement_cost(judgement)
+        self.labeled_count += 1
+        return judgement

--- a/src/langres/core/metrics.py
+++ b/src/langres/core/metrics.py
@@ -14,13 +14,14 @@ References:
 """
 
 import math
+from collections.abc import Sequence
 from typing import Any, Literal
 
 from pydantic import BaseModel
 from ranx import Qrels, Run, evaluate  # type: ignore[import-untyped]
 
 from langres.core.debugging import CandidateStats
-from langres.core.models import ERCandidate
+from langres.core.models import ERCandidate, PairwiseJudgement
 
 BinStrategy = Literal["quantile", "uniform"]
 """Binning strategy for calibration metrics: equal-mass quantile bins or equal-width bins."""
@@ -243,6 +244,109 @@ def pairs_from_clusters(clusters: list[set[str]]) -> set[tuple[str, str]]:
         [('e1', 'e2'), ('e1', 'e3'), ('e2', 'e3'), ('e4', 'e5')]
     """
     return _clusters_to_pairs(clusters)
+
+
+class PairMetrics(BaseModel):
+    """Pair-level (pre-clustering) classification metrics for one threshold.
+
+    Unlike :func:`calculate_pairwise_metrics` (which scores pairs *after*
+    clustering, so transitive closure can chain one false-positive edge into many
+    false-positive pairs), these metrics classify each candidate
+    :class:`~langres.core.models.PairwiseJudgement` directly against the gold
+    match pairs at a fixed score threshold. This isolates the *scorer's* quality
+    from the clusterer's amplification, giving an unbiased ranking signal across
+    judges of differing recall.
+
+    Attributes:
+        threshold: Score threshold applied; a judgement is a predicted match iff
+            ``score >= threshold``.
+        precision: ``tp / (tp + fp)`` (0.0 when nothing is predicted).
+        recall: ``tp / (tp + fn)`` (0.0 when there are no gold pairs).
+        f1: Harmonic mean of precision and recall (0.0 when both are 0).
+        tp: Predicted-match pairs that are gold matches.
+        fp: Predicted-match pairs that are not gold matches.
+        fn: Gold match pairs not predicted (missed by the blocker or rejected by
+            the threshold).
+    """
+
+    threshold: float
+    precision: float
+    recall: float
+    f1: float
+    tp: int
+    fp: int
+    fn: int
+
+
+def classify_pairs(
+    judgements: list[PairwiseJudgement],
+    gold_pairs: set[frozenset[str]],
+    threshold: float,
+) -> PairMetrics:
+    """Classify candidate judgements against gold match pairs at one threshold.
+
+    Each judgement is a predicted match iff ``score >= threshold``. A judgement's
+    pair is identified order-independently by ``frozenset({left_id, right_id})``,
+    so candidate ordering never affects the counts. ``fn`` counts gold pairs that
+    were *not* predicted — covering both pairs the blocker never surfaced as a
+    judgement and pairs scored below ``threshold`` — because ``gold_pairs - {predicted}``
+    is exactly the set of unrecovered true matches.
+
+    Args:
+        judgements: Candidate judgements from a scorer (pre-clustering).
+        gold_pairs: True match pairs as order-independent ``frozenset`` pairs.
+        threshold: Match cut-off applied to each judgement's ``score``.
+
+    Returns:
+        A :class:`PairMetrics` for this threshold.
+    """
+    predicted: set[frozenset[str]] = {
+        frozenset({j.left_id, j.right_id}) for j in judgements if j.score >= threshold
+    }
+    tp = len(predicted & gold_pairs)
+    fp = len(predicted - gold_pairs)
+    fn = len(gold_pairs - predicted)
+
+    precision = tp / (tp + fp) if (tp + fp) > 0 else 0.0
+    recall = tp / (tp + fn) if (tp + fn) > 0 else 0.0
+    f1 = 2 * (precision * recall) / (precision + recall) if (precision + recall) > 0 else 0.0
+
+    return PairMetrics(
+        threshold=threshold,
+        precision=precision,
+        recall=recall,
+        f1=f1,
+        tp=tp,
+        fp=fp,
+        fn=fn,
+    )
+
+
+def pair_pr_curve(
+    judgements: list[PairwiseJudgement],
+    gold_pairs: set[frozenset[str]],
+    grid: Sequence[float],
+) -> list[PairMetrics]:
+    """Pair-level precision/recall/F1 across a grid of thresholds.
+
+    Calls :func:`classify_pairs` once per threshold in ``grid`` (preserving its
+    order), so callers can pick the threshold maximizing pair-level F1 or trace
+    the precision/recall trade-off without re-clustering.
+
+    Args:
+        judgements: Candidate judgements from a scorer (pre-clustering).
+        gold_pairs: True match pairs as order-independent ``frozenset`` pairs.
+        grid: Thresholds to evaluate.
+
+    Returns:
+        One :class:`PairMetrics` per threshold, in ``grid`` order.
+
+    Raises:
+        ValueError: If ``grid`` is empty.
+    """
+    if not grid:
+        raise ValueError("grid is empty; nothing to sweep over")
+    return [classify_pairs(judgements, gold_pairs, t) for t in grid]
 
 
 def _clusters_to_pairs(clusters: list[set[str]]) -> set[tuple[str, str]]:

--- a/src/langres/data/er_benchmarks.py
+++ b/src/langres/data/er_benchmarks.py
@@ -14,12 +14,23 @@ import csv
 import logging
 import random
 from collections import defaultdict
-from collections.abc import Iterable, Sequence
+from collections.abc import Sequence
 from importlib import resources
 from typing import Literal
 
 from pydantic import BaseModel, Field, computed_field
 
+from langres.core.benchmark import (
+    Benchmark,
+    complete_partition,
+    gold_pairs_from_clusters,
+)
+from langres.core.benchmark import (
+    evaluate_resolver_bcubed as _generic_evaluate_resolver_bcubed,
+)
+from langres.core.benchmark import (
+    tune_threshold_on_train as _generic_tune_threshold_on_train,
+)
 from langres.core.blocker import Blocker
 from langres.core.blockers.all_pairs import register_schema_idempotent
 from langres.core.blockers.vector import VectorBlocker
@@ -28,11 +39,32 @@ from langres.core.comparator import Comparator
 from langres.core.embeddings import SentenceTransformerEmbedder
 from langres.core.indexes.vector_index import FAISSIndex
 from langres.core.judges.weighted_average import WeightedAverageJudge
-from langres.core.metrics import calculate_bcubed_metrics, evaluate_blocking
+from langres.core.metrics import evaluate_blocking
 from langres.core.models import ERCandidate
 from langres.core.resolver import Resolver
 
 logger = logging.getLogger(__name__)
+
+# ``complete_partition`` is re-exported above (it moved to the dataset-agnostic
+# ``langres.core.benchmark`` harness); importers that still do
+# ``from langres.data.er_benchmarks import complete_partition`` keep working.
+__all__ = [
+    "DEFAULT_BLOCKING_K",
+    "DEFAULT_THRESHOLD_GRID",
+    "RECALL_GATE",
+    "BCubedEvalResult",
+    "FodorsZagatBenchmark",
+    "RestaurantSchema",
+    "build_restaurant_blocker",
+    "build_restaurant_resolver",
+    "complete_partition",
+    "evaluate_resolver_bcubed",
+    "load_fodors_zagat",
+    "pick_blocking_k",
+    "split_restaurant_corpus",
+    "sweep_blocking_k",
+    "tune_threshold_on_train",
+]
 
 _DATASET_PACKAGE = "langres.data.datasets.fodors_zagat"
 _FODORS_FILE = "fodors.csv"
@@ -480,32 +512,6 @@ class BCubedEvalResult(BaseModel):
     sanity_floor_f1: float = Field(ge=0.0, le=1.0)
 
 
-def complete_partition(
-    predicted_clusters: list[set[str]], all_ids: Iterable[str]
-) -> list[set[str]]:
-    """Complete a predicted clustering into a full partition over ``all_ids``.
-
-    The :class:`~langres.core.clusterer.Clusterer` drops singletons, so a record
-    that was never merged is simply absent from ``predicted_clusters``. BCubed
-    must average over *every* item, so this appends a singleton ``{id}`` for each
-    id not already in a predicted cluster. Even with the partition-safe metric
-    fix, completing the partition is required so BCubed *precision* averages over
-    all items rather than only the merged ones.
-
-    Args:
-        predicted_clusters: Multi-record clusters from ``Resolver.resolve``.
-        all_ids: Every record id in the split (e.g. ``[r.id for r in records]``).
-
-    Returns:
-        ``predicted_clusters`` followed by one singleton per uncovered id (in
-        ``all_ids`` order, so the result is deterministic).
-    """
-    clustered = {rid for cluster in predicted_clusters for rid in cluster}
-    completed = list(predicted_clusters)
-    completed.extend({rid} for rid in all_ids if rid not in clustered)
-    return completed
-
-
 def _cross_source_pair_completeness(
     blocker: Blocker[RestaurantSchema],
     record_dicts: list[dict[str, object]],
@@ -549,26 +555,22 @@ def evaluate_resolver_bcubed(
         A :class:`BCubedEvalResult` with precision/recall/F1, Pair-Completeness,
         and the sanity floor.
     """
+    # Delegate the dataset-agnostic BCubed + sanity-floor scoring to the core
+    # harness (which runs ``resolver.resolve`` and builds the index), then add the
+    # restaurant-specific cross-source Pair-Completeness by reusing the now-built
+    # ``resolver.blocker`` — keeping the measured blocking identical to resolution.
+    track = _generic_evaluate_resolver_bcubed(resolver, test_records, test_truth_clusters)
     record_dicts = [r.model_dump() for r in test_records]
-    all_ids = [r.id for r in test_records]
-
-    predicted = resolver.resolve(record_dicts)
-    completed = complete_partition(predicted, all_ids)
-    bcubed = calculate_bcubed_metrics(completed, test_truth_clusters)
-
-    # Sanity floor: the resolver merges nothing -> every record is a singleton.
-    floor = calculate_bcubed_metrics([{rid} for rid in all_ids], test_truth_clusters)
-
     pair_completeness = _cross_source_pair_completeness(
         resolver.blocker, record_dicts, test_truth_clusters
     )
 
     return BCubedEvalResult(
-        precision=bcubed["precision"],
-        recall=bcubed["recall"],
-        f1=bcubed["f1"],
+        precision=track.bcubed_p,
+        recall=track.bcubed_r,
+        f1=track.bcubed_f1,
         pair_completeness=pair_completeness,
-        sanity_floor_f1=floor["f1"],
+        sanity_floor_f1=track.sanity_floor_f1,
     )
 
 
@@ -605,16 +607,40 @@ def tune_threshold_on_train(
     Raises:
         ValueError: If ``thresholds`` is empty.
     """
-    if not thresholds:
-        raise ValueError("thresholds is empty; nothing to tune over")
+    # Inject the restaurant resolver builder into the dataset-agnostic core tuner.
+    return _generic_tune_threshold_on_train(
+        lambda threshold: build_restaurant_resolver(threshold, k_neighbors=k_neighbors),
+        train_records,
+        train_clusters,
+        thresholds=thresholds,
+    )
 
-    best_threshold = thresholds[0]
-    best_f1 = -1.0
-    for threshold in thresholds:
-        resolver = build_restaurant_resolver(threshold, k_neighbors=k_neighbors)
-        result = evaluate_resolver_bcubed(resolver, train_records, train_clusters)
-        logger.info("threshold=%.2f -> train BCubed F1=%.4f", threshold, result.f1)
-        if result.f1 > best_f1:
-            best_f1 = result.f1
-            best_threshold = threshold
-    return best_threshold
+
+class FodorsZagatBenchmark(Benchmark[RestaurantSchema]):
+    """Fodors-Zagat as a :class:`~langres.core.benchmark.Benchmark` conformer.
+
+    Adapts the restaurant loaders/splitters to the dataset-agnostic harness so
+    :func:`~langres.core.benchmark.run_method` can run any resolver factory
+    against it: ``load`` returns the corpus, the closed-world gold partition, and
+    the gold match pairs; ``split`` delegates to :func:`split_restaurant_corpus`.
+    The canonical resolver factory is :func:`build_restaurant_resolver`, passed
+    separately to ``run_method``.
+    """
+
+    name = "fodors_zagat"
+    threshold_grid = DEFAULT_THRESHOLD_GRID
+
+    def load(self) -> tuple[list[RestaurantSchema], list[set[str]], set[frozenset[str]]]:
+        """Return ``(corpus, gold_clusters, gold_pairs)`` for Fodors-Zagat."""
+        corpus, gold_clusters = load_fodors_zagat()
+        return corpus, gold_clusters, gold_pairs_from_clusters(gold_clusters)
+
+    def split(
+        self,
+        corpus: list[RestaurantSchema],
+        gold_clusters: list[set[str]],
+        *,
+        seed: int,
+    ) -> tuple[list[RestaurantSchema], list[RestaurantSchema], list[set[str]], list[set[str]]]:
+        """Leakage-free stratified split, delegating to :func:`split_restaurant_corpus`."""
+        return split_restaurant_corpus(corpus, gold_clusters, seed=seed)

--- a/src/langres/data/er_benchmarks.py
+++ b/src/langres/data/er_benchmarks.py
@@ -28,9 +28,6 @@ from langres.core.benchmark import (
 from langres.core.benchmark import (
     evaluate_resolver_bcubed as _generic_evaluate_resolver_bcubed,
 )
-from langres.core.benchmark import (
-    tune_threshold_on_train as _generic_tune_threshold_on_train,
-)
 from langres.core.blocker import Blocker
 from langres.core.blockers.all_pairs import register_schema_idempotent
 from langres.core.blockers.vector import VectorBlocker
@@ -607,13 +604,25 @@ def tune_threshold_on_train(
     Raises:
         ValueError: If ``thresholds`` is empty.
     """
-    # Inject the restaurant resolver builder into the dataset-agnostic core tuner.
-    return _generic_tune_threshold_on_train(
-        lambda threshold: build_restaurant_resolver(threshold, k_neighbors=k_neighbors),
-        train_records,
-        train_clusters,
-        thresholds=thresholds,
-    )
+    # Restaurant-specific loop (kept thin and self-contained rather than
+    # delegating to the core generic tuner) so it scores via *this* module's
+    # ``evaluate_resolver_bcubed`` — the cross-source-PC-aware wrapper. The
+    # generic resolver-factory tuner lives in ``langres.core.benchmark`` and is
+    # what ``run_method`` uses; the FZ ``run_method`` parity test confirms the two
+    # paths agree on the held-out numbers.
+    if not thresholds:
+        raise ValueError("thresholds is empty; nothing to tune over")
+
+    best_threshold = thresholds[0]
+    best_f1 = -1.0
+    for threshold in thresholds:
+        resolver = build_restaurant_resolver(threshold, k_neighbors=k_neighbors)
+        result = evaluate_resolver_bcubed(resolver, train_records, train_clusters)
+        logger.info("threshold=%.2f -> train BCubed F1=%.4f", threshold, result.f1)
+        if result.f1 > best_f1:
+            best_f1 = result.f1
+            best_threshold = threshold
+    return best_threshold
 
 
 class FodorsZagatBenchmark(Benchmark[RestaurantSchema]):

--- a/tests/core/test_benchmark.py
+++ b/tests/core/test_benchmark.py
@@ -20,6 +20,7 @@ from langres.core.benchmark import (
     BudgetedModuleRunner,
     MethodResult,
     PipelineTrack,
+    _cost_track,
     complete_partition,
     gold_pairs_from_clusters,
     run_method,
@@ -52,16 +53,20 @@ class _FakeModule(Module[CompanySchema]):
         cost_key: str = "cost_usd",
         boom_ids: frozenset[str] = frozenset(),
         empty_ids: frozenset[str] = frozenset(),
+        blind_ids: frozenset[str] = frozenset(),
     ) -> None:
         self._cost = cost
         self._cost_key = cost_key
         self._boom_ids = boom_ids
         self._empty_ids = empty_ids
+        self._blind_ids = blind_ids
 
     def forward(
         self, candidates: Iterator[ERCandidate[CompanySchema]]
     ) -> Iterator[PairwiseJudgement]:
         for cand in candidates:
+            if cand.left.id in self._blind_ids:
+                raise BlindCostError(f"untrackable spend for {cand.left.id}")
             if cand.left.id in self._boom_ids:
                 raise RuntimeError(f"boom for {cand.left.id}")
             if cand.left.id in self._empty_ids:
@@ -181,6 +186,18 @@ def test_runner_isolates_per_call_exceptions() -> None:
     assert [j.left_id for j in out] == ["l0", "l2"]
     assert runner.skipped_count == 1
     assert runner.labeled_count == 2
+
+
+def test_runner_propagates_blind_cost_error_from_module() -> None:
+    # A module that signals untrackable spend must abort the run, not be swallowed
+    # as a skip (else the cap keeps accruing unknowable cost).
+    runner = BudgetedModuleRunner(
+        _FakeModule(blind_ids=frozenset({"l1"})),
+        budget_usd=100.0,
+        budget_soft_usd=100.0,
+    )
+    with pytest.raises(BlindCostError, match="untrackable spend"):
+        runner.run(_candidates(3), price_per_token_or_pair=0.001)
 
 
 # ---------------------------------------------------------------------------
@@ -351,6 +368,14 @@ def test_benchmark_table_renders_one_row_per_result() -> None:
 
 def test_benchmark_table_empty_is_header_only() -> None:
     assert BenchmarkTable().to_markdown().count("\n") == 1  # header + separator
+
+
+def test_cost_track_empty_judgements_is_zero() -> None:
+    # No candidates -> no per-pair division; all spend figures fall back to 0.
+    track = _cost_track([])
+    assert track.usd_total == 0.0
+    assert track.usd_per_1k_pairs == 0.0
+    assert track.est_usd_per_100k == 0.0
 
 
 # ---------------------------------------------------------------------------

--- a/tests/core/test_benchmark.py
+++ b/tests/core/test_benchmark.py
@@ -279,7 +279,7 @@ def _cost_resolver_factory(threshold: float) -> Resolver:
 
 
 def test_run_method_raises_when_budget_exceeded() -> None:
-    with pytest.raises(BlindCostError, match="exceeding budget"):
+    with pytest.raises(ValueError, match="exceeding budget"):
         run_method(_FakeBenchmark(), _cost_resolver_factory, seed=0, budget=0.0)
 
 

--- a/tests/core/test_benchmark.py
+++ b/tests/core/test_benchmark.py
@@ -120,9 +120,7 @@ def test_runner_blind_cost_error_on_zero_price() -> None:
 
 def test_runner_preflight_cap_truncates_in_input_order() -> None:
     # worst_case_per_pair = 1 * 0.5 = 0.5; floor(1.0 / 0.5) = 2 pairs kept.
-    runner = BudgetedModuleRunner(
-        _FakeModule(cost=0.0), budget_usd=1.0, budget_soft_usd=1.0
-    )
+    runner = BudgetedModuleRunner(_FakeModule(cost=0.0), budget_usd=1.0, budget_soft_usd=1.0)
     out = runner.run(_candidates(5), price_per_token_or_pair=0.5)
     assert len(out) == 2
     assert runner.dropped_by_cap_count == 3
@@ -132,9 +130,7 @@ def test_runner_preflight_cap_truncates_in_input_order() -> None:
 def test_runner_budget_stop_returns_paid_work_before_crossing() -> None:
     # Preflight keeps floor(0.9/0.3)=3; actual cost 0.5/pair exceeds the 0.3
     # worst-case estimate, so the per-pair gate stops after 2 pairs.
-    runner = BudgetedModuleRunner(
-        _FakeModule(cost=0.5), budget_usd=1.0, budget_soft_usd=0.9
-    )
+    runner = BudgetedModuleRunner(_FakeModule(cost=0.5), budget_usd=1.0, budget_soft_usd=0.9)
     out = runner.run(_candidates(4), price_per_token_or_pair=0.3)
     assert len(out) == 2
     assert runner.total_spent_usd == pytest.approx(1.0)
@@ -222,8 +218,10 @@ class _FakeBenchmark(Benchmark[CompanySchema]):
     _GOLD = [{"c1", "c1b"}, {"c2"}, {"c3", "c3b"}, {"c4"}]
 
     def load(self) -> tuple[list[CompanySchema], list[set[str]], set[frozenset[str]]]:
-        return list(self._CORPUS), [set(c) for c in self._GOLD], gold_pairs_from_clusters(
-            [set(c) for c in self._GOLD]
+        return (
+            list(self._CORPUS),
+            [set(c) for c in self._GOLD],
+            gold_pairs_from_clusters([set(c) for c in self._GOLD]),
         )
 
     def split(
@@ -326,9 +324,7 @@ def test_generic_tune_picks_argmax_train_f1(monkeypatch: pytest.MonkeyPatch) -> 
         )
 
     monkeypatch.setattr(benchmark_module, "evaluate_resolver_bcubed", fake_eval)
-    best = tune_threshold_on_train(
-        _resolver_factory, [], [], thresholds=tuple(f1_by_threshold)
-    )
+    best = tune_threshold_on_train(_resolver_factory, [], [], thresholds=tuple(f1_by_threshold))
     assert best == 0.5
 
 
@@ -400,9 +396,7 @@ def test_core_benchmark_does_not_import_langres_data() -> None:
         "bad = [m for m in sys.modules if m.startswith('langres.data')]; "
         "assert not bad, bad; print('ok')"
     )
-    proc = subprocess.run(
-        [sys.executable, "-c", code], capture_output=True, text=True, check=False
-    )
+    proc = subprocess.run([sys.executable, "-c", code], capture_output=True, text=True, check=False)
     assert proc.returncode == 0, proc.stderr
     assert "ok" in proc.stdout
 

--- a/tests/core/test_benchmark.py
+++ b/tests/core/test_benchmark.py
@@ -12,12 +12,14 @@ from collections.abc import Iterator
 
 import pytest
 
+import langres.core.benchmark as benchmark_module
 from langres.core.benchmark import (
     Benchmark,
     BenchmarkTable,
     BlindCostError,
     BudgetedModuleRunner,
     MethodResult,
+    PipelineTrack,
     complete_partition,
     gold_pairs_from_clusters,
     run_method,
@@ -289,6 +291,44 @@ def test_tune_threshold_on_train_empty_grid_raises() -> None:
             [{"c1", "c1b"}],
             thresholds=[],
         )
+
+
+def test_generic_tune_picks_argmax_train_f1(monkeypatch: pytest.MonkeyPatch) -> None:
+    # Map each candidate threshold to a known train F1; the tuner returns the max.
+    f1_by_threshold = {0.3: 0.10, 0.4: 0.50, 0.5: 0.90, 0.6: 0.40}
+
+    def fake_eval(resolver: Resolver, records: object, clusters: object) -> PipelineTrack:
+        f1 = f1_by_threshold[resolver.clusterer.threshold]
+        return PipelineTrack(
+            bcubed_p=0.0,
+            bcubed_r=0.0,
+            bcubed_f1=f1,
+            cluster_pairwise_f1=0.0,
+            delta_above_floor=0.0,
+            sanity_floor_f1=0.0,
+        )
+
+    monkeypatch.setattr(benchmark_module, "evaluate_resolver_bcubed", fake_eval)
+    best = tune_threshold_on_train(
+        _resolver_factory, [], [], thresholds=tuple(f1_by_threshold)
+    )
+    assert best == 0.5
+
+
+def test_generic_tune_breaks_ties_to_first(monkeypatch: pytest.MonkeyPatch) -> None:
+    def fake_eval(resolver: Resolver, records: object, clusters: object) -> PipelineTrack:
+        return PipelineTrack(
+            bcubed_p=0.0,
+            bcubed_r=0.0,
+            bcubed_f1=0.5,
+            cluster_pairwise_f1=0.0,
+            delta_above_floor=0.0,
+            sanity_floor_f1=0.0,
+        )
+
+    monkeypatch.setattr(benchmark_module, "evaluate_resolver_bcubed", fake_eval)
+    best = tune_threshold_on_train(_resolver_factory, [], [], thresholds=(0.4, 0.5, 0.6))
+    assert best == 0.4
 
 
 # ---------------------------------------------------------------------------

--- a/tests/core/test_benchmark.py
+++ b/tests/core/test_benchmark.py
@@ -1,0 +1,352 @@
+"""Tests for the dataset-agnostic benchmark harness (``langres.core.benchmark``).
+
+Covers the budgeted module runner (preflight cap, budget stop, blind-cost guard,
+per-call isolation, both cost-key paths), the generic ``run_method`` orchestration
+on a fully-deterministic fake benchmark (no embeddings, no LLM), ``BenchmarkTable``
+rendering, and the import-cycle guard (core must not import ``langres.data``).
+"""
+
+import subprocess
+import sys
+from collections.abc import Iterator
+
+import pytest
+
+from langres.core.benchmark import (
+    Benchmark,
+    BenchmarkTable,
+    BlindCostError,
+    BudgetedModuleRunner,
+    MethodResult,
+    complete_partition,
+    gold_pairs_from_clusters,
+    run_method,
+    tune_threshold_on_train,
+)
+from langres.core.blockers.all_pairs import AllPairsBlocker
+from langres.core.clusterer import Clusterer
+from langres.core.models import CompanySchema, ERCandidate, PairwiseJudgement
+from langres.core.module import Module
+from langres.core.reports import ScoreInspectionReport
+from langres.core.resolver import Resolver
+
+# ---------------------------------------------------------------------------
+# Fakes
+# ---------------------------------------------------------------------------
+
+
+class _FakeModule(Module[CompanySchema]):
+    """Yields one judgement per candidate with a controllable cost / failure.
+
+    ``cost_key`` selects which provenance key carries the spend (``cost_usd`` or
+    ``llm_cost_usd``); ``boom_ids`` forces a ``RuntimeError`` for a candidate
+    whose left id is listed (to exercise per-call isolation).
+    """
+
+    def __init__(
+        self,
+        *,
+        cost: float = 0.0,
+        cost_key: str = "cost_usd",
+        boom_ids: frozenset[str] = frozenset(),
+        empty_ids: frozenset[str] = frozenset(),
+    ) -> None:
+        self._cost = cost
+        self._cost_key = cost_key
+        self._boom_ids = boom_ids
+        self._empty_ids = empty_ids
+
+    def forward(
+        self, candidates: Iterator[ERCandidate[CompanySchema]]
+    ) -> Iterator[PairwiseJudgement]:
+        for cand in candidates:
+            if cand.left.id in self._boom_ids:
+                raise RuntimeError(f"boom for {cand.left.id}")
+            if cand.left.id in self._empty_ids:
+                continue  # yield nothing for this candidate
+            yield PairwiseJudgement(
+                left_id=cand.left.id,
+                right_id=cand.right.id,
+                score=1.0,
+                score_type="heuristic",
+                decision_step="fake",
+                provenance={self._cost_key: self._cost},
+            )
+
+    def inspect_scores(
+        self, judgements: list[PairwiseJudgement], sample_size: int = 10
+    ) -> ScoreInspectionReport:
+        raise NotImplementedError  # pragma: no cover — unused by the runner
+
+
+def _candidates(n: int) -> list[ERCandidate[CompanySchema]]:
+    return [
+        ERCandidate(
+            left=CompanySchema(id=f"l{i}", name=f"L{i}"),
+            right=CompanySchema(id=f"r{i}", name=f"R{i}"),
+            blocker_name="test",
+        )
+        for i in range(n)
+    ]
+
+
+# ---------------------------------------------------------------------------
+# BudgetedModuleRunner
+# ---------------------------------------------------------------------------
+
+
+def test_runner_rejects_bad_budgets() -> None:
+    module = _FakeModule()
+    with pytest.raises(ValueError, match="budgets must be positive"):
+        BudgetedModuleRunner(module, budget_usd=0.0)
+    with pytest.raises(ValueError, match="must not exceed"):
+        BudgetedModuleRunner(module, budget_usd=1.0, budget_soft_usd=2.0)
+    with pytest.raises(ValueError, match="worst_case_units_per_pair must be positive"):
+        BudgetedModuleRunner(module, worst_case_units_per_pair=0.0)
+
+
+def test_runner_blind_cost_error_on_zero_price() -> None:
+    runner = BudgetedModuleRunner(_FakeModule(), budget_usd=10.0, budget_soft_usd=10.0)
+    with pytest.raises(BlindCostError, match="blind"):
+        runner.run(_candidates(3), price_per_token_or_pair=0.0)
+
+
+def test_runner_preflight_cap_truncates_in_input_order() -> None:
+    # worst_case_per_pair = 1 * 0.5 = 0.5; floor(1.0 / 0.5) = 2 pairs kept.
+    runner = BudgetedModuleRunner(
+        _FakeModule(cost=0.0), budget_usd=1.0, budget_soft_usd=1.0
+    )
+    out = runner.run(_candidates(5), price_per_token_or_pair=0.5)
+    assert len(out) == 2
+    assert runner.dropped_by_cap_count == 3
+    assert [j.left_id for j in out] == ["l0", "l1"]
+
+
+def test_runner_budget_stop_returns_paid_work_before_crossing() -> None:
+    # Preflight keeps floor(0.9/0.3)=3; actual cost 0.5/pair exceeds the 0.3
+    # worst-case estimate, so the per-pair gate stops after 2 pairs.
+    runner = BudgetedModuleRunner(
+        _FakeModule(cost=0.5), budget_usd=1.0, budget_soft_usd=0.9
+    )
+    out = runner.run(_candidates(4), price_per_token_or_pair=0.3)
+    assert len(out) == 2
+    assert runner.total_spent_usd == pytest.approx(1.0)
+    assert runner.dropped_by_cap_count == 1  # 4 input -> 3 preflight
+    assert runner.labeled_count == 2
+
+
+def test_runner_tallies_llm_cost_usd_key() -> None:
+    # CascadeModule writes ``llm_cost_usd``; the tally must read it as a fallback.
+    runner = BudgetedModuleRunner(
+        _FakeModule(cost=0.2, cost_key="llm_cost_usd"),
+        budget_usd=100.0,
+        budget_soft_usd=100.0,
+    )
+    out = runner.run(_candidates(3), price_per_token_or_pair=0.001)
+    assert len(out) == 3
+    assert runner.total_spent_usd == pytest.approx(0.6)
+
+
+def test_runner_tallies_cost_usd_key() -> None:
+    runner = BudgetedModuleRunner(
+        _FakeModule(cost=0.2, cost_key="cost_usd"),
+        budget_usd=100.0,
+        budget_soft_usd=100.0,
+    )
+    runner.run(_candidates(3), price_per_token_or_pair=0.001)
+    assert runner.total_spent_usd == pytest.approx(0.6)
+
+
+def test_runner_skips_when_module_yields_nothing() -> None:
+    runner = BudgetedModuleRunner(
+        _FakeModule(cost=0.0, empty_ids=frozenset({"l1"})),
+        budget_usd=100.0,
+        budget_soft_usd=100.0,
+    )
+    out = runner.run(_candidates(3), price_per_token_or_pair=0.001)
+    assert [j.left_id for j in out] == ["l0", "l2"]
+    assert runner.skipped_count == 1
+
+
+def test_runner_isolates_per_call_exceptions() -> None:
+    runner = BudgetedModuleRunner(
+        _FakeModule(cost=0.0, boom_ids=frozenset({"l1"})),
+        budget_usd=100.0,
+        budget_soft_usd=100.0,
+    )
+    out = runner.run(_candidates(3), price_per_token_or_pair=0.001)
+    # l1 raised -> skipped; l0 and l2 survive (paid work not lost).
+    assert [j.left_id for j in out] == ["l0", "l2"]
+    assert runner.skipped_count == 1
+    assert runner.labeled_count == 2
+
+
+# ---------------------------------------------------------------------------
+# Fake benchmark + run_method
+# ---------------------------------------------------------------------------
+
+
+class _FakeBenchmark(Benchmark[CompanySchema]):
+    """A tiny deterministic CompanySchema benchmark (two dup clusters, no embeds)."""
+
+    name = "fake"
+    threshold_grid = (0.3, 0.5, 0.7, 0.9)
+
+    _CORPUS = [
+        CompanySchema(id="c1", name="Acme Corporation", address="1 Main St"),
+        CompanySchema(id="c1b", name="Acme Corporation", address="1 Main St"),
+        CompanySchema(id="c2", name="Zeta Holdings", address="9 Pine Rd"),
+        CompanySchema(id="c3", name="Beta Incorporated", address="2 Oak Ave"),
+        CompanySchema(id="c3b", name="Beta Incorporated", address="2 Oak Ave"),
+        CompanySchema(id="c4", name="Omega Limited", address="7 Elm Blvd"),
+    ]
+    _GOLD = [{"c1", "c1b"}, {"c2"}, {"c3", "c3b"}, {"c4"}]
+
+    def load(self) -> tuple[list[CompanySchema], list[set[str]], set[frozenset[str]]]:
+        return list(self._CORPUS), [set(c) for c in self._GOLD], gold_pairs_from_clusters(
+            [set(c) for c in self._GOLD]
+        )
+
+    def split(
+        self,
+        corpus: list[CompanySchema],
+        gold_clusters: list[set[str]],
+        *,
+        seed: int,
+    ) -> tuple[list[CompanySchema], list[CompanySchema], list[set[str]], list[set[str]]]:
+        by_id = {r.id: r for r in corpus}
+        train_clusters = [{"c1", "c1b"}, {"c2"}]
+        test_clusters = [{"c3", "c3b"}, {"c4"}]
+        train = [by_id[i] for c in train_clusters for i in sorted(c)]
+        test = [by_id[i] for c in test_clusters for i in sorted(c)]
+        return train, test, train_clusters, test_clusters
+
+
+def _resolver_factory(threshold: float) -> Resolver:
+    # Name-dominant weights so identical-name duplicates clear the evidence floor.
+    return Resolver.from_schema(
+        CompanySchema, threshold=threshold, weights={"name": 0.7, "address": 0.3}
+    )
+
+
+def test_run_method_computes_both_tracks_cost_and_latency() -> None:
+    result = run_method(_FakeBenchmark(), _resolver_factory, seed=0)
+
+    assert isinstance(result, MethodResult)
+    assert result.dataset == "fake"
+    assert result.seed == 0
+    assert result.threshold in _FakeBenchmark.threshold_grid
+    assert result.method == "weighted_average_judge"
+
+    # Pipeline track: the two identical Beta records merge -> perfect on test.
+    assert result.pipeline.bcubed_f1 == pytest.approx(1.0)
+    assert result.pipeline.delta_above_floor >= 0.0
+    assert result.pipeline.bcubed_f1 >= result.pipeline.sanity_floor_f1
+
+    # Pair track: the one gold test pair (c3/c3b) is recovered.
+    assert result.pair.recall == pytest.approx(1.0)
+    assert result.pair.pr_curve is not None
+    assert len(result.pair.pr_curve) == len(_FakeBenchmark.threshold_grid)
+
+    # Zero-spend method: cost is all zeros, optionals stay empty.
+    assert result.cost.usd_total == 0.0
+    assert result.cost.usd_per_1k_pairs == 0.0
+    assert result.cost.escalation_rate is None
+    assert result.cost.llm_calls_per_candidate is None
+
+    # Latency populated; optionals empty.
+    assert result.latency.seconds_per_pair >= 0.0
+    assert result.latency.throttle_seconds is None
+
+
+def test_run_method_budget_zero_passes_for_zero_spend() -> None:
+    # A zero-spend method must satisfy a $0 ceiling without raising.
+    result = run_method(_FakeBenchmark(), _resolver_factory, seed=0, budget=0.0)
+    assert result.cost.usd_total == 0.0
+
+
+def _cost_resolver_factory(threshold: float) -> Resolver:
+    # A resolver whose module charges a fixed cost per pair, so the budget guard
+    # has spend to bound (no comparator needed — _FakeModule reads raw entities).
+    return Resolver(
+        blocker=AllPairsBlocker(schema=CompanySchema),
+        comparator=None,
+        module=_FakeModule(cost=0.01),
+        clusterer=Clusterer(threshold=threshold),
+    )
+
+
+def test_run_method_raises_when_budget_exceeded() -> None:
+    with pytest.raises(BlindCostError, match="exceeding budget"):
+        run_method(_FakeBenchmark(), _cost_resolver_factory, seed=0, budget=0.0)
+
+
+def test_tune_threshold_on_train_empty_grid_raises() -> None:
+    with pytest.raises(ValueError, match="thresholds is empty"):
+        tune_threshold_on_train(
+            _resolver_factory,
+            list(_FakeBenchmark._CORPUS),
+            [{"c1", "c1b"}],
+            thresholds=[],
+        )
+
+
+# ---------------------------------------------------------------------------
+# BenchmarkTable
+# ---------------------------------------------------------------------------
+
+
+def test_benchmark_table_renders_one_row_per_result() -> None:
+    table = BenchmarkTable()
+    result = run_method(_FakeBenchmark(), _resolver_factory, seed=0)
+    table.add(result)
+    md = table.to_markdown()
+
+    lines = md.splitlines()
+    assert lines[0].startswith("| method | dataset | seed")
+    assert "| --- |" in lines[1]
+    assert len([line for line in lines if "| fake |" in line]) == 1
+    assert "weighted_average_judge" in md
+
+
+def test_benchmark_table_empty_is_header_only() -> None:
+    assert BenchmarkTable().to_markdown().count("\n") == 1  # header + separator
+
+
+# ---------------------------------------------------------------------------
+# complete_partition (re-homed to core)
+# ---------------------------------------------------------------------------
+
+
+def test_complete_partition_adds_singletons_for_uncovered_ids() -> None:
+    assert complete_partition([{"a", "b"}], ["a", "b", "c"]) == [{"a", "b"}, {"c"}]
+
+
+# ---------------------------------------------------------------------------
+# Import-cycle guard: core.benchmark must not import langres.data
+# ---------------------------------------------------------------------------
+
+
+def test_core_benchmark_does_not_import_langres_data() -> None:
+    # A fresh interpreter importing only the harness must not pull in langres.data
+    # (the cycle that would break ``import langres`` at import time).
+    code = (
+        "import langres.core.benchmark, sys; "
+        "bad = [m for m in sys.modules if m.startswith('langres.data')]; "
+        "assert not bad, bad; print('ok')"
+    )
+    proc = subprocess.run(
+        [sys.executable, "-c", code], capture_output=True, text=True, check=False
+    )
+    assert proc.returncode == 0, proc.stderr
+    assert "ok" in proc.stdout
+
+
+def test_import_langres_succeeds() -> None:
+    proc = subprocess.run(
+        [sys.executable, "-c", "import langres; print('ok')"],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    assert proc.returncode == 0, proc.stderr

--- a/tests/core/test_benchmark.py
+++ b/tests/core/test_benchmark.py
@@ -184,16 +184,19 @@ def test_runner_isolates_per_call_exceptions() -> None:
     assert runner.labeled_count == 2
 
 
-def test_runner_propagates_blind_cost_error_from_module() -> None:
+def test_runner_propagates_blind_cost_error_with_partial() -> None:
     # A module that signals untrackable spend must abort the run, not be swallowed
-    # as a skip (else the cap keeps accruing unknowable cost).
+    # as a skip (else the cap keeps accruing unknowable cost) — and the already-paid
+    # judgement(s) must survive on exc.partial.
     runner = BudgetedModuleRunner(
         _FakeModule(blind_ids=frozenset({"l1"})),
         budget_usd=100.0,
         budget_soft_usd=100.0,
     )
-    with pytest.raises(BlindCostError, match="untrackable spend"):
+    with pytest.raises(BlindCostError, match="untrackable spend") as excinfo:
         runner.run(_candidates(3), price_per_token_or_pair=0.001)
+    # l0 was scored (and paid for) before l1 aborted -> recoverable on partial.
+    assert [j.left_id for j in excinfo.value.partial] == ["l0"]
 
 
 # ---------------------------------------------------------------------------

--- a/tests/core/test_pair_metrics.py
+++ b/tests/core/test_pair_metrics.py
@@ -1,0 +1,99 @@
+"""Unit tests for pair-level (pre-clustering) metrics.
+
+``classify_pairs`` / ``pair_pr_curve`` classify each candidate judgement against
+the gold match pairs *before* clustering, on small hand-built inputs with known
+TP/FP/FN. These isolate the scorer from the clusterer's transitive-closure
+amplification (the M3 methodology fix).
+"""
+
+import pytest
+
+from langres.core.metrics import PairMetrics, classify_pairs, pair_pr_curve
+from langres.core.models import PairwiseJudgement
+
+
+def _judgement(left: str, right: str, score: float) -> PairwiseJudgement:
+    return PairwiseJudgement(
+        left_id=left,
+        right_id=right,
+        score=score,
+        score_type="calibrated_prob",
+        decision_step="test",
+        provenance={},
+    )
+
+
+# Gold: a/b and d/e and f/g are true matches; f/g is never even judged (the
+# blocker missed it), so it must still count as a false negative.
+_GOLD = {frozenset({"a", "b"}), frozenset({"d", "e"}), frozenset({"f", "g"})}
+
+
+def test_classify_pairs_counts_tp_fp_fn_at_threshold() -> None:
+    judgements = [
+        _judgement("a", "b", 0.9),  # gold + predicted -> TP
+        _judgement("a", "c", 0.8),  # not gold + predicted -> FP
+        _judgement("d", "e", 0.2),  # gold but below threshold -> FN (rejected)
+    ]
+    result = classify_pairs(judgements, _GOLD, threshold=0.5)
+
+    assert result.tp == 1
+    assert result.fp == 1
+    # d/e rejected + f/g never judged = 2 missed gold pairs.
+    assert result.fn == 2
+    assert result.precision == pytest.approx(0.5)
+    assert result.recall == pytest.approx(1 / 3)
+    assert result.f1 == pytest.approx(2 * 0.5 * (1 / 3) / (0.5 + 1 / 3))
+    assert result.threshold == 0.5
+
+
+def test_classify_pairs_is_order_independent() -> None:
+    # Same pair, ids swapped, must classify identically (frozenset keying).
+    a = classify_pairs([_judgement("a", "b", 0.9)], _GOLD, threshold=0.5)
+    b = classify_pairs([_judgement("b", "a", 0.9)], _GOLD, threshold=0.5)
+    assert a.tp == b.tp == 1
+
+
+def test_classify_pairs_no_predictions_is_zero_precision() -> None:
+    # All judgements below threshold -> nothing predicted, precision falls back to 0.
+    result = classify_pairs([_judgement("a", "b", 0.1)], _GOLD, threshold=0.5)
+    assert result.tp == 0
+    assert result.fp == 0
+    assert result.precision == 0.0
+    assert result.recall == 0.0
+    assert result.f1 == 0.0
+
+
+def test_classify_pairs_no_gold_is_zero_recall() -> None:
+    result = classify_pairs([_judgement("a", "b", 0.9)], set(), threshold=0.5)
+    assert result.tp == 0
+    assert result.fp == 1
+    assert result.fn == 0
+    assert result.recall == 0.0
+
+
+def test_classify_pairs_threshold_is_inclusive() -> None:
+    # score == threshold counts as a predicted match.
+    result = classify_pairs([_judgement("a", "b", 0.5)], _GOLD, threshold=0.5)
+    assert result.tp == 1
+
+
+def test_pair_pr_curve_one_entry_per_threshold_in_order() -> None:
+    judgements = [
+        _judgement("a", "b", 0.9),
+        _judgement("a", "c", 0.8),
+        _judgement("d", "e", 0.2),
+    ]
+    grid = [0.5, 0.85]
+    curve = pair_pr_curve(judgements, _GOLD, grid)
+
+    assert [m.threshold for m in curve] == grid
+    assert all(isinstance(m, PairMetrics) for m in curve)
+    # At 0.85, only a/b (0.9) is predicted: 1 TP, 0 FP.
+    assert curve[1].tp == 1
+    assert curve[1].fp == 0
+    assert curve[1].precision == pytest.approx(1.0)
+
+
+def test_pair_pr_curve_empty_grid_raises() -> None:
+    with pytest.raises(ValueError, match="grid is empty"):
+        pair_pr_curve([_judgement("a", "b", 0.9)], _GOLD, [])

--- a/tests/data/test_m3_parity_slow.py
+++ b/tests/data/test_m3_parity_slow.py
@@ -1,0 +1,49 @@
+"""M3 Wave-1 parity gate: the refactored harness reproduces the M2 baseline.
+
+Runs the full Fodors-Zagat pipeline through the *new* dataset-agnostic
+``run_method`` harness (``FodorsZagatBenchmark`` + ``build_restaurant_resolver``)
+with real MiniLM embeddings and ZERO spend, and asserts it reproduces the M2
+held-out numbers exactly: seed=0, threshold tuned to 0.8, BCubed P/R/F1 =
+0.991 / 0.969 / 0.980, merge-nothing floor = 0.932.
+
+This is the no-behavior-change guard for the M2 -> M3 extraction. Marked
+``slow`` (it embeds the corpus) but RUNS in CI.
+"""
+
+import pytest
+
+from langres.core.benchmark import run_method
+from langres.data.er_benchmarks import (
+    FodorsZagatBenchmark,
+    build_restaurant_resolver,
+)
+
+# Pinned M2 baseline (see memory: M2 completion, PR #42 — held-out BCubed F1
+# 0.980, floor 0.932 vs true ground truth). abs tol absorbs cross-machine
+# FAISS/embedding nondeterminism.
+_ATOL = 0.005
+
+
+@pytest.mark.slow
+def test_run_method_reproduces_m2_baseline() -> None:
+    result = run_method(
+        FodorsZagatBenchmark(),
+        build_restaurant_resolver,
+        seed=0,
+    )
+
+    # Threshold tuned on TRAIN lands at the M2 value.
+    assert result.threshold == pytest.approx(0.8)
+
+    # Pipeline track == the M2 held-out BCubed numbers.
+    assert result.pipeline.bcubed_p == pytest.approx(0.991, abs=_ATOL)
+    assert result.pipeline.bcubed_r == pytest.approx(0.969, abs=_ATOL)
+    assert result.pipeline.bcubed_f1 == pytest.approx(0.980, abs=_ATOL)
+    assert result.pipeline.sanity_floor_f1 == pytest.approx(0.932, abs=_ATOL)
+
+    # The baseline carries signal over merging nothing.
+    assert result.pipeline.delta_above_floor > 0.0
+    assert result.pipeline.bcubed_f1 > result.pipeline.sanity_floor_f1
+
+    # Zero-spend: no cost recorded.
+    assert result.cost.usd_total == 0.0


### PR DESCRIPTION
## What

Wave 1 of M3: extract a **dataset-agnostic benchmark harness** out of the 620-line `data/er_benchmarks.py` god-module into `langres.core`, add **pair-level metrics**, a **two-track `run_method`**, and a **budgeted module runner**. Zero LLM spend — everything deterministic/mocked. This wave gates the rest of M3, so correctness + no-behavior-change were the priority.

## Key pieces

- **`src/langres/core/benchmark.py`** (new, no `langres.data` imports):
  - `complete_partition` + `BlindCostError` moved here (re-exported for back-compat).
  - `Benchmark` protocol (generic over the record type) — the FZ loader conforms.
  - Generic `run_method(benchmark, resolver_factory, *, seed, budget=None) -> MethodResult`: leakage-free split, tune clusterer threshold on TRAIN, tune pair threshold on TRAIN pair-F1, score TEST once, compute **both tracks** + cost + latency.
  - Generic `tune_threshold_on_train` / `evaluate_resolver_bcubed` taking a `resolver_factory` (never imports a concrete builder → no `core → data → core` cycle).
  - `MethodResult` / `PairTrack` / `PipelineTrack` / `CostTrack` / `LatencyTrack` (optional fields truly optional for zero-spend), `BenchmarkTable.to_markdown()`, `BudgetedModuleRunner`.
- **`src/langres/core/metrics.py`**: `classify_pairs` + `pair_pr_curve` (pre-clustering, cleanly int-typed, 100% tested). Two tracks because ranking judges only by post-clustering pairwise F1 is biased — transitive closure lets one false-positive edge chain-merge and tank precision.
- **`src/langres/data/er_benchmarks.py`**: re-exports moved symbols; keeps `split_restaurant_corpus`, builders, `RestaurantSchema`, cross-source PC; adds a `FodorsZagatBenchmark` conformer (exposes `gold_pairs`). The restaurant `evaluate_resolver_bcubed` delegates BCubed to core and adds cross-source PC; the restaurant `tune_threshold_on_train` keeps its own thin loop (scores via the PC-aware evaluate) so existing M2 tests pass verbatim.
- **`BlindCostError`** moved to core; `bootstrap/labelers.py` imports + re-exports it (no duplication, no `core → bootstrap` coupling).

## Design constraints honored

- **No import cycle** — guarded by a subprocess test (`import langres.core.benchmark` pulls in no `langres.data`).
- **Harness consumes a `Resolver` factory**, not a raw module factory (comparison-aware judges need a Comparator upstream).
- **Back-compat re-exports** keep the 7 downstream importers working unchanged.
- **Budgeted runner** mirrors `TeacherLabeler`'s proven 3-layer cap: pre-flight hard pair cap, per-pair worst-case stop, per-call isolation; tallies `cost_usd` with `llm_cost_usd` fallback; raises `BlindCostError` on a $0 (blind) price and re-raises it from the module.

## Verification

- **Parity (no-behavior-change):** the refactored FZ pipeline run through the new `run_method` reproduces the M2 baseline exactly — held-out seed=0, threshold tuned to **0.8**, BCubed **P/R/F1 = 0.991 / 0.969 / 0.980**, merge-nothing floor **0.932** (`tests/data/test_m3_parity_slow.py`).
- Full non-integration suite: **1143 passed**, coverage **98.95%** (≥95 gate); **100%** on `core/benchmark.py`, `data/er_benchmarks.py`, `bootstrap/labelers.py`; new metrics functions fully covered.
- `ruff check` clean, `mypy src/` strict clean, no `print()` in src.
- Self-review (langres-code-reviewer) run; both warranted findings fixed in this PR (BlindCostError re-raise; DRY `_pipeline_track`).

## Design decisions not pre-specified

- **Generic `Benchmark` is `Protocol[RecordT]`** (generic over record type) so the FZ conformer keeps `RestaurantSchema` typing without `list`-invariance friction — mypy-clean.
- **`run_method` `budget` is a post-run ceiling guard** (raises `ValueError` if measured `usd_total` exceeds it). Per-pair *enforcement* is `BudgetedModuleRunner`'s job; for W1 zero-spend, `budget=0.0` asserts no spend.
- **Restaurant `tune_threshold_on_train` kept its own loop** (rather than delegating to the generic tuner) so the existing M2 monkeypatch tests pass verbatim; the generic tuner is exercised by `run_method` + new core tests, and the FZ parity test confirms both paths agree.

https://claude.ai/code/session_01Qik2ZVTbXtYt6rx2uLkYSd