### PR TITLE
M3 W3: 5 methods behind one resolver-factory + EmbeddingScoreJudge

### DIFF
--- a/src/langres/core/__init__.py
+++ b/src/langres/core/__init__.py
@@ -35,6 +35,7 @@ from langres.core.indexes import (
     QdrantHybridIndex,
     VectorIndex,
 )
+from langres.core.judges.embedding_score import EmbeddingScoreJudge
 from langres.core.judges.weighted_average import WeightedAverageJudge
 from langres.core.models import (
     CompanySchema,
@@ -80,6 +81,7 @@ __all__ = [
     "ComparisonVector",
     "ComponentSpec",
     "EmbeddingProvider",
+    "EmbeddingScoreJudge",
     "EntityProtocol",
     "ERCandidate",
     "ErrorExample",

--- a/src/langres/core/judges/__init__.py
+++ b/src/langres/core/judges/__init__.py
@@ -2,9 +2,14 @@
 
 A judge is a :class:`~langres.core.module.Module` that turns candidate pairs
 into :class:`~langres.core.models.PairwiseJudgement` scores. Wave 2a ships the
-:class:`~langres.core.judges.weighted_average.WeightedAverageJudge`.
+:class:`~langres.core.judges.weighted_average.WeightedAverageJudge`; M3 adds the
+zero-spend :class:`~langres.core.judges.embedding_score.EmbeddingScoreJudge`.
+
+Importing both here fires their ``@register`` decorators on package import, so a
+fresh process can ``Resolver.load`` an artifact using either judge.
 """
 
+from langres.core.judges.embedding_score import EmbeddingScoreJudge
 from langres.core.judges.weighted_average import WeightedAverageJudge
 
-__all__ = ["WeightedAverageJudge"]
+__all__ = ["EmbeddingScoreJudge", "WeightedAverageJudge"]

--- a/src/langres/core/judges/embedding_score.py
+++ b/src/langres/core/judges/embedding_score.py
@@ -1,0 +1,111 @@
+"""EmbeddingScoreJudge: the zero-spend embedding-cosine scorer Module.
+
+This judge is the scorer slot for the ``embedding_cosine`` method. Unlike
+:class:`~langres.core.judges.weighted_average.WeightedAverageJudge` (which needs
+a Comparator upstream) it consumes nothing but each candidate's
+``similarity_score`` — the cosine similarity a :class:`~langres.core.blockers.vector.VectorBlocker`
+already attached during blocking. It emits a
+:class:`~langres.core.models.PairwiseJudgement` whose ``score`` *is* that
+similarity, so the Clusterer can threshold the raw embedding signal directly with
+no second model call.
+
+Because it reads ``candidate.similarity_score``, it requires a VectorBlocker
+upstream: any blocker that leaves ``similarity_score`` as ``None`` (e.g.
+``AllPairsBlocker``) makes the score undefined, and the judge raises a clear
+``ValueError`` pointing the caller at the VectorBlocker.
+
+It is registry-serializable exactly like ``WeightedAverageJudge``
+(``@register("embedding_score_judge")`` + ``type_name`` + ``config`` /
+``from_config``), so a Resolver with it in the ``module`` slot round-trips
+through ``save`` / ``load``.
+"""
+
+from collections.abc import Iterator
+from typing import ClassVar
+
+from langres.core.models import ERCandidate, PairwiseJudgement
+from langres.core.module import Module, SchemaT
+from langres.core.registry import register
+from langres.core.reports import ScoreInspectionReport, _inspect_scores_impl
+
+
+@register("embedding_score_judge")
+class EmbeddingScoreJudge(Module[SchemaT]):
+    """Scorer that passes a VectorBlocker's cosine ``similarity_score`` through.
+
+    Owns a single ``threshold`` used only to label each judgement's
+    ``decision_step`` (``embedding_match`` / ``embedding_no_match``); the emitted
+    ``score`` is always the raw similarity, never thresholded (the Clusterer owns
+    the actual cut). Holds no model and makes no API call: it is fully zero-spend.
+    """
+
+    # Registry key, mirrored as a class attribute so the Resolver's uniform
+    # serialization helper can discover the type name (see resolver.py).
+    type_name: ClassVar[str] = "embedding_score_judge"
+
+    def __init__(self, threshold: float = 0.5) -> None:
+        """Initialize with the decision threshold.
+
+        Args:
+            threshold: Similarity at/above which a pair is labelled a match in
+                ``decision_step``. Does not affect the emitted ``score`` (which is
+                the raw similarity) — clustering is the Clusterer's job.
+
+        Raises:
+            ValueError: If ``threshold`` is not in ``[0.0, 1.0]``.
+        """
+        if not 0.0 <= threshold <= 1.0:
+            raise ValueError("threshold must be between 0.0 and 1.0")
+        self.threshold = threshold
+
+    def forward(self, candidates: Iterator[ERCandidate[SchemaT]]) -> Iterator[PairwiseJudgement]:
+        """Emit one PairwiseJudgement per candidate, scoring on ``similarity_score``.
+
+        Args:
+            candidates: Stream of normalized pairs from a ``VectorBlocker`` (each
+                carrying the cosine ``similarity_score`` it computed at blocking).
+
+        Yields:
+            One PairwiseJudgement per candidate whose ``score`` is the candidate's
+            ``similarity_score``.
+
+        Raises:
+            ValueError: If a candidate's ``similarity_score`` is ``None`` (the
+                upstream blocker is not a VectorBlocker, so there is no similarity
+                to score on).
+        """
+        for candidate in candidates:
+            similarity = candidate.similarity_score
+            if similarity is None:
+                raise ValueError(
+                    "EmbeddingScoreJudge requires candidates carrying a "
+                    "similarity_score — use a VectorBlocker upstream (an AllPairs "
+                    "or other non-vector blocker leaves similarity_score unset)."
+                )
+            decision_step = (
+                "embedding_match" if similarity >= self.threshold else "embedding_no_match"
+            )
+            yield PairwiseJudgement(
+                left_id=candidate.left.id,  # type: ignore[attr-defined]
+                right_id=candidate.right.id,  # type: ignore[attr-defined]
+                score=similarity,
+                score_type="sim_cos",
+                decision_step=decision_step,
+                provenance={"similarity_score": similarity, "threshold": self.threshold},
+            )
+
+    def inspect_scores(
+        self, judgements: list[PairwiseJudgement], sample_size: int = 10
+    ) -> ScoreInspectionReport:
+        """Explore scores without ground truth (shared Module utility)."""
+        return _inspect_scores_impl(judgements, sample_size)
+
+    @property
+    def config(self) -> dict[str, object]:
+        """Serializable config: the decision threshold."""
+        return {"threshold": self.threshold}
+
+    @classmethod
+    def from_config(cls, config: dict[str, object]) -> "EmbeddingScoreJudge[SchemaT]":
+        """Reconstruct from :attr:`config`."""
+        return cls(threshold=float(config["threshold"]))  # type: ignore[arg-type]

--- a/src/langres/core/modules/cascade.py
+++ b/src/langres/core/modules/cascade.py
@@ -27,7 +27,13 @@ logger = logging.getLogger(__name__)
 # The neutral LLM prompt is centralized in ``llm_judge`` (single source of
 # truth). ``DEFAULT_PROMPT`` is re-exported here for backward compatibility;
 # new code should call ``render_default_prompt(entity_noun)``.
-__all__ = ["CascadeModule", "DEFAULT_PROMPT"]
+#
+# Single source of truth for the ``decision_step`` a cascade pair carries once it
+# escalates to the LLM (the uncertain band). Consumers that count escalations
+# (e.g. ``langres.methods.cascade_cost_track``) import this rather than repeating
+# the literal, so a rename can't silently desync escalation accounting.
+CASCADE_LLM_DECISION_STEP = "llm_judgment"
+__all__ = ["CASCADE_LLM_DECISION_STEP", "CascadeModule", "DEFAULT_PROMPT"]
 
 
 class CascadeModule(Module[SchemaT]):
@@ -232,7 +238,7 @@ class CascadeModule(Module[SchemaT]):
                 right_id=candidate.right.id,  # type: ignore[attr-defined]
                 score=llm_score,
                 score_type="prob_llm",
-                decision_step="llm_judgment",
+                decision_step=CASCADE_LLM_DECISION_STEP,
                 reasoning=llm_reasoning,
                 provenance={
                     "embed_score": float(embed_score),

--- a/src/langres/data/er_benchmarks.py
+++ b/src/langres/data/er_benchmarks.py
@@ -634,10 +634,27 @@ class FodorsZagatBenchmark(Benchmark[RestaurantSchema]):
     the gold match pairs; ``split`` delegates to :func:`split_restaurant_corpus`.
     The canonical resolver factory is :func:`build_restaurant_resolver`, passed
     separately to ``run_method``.
+
+    It also conforms to ``langres.methods.BlockingBenchmark`` by exposing its
+    record ``schema`` and pinned blocking config (``blocking_k`` +
+    :meth:`build_blocker`), so the method registry can race *any* of the five
+    methods against it on the identical candidate set.
     """
 
     name = "fodors_zagat"
     threshold_grid = DEFAULT_THRESHOLD_GRID
+    #: Record type, exposed for the method registry's Comparator/rapidfuzz fields.
+    schema = RestaurantSchema
+    #: Pinned blocking neighbour count (blocking held constant across methods).
+    blocking_k = DEFAULT_BLOCKING_K
+
+    def build_blocker(self, k_neighbors: int) -> VectorBlocker[RestaurantSchema]:
+        """Return a fresh restaurant VectorBlocker (MiniLM + FAISS-cosine).
+
+        Delegates to :func:`build_restaurant_blocker` so the race shares the exact
+        blocking config used elsewhere; each call yields a fresh, unbuilt index.
+        """
+        return build_restaurant_blocker(k_neighbors)
 
     def load(self) -> tuple[list[RestaurantSchema], list[set[str]], set[frozenset[str]]]:
         """Return ``(corpus, gold_clusters, gold_pairs)`` for Fodors-Zagat."""

--- a/src/langres/methods.py
+++ b/src/langres/methods.py
@@ -1,0 +1,247 @@
+"""The competing-method registry: one uniform resolver-factory per method.
+
+M3 races five resolution *methods* against each other on the same datasets. The
+:mod:`langres.core.benchmark` harness consumes a ``resolver_factory:
+Callable[[float], Resolver]`` (a clusterer threshold -> a built pipeline) and
+runs it through both evaluation tracks. This module is the single place that maps
+a method name to such a factory, so :func:`~langres.core.benchmark.run_method`
+can race *any* method on *any* dataset.
+
+The five methods differ **only in the scorer** (the ``module`` slot) — blocking
+is held constant per dataset so the race compares judges, not blockers:
+
+- ``rapidfuzz`` — VectorBlocker -> ``RapidfuzzModule`` (string similarity over the
+  schema's comparable string fields) -> Clusterer.
+- ``weighted_average`` — VectorBlocker -> ``Comparator.from_schema`` ->
+  ``WeightedAverageJudge`` -> Clusterer (generalizes ``build_restaurant_resolver``
+  to an arbitrary schema).
+- ``embedding_cosine`` — VectorBlocker -> ``EmbeddingScoreJudge`` (passes the
+  blocker's cosine similarity through) -> Clusterer. No Comparator.
+- ``llm_judge`` — VectorBlocker -> ``LLMJudge`` -> Clusterer. The LLM client is
+  *injected* (a mock in tests, the real frontier/GLM client in W4); it is never a
+  hard import-time requirement.
+- ``cascade`` — VectorBlocker -> ``CascadeModule`` (embedding early-exit, LLM only
+  on the uncertain band) -> Clusterer. Its OpenAI client is injected the same way.
+
+A dataset participates by conforming to :class:`BlockingBenchmark` — exposing its
+record ``schema`` plus a pinned blocking config (``blocking_k`` and a
+``build_blocker`` that returns a *fresh* VectorBlocker each call). This module
+imports no dataset (no ``langres.data``), so it stays free of the
+``core -> data -> core`` cycle the harness was designed to avoid.
+"""
+
+from collections.abc import Callable
+from typing import Any, Protocol
+
+from langres.core.benchmark import CostTrack, _cost_track
+from langres.core.blockers.vector import VectorBlocker
+from langres.core.clusterer import Clusterer
+from langres.core.comparator import Comparator
+from langres.core.judges.embedding_score import EmbeddingScoreJudge
+from langres.core.judges.weighted_average import WeightedAverageJudge
+from langres.core.models import PairwiseJudgement
+from langres.core.module import Module
+from langres.core.modules.cascade import CascadeModule
+from langres.core.modules.llm_judge import LLMJudge
+from langres.core.modules.rapidfuzz import RapidfuzzModule
+from langres.core.resolver import Resolver
+
+#: Methods whose scorer makes no API call — fully deterministic and zero-spend.
+ZERO_SPEND_METHODS: tuple[str, ...] = ("rapidfuzz", "weighted_average", "embedding_cosine")
+
+#: Methods whose scorer calls an LLM — they take an injected client (mock/real).
+LLM_METHODS: tuple[str, ...] = ("llm_judge", "cascade")
+
+#: Every method the registry can build, in race order.
+ALL_METHODS: tuple[str, ...] = ZERO_SPEND_METHODS + LLM_METHODS
+
+#: Default LLM model id for the LLM/cascade methods. Overridden in W4 with the
+#: real frontier/GLM model; tests inject a mock client and ignore the model.
+DEFAULT_LLM_MODEL = "openrouter/openai/gpt-4o-mini"
+
+
+class BlockingBenchmark(Protocol):
+    """A benchmark that exposes its schema + pinned blocking config to a method.
+
+    This is the extra contract (beyond the core
+    :class:`~langres.core.benchmark.Benchmark`) a dataset must satisfy to be raced
+    by this registry. ``build_blocker`` must return a **fresh, unbuilt**
+    VectorBlocker on every call (its index is populated later, per resolver), so
+    each ``resolver_factory(threshold)`` gets an independent blocker.
+
+    Attributes:
+        schema: The Pydantic record type (drives Comparator/rapidfuzz fields).
+        blocking_k: The pinned nearest-neighbour count (blocking held constant).
+    """
+
+    schema: type[Any]
+    blocking_k: int
+
+    def build_blocker(self, k_neighbors: int) -> VectorBlocker[Any]:
+        """Return a fresh VectorBlocker over the dataset's blocking text."""
+        ...  # pragma: no cover
+
+
+def _field_getter(field: str) -> Callable[[Any], str]:
+    """A string extractor for ``field`` (missing / non-str -> empty string)."""
+
+    def get(entity: Any) -> str:
+        value = getattr(entity, field, None)
+        return value if isinstance(value, str) else ""
+
+    return get
+
+
+def _rapidfuzz_extractors(
+    schema: type[Any],
+) -> dict[str, tuple[Callable[[Any], str], float]]:
+    """Derive RapidfuzzModule field extractors from a schema's comparable fields.
+
+    Reuses ``Comparator.from_schema``'s field selection (``str | None`` fields,
+    ``id`` excluded) and weights, so ``rapidfuzz`` and ``weighted_average`` score
+    on the *same* fields — the race isolates the scorer, not the field set.
+    """
+    specs = Comparator.from_schema(schema).feature_specs
+    return {spec.name: (_field_getter(spec.name), spec.weight) for spec in specs}
+
+
+def _build_cascade_module(
+    *,
+    llm_client: Any,
+    llm_model: str,
+    low_threshold: float,
+    high_threshold: float,
+) -> CascadeModule[Any]:
+    """Build a CascadeModule with an injected LLM client.
+
+    ``CascadeModule`` requires a non-empty ``llm_api_key`` at construction even
+    when no pair escalates. We satisfy that with a placeholder and inject the real
+    client (a mock in tests, the live client in W4) so no live key is ever needed
+    at build time.
+    """
+    module: CascadeModule[Any] = CascadeModule(
+        llm_model=llm_model,
+        llm_api_key="injected",
+        low_threshold=low_threshold,
+        high_threshold=high_threshold,
+    )
+    if llm_client is not None:
+        module._llm_client = llm_client
+    return module
+
+
+def _make_module_builder(
+    method: str,
+    schema: type[Any],
+    *,
+    llm_client: Any,
+    llm_model: str,
+    cascade_low: float,
+    cascade_high: float,
+) -> tuple[Callable[[], Module[Any]], Comparator[Any] | None]:
+    """Resolve a method name to its (module-builder, comparator) pair.
+
+    The module builder is called once per resolver (fresh scorer each threshold);
+    the comparator (if any) is shared across thresholds — it is stateless.
+    """
+    if method == "rapidfuzz":
+        extractors = _rapidfuzz_extractors(schema)
+        return (lambda: RapidfuzzModule(field_extractors=extractors)), None
+    if method == "weighted_average":
+        comparator: Comparator[Any] = Comparator.from_schema(schema)
+        specs = comparator.feature_specs
+        return (lambda: WeightedAverageJudge(feature_specs=specs)), comparator
+    if method == "embedding_cosine":
+        return (lambda: EmbeddingScoreJudge()), None
+    if method == "llm_judge":
+        return (lambda: LLMJudge(client=llm_client, model=llm_model)), None
+    if method == "cascade":
+        return (
+            lambda: _build_cascade_module(
+                llm_client=llm_client,
+                llm_model=llm_model,
+                low_threshold=cascade_low,
+                high_threshold=cascade_high,
+            )
+        ), None
+    raise ValueError(f"unknown method {method!r}; choose one of {ALL_METHODS}")
+
+
+def make_resolver_factory(
+    method: str,
+    benchmark: BlockingBenchmark,
+    *,
+    llm_client: Any = None,
+    llm_model: str = DEFAULT_LLM_MODEL,
+    cascade_low: float = 0.3,
+    cascade_high: float = 0.9,
+) -> Callable[[float], Resolver]:
+    """Build a ``threshold -> Resolver`` factory for ``method`` on ``benchmark``.
+
+    The returned factory is exactly the contract
+    :func:`~langres.core.benchmark.run_method` consumes: each call builds a fresh,
+    independent resolver (fresh blocker + scorer) at the given clusterer
+    threshold, with blocking pinned to ``benchmark.blocking_k`` so every method
+    races on the identical candidate set.
+
+    Args:
+        method: One of :data:`ALL_METHODS`.
+        benchmark: The dataset adapter (must expose ``schema`` + ``build_blocker``).
+        llm_client: Injected LLM client for ``llm_judge`` / ``cascade`` (a mock in
+            tests, the real client in W4). Ignored by zero-spend methods. Never a
+            live key requirement at build time.
+        llm_model: Model id for the LLM methods (overridden in W4).
+        cascade_low: Cascade lower early-exit threshold (below = not a match).
+        cascade_high: Cascade upper early-exit threshold (above = a match).
+
+    Returns:
+        A ``Callable[[float], Resolver]`` ready for ``run_method`` or direct use.
+
+    Raises:
+        ValueError: If ``method`` is not a known method name.
+    """
+    make_module, comparator = _make_module_builder(
+        method,
+        benchmark.schema,
+        llm_client=llm_client,
+        llm_model=llm_model,
+        cascade_low=cascade_low,
+        cascade_high=cascade_high,
+    )
+    k_neighbors = benchmark.blocking_k
+
+    def factory(threshold: float) -> Resolver:
+        return Resolver(
+            blocker=benchmark.build_blocker(k_neighbors),
+            comparator=comparator,
+            module=make_module(),
+            clusterer=Clusterer(threshold=threshold),
+        )
+
+    return factory
+
+
+def cascade_cost_track(judgements: list[PairwiseJudgement]) -> CostTrack:
+    """Aggregate cascade judgements into a CostTrack with escalation diagnostics.
+
+    The generic :func:`~langres.core.benchmark._cost_track` cannot derive the
+    cascade-only ``escalation_rate`` / ``llm_calls_per_candidate`` from a flat
+    judgement list, so it leaves them ``None``. This fills them from each
+    judgement's ``decision_step``: a cascade pair escalates (one LLM call) iff its
+    step is ``"llm_judgment"``. Spend totals reuse ``_cost_track`` (which reads the
+    ``llm_cost_usd`` provenance key cascade writes).
+
+    Args:
+        judgements: The cascade module's per-pair judgements.
+
+    Returns:
+        A :class:`~langres.core.benchmark.CostTrack` with spend totals plus the
+        escalation rate and mean LLM-calls-per-candidate populated.
+    """
+    base = _cost_track(judgements)
+    n_pairs = len(judgements)
+    escalated = sum(1 for j in judgements if j.decision_step == "llm_judgment")
+    rate = escalated / n_pairs if n_pairs > 0 else 0.0
+    return base.model_copy(
+        update={"escalation_rate": rate, "llm_calls_per_candidate": rate}
+    )

--- a/src/langres/methods.py
+++ b/src/langres/methods.py
@@ -33,6 +33,10 @@ imports no dataset (no ``langres.data``), so it stays free of the
 from collections.abc import Callable
 from typing import Any, Protocol
 
+# ``_cost_track`` is the harness's spend aggregator. We deliberately reuse it
+# (rather than re-implement its cost-key fallback math) so cascade spend totals
+# stay identical to every other method's; it is a stable same-package internal
+# that the harness's own tests also import directly.
 from langres.core.benchmark import CostTrack, _cost_track
 from langres.core.blockers.vector import VectorBlocker
 from langres.core.clusterer import Clusterer
@@ -41,7 +45,7 @@ from langres.core.judges.embedding_score import EmbeddingScoreJudge
 from langres.core.judges.weighted_average import WeightedAverageJudge
 from langres.core.models import PairwiseJudgement
 from langres.core.module import Module
-from langres.core.modules.cascade import CascadeModule
+from langres.core.modules.cascade import CASCADE_LLM_DECISION_STEP, CascadeModule
 from langres.core.modules.llm_judge import LLMJudge
 from langres.core.modules.rapidfuzz import RapidfuzzModule
 from langres.core.resolver import Resolver
@@ -240,8 +244,6 @@ def cascade_cost_track(judgements: list[PairwiseJudgement]) -> CostTrack:
     """
     base = _cost_track(judgements)
     n_pairs = len(judgements)
-    escalated = sum(1 for j in judgements if j.decision_step == "llm_judgment")
+    escalated = sum(1 for j in judgements if j.decision_step == CASCADE_LLM_DECISION_STEP)
     rate = escalated / n_pairs if n_pairs > 0 else 0.0
-    return base.model_copy(
-        update={"escalation_rate": rate, "llm_calls_per_candidate": rate}
-    )
+    return base.model_copy(update={"escalation_rate": rate, "llm_calls_per_candidate": rate})

--- a/src/langres/methods.py
+++ b/src/langres/methods.py
@@ -87,7 +87,16 @@ class BlockingBenchmark(Protocol):
 
 
 def _field_getter(field: str) -> Callable[[Any], str]:
-    """A string extractor for ``field`` (missing / non-str -> empty string)."""
+    """A string extractor for ``field`` (missing / non-str -> empty string).
+
+    The ``-> ""`` for a missing value is RapidfuzzModule's documented convention
+    (``lambda x: x.address or ""``). Note this makes ``rapidfuzz`` score a field
+    that is absent on *both* records as a perfect match (``fuzz.ratio("", "")``
+    is ``100``), so missing data lifts the score — unlike the missing-aware
+    ``weighted_average``, which drops absent features. That asymmetry is an
+    *intrinsic* property of the classical string baseline, not a wiring bug: the
+    race is meant to surface exactly such method differences, so it is left as-is.
+    """
 
     def get(entity: Any) -> str:
         value = getattr(entity, field, None)
@@ -103,7 +112,8 @@ def _rapidfuzz_extractors(
 
     Reuses ``Comparator.from_schema``'s field selection (``str | None`` fields,
     ``id`` excluded) and weights, so ``rapidfuzz`` and ``weighted_average`` score
-    on the *same* fields — the race isolates the scorer, not the field set.
+    on the *same* fields — the race isolates the scorer, not the field set. (They
+    still differ in *missing-field handling*; see :func:`_field_getter`.)
     """
     specs = Comparator.from_schema(schema).feature_specs
     return {spec.name: (_field_getter(spec.name), spec.weight) for spec in specs}
@@ -121,7 +131,9 @@ def _build_cascade_module(
     ``CascadeModule`` requires a non-empty ``llm_api_key`` at construction even
     when no pair escalates. We satisfy that with a placeholder and inject the real
     client (a mock in tests, the live client in W4) so no live key is ever needed
-    at build time.
+    at build time. The injected client must be **OpenAI-shaped** — cascade calls
+    ``client.chat.completions.create(...)``, not the ``completion(...)`` an
+    ``llm_judge`` (LiteLLM) client exposes.
     """
     module: CascadeModule[Any] = CascadeModule(
         llm_model=llm_model,
@@ -193,7 +205,14 @@ def make_resolver_factory(
         benchmark: The dataset adapter (must expose ``schema`` + ``build_blocker``).
         llm_client: Injected LLM client for ``llm_judge`` / ``cascade`` (a mock in
             tests, the real client in W4). Ignored by zero-spend methods. Never a
-            live key requirement at build time.
+            live key requirement at build time. **The two LLM methods expect
+            different client shapes and are not interchangeable:** ``llm_judge``
+            calls ``client.completion(...)`` (LiteLLM-shaped, e.g.
+            ``langres.clients.create_llm_client``) while ``cascade`` calls
+            ``client.chat.completions.create(...)`` (OpenAI-shaped) — a
+            pre-existing ``CascadeModule`` constraint. W4 must pass a separate
+            OpenAI-shaped client for ``cascade`` (do not reuse one client for
+            both).
         llm_model: Model id for the LLM methods (overridden in W4).
         cascade_low: Cascade lower early-exit threshold (below = not a match).
         cascade_high: Cascade upper early-exit threshold (above = a match).

--- a/tests/core/judges/__init__.py
+++ b/tests/core/judges/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for scorer Modules (judges)."""

--- a/tests/core/judges/test_embedding_score_judge.py
+++ b/tests/core/judges/test_embedding_score_judge.py
@@ -1,0 +1,167 @@
+"""Tests for EmbeddingScoreJudge (the embedding-cosine scorer Module).
+
+The judge is the zero-spend scorer that turns a ``VectorBlocker``'s attached
+``similarity_score`` into a ``PairwiseJudgement`` (no Comparator, no LLM). It
+must be registry-serializable exactly like ``WeightedAverageJudge``: register
+under ``embedding_score_judge``, round-trip through a Resolver artifact, and load
+in a fresh process via the public package alone.
+"""
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+from langres.core.judges.embedding_score import EmbeddingScoreJudge
+from langres.core.models import CompanySchema, ERCandidate
+from langres.core.registry import get_component
+
+
+def _candidate(similarity: float | None) -> ERCandidate[CompanySchema]:
+    """A candidate pair carrying ``similarity`` as its ``similarity_score``."""
+    return ERCandidate(
+        left=CompanySchema(id="a", name="Acme"),
+        right=CompanySchema(id="b", name="Acme Inc"),
+        blocker_name="vector",
+        similarity_score=similarity,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Scoring behaviour
+# ---------------------------------------------------------------------------
+
+
+def test_score_equals_similarity_score() -> None:
+    """The emitted judgement's score is exactly the candidate's similarity_score."""
+    judge: EmbeddingScoreJudge[CompanySchema] = EmbeddingScoreJudge(threshold=0.5)
+    [judgement] = list(judge.forward(iter([_candidate(0.83)])))
+
+    assert judgement.left_id == "a"
+    assert judgement.right_id == "b"
+    assert judgement.score == pytest.approx(0.83)
+    assert judgement.score_type == "sim_cos"
+    assert judgement.provenance["similarity_score"] == pytest.approx(0.83)
+    assert judgement.provenance["threshold"] == pytest.approx(0.5)
+
+
+def test_decision_step_reflects_threshold() -> None:
+    """decision_step records match/no-match against the judge threshold (score unchanged)."""
+    judge: EmbeddingScoreJudge[CompanySchema] = EmbeddingScoreJudge(threshold=0.7)
+
+    [above] = list(judge.forward(iter([_candidate(0.71)])))
+    [at] = list(judge.forward(iter([_candidate(0.70)])))
+    [below] = list(judge.forward(iter([_candidate(0.69)])))
+
+    assert above.decision_step == "embedding_match"
+    assert at.decision_step == "embedding_match"  # >= threshold is a match
+    assert below.decision_step == "embedding_no_match"
+    # The score itself is always the raw similarity, never thresholded.
+    assert below.score == pytest.approx(0.69)
+
+
+def test_missing_similarity_raises_with_actionable_message() -> None:
+    """A None similarity_score (non-VectorBlocker upstream) raises a clear ValueError."""
+    judge: EmbeddingScoreJudge[CompanySchema] = EmbeddingScoreJudge()
+    with pytest.raises(ValueError, match="VectorBlocker"):
+        list(judge.forward(iter([_candidate(None)])))
+
+
+def test_rejects_out_of_range_threshold() -> None:
+    """The threshold is validated to ``[0, 1]`` at construction."""
+    with pytest.raises(ValueError, match="threshold"):
+        EmbeddingScoreJudge(threshold=1.5)
+    with pytest.raises(ValueError, match="threshold"):
+        EmbeddingScoreJudge(threshold=-0.1)
+
+
+def test_inspect_scores_delegates_to_shared_util() -> None:
+    """inspect_scores returns a report over the judged pairs (shared Module utility)."""
+    judge: EmbeddingScoreJudge[CompanySchema] = EmbeddingScoreJudge()
+    judgements = list(judge.forward(iter([_candidate(0.4), _candidate(0.9)])))
+    report = judge.inspect_scores(judgements, sample_size=2)
+    assert report.total_judgements == 2
+
+
+# ---------------------------------------------------------------------------
+# Registry serialization (langres DoD #1)
+# ---------------------------------------------------------------------------
+
+
+def test_is_registered_with_type_name() -> None:
+    """EmbeddingScoreJudge is discoverable in the registry under its type_name."""
+    assert get_component("embedding_score_judge") is EmbeddingScoreJudge
+    assert EmbeddingScoreJudge.type_name == "embedding_score_judge"
+
+
+def test_config_round_trips() -> None:
+    """config -> from_config rebuilds an equivalent judge (JSON-serializable)."""
+    original: EmbeddingScoreJudge[CompanySchema] = EmbeddingScoreJudge(threshold=0.62)
+    config = original.config
+
+    assert config == {"threshold": 0.62}
+    json.dumps(config)  # must be JSON-serializable
+
+    rebuilt = EmbeddingScoreJudge.from_config(config)
+    assert rebuilt.threshold == pytest.approx(0.62)
+
+
+def test_resolver_with_embedding_judge_saves_and_loads(tmp_path: Path) -> None:
+    """A Resolver with an EmbeddingScoreJudge in the module slot round-trips offline."""
+    from langres.core import AllPairsBlocker, Clusterer, Resolver
+
+    judge: EmbeddingScoreJudge[CompanySchema] = EmbeddingScoreJudge(threshold=0.55)
+    resolver = Resolver(
+        blocker=AllPairsBlocker(schema=CompanySchema),
+        comparator=None,
+        module=judge,
+        clusterer=Clusterer(threshold=0.7),
+    )
+    resolver.save(tmp_path)
+
+    manifest = json.loads((tmp_path / "resolver.json").read_text())
+    module_spec = next(c for c in manifest["components"] if c["slot"] == "module")
+    assert module_spec["type_name"] == "embedding_score_judge"
+    assert module_spec["config"]["threshold"] == pytest.approx(0.55)
+
+    reloaded = Resolver.load(tmp_path)
+    assert isinstance(reloaded.module, EmbeddingScoreJudge)
+    assert reloaded.module.threshold == pytest.approx(0.55)
+
+
+@pytest.mark.slow
+def test_resolver_load_registers_judge_in_a_fresh_process(tmp_path: Path) -> None:
+    """A clean process can ``Resolver.load`` the judge via ``langres.core`` alone.
+
+    Regression for the load-path registration contract: ``@register`` only fires
+    when the judge module is imported, so ``langres.core.__init__`` must import it.
+    The subprocess imports ONLY ``langres.core`` (the public package), never the
+    judge module directly — that is the whole point of the check.
+    """
+    from langres.core import AllPairsBlocker, Clusterer, Resolver
+
+    resolver = Resolver(
+        blocker=AllPairsBlocker(schema=CompanySchema),
+        comparator=None,
+        module=EmbeddingScoreJudge(threshold=0.55),
+        clusterer=Clusterer(threshold=0.7),
+    )
+    resolver.save(tmp_path)
+
+    result = subprocess.run(
+        [
+            sys.executable,
+            "-c",
+            f"from langres.core import Resolver; Resolver.load(r'{tmp_path}')",
+        ],
+        capture_output=True,
+        text=True,
+    )
+
+    assert result.returncode == 0, (
+        "fresh-process Resolver.load failed (EmbeddingScoreJudge not registered on "
+        f"the import-langres.core path).\nSTDOUT:\n{result.stdout}\nSTDERR:\n{result.stderr}"
+    )
+    assert "UnknownComponentType" not in result.stderr

--- a/tests/test_methods.py
+++ b/tests/test_methods.py
@@ -1,0 +1,467 @@
+"""Tests for the competing-method registry (``langres.methods``).
+
+Covers, with zero real LLM spend:
+
+- the five method factories each build a valid ``Resolver`` and run end-to-end on
+  a tiny synthetic corpus (LLM/cascade with a MOCK client returning canned
+  judgements + synthetic provenance cost);
+- ``BudgetedModuleRunner`` integration for the LLM/cascade modules (pre-flight
+  cap, ``BlindCostError`` on a $0 price, per-call isolation, and the cascade
+  ``llm_cost_usd`` provenance key flowing through the runner's fallback);
+- ``cascade_cost_track`` surfacing escalation-rate + llm-calls-per-candidate;
+- a fast ``run_method`` race for the three deterministic methods on a synthetic
+  ``Benchmark`` (FakeVectorIndex, no real embeddings) asserting both tracks
+  populate; and a slow real-embedding race on ``FodorsZagatBenchmark``.
+
+The un-fakeable real-network LLM glue lives behind an ``OPENROUTER_API_KEY``
+skipif, so ``--cov`` stays green without a live key.
+"""
+
+import os
+from collections.abc import Iterator
+from types import SimpleNamespace
+from typing import Any
+
+import pytest
+
+from langres.core.benchmark import (
+    Benchmark,
+    BlindCostError,
+    BudgetedModuleRunner,
+    MethodResult,
+    gold_pairs_from_clusters,
+    run_method,
+)
+from langres.core.indexes.vector_index import FakeVectorIndex
+from langres.core.judges.embedding_score import EmbeddingScoreJudge
+from langres.core.judges.weighted_average import WeightedAverageJudge
+from langres.core.models import CompanySchema, ERCandidate, PairwiseJudgement
+from langres.core.modules.cascade import CascadeModule
+from langres.core.modules.llm_judge import LLMJudge
+from langres.core.modules.rapidfuzz import RapidfuzzModule
+from langres.core.resolver import Resolver
+from langres.methods import (
+    ALL_METHODS,
+    ZERO_SPEND_METHODS,
+    cascade_cost_track,
+    make_resolver_factory,
+)
+from langres.core.blockers.vector import VectorBlocker
+
+# ---------------------------------------------------------------------------
+# Synthetic, embedding-free benchmark (FakeVectorIndex) for fast tests
+# ---------------------------------------------------------------------------
+
+
+def _company_factory(record: dict[str, Any]) -> CompanySchema:
+    return CompanySchema(**{f: record.get(f) for f in CompanySchema.model_fields})
+
+
+class _FakeBlockingBenchmark(Benchmark[CompanySchema]):
+    """A tiny CompanySchema benchmark whose blocker uses a FakeVectorIndex.
+
+    Conforms to both the core ``Benchmark`` protocol and
+    ``langres.methods.BlockingBenchmark`` (``schema`` + ``blocking_k`` +
+    ``build_blocker``), so it drives both the factory tests and a *fast*
+    ``run_method`` race with no real embeddings.
+    """
+
+    name = "fake"
+    threshold_grid = (0.3, 0.5, 0.7, 0.9)
+    schema = CompanySchema
+    blocking_k = 2
+
+    _CORPUS = [
+        CompanySchema(id="c1", name="Acme Corporation", address="1 Main St"),
+        CompanySchema(id="c1b", name="Acme Corporation", address="1 Main St"),
+        CompanySchema(id="c2", name="Zeta Holdings", address="9 Pine Rd"),
+        CompanySchema(id="c3", name="Beta Incorporated", address="2 Oak Ave"),
+        CompanySchema(id="c3b", name="Beta Incorporated", address="2 Oak Ave"),
+        CompanySchema(id="c4", name="Omega Limited", address="7 Elm Blvd"),
+    ]
+    _GOLD = [{"c1", "c1b"}, {"c2"}, {"c3", "c3b"}, {"c4"}]
+
+    def build_blocker(self, k_neighbors: int) -> VectorBlocker[CompanySchema]:
+        return VectorBlocker(
+            schema_factory=_company_factory,
+            text_field_extractor=lambda e: e.name,
+            vector_index=FakeVectorIndex(),
+            k_neighbors=k_neighbors,
+        )
+
+    def load(self) -> tuple[list[CompanySchema], list[set[str]], set[frozenset[str]]]:
+        gold = [set(c) for c in self._GOLD]
+        return list(self._CORPUS), gold, gold_pairs_from_clusters(gold)
+
+    def split(
+        self,
+        corpus: list[CompanySchema],
+        gold_clusters: list[set[str]],
+        *,
+        seed: int,
+    ) -> tuple[list[CompanySchema], list[CompanySchema], list[set[str]], list[set[str]]]:
+        by_id = {r.id: r for r in corpus}
+        train_clusters = [{"c1", "c1b"}, {"c2"}]
+        test_clusters = [{"c3", "c3b"}, {"c4"}]
+        train = [by_id[i] for c in train_clusters for i in sorted(c)]
+        test = [by_id[i] for c in test_clusters for i in sorted(c)]
+        return train, test, train_clusters, test_clusters
+
+
+def _records() -> list[dict[str, Any]]:
+    return [r.model_dump() for r in _FakeBlockingBenchmark._CORPUS]
+
+
+# ---------------------------------------------------------------------------
+# Mock LLM clients (no network, no spend) + a scripted embedding model
+# ---------------------------------------------------------------------------
+
+
+def _fake_response(content: str) -> SimpleNamespace:
+    """An OpenAI/LiteLLM-shaped response carrying ``content`` + token usage."""
+    message = SimpleNamespace(content=content)
+    choice = SimpleNamespace(message=message)
+    usage = SimpleNamespace(prompt_tokens=10, completion_tokens=5)
+    return SimpleNamespace(choices=[choice], usage=usage)
+
+
+class _MockLiteLLMClient:
+    """LiteLLM-shaped client for ``LLMJudge`` (``client.completion(...)``)."""
+
+    def __init__(self, content: str = "MATCH\nScore: 0.90\nReasoning: same", boom_on_call: int | None = None) -> None:
+        self._content = content
+        self._boom_on_call = boom_on_call
+        self.calls = 0
+
+    def completion(self, *, model: str, messages: list[dict[str, str]], temperature: float) -> SimpleNamespace:
+        self.calls += 1
+        if self._boom_on_call is not None and self.calls == self._boom_on_call:
+            raise RuntimeError("simulated LLM failure")
+        return _fake_response(self._content)
+
+
+class _MockOpenAIClient:
+    """OpenAI-shaped client for ``CascadeModule`` (``client.chat.completions.create``)."""
+
+    def __init__(self, content: str = "MATCH\nScore: 0.80\nReasoning: x") -> None:
+        self._content = content
+        self.calls = 0
+        self.chat = SimpleNamespace(completions=SimpleNamespace(create=self._create))
+
+    def _create(self, *, model: str, messages: list[dict[str, str]], temperature: float) -> SimpleNamespace:
+        self.calls += 1
+        return _fake_response(self._content)
+
+
+class _ScriptedEmbeddingModel:
+    """Cascade embedding double: pops a preset ``[left_vec, right_vec]`` per encode.
+
+    Lets a test force each pair's stage-1 cosine into the early-exit-low,
+    early-exit-high, or LLM-escalation band deterministically (no real MiniLM).
+    """
+
+    def __init__(self, pairs: list[list[list[float]]]) -> None:
+        self._pairs = pairs
+        self._i = 0
+
+    def encode(self, texts: list[str], convert_to_numpy: bool = True) -> Any:
+        import numpy as np
+
+        pair = self._pairs[self._i]
+        self._i += 1
+        return np.array(pair, dtype=np.float32)
+
+
+class _ConstantEmbeddingModel:
+    """Cascade embedding double: every encode returns the same ``[left, right]`` pair."""
+
+    def __init__(self, pair: list[list[float]]) -> None:
+        self._pair = pair
+
+    def encode(self, texts: list[str], convert_to_numpy: bool = True) -> Any:
+        import numpy as np
+
+        return np.array(self._pair, dtype=np.float32)
+
+
+# Vector pairs whose cosine lands in a known band for low=0.3, high=0.9.
+_ESCALATE = [[1.0, 0.0], [1.0, 1.0]]  # cosine ~0.707 -> uncertain -> LLM
+_EXIT_LOW = [[1.0, 0.0], [0.0, 1.0]]  # cosine 0.0 -> early exit (no match)
+
+
+@pytest.fixture(autouse=True)
+def _patch_completion_cost(mocker: Any) -> None:
+    """Make ``litellm.completion_cost`` deterministic (so no real pricing call)."""
+    mocker.patch("litellm.completion_cost", return_value=0.002)
+
+
+def _candidates(n: int) -> list[ERCandidate[CompanySchema]]:
+    return [
+        ERCandidate(
+            left=CompanySchema(id=f"l{i}", name=f"Acme {i}"),
+            right=CompanySchema(id=f"r{i}", name=f"Acme {i} Inc"),
+            blocker_name="test",
+            similarity_score=0.8,
+        )
+        for i in range(n)
+    ]
+
+
+# ---------------------------------------------------------------------------
+# Factory wiring
+# ---------------------------------------------------------------------------
+
+
+def test_unknown_method_raises() -> None:
+    with pytest.raises(ValueError, match="unknown method"):
+        make_resolver_factory("does_not_exist", _FakeBlockingBenchmark())
+
+
+@pytest.mark.parametrize(
+    ("method", "module_type", "needs_comparator"),
+    [
+        ("rapidfuzz", RapidfuzzModule, False),
+        ("weighted_average", WeightedAverageJudge, True),
+        ("embedding_cosine", EmbeddingScoreJudge, False),
+        ("llm_judge", LLMJudge, False),
+        ("cascade", CascadeModule, False),
+    ],
+)
+def test_factory_builds_valid_resolver(
+    method: str, module_type: type, needs_comparator: bool
+) -> None:
+    """Each method builds a Resolver with the right scorer + comparator wiring."""
+    factory = make_resolver_factory(
+        method, _FakeBlockingBenchmark(), llm_client=_MockLiteLLMClient()
+    )
+    resolver = factory(0.6)
+
+    assert isinstance(resolver, Resolver)
+    assert isinstance(resolver.blocker, VectorBlocker)
+    assert isinstance(resolver.module, module_type)
+    assert resolver.clusterer.threshold == pytest.approx(0.6)
+    assert (resolver.comparator is not None) is needs_comparator
+
+
+def test_factory_yields_fresh_independent_blockers() -> None:
+    """Each ``factory(threshold)`` builds a NEW blocker (no shared, pre-built index)."""
+    factory = make_resolver_factory("embedding_cosine", _FakeBlockingBenchmark())
+    a = factory(0.5)
+    b = factory(0.5)
+    assert a.blocker is not b.blocker
+    assert a.module is not b.module
+
+
+def test_blocking_held_constant_uses_pinned_k() -> None:
+    """The factory pins blocking to ``benchmark.blocking_k`` for every method."""
+    bench = _FakeBlockingBenchmark()
+    for method in ALL_METHODS:
+        factory = make_resolver_factory(method, bench, llm_client=_MockOpenAIClient())
+        resolver = factory(0.5)
+        assert isinstance(resolver.blocker, VectorBlocker)
+        assert resolver.blocker.k_neighbors == bench.blocking_k
+
+
+# ---------------------------------------------------------------------------
+# Deterministic methods: end-to-end predict on the tiny corpus
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("method", ZERO_SPEND_METHODS)
+def test_deterministic_method_runs_end_to_end(method: str) -> None:
+    factory = make_resolver_factory(method, _FakeBlockingBenchmark())
+    judgements = factory(0.5).predict(_records())
+
+    assert judgements  # candidates were generated and scored
+    assert all(isinstance(j, PairwiseJudgement) for j in judgements)
+    # Zero-spend: no cost recorded in provenance.
+    assert all(
+        "cost_usd" not in j.provenance and "llm_cost_usd" not in j.provenance
+        for j in judgements
+    )
+
+
+def test_rapidfuzz_and_weighted_average_score_the_same_fields() -> None:
+    """rapidfuzz extractors mirror Comparator.from_schema (same fields raced)."""
+    from langres.core.comparator import Comparator
+    from langres.methods import _rapidfuzz_extractors
+
+    extractors = _rapidfuzz_extractors(CompanySchema)
+    comparator_fields = {s.name for s in Comparator.from_schema(CompanySchema).feature_specs}
+    assert set(extractors) == comparator_fields
+    assert "id" not in extractors  # id is excluded from comparison
+
+
+# ---------------------------------------------------------------------------
+# LLM / cascade: end-to-end predict with a MOCK client (zero spend)
+# ---------------------------------------------------------------------------
+
+
+def test_llm_judge_runs_end_to_end_with_mock_client() -> None:
+    client = _MockLiteLLMClient(content="MATCH\nScore: 0.95\nReasoning: same co")
+    factory = make_resolver_factory("llm_judge", _FakeBlockingBenchmark(), llm_client=client)
+    judgements = factory(0.5).predict(_records())
+
+    assert judgements
+    assert client.calls == len(judgements)  # one LLM call per candidate
+    assert all(j.score == pytest.approx(0.95) for j in judgements)
+    assert all(j.provenance["cost_usd"] == pytest.approx(0.002) for j in judgements)
+
+
+def test_cascade_runs_end_to_end_with_mock_client() -> None:
+    """Cascade escalates the uncertain band to the (mock) LLM, recording llm_cost_usd."""
+    bench = _FakeBlockingBenchmark()
+    client = _MockOpenAIClient(content="MATCH\nScore: 0.70\nReasoning: maybe")
+    resolver = make_resolver_factory("cascade", bench, llm_client=client)(0.5)
+
+    # Force every pair into the uncertain band so each escalates to the LLM.
+    cascade = resolver.module
+    assert isinstance(cascade, CascadeModule)
+    cascade._embedding_model = _ConstantEmbeddingModel(_ESCALATE)
+
+    judgements = resolver.predict(_records())
+    assert judgements
+    assert client.calls == len(judgements)
+    assert all(j.decision_step == "llm_judgment" for j in judgements)
+    assert all(j.provenance["llm_cost_usd"] == pytest.approx(0.002) for j in judgements)
+
+
+# ---------------------------------------------------------------------------
+# BudgetedModuleRunner integration (LLM + cascade modules)
+# ---------------------------------------------------------------------------
+
+
+def test_budgeted_runner_preflight_cap_on_llm_module() -> None:
+    module: LLMJudge[CompanySchema] = LLMJudge(client=_MockLiteLLMClient(), model="mock")
+    runner = BudgetedModuleRunner(module, budget_usd=1.0, budget_soft_usd=1.0)
+    # worst_case_per_pair = 1 * 0.5 = 0.5 -> floor(1.0/0.5) = 2 kept of 5.
+    out = runner.run(_candidates(5), price_per_token_or_pair=0.5)
+    assert len(out) == 2
+    assert runner.dropped_by_cap_count == 3
+
+
+def test_budgeted_runner_blind_cost_error_on_zero_price() -> None:
+    module: LLMJudge[CompanySchema] = LLMJudge(client=_MockLiteLLMClient(), model="mock")
+    runner = BudgetedModuleRunner(module, budget_usd=10.0, budget_soft_usd=10.0)
+    with pytest.raises(BlindCostError, match="blind"):
+        runner.run(_candidates(3), price_per_token_or_pair=0.0)
+
+
+def test_budgeted_runner_isolates_per_call_failure() -> None:
+    """A single failed LLM call is skipped; already-paid judgements survive."""
+    module: LLMJudge[CompanySchema] = LLMJudge(
+        client=_MockLiteLLMClient(boom_on_call=2), model="mock"
+    )
+    runner = BudgetedModuleRunner(module, budget_usd=100.0, budget_soft_usd=100.0)
+    out = runner.run(_candidates(3), price_per_token_or_pair=0.001)
+    assert len(out) == 2  # the 2nd candidate's call raised -> skipped
+    assert runner.skipped_count == 1
+    assert runner.labeled_count == 2
+
+
+def test_budgeted_runner_tallies_cascade_llm_cost_usd_key() -> None:
+    """Cascade's ``llm_cost_usd`` provenance flows through the runner's fallback tally."""
+    cascade: CascadeModule[CompanySchema] = CascadeModule(llm_api_key="injected", llm_model="mock")
+    cascade._llm_client = _MockOpenAIClient()
+    cascade._embedding_model = _ConstantEmbeddingModel(_ESCALATE)
+
+    runner = BudgetedModuleRunner(cascade, budget_usd=100.0, budget_soft_usd=100.0)
+    out = runner.run(_candidates(3), price_per_token_or_pair=0.001)
+    assert len(out) == 3
+    # 3 escalated pairs * $0.002 each, read from the llm_cost_usd fallback key.
+    assert runner.total_spent_usd == pytest.approx(0.006)
+
+
+# ---------------------------------------------------------------------------
+# cascade_cost_track: escalation-rate + llm-calls-per-candidate
+# ---------------------------------------------------------------------------
+
+
+def test_cascade_cost_track_surfaces_escalation() -> None:
+    cascade: CascadeModule[CompanySchema] = CascadeModule(llm_api_key="injected", llm_model="mock")
+    cascade._llm_client = _MockOpenAIClient()
+    # 2 escalate (LLM), 1 early-exits low -> escalation rate 2/3.
+    cascade._embedding_model = _ScriptedEmbeddingModel([_ESCALATE, _EXIT_LOW, _ESCALATE])
+
+    judgements = list(cascade.forward(iter(_candidates(3))))
+    track = cascade_cost_track(judgements)
+
+    assert track.escalation_rate == pytest.approx(2 / 3)
+    assert track.llm_calls_per_candidate == pytest.approx(2 / 3)
+    assert track.usd_total == pytest.approx(0.004)  # 2 escalations * $0.002
+
+
+def test_cascade_cost_track_empty_is_zero() -> None:
+    track = cascade_cost_track([])
+    assert track.escalation_rate == 0.0
+    assert track.llm_calls_per_candidate == 0.0
+    assert track.usd_total == 0.0
+
+
+# ---------------------------------------------------------------------------
+# run_method races
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("method", ZERO_SPEND_METHODS)
+def test_fast_run_method_race_populates_both_tracks(method: str) -> None:
+    """A fast (FakeVectorIndex) race: each deterministic method yields full tracks."""
+    bench = _FakeBlockingBenchmark()
+    result = run_method(bench, make_resolver_factory(method, bench), seed=0)
+
+    assert isinstance(result, MethodResult)
+    assert result.dataset == "fake"
+    # Pair track populated.
+    assert 0.0 <= result.pair.f1 <= 1.0
+    assert result.pair.pr_curve is not None
+    assert len(result.pair.pr_curve) == len(bench.threshold_grid)
+    # Pipeline track populated (quality is not asserted here: the FakeVectorIndex
+    # emits content-blind similarities, so embedding_cosine can sit below the
+    # all-singletons floor — that is a property of the synthetic blocker, not a
+    # bug. The slow Fodors-Zagat race exercises real embeddings).
+    assert 0.0 <= result.pipeline.bcubed_f1 <= 1.0
+    assert 0.0 <= result.pipeline.sanity_floor_f1 <= 1.0
+    assert result.pipeline.delta_above_floor == pytest.approx(
+        result.pipeline.bcubed_f1 - result.pipeline.sanity_floor_f1
+    )
+    # Zero-spend.
+    assert result.cost.usd_total == 0.0
+
+
+@pytest.mark.slow
+@pytest.mark.parametrize("method", ZERO_SPEND_METHODS)
+def test_slow_fodors_zagat_race(method: str) -> None:
+    """The zero-spend mini-race on real Fodors-Zagat embeddings: full tracks per method."""
+    from langres.data.er_benchmarks import FodorsZagatBenchmark
+
+    bench = FodorsZagatBenchmark()
+    result = run_method(bench, make_resolver_factory(method, bench), seed=0)
+
+    assert result.dataset == "fodors_zagat"
+    assert 0.0 <= result.pair.f1 <= 1.0
+    assert result.pair.pr_curve is not None
+    assert 0.0 <= result.pipeline.bcubed_f1 <= 1.0
+    assert result.cost.usd_total == 0.0  # zero-spend methods
+
+
+# ---------------------------------------------------------------------------
+# Real-network glue (un-fakeable) — skipped without a live key
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.integration
+@pytest.mark.skipif(
+    not os.getenv("OPENROUTER_API_KEY"),
+    reason="needs OPENROUTER_API_KEY for a real LLM call",
+)
+def test_llm_judge_real_network_smoke() -> None:  # pragma: no cover - requires live key
+    """A single real LLM judgement via the injected env client (W4 path)."""
+    from langres.clients import Settings, create_llm_client
+
+    bench = _FakeBlockingBenchmark()
+    client = create_llm_client(Settings())
+    factory = make_resolver_factory(
+        "llm_judge", bench, llm_client=client, llm_model="openrouter/openai/gpt-4o-mini"
+    )
+    judgements = factory(0.5).predict(_records()[:2])
+    assert all(0.0 <= j.score <= 1.0 for j in judgements)

--- a/tests/test_methods.py
+++ b/tests/test_methods.py
@@ -18,7 +18,6 @@ skipif, so ``--cov`` stays green without a live key.
 """
 
 import os
-from collections.abc import Iterator
 from types import SimpleNamespace
 from typing import Any
 
@@ -128,12 +127,16 @@ def _fake_response(content: str) -> SimpleNamespace:
 class _MockLiteLLMClient:
     """LiteLLM-shaped client for ``LLMJudge`` (``client.completion(...)``)."""
 
-    def __init__(self, content: str = "MATCH\nScore: 0.90\nReasoning: same", boom_on_call: int | None = None) -> None:
+    def __init__(
+        self, content: str = "MATCH\nScore: 0.90\nReasoning: same", boom_on_call: int | None = None
+    ) -> None:
         self._content = content
         self._boom_on_call = boom_on_call
         self.calls = 0
 
-    def completion(self, *, model: str, messages: list[dict[str, str]], temperature: float) -> SimpleNamespace:
+    def completion(
+        self, *, model: str, messages: list[dict[str, str]], temperature: float
+    ) -> SimpleNamespace:
         self.calls += 1
         if self._boom_on_call is not None and self.calls == self._boom_on_call:
             raise RuntimeError("simulated LLM failure")
@@ -148,7 +151,9 @@ class _MockOpenAIClient:
         self.calls = 0
         self.chat = SimpleNamespace(completions=SimpleNamespace(create=self._create))
 
-    def _create(self, *, model: str, messages: list[dict[str, str]], temperature: float) -> SimpleNamespace:
+    def _create(
+        self, *, model: str, messages: list[dict[str, str]], temperature: float
+    ) -> SimpleNamespace:
         self.calls += 1
         return _fake_response(self._content)
 
@@ -218,22 +223,23 @@ def test_unknown_method_raises() -> None:
 
 
 @pytest.mark.parametrize(
-    ("method", "module_type", "needs_comparator"),
+    ("method", "module_type", "needs_comparator", "client"),
     [
-        ("rapidfuzz", RapidfuzzModule, False),
-        ("weighted_average", WeightedAverageJudge, True),
-        ("embedding_cosine", EmbeddingScoreJudge, False),
-        ("llm_judge", LLMJudge, False),
-        ("cascade", CascadeModule, False),
+        ("rapidfuzz", RapidfuzzModule, False, None),
+        ("weighted_average", WeightedAverageJudge, True, None),
+        ("embedding_cosine", EmbeddingScoreJudge, False, None),
+        # The injected client must match each scorer's call shape: LLMJudge calls
+        # ``client.completion(...)`` (LiteLLM-shaped); CascadeModule calls
+        # ``client.chat.completions.create(...)`` (OpenAI-shaped).
+        ("llm_judge", LLMJudge, False, _MockLiteLLMClient()),
+        ("cascade", CascadeModule, False, _MockOpenAIClient()),
     ],
 )
 def test_factory_builds_valid_resolver(
-    method: str, module_type: type, needs_comparator: bool
+    method: str, module_type: type, needs_comparator: bool, client: object
 ) -> None:
     """Each method builds a Resolver with the right scorer + comparator wiring."""
-    factory = make_resolver_factory(
-        method, _FakeBlockingBenchmark(), llm_client=_MockLiteLLMClient()
-    )
+    factory = make_resolver_factory(method, _FakeBlockingBenchmark(), llm_client=client)
     resolver = factory(0.6)
 
     assert isinstance(resolver, Resolver)
@@ -241,6 +247,18 @@ def test_factory_builds_valid_resolver(
     assert isinstance(resolver.module, module_type)
     assert resolver.clusterer.threshold == pytest.approx(0.6)
     assert (resolver.comparator is not None) is needs_comparator
+
+
+def test_cascade_factory_without_client_does_not_require_live_key() -> None:
+    """Building the cascade resolver with no injected client still succeeds.
+
+    The placeholder key satisfies CascadeModule's constructor; the real client is
+    injected later (W4) — never a live-key requirement at build time. Here no
+    client is injected, so the module's client stays unset.
+    """
+    resolver = make_resolver_factory("cascade", _FakeBlockingBenchmark())(0.5)
+    assert isinstance(resolver.module, CascadeModule)
+    assert resolver.module._llm_client is None
 
 
 def test_factory_yields_fresh_independent_blockers() -> None:
@@ -276,8 +294,7 @@ def test_deterministic_method_runs_end_to_end(method: str) -> None:
     assert all(isinstance(j, PairwiseJudgement) for j in judgements)
     # Zero-spend: no cost recorded in provenance.
     assert all(
-        "cost_usd" not in j.provenance and "llm_cost_usd" not in j.provenance
-        for j in judgements
+        "cost_usd" not in j.provenance and "llm_cost_usd" not in j.provenance for j in judgements
     )
 
 


### PR DESCRIPTION
## M3 Wave 3 — competing methods behind one resolver-factory + the missing judge

Wires the **5 competing methods** behind ONE uniform `resolver_factory` interface so the W1 benchmark harness (`run_method`) can race them on any dataset, and builds the one missing judge. **Zero real LLM spend in this wave** — LLM/cascade are tested with a mocked client; the paid run is W4.

### Deliverables

**1. `EmbeddingScoreJudge`** (`src/langres/core/judges/embedding_score.py`) — registry-serializable embedding-cosine scorer. Reads `ERCandidate.similarity_score` (set by `VectorBlocker`), emits a `PairwiseJudgement` whose `score` is that cosine; raises a clear `ValueError` pointing at `VectorBlocker` when `similarity_score is None`. `@register("embedding_score_judge")` + `config`/`from_config`, imported in `core/__init__` + `judges/__init__`, with a fresh-process subprocess reload test. **100% coverage.**

**2. `langres.methods`** — the method registry. `make_resolver_factory(method, benchmark, *, llm_client=...)` returns `Callable[[float], Resolver]`. Blocking is held constant per dataset (`benchmark.build_blocker(benchmark.blocking_k)`), so the race compares **judges, not blockers**:

| method | wiring |
|---|---|
| `rapidfuzz` | VectorBlocker → `RapidfuzzModule` (field extractors derived from the schema's comparable fields, same set as the comparator) → Clusterer |
| `weighted_average` | VectorBlocker → `Comparator.from_schema` → `WeightedAverageJudge` → Clusterer (generalizes `build_restaurant_resolver` to any schema) |
| `embedding_cosine` | VectorBlocker → `EmbeddingScoreJudge` → Clusterer (no Comparator) |
| `llm_judge` | VectorBlocker → `LLMJudge(client=injected)` → Clusterer (mock in tests, real GLM/frontier client in W4; never a live-key requirement at build) |
| `cascade` | VectorBlocker → `CascadeModule` (placeholder key + injected `_llm_client`) → Clusterer |

A dataset opts in by conforming to the new `BlockingBenchmark` protocol (`schema` + `blocking_k` + `build_blocker`). `FodorsZagatBenchmark` gets those three (minimal). `cascade_cost_track` surfaces escalation-rate + llm-calls-per-candidate (the generic `_cost_track` leaves them `None`).

**3. Tests** (deterministic, zero spend): judge unit + reload; each factory builds a valid `Resolver` and runs end-to-end on a tiny synthetic corpus (LLM/cascade with a mock client); `BudgetedModuleRunner` integration (pre-flight cap, `BlindCostError` on $0, per-call isolation, cascade `llm_cost_usd` flowing through the runner's fallback); a fast `run_method` race on a `FakeVectorIndex` benchmark + a slow real-embedding race on `FodorsZagatBenchmark`, each asserting both pair-level and pipeline tracks populate; real-network glue behind an `OPENROUTER_API_KEY` skipif.

### Verification
- Full suite (incl. slow, excl. integration): **1181 passed**, **98.97%** total coverage. **100%** on `methods.py`, `embedding_score.py`, and `er_benchmarks.py`.
- mypy strict clean; ruff clean; no new deps; no public Resolver/Blocker/Module/judge API changes.
- Did not touch `data/amazon_google.py` or the `amazon_google/` dataset (W2).
- Self-reviewed (langres-code-reviewer); fixed warranted findings in this PR (single-source `CASCADE_LLM_DECISION_STEP`, call-shape-correct mocks).

### Note for W4
The implemented `CascadeModule` is **embedding → LLM** (no rapidfuzz stage); the task brief's "rapidfuzz→embedding→LLM" doesn't match the existing class, which was left unchanged (out of scope). W4 swaps the mock client for the real one via `make_resolver_factory(..., llm_client=<real>)`.

https://claude.ai/code/session_01Qik2ZVTbXtYt6rx2uLkYSd
