### PR TITLE
M3 W3.5: Amazon-Google in the protocol + zero-spend end-to-end validation

### DIFF
--- a/examples/m3_zero_spend_race.py
+++ b/examples/m3_zero_spend_race.py
@@ -1,0 +1,172 @@
+"""M3 zero-spend race — the full benchmark harness, end-to-end, with NO LLM spend.
+
+Validates the complete M3 protocol (``run_method`` + the method registry + the
+two dataset conformers) before the paid LLM race (W4), using only the three
+deterministic, zero-spend scorers:
+
+    rapidfuzz · weighted_average · embedding_cosine   (``ZERO_SPEND_METHODS``)
+
+Each scorer is raced on BOTH datasets at seed=0:
+
+    FodorsZagatBenchmark  — saturated, easy (blocking PC >= 0.99)
+    AmazonGoogleBenchmark — hard, unsaturated (blocking PC ~0.84, recall-capped)
+
+For every (dataset, scorer) cell it reports both evaluation tracks: pair-level
+Precision/Recall/F1 (pre-clustering, isolating the scorer) AND the pipeline
+BCubed P/R/F1, the transitive-closure cluster pairwise-F1, the all-singletons
+sanity floor, and Δ above that floor. Real MiniLM embeddings drive blocking; the
+scorers make no API call, so the whole run is deterministic and costs $0.
+
+Run:
+    uv run python examples/m3_zero_spend_race.py
+
+The committed ``examples/m3_zero_spend_race_output.md`` captures a reference run
+so the numbers survive without re-embedding.
+"""
+
+import os
+
+# Pin OpenMP / FAISS threading BEFORE importing anything that loads torch/faiss,
+# so the run is deterministic and avoids the macOS libomp duplicate-load crash.
+os.environ.setdefault("OMP_NUM_THREADS", "1")
+os.environ.setdefault("KMP_DUPLICATE_LIB_OK", "TRUE")
+
+from typing import Any, Protocol  # noqa: E402
+
+from langres.core.benchmark import Benchmark, BenchmarkTable, MethodResult, run_method  # noqa: E402
+from langres.data.amazon_google import AmazonGoogleBenchmark  # noqa: E402
+from langres.data.er_benchmarks import FodorsZagatBenchmark  # noqa: E402
+from langres.methods import (  # noqa: E402
+    BlockingBenchmark,
+    ZERO_SPEND_METHODS,
+    make_resolver_factory,
+)
+
+SEED = 0
+
+
+class _RaceBenchmark(Benchmark[Any], BlockingBenchmark, Protocol):
+    """A benchmark usable by BOTH the harness and the method registry.
+
+    ``run_method`` needs the :class:`~langres.core.benchmark.Benchmark` contract
+    (``name``/``load``/``split``/``threshold_grid``); ``make_resolver_factory``
+    needs the :class:`~langres.methods.BlockingBenchmark` contract (``schema`` +
+    pinned blocking). Both conformers satisfy this intersection structurally, so
+    one heterogeneous tuple can be typed without losing either contract.
+    """
+
+
+#: The two datasets, in race order (easy/saturated first, then hard/unsaturated).
+_BENCHMARKS: tuple[_RaceBenchmark, ...] = (FodorsZagatBenchmark(), AmazonGoogleBenchmark())
+
+
+def run_zero_spend_race(seed: int = SEED) -> BenchmarkTable:
+    """Race every zero-spend scorer on both benchmarks, collecting a table.
+
+    Drives the real harness: ``make_resolver_factory(method, bench)`` →
+    ``run_method(bench, factory, seed, budget=0.0)``. ``budget=0.0`` is a hard
+    assertion that these methods truly spend nothing (``run_method`` raises if any
+    measured spend exceeds it). Results are appended in (dataset, method) order.
+
+    Args:
+        seed: Split seed (same leakage-free split for every method on a dataset).
+
+    Returns:
+        A :class:`BenchmarkTable` with one :class:`MethodResult` per cell
+        (``len == len(_BENCHMARKS) * len(ZERO_SPEND_METHODS)``).
+    """
+    table = BenchmarkTable()
+    for bench in _BENCHMARKS:
+        for method in ZERO_SPEND_METHODS:
+            factory = make_resolver_factory(method, bench)
+            # budget=0.0 asserts genuine zero spend (raises if anything is charged).
+            result = run_method(bench, factory, seed=seed, budget=0.0)
+            table.add(result)
+    return table
+
+
+def format_detailed_report(table: BenchmarkTable) -> str:
+    """Render both tracks per cell as a Markdown table (the headline `to_markdown`
+    only carries BCubed-F1 + pair-F1; this adds the full P/R and pipeline diagnostics).
+
+    Args:
+        table: A table populated by :func:`run_zero_spend_race`.
+
+    Returns:
+        A Markdown table string: one row per (dataset, scorer) with pair-level
+        Precision/Recall/F1 and pipeline BCubed P/R/F1, cluster pairwise-F1,
+        sanity floor, Δ-above-floor, spend, and seconds/pair.
+    """
+    header = (
+        "| dataset | scorer | thr | pair_P | pair_R | pair_F1 "
+        "| bc_P | bc_R | bc_F1 | clus_F1 | floor_F1 | Δ_floor | usd | s/pair |\n"
+        "| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |"
+    )
+    rows: list[str] = []
+    for r in table.results:
+        rows.append(
+            f"| {r.dataset} | {r.method} | {r.threshold:.2f} "
+            f"| {r.pair.precision:.4f} | {r.pair.recall:.4f} | {r.pair.f1:.4f} "
+            f"| {r.pipeline.bcubed_p:.4f} | {r.pipeline.bcubed_r:.4f} | {r.pipeline.bcubed_f1:.4f} "
+            f"| {r.pipeline.cluster_pairwise_f1:.4f} | {r.pipeline.sanity_floor_f1:.4f} "
+            f"| {r.pipeline.delta_above_floor:+.4f} | {r.cost.usd_total:.4f} "
+            f"| {r.latency.seconds_per_pair:.6f} |"
+        )
+    return "\n".join([header, *rows])
+
+
+def _ag_pair_f1_spread(table: BenchmarkTable) -> tuple[float, float, float]:
+    """Return ``(min, max, spread)`` of Amazon-Google pair-level F1 across scorers.
+
+    The spread (max − min) is the discrimination signal: a hard dataset where the
+    three scorers separate tells us the benchmark distinguishes methods (and sets
+    the bar the W4 LLM judge must beat).
+    """
+    ag_f1s = [r.pair.f1 for r in table.results if r.dataset == "amazon_google"]
+    return min(ag_f1s), max(ag_f1s), max(ag_f1s) - min(ag_f1s)
+
+
+def _best_ag_pair_f1(table: BenchmarkTable) -> MethodResult:
+    """The Amazon-Google cell with the highest pair-level F1 (the zero-spend bar)."""
+    ag = [r for r in table.results if r.dataset == "amazon_google"]
+    return max(ag, key=lambda r: r.pair.f1)
+
+
+def main() -> None:
+    """Run the deterministic, zero-spend race and print both report views."""
+    print("=" * 78)
+    print("M3 zero-spend race — full harness on Fodors-Zagat + Amazon-Google (seed=0)")
+    print("=" * 78)
+
+    table = run_zero_spend_race(SEED)
+
+    print("\n## Both tracks per (dataset, scorer)\n")
+    print(format_detailed_report(table))
+
+    print("\n## Headline table (BenchmarkTable.to_markdown)\n")
+    print(table.to_markdown())
+
+    ag_min, ag_max, spread = _ag_pair_f1_spread(table)
+    best = _best_ag_pair_f1(table)
+    print("\n## Amazon-Google read-out\n")
+    print(
+        f"- Pair-level F1 spread across the 3 scorers: {spread:.4f} "
+        f"(min {ag_min:.4f}, max {ag_max:.4f}) — {'DISCRIMINATES' if spread >= 0.05 else 'flat'}"
+    )
+    print(
+        f"- Best zero-spend pair-level F1: {best.pair.f1:.4f} "
+        f"({best.method}) — the bar W4's LLM judge must beat."
+    )
+    print(
+        f"- Pipeline BCubed recall is blocking-ceiling-limited (AG blocking "
+        f"Pair-Completeness caps ~0.84): best AG bcubed_R = "
+        f"{max(r.pipeline.bcubed_r for r in table.results if r.dataset == 'amazon_google'):.4f}."
+    )
+    print(
+        f"- Total spend across all {len(table.results)} cells: "
+        f"${sum(r.cost.usd_total for r in table.results):.4f} (zero-spend)."
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/m3_zero_spend_race_output.md
+++ b/examples/m3_zero_spend_race_output.md
@@ -1,0 +1,69 @@
+# M3 zero-spend race — reference output
+
+Reference run of `examples/m3_zero_spend_race.py` (seed=0, real MiniLM
+embeddings, **zero LLM spend**). Captured so the numbers survive without
+re-embedding. Reproduce with:
+
+```
+uv run python examples/m3_zero_spend_race.py
+```
+
+The three zero-spend scorers (`rapidfuzz`, `weighted_average`,
+`embedding_cosine`) are each raced through `run_method` on **both**
+`FodorsZagatBenchmark` and `AmazonGoogleBenchmark`. Embedding/FAISS
+nondeterminism moves the low-order digits slightly across machines; the headline
+conclusions (FZ saturated, AG hard + discriminative, embedding_cosine over-merges
+at the grid-capped threshold) are stable.
+
+## Both tracks per (dataset, scorer)
+
+| dataset | scorer | thr | pair_P | pair_R | pair_F1 | bc_P | bc_R | bc_F1 | clus_F1 | floor_F1 | Δ_floor | usd | s/pair |
+| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
+| fodors_zagat | RapidfuzzModule | 0.80 | 0.6857 | 0.7273 | 0.7059 | 0.9922 | 0.9651 | 0.9785 | 0.8136 | 0.9317 | +0.0468 | 0.0000 | 0.003731 |
+| fodors_zagat | weighted_average_judge | 0.80 | 0.6944 | 0.7576 | 0.7246 | 0.9910 | 0.9690 | 0.9799 | 0.8197 | 0.9317 | +0.0482 | 0.0000 | 0.003739 |
+| fodors_zagat | embedding_score_judge | 0.80 | 0.0554 | 1.0000 | 0.1049 | 0.1988 | 1.0000 | 0.3316 | 0.0034 | 0.9317 | -0.6000 | 0.0000 | 0.003655 |
+| amazon_google | RapidfuzzModule | 0.80 | 0.0468 | 0.0976 | 0.0633 | 0.7156 | 0.7642 | 0.7391 | 0.0322 | 0.8545 | -0.1154 | 0.0000 | 0.000105 |
+| amazon_google | weighted_average_judge | 0.80 | 0.1538 | 0.1857 | 0.1683 | 0.8415 | 0.7902 | 0.8151 | 0.1353 | 0.8545 | -0.0394 | 0.0000 | 0.000106 |
+| amazon_google | embedding_score_judge | 0.80 | 0.1358 | 0.9357 | 0.2372 | 0.4538 | 0.9879 | 0.6219 | 0.0248 | 0.8545 | -0.2326 | 0.0000 | 0.000096 |
+
+## Headline table (`BenchmarkTable.to_markdown`)
+
+| method | dataset | seed | threshold | bcubed_f1 | pair_f1 | usd_total | s_per_pair |
+| --- | --- | --- | --- | --- | --- | --- | --- |
+| RapidfuzzModule | fodors_zagat | 0 | 0.80 | 0.9785 | 0.7059 | 0.0000 | 0.003731 |
+| weighted_average_judge | fodors_zagat | 0 | 0.80 | 0.9799 | 0.7246 | 0.0000 | 0.003739 |
+| embedding_score_judge | fodors_zagat | 0 | 0.80 | 0.3316 | 0.1049 | 0.0000 | 0.003655 |
+| RapidfuzzModule | amazon_google | 0 | 0.80 | 0.7391 | 0.0633 | 0.0000 | 0.000105 |
+| weighted_average_judge | amazon_google | 0 | 0.80 | 0.8151 | 0.1683 | 0.0000 | 0.000106 |
+| embedding_score_judge | amazon_google | 0 | 0.80 | 0.6219 | 0.2372 | 0.0000 | 0.000096 |
+
+## Amazon-Google read-out
+
+- **Pair-level F1 spread across the 3 scorers: 0.1740** (min 0.0633 `rapidfuzz`,
+  max 0.2372 `embedding_cosine`) — **DISCRIMINATES** (well above the 0.05 bar).
+- **Best zero-spend pair-level F1: 0.2372 (`embedding_cosine`)** — the bar W4's
+  LLM judge must beat on Amazon-Google.
+- Pipeline BCubed recall is **blocking-ceiling-limited**: AG blocking
+  Pair-Completeness caps ~0.84, and the best AG `bcubed_R` here is 0.9879 only
+  because `embedding_cosine` over-merges (it pulls in nearly everything the
+  blocker surfaced). The *useful* signal is the pair track, which is exactly why
+  the harness reports it alongside BCubed.
+- **Total spend across all 6 cells: $0.0000.**
+
+## What the numbers say
+
+- **Fodors-Zagat is saturated and easy.** `rapidfuzz` (0.9785) and
+  `weighted_average` (0.9799) both clear the all-singletons floor (0.9317) with
+  pipeline BCubed F1 ≈ 0.98 — reproducing the M2 baseline.
+- **`embedding_cosine` over-merges at the grid-capped threshold.** Raw cosine
+  similarity between blocked neighbours sits above the grid's top threshold
+  (0.80) on FZ, so the clusterer merges almost everything (recall 1.0, precision
+  0.05 → BCubed F1 0.33, far *below* the floor). This is an honest method
+  weakness surfaced by the race, not a wiring bug: passing un-calibrated cosine
+  as a match probability needs a higher / calibrated threshold than the shared
+  grid provides.
+- **Amazon-Google is hard and recall-capped.** Every method's pipeline BCubed F1
+  sits at or below the high all-singletons floor (0.8545) — the corpus is mostly
+  singletons, so "merge nothing" is a strong baseline. The **pair-level track**
+  is where the methods separate (spread 0.174), confirming AG discriminates and
+  that the pre-clustering scorer comparison is the right lens for W4.

--- a/src/langres/data/_benchmark_utils.py
+++ b/src/langres/data/_benchmark_utils.py
@@ -1,0 +1,245 @@
+"""Shared, dataset-agnostic helpers for the ER benchmark adapters (M3 W3.5).
+
+Both :mod:`langres.data.er_benchmarks` (Fodors-Zagat) and
+:mod:`langres.data.amazon_google` (Amazon-Google) need the *same* primitives: a
+packaged-CSV reader, a cross-source candidate filter, a vector-blocking k-sweep
+and picker, and a leakage-free stratified cluster-level split. This module owns
+that genuinely-shared logic once; each adapter keeps its own public,
+schema-typed wrappers (preserving its distinct defaults — e.g. the recall gate —
+and concrete record type) that delegate here.
+
+Keeping the shared core generic (over the dataset's Pydantic record type) and the
+public surface in the adapters means: no public API change, no duplicated
+algorithm, and the adapters stay the single source of truth for their pinned
+constants. The helpers are intentionally free of any per-dataset schema import,
+so this module never imports ``er_benchmarks`` or ``amazon_google``.
+"""
+
+import csv
+import logging
+import random
+from collections.abc import Sequence
+from importlib import resources
+from typing import Any, Protocol, TypeVar
+
+from pydantic import BaseModel
+
+from langres.core.blockers.vector import VectorBlocker
+from langres.core.embeddings import SentenceTransformerEmbedder
+from langres.core.indexes.vector_index import FAISSIndex
+from langres.core.metrics import evaluate_blocking
+from langres.core.models import ERCandidate
+
+logger = logging.getLogger(__name__)
+
+
+class _HasId(Protocol):
+    """Minimal record contract the stratified split needs: a globally-unique id."""
+
+    id: str
+
+
+SchemaT = TypeVar("SchemaT", bound=BaseModel)
+"""The dataset's Pydantic record type (exposes ``model_dump`` + the text field)."""
+
+RecordT = TypeVar("RecordT", bound=_HasId)
+"""A record exposing ``id`` (the only attribute the split logic reads)."""
+
+CandidateT = TypeVar("CandidateT", bound=ERCandidate[Any])
+"""A normalized candidate pair (its ``left``/``right`` expose ``source``)."""
+
+_EMBED_MODEL = "all-MiniLM-L6-v2"
+
+
+def read_csv_rows(package: str, filename: str) -> list[dict[str, str]]:
+    """Read a packaged benchmark CSV into a list of header-keyed row dicts.
+
+    Args:
+        package: The importable package holding the CSV (e.g.
+            ``"langres.data.datasets.fodors_zagat"``).
+        filename: The CSV filename within ``package``.
+
+    Returns:
+        One dict per data row, keyed by the CSV header.
+    """
+    text = resources.files(package).joinpath(filename).read_text(encoding="utf-8")
+    reader = csv.DictReader(text.splitlines())
+    return [dict(row) for row in reader]
+
+
+def cross_source(candidates: list[CandidateT]) -> list[CandidateT]:
+    """Keep only candidate pairs whose two records come from different sources.
+
+    Both benchmarks are *linkage* tasks whose true matches are all cross-source;
+    intra-source pairs are noise (see each adapter's module docstring). Generic
+    over the candidate type so each adapter keeps its concrete
+    ``ERCandidate[Schema]`` typing through this filter.
+    """
+    return [c for c in candidates if c.left.source != c.right.source]
+
+
+def sweep_blocking_k(
+    corpus: Sequence[SchemaT],
+    gold_clusters: list[set[str]],
+    schema: type[SchemaT],
+    *,
+    text_field: str,
+    ks: tuple[int, ...],
+) -> dict[int, float]:
+    """Measure cross-source Pair-Completeness of vector blocking across ``ks``.
+
+    Builds the FAISS index once over ``text_field`` and reuses it across every
+    ``k`` (only ``k_neighbors`` changes), so the corpus is embedded a single
+    time. For each ``k`` the candidates are filtered to cross-source pairs before
+    recall is measured via :func:`~langres.core.metrics.evaluate_blocking`.
+    ``candidate_recall`` *is* Pair-Completeness (the fraction of gold match pairs
+    surfaced as candidates), which is what the blocking gate is defined on.
+
+    Args:
+        corpus: Combined record list for the dataset.
+        gold_clusters: The complete closed-world partition (match sets +
+            singletons) for the dataset.
+        schema: The Pydantic record type, passed declaratively to each
+            :class:`VectorBlocker` so the blocker stays config-serializable.
+        text_field: Attribute name holding each record's blocking text (e.g.
+            ``"embed_text"``).
+        ks: Neighbor counts to sweep.
+
+    Returns:
+        Mapping of ``k`` to cross-source Pair-Completeness.
+    """
+    embedder = SentenceTransformerEmbedder(_EMBED_MODEL)
+    index = FAISSIndex(embedder=embedder, metric="cosine")
+    index.create_index([getattr(r, text_field) for r in corpus])
+    records = [r.model_dump() for r in corpus]
+
+    recalls: dict[int, float] = {}
+    for k in ks:
+        # Fresh blocker per k (the pre-built FAISS index is reused, so this is
+        # cheap); only k_neighbors varies. ``k`` lives on the blocker, not the
+        # index, so sharing one index across ks is safe.
+        blocker: VectorBlocker[SchemaT] = VectorBlocker(
+            vector_index=index,
+            schema=schema,
+            text_field=text_field,
+            k_neighbors=k,
+        )
+        candidates = cross_source(list(blocker.stream(records)))
+        recall = evaluate_blocking(candidates, gold_clusters).candidate_recall
+        recalls[k] = recall
+        logger.info("blocking k=%d -> cross-source recall=%.4f", k, recall)
+    return recalls
+
+
+def pick_blocking_k(recalls: dict[int, float], threshold: float) -> int:
+    """Pick the smallest ``k`` whose recall clears ``threshold``.
+
+    If no ``k`` reaches ``threshold``, returns the ``k`` with the highest recall
+    (the honest best-effort fallback; callers should document the shortfall
+    rather than fake the gate).
+
+    Args:
+        recalls: Mapping of ``k`` to recall, e.g. from :func:`sweep_blocking_k`.
+        threshold: Minimum acceptable recall.
+
+    Returns:
+        The chosen ``k``.
+
+    Raises:
+        ValueError: If ``recalls`` is empty.
+    """
+    if not recalls:
+        raise ValueError("recalls is empty; nothing to pick from")
+    passing = [k for k in sorted(recalls) if recalls[k] >= threshold]
+    if passing:
+        return passing[0]
+    return max(recalls, key=lambda k: recalls[k])
+
+
+def _split_stratum(
+    clusters: list[set[str]], test_size: float, rng: random.Random
+) -> tuple[list[set[str]], list[set[str]]]:
+    """Split one same-size cluster stratum into (train, test) whole clusters.
+
+    Clusters are sorted into a canonical order (by their sorted id tuple) before
+    shuffling so the split is deterministic given ``rng`` regardless of input
+    ordering. At least one cluster always goes to test (mirrors
+    ``stratified_dedup_split``).
+    """
+    ordered = sorted(clusters, key=lambda c: tuple(sorted(c)))
+    rng.shuffle(ordered)
+    n_test = max(1, int(len(ordered) * test_size))
+    return ordered[:-n_test], ordered[-n_test:]
+
+
+def stratified_corpus_split(
+    corpus: Sequence[RecordT],
+    gold_clusters: list[set[str]],
+    *,
+    test_size: float = 0.3,
+    seed: int = 0,
+) -> tuple[list[RecordT], list[RecordT], list[set[str]], list[set[str]]]:
+    """Stratified, leakage-free train/test split over full records.
+
+    Stratifies by gold-cluster size (singletons in their own band, matched groups
+    split within each size band, whole clusters kept together). Because whole gold
+    clusters are assigned to one side, no match pair ever straddles the split (no
+    test-set leakage), and each returned cluster list partitions exactly its
+    split's ids. Generic over the record type: any schema exposing ``id`` works,
+    so both benchmarks (Fodors-Zagat ``f``/``z`` ids, Amazon-Google ``a``/``g``
+    ids) share one implementation.
+
+    Args:
+        corpus: The full record list (each record exposes ``id``).
+        gold_clusters: The complete closed-world partition (match sets +
+            singletons).
+        test_size: Fraction of each stratum assigned to test (in ``(0, 1)``).
+        seed: Seed for the deterministic shuffle.
+
+    Returns:
+        ``(train_records, test_records, train_clusters, test_clusters)``.
+
+    Raises:
+        ValueError: If ``test_size`` is not in the open interval ``(0, 1)``.
+    """
+    if not 0.0 < test_size < 1.0:
+        raise ValueError(f"test_size must be in (0, 1); got {test_size}")
+
+    by_id = {r.id: r for r in corpus}
+    rng = random.Random(seed)
+
+    # Stratify: singletons in their own band, matched groups by cluster size.
+    singletons = [c for c in gold_clusters if len(c) == 1]
+    groups_by_size: dict[int, list[set[str]]] = {}
+    for cluster in gold_clusters:
+        if len(cluster) >= 2:
+            groups_by_size.setdefault(len(cluster), []).append(cluster)
+
+    train_clusters: list[set[str]] = []
+    test_clusters: list[set[str]] = []
+    # Process strata in a fixed order (singletons, then ascending size) so rng
+    # consumption — and thus the split — is reproducible.
+    strata = [singletons] + [groups_by_size[size] for size in sorted(groups_by_size)]
+    for stratum in strata:
+        train_part, test_part = _split_stratum(stratum, test_size, rng)
+        train_clusters.extend(train_part)
+        test_clusters.extend(test_part)
+
+    train_ids = {rid for cluster in train_clusters for rid in cluster}
+    test_ids = {rid for cluster in test_clusters for rid in cluster}
+
+    # Natural sort (a1, a2, a10 — not a1, a10, a2) so the returned record order is
+    # intuitive for callers; ids are always a source letter + integer.
+    def _natural(rid: str) -> tuple[str, int]:
+        return (rid[0], int(rid[1:]))
+
+    train_records = [by_id[rid] for rid in sorted(train_ids, key=_natural)]
+    test_records = [by_id[rid] for rid in sorted(test_ids, key=_natural)]
+    logger.info(
+        "stratified_corpus_split: %d train records (%d clusters), %d test records (%d clusters)",
+        len(train_records),
+        len(train_clusters),
+        len(test_records),
+        len(test_clusters),
+    )
+    return train_records, test_records, train_clusters, test_clusters

--- a/src/langres/data/_benchmark_utils.py
+++ b/src/langres/data/_benchmark_utils.py
@@ -229,7 +229,9 @@ def stratified_corpus_split(
     test_ids = {rid for cluster in test_clusters for rid in cluster}
 
     # Natural sort (a1, a2, a10 — not a1, a10, a2) so the returned record order is
-    # intuitive for callers; ids are always a source letter + integer.
+    # intuitive for callers. Assumes ids are a single-letter source prefix + a pure
+    # integer (e.g. "f1"/"z42", "a1"/"g123") — the format both benchmarks use; a
+    # different id scheme (e.g. "amazon_1") would raise ValueError on int(rid[1:]).
     def _natural(rid: str) -> tuple[str, int]:
         return (rid[0], int(rid[1:]))
 

--- a/src/langres/data/amazon_google.py
+++ b/src/langres/data/amazon_google.py
@@ -22,28 +22,32 @@ two records, not just cross-source pairs.
 
 This module deliberately mirrors the Fodors-Zagat adapter's patterns (schema with
 a ``@computed_field embed_text``, idempotent schema registration at import, a
-combined source-prefixed corpus, a vector blocking k-sweep) in a *separate* file
-so the two benchmarks stay decoupled.
+combined source-prefixed corpus, a vector blocking k-sweep). The genuinely-shared
+mechanics (CSV reading, the cross-source filter, the k-sweep/picker, and the
+stratified split) live once in :mod:`langres.data._benchmark_utils`; this module
+keeps the Amazon-Google-specific schema, pinned constants, and public wrappers.
 
-# TODO(W3/W4): wrap as Benchmark protocol once core.benchmark lands (integration
-# adds the thin protocol adapter; intentionally out of scope for this module).
+:class:`AmazonGoogleBenchmark` adapts this loader to the dataset-agnostic
+:class:`~langres.core.benchmark.Benchmark` protocol so
+:func:`~langres.core.benchmark.run_method` can race any resolver factory against
+it (it also conforms to ``langres.methods.BlockingBenchmark`` by exposing its
+``schema`` + pinned blocking config), mirroring ``FodorsZagatBenchmark``.
 """
 
-import csv
 import logging
 from collections import defaultdict
 from collections.abc import Iterable
-from importlib import resources
 from typing import Literal
 
 from pydantic import BaseModel, computed_field
 
+from langres.core.benchmark import Benchmark, gold_pairs_from_clusters
 from langres.core.blockers.all_pairs import register_schema_idempotent
 from langres.core.blockers.vector import VectorBlocker
 from langres.core.embeddings import SentenceTransformerEmbedder
 from langres.core.indexes.vector_index import FAISSIndex
-from langres.core.metrics import evaluate_blocking
 from langres.core.models import ERCandidate
+from langres.data import _benchmark_utils as _bu
 
 logger = logging.getLogger(__name__)
 
@@ -51,7 +55,9 @@ __all__ = [
     "ACHIEVED_PC_AT_DEFAULT_K",
     "AG_RECALL_GATE",
     "DEFAULT_AG_BLOCKING_K",
+    "DEFAULT_AG_THRESHOLD_GRID",
     "GATE_MET",
+    "AmazonGoogleBenchmark",
     "ProductSchema",
     "build_product_blocker",
     "load_amazon_google",
@@ -112,6 +118,13 @@ ACHIEVED_PC_AT_DEFAULT_K = 0.8388
 #: hidden.
 GATE_MET = ACHIEVED_PC_AT_DEFAULT_K >= AG_RECALL_GATE
 
+#: Candidate Clusterer thresholds swept by ``run_method`` when racing methods on
+#: Amazon-Google. Mirrors Fodors-Zagat's ``DEFAULT_THRESHOLD_GRID``: the zero-spend
+#: judges score in ``[0, 1]``, and this small grid brackets the useful range
+#: (tuned on TRAIN only). Amazon-Google is harder, so the best train threshold
+#: typically lands lower than on Fodors-Zagat, but the same grid covers it.
+DEFAULT_AG_THRESHOLD_GRID: tuple[float, ...] = (0.3, 0.4, 0.5, 0.6, 0.7, 0.8)
+
 
 class ProductSchema(BaseModel):
     """A single product record from the Amazon-Google benchmark.
@@ -157,10 +170,8 @@ register_schema_idempotent(ProductSchema)
 
 
 def _read_csv_rows(filename: str) -> list[dict[str, str]]:
-    """Read a packaged benchmark CSV into a list of header-keyed row dicts."""
-    text = resources.files(_DATASET_PACKAGE).joinpath(filename).read_text(encoding="utf-8")
-    reader = csv.DictReader(text.splitlines())
-    return [dict(row) for row in reader]
+    """Read a packaged Amazon-Google CSV into a list of header-keyed row dicts."""
+    return _bu.read_csv_rows(_DATASET_PACKAGE, filename)
 
 
 def _record_from_row(row: dict[str, str], source: ProductSource, prefix: str) -> ProductSchema:
@@ -341,8 +352,11 @@ def build_product_blocker(
 def _cross_source(
     candidates: list[ERCandidate[ProductSchema]],
 ) -> list[ERCandidate[ProductSchema]]:
-    """Keep only candidate pairs whose two records come from different sources."""
-    return [c for c in candidates if c.left.source != c.right.source]
+    """Keep only candidate pairs whose two records come from different sources.
+
+    Product-typed wrapper over :func:`langres.data._benchmark_utils.cross_source`.
+    """
+    return _bu.cross_source(candidates)
 
 
 def sweep_blocking_k(
@@ -352,17 +366,12 @@ def sweep_blocking_k(
 ) -> dict[int, float]:
     """Measure cross-source Pair-Completeness of vector blocking across ``ks``.
 
-    Builds the FAISS index once over ``embed_text`` and reuses it across all
-    ``k`` (only ``k_neighbors`` changes). For each ``k`` the candidates are
-    filtered to cross-source pairs before recall is measured via
-    :func:`~langres.core.metrics.evaluate_blocking`. Mirrors the Fodors-Zagat
-    sweep.
-
-    ``candidate_recall`` from :func:`evaluate_blocking` *is* Pair-Completeness
-    (fraction of gold match pairs surfaced as candidates), which is the quantity
-    the gate is defined on — so this uses ``evaluate_blocking`` rather than
-    ``evaluate_blocking_with_ranking`` (the latter reports truncated Recall@K and
-    requires per-candidate ``similarity_score``).
+    Product-typed wrapper over
+    :func:`langres.data._benchmark_utils.sweep_blocking_k`, binding
+    ``ProductSchema`` + ``embed_text``: builds the FAISS index once and reuses it
+    across all ``k``, filtering to cross-source pairs before measuring recall.
+    ``candidate_recall`` *is* Pair-Completeness (fraction of gold match pairs
+    surfaced as candidates), the quantity the gate is defined on.
 
     Args:
         corpus: Combined record list from :func:`load_amazon_google`.
@@ -372,39 +381,23 @@ def sweep_blocking_k(
     Returns:
         Mapping of ``k`` to cross-source Pair-Completeness (``candidate_recall``).
     """
-    embedder = SentenceTransformerEmbedder("all-MiniLM-L6-v2")
-    index = FAISSIndex(embedder=embedder, metric="cosine")
-    index.create_index([r.embed_text for r in corpus])
-    records = [r.model_dump() for r in corpus]
-
-    recalls: dict[int, float] = {}
-    for k in ks:
-        # Construct a fresh blocker per k (the pre-built FAISS index is reused, so
-        # this is cheap); only k_neighbors varies. ``k`` lives on the blocker, not
-        # the index, so sharing one index across ks is safe.
-        blocker: VectorBlocker[ProductSchema] = VectorBlocker(
-            vector_index=index,
-            schema=ProductSchema,
-            text_field="embed_text",
-            k_neighbors=k,
-        )
-        candidates = _cross_source(list(blocker.stream(records)))
-        recall = evaluate_blocking(candidates, gold_clusters).candidate_recall
-        recalls[k] = recall
-        logger.info("blocking k=%d -> cross-source recall=%.4f", k, recall)
-    return recalls
+    return _bu.sweep_blocking_k(
+        corpus, gold_clusters, ProductSchema, text_field="embed_text", ks=ks
+    )
 
 
 def pick_blocking_k(recalls: dict[int, float], threshold: float = AG_RECALL_GATE) -> int:
-    """Pick the smallest ``k`` whose recall clears ``threshold``.
+    """Pick the smallest ``k`` whose recall clears ``threshold`` (default the AG gate).
 
-    If no ``k`` reaches ``threshold``, returns the ``k`` with the highest recall
-    (the honest best-effort fallback; callers should document the shortfall
-    rather than fake the gate). Mirrors the Fodors-Zagat picker.
+    Product-typed wrapper over
+    :func:`langres.data._benchmark_utils.pick_blocking_k` defaulting ``threshold``
+    to the Amazon-Google :data:`AG_RECALL_GATE` (0.90). If no ``k`` reaches it,
+    returns the ``k`` with the highest recall (honest fallback — see the sweep
+    note above; the gate is not met within ``k<=50``).
 
     Args:
         recalls: Mapping of ``k`` to recall, e.g. from :func:`sweep_blocking_k`.
-        threshold: Minimum acceptable recall.
+        threshold: Minimum acceptable recall (defaults to :data:`AG_RECALL_GATE`).
 
     Returns:
         The chosen ``k``.
@@ -412,9 +405,60 @@ def pick_blocking_k(recalls: dict[int, float], threshold: float = AG_RECALL_GATE
     Raises:
         ValueError: If ``recalls`` is empty.
     """
-    if not recalls:
-        raise ValueError("recalls is empty; nothing to pick from")
-    passing = [k for k in sorted(recalls) if recalls[k] >= threshold]
-    if passing:
-        return passing[0]
-    return max(recalls, key=lambda k: recalls[k])
+    return _bu.pick_blocking_k(recalls, threshold)
+
+
+class AmazonGoogleBenchmark(Benchmark[ProductSchema]):
+    """Amazon-Google as a :class:`~langres.core.benchmark.Benchmark` conformer.
+
+    Adapts the product loader/splitter to the dataset-agnostic harness so
+    :func:`~langres.core.benchmark.run_method` can run any resolver factory
+    against it: ``load`` returns the corpus, the closed-world gold partition, and
+    the within-cluster gold match pairs; ``split`` delegates to the shared
+    stratified split. Mirrors ``FodorsZagatBenchmark`` exactly, swapping the
+    restaurant schema/loaders for the product ones.
+
+    It also conforms to ``langres.methods.BlockingBenchmark`` by exposing its
+    record ``schema`` and pinned blocking config (``blocking_k`` +
+    :meth:`build_blocker`), so the method registry can race *any* of the five
+    methods against it on the identical candidate set. Blocking is pinned to the
+    honest best ``k`` (:data:`DEFAULT_AG_BLOCKING_K`); the 0.90 Pair-Completeness
+    gate is *not* met (see :data:`ACHIEVED_PC_AT_DEFAULT_K` / :data:`GATE_MET`),
+    so end-to-end recall is ceiling-limited at ~0.84 here.
+    """
+
+    name = "amazon_google"
+    threshold_grid = DEFAULT_AG_THRESHOLD_GRID
+    #: Record type, exposed for the method registry's Comparator/rapidfuzz fields.
+    schema = ProductSchema
+    #: Pinned blocking neighbour count (blocking held constant across methods).
+    blocking_k = DEFAULT_AG_BLOCKING_K
+
+    def build_blocker(self, k_neighbors: int) -> VectorBlocker[ProductSchema]:
+        """Return a fresh product VectorBlocker (MiniLM + FAISS-cosine).
+
+        Delegates to :func:`build_product_blocker` so the race shares the exact
+        blocking config used elsewhere; each call yields a fresh, unbuilt index.
+        """
+        return build_product_blocker(k_neighbors)
+
+    def load(self) -> tuple[list[ProductSchema], list[set[str]], set[frozenset[str]]]:
+        """Return ``(corpus, gold_clusters, gold_pairs)`` for Amazon-Google.
+
+        ``gold_pairs`` is derived from the gold partition (every within-cluster
+        pair, including the transitive closure of the many-to-many matches) so the
+        protocol's pair semantics match Fodors-Zagat and what ``run_method``
+        recomputes per split.
+        """
+        corpus, gold_clusters, _gold_pairs = load_amazon_google()
+        return corpus, gold_clusters, gold_pairs_from_clusters(gold_clusters)
+
+    def split(
+        self,
+        corpus: list[ProductSchema],
+        gold_clusters: list[set[str]],
+        *,
+        seed: int,
+    ) -> tuple[list[ProductSchema], list[ProductSchema], list[set[str]], list[set[str]]]:
+        """Leakage-free stratified split via the shared ``stratified_corpus_split``."""
+        return _bu.stratified_corpus_split(corpus, gold_clusters, seed=seed)

--- a/src/langres/data/er_benchmarks.py
+++ b/src/langres/data/er_benchmarks.py
@@ -10,12 +10,8 @@ therefore filters candidate pairs to cross-source ones before measuring recall
 (intra-source pairs are noise for this task; see DESIGN-REVIEW B2).
 """
 
-import csv
 import logging
-import random
-from collections import defaultdict
 from collections.abc import Sequence
-from importlib import resources
 from typing import Literal
 
 from pydantic import BaseModel, Field, computed_field
@@ -39,6 +35,7 @@ from langres.core.judges.weighted_average import WeightedAverageJudge
 from langres.core.metrics import evaluate_blocking
 from langres.core.models import ERCandidate
 from langres.core.resolver import Resolver
+from langres.data import _benchmark_utils as _bu
 
 logger = logging.getLogger(__name__)
 
@@ -164,10 +161,8 @@ def _unquote(value: str) -> str:
 
 
 def _read_csv_rows(filename: str) -> list[dict[str, str]]:
-    """Read a packaged benchmark CSV into a list of header-keyed row dicts."""
-    text = resources.files(_DATASET_PACKAGE).joinpath(filename).read_text(encoding="utf-8")
-    reader = csv.DictReader(text.splitlines())
-    return [dict(row) for row in reader]
+    """Read a packaged Fodors-Zagat CSV into a list of header-keyed row dicts."""
+    return _bu.read_csv_rows(_DATASET_PACKAGE, filename)
 
 
 def _record_from_row(
@@ -313,22 +308,6 @@ def build_restaurant_resolver(threshold: float, k_neighbors: int = DEFAULT_BLOCK
     )
 
 
-def _split_stratum(
-    clusters: list[set[str]], test_size: float, rng: random.Random
-) -> tuple[list[set[str]], list[set[str]]]:
-    """Split one same-size cluster stratum into (train, test) whole clusters.
-
-    Clusters are sorted into a canonical order (by their sorted id tuple) before
-    shuffling so the split is deterministic given ``rng`` regardless of input
-    ordering. At least one cluster always goes to test (mirrors
-    :func:`stratified_dedup_split`).
-    """
-    ordered = sorted(clusters, key=lambda c: tuple(sorted(c)))
-    rng.shuffle(ordered)
-    n_test = max(1, int(len(ordered) * test_size))
-    return ordered[:-n_test], ordered[-n_test:]
-
-
 def split_restaurant_corpus(
     corpus: list[RestaurantSchema],
     gold_clusters: list[set[str]],
@@ -338,16 +317,13 @@ def split_restaurant_corpus(
 ) -> tuple[list[RestaurantSchema], list[RestaurantSchema], list[set[str]], list[set[str]]]:
     """Stratified, leakage-free train/test split over full restaurant records.
 
-    Mirrors :func:`~langres.data.splitting.stratified_dedup_split`'s
-    cluster-size stratification (singletons distributed separately; matched
-    groups split within each size band, whole clusters kept together) but
-    operates on full :class:`RestaurantSchema` records — preserving ``source``
-    and the ``f``/``z`` ids — instead of the ``{id, name}``-only int-cast dicts
-    that function produces (which can't reconstruct ``RestaurantSchema``).
-
-    Because whole gold clusters are assigned to one side, no match pair ever
-    straddles the split (no test-set leakage), and each returned cluster list
-    partitions exactly its split's ids.
+    Thin restaurant-typed wrapper over the shared
+    :func:`langres.data._benchmark_utils.stratified_corpus_split`: cluster-size
+    stratification (singletons distributed separately; matched groups split within
+    each size band, whole clusters kept together) over full
+    :class:`RestaurantSchema` records — preserving ``source`` and the ``f``/``z``
+    ids. Because whole gold clusters are assigned to one side, no match pair ever
+    straddles the split (no test-set leakage).
 
     Args:
         corpus: Records from :func:`load_fodors_zagat` (the complete corpus).
@@ -362,54 +338,7 @@ def split_restaurant_corpus(
     Raises:
         ValueError: If ``test_size`` is not in the open interval ``(0, 1)``.
     """
-    if not 0.0 < test_size < 1.0:
-        raise ValueError(f"test_size must be in (0, 1); got {test_size}")
-
-    by_id = {r.id: r for r in corpus}
-    rng = random.Random(seed)
-
-    # Stratify: singletons in their own band, matched groups by cluster size.
-    singletons = [c for c in gold_clusters if len(c) == 1]
-    groups_by_size: dict[int, list[set[str]]] = defaultdict(list)
-    for cluster in gold_clusters:
-        if len(cluster) >= 2:
-            groups_by_size[len(cluster)].append(cluster)
-
-    train_clusters: list[set[str]] = []
-    test_clusters: list[set[str]] = []
-    # Process strata in a fixed order (singletons, then ascending size) so rng
-    # consumption — and thus the split — is reproducible.
-    strata = [singletons] + [groups_by_size[size] for size in sorted(groups_by_size)]
-    for stratum in strata:
-        train_part, test_part = _split_stratum(stratum, test_size, rng)
-        train_clusters.extend(train_part)
-        test_clusters.extend(test_part)
-
-    train_ids = {rid for cluster in train_clusters for rid in cluster}
-    test_ids = {rid for cluster in test_clusters for rid in cluster}
-
-    # Natural sort (f1, f2, f10 — not f1, f10, f2) so the returned record order
-    # is intuitive for callers; ids are always a source letter + integer.
-    def _natural(rid: str) -> tuple[str, int]:
-        return (rid[0], int(rid[1:]))
-
-    train_records = [by_id[rid] for rid in sorted(train_ids, key=_natural)]
-    test_records = [by_id[rid] for rid in sorted(test_ids, key=_natural)]
-    logger.info(
-        "split_restaurant_corpus: %d train records (%d clusters), %d test records (%d clusters)",
-        len(train_records),
-        len(train_clusters),
-        len(test_records),
-        len(test_clusters),
-    )
-    return train_records, test_records, train_clusters, test_clusters
-
-
-def _cross_source(
-    candidates: list[ERCandidate[RestaurantSchema]],
-) -> list[ERCandidate[RestaurantSchema]]:
-    """Keep only candidate pairs whose two records come from different sources."""
-    return [c for c in candidates if c.left.source != c.right.source]
+    return _bu.stratified_corpus_split(corpus, gold_clusters, test_size=test_size, seed=seed)
 
 
 def sweep_blocking_k(
@@ -419,10 +348,11 @@ def sweep_blocking_k(
 ) -> dict[int, float]:
     """Measure cross-source Pair-Completeness of vector blocking across ``ks``.
 
-    Builds the FAISS index once over ``embed_text`` and reuses it across all
-    ``k`` (only ``k_neighbors`` changes). For each ``k`` the candidates are
-    filtered to cross-source pairs (DESIGN-REVIEW B2) before recall is measured
-    via :func:`evaluate_blocking`.
+    Restaurant-typed wrapper over the shared
+    :func:`langres.data._benchmark_utils.sweep_blocking_k`, binding
+    ``RestaurantSchema`` + ``embed_text``: builds the FAISS index once and reuses
+    it across all ``k``, filtering to cross-source pairs (DESIGN-REVIEW B2) before
+    measuring recall.
 
     Args:
         corpus: Combined record list from :func:`load_fodors_zagat`.
@@ -432,38 +362,22 @@ def sweep_blocking_k(
     Returns:
         Mapping of ``k`` to cross-source Pair-Completeness (``candidate_recall``).
     """
-    embedder = SentenceTransformerEmbedder("all-MiniLM-L6-v2")
-    index = FAISSIndex(embedder=embedder, metric="cosine")
-    index.create_index([r.embed_text for r in corpus])
-    records = [r.model_dump() for r in corpus]
-
-    recalls: dict[int, float] = {}
-    for k in ks:
-        # Construct a fresh blocker per k (the pre-built FAISS index is reused,
-        # so this is cheap) rather than mutating k_neighbors in place.
-        blocker: VectorBlocker[RestaurantSchema] = VectorBlocker(
-            vector_index=index,
-            schema=RestaurantSchema,
-            text_field="embed_text",
-            k_neighbors=k,
-        )
-        candidates = _cross_source(list(blocker.stream(records)))
-        recall = evaluate_blocking(candidates, gold_clusters).candidate_recall
-        recalls[k] = recall
-        logger.info("blocking k=%d -> cross-source recall=%.4f", k, recall)
-    return recalls
+    return _bu.sweep_blocking_k(
+        corpus, gold_clusters, RestaurantSchema, text_field="embed_text", ks=ks
+    )
 
 
 def pick_blocking_k(recalls: dict[int, float], threshold: float = RECALL_GATE) -> int:
-    """Pick the smallest ``k`` whose recall clears ``threshold``.
+    """Pick the smallest ``k`` whose recall clears ``threshold`` (default the FZ gate).
 
-    If no ``k`` reaches ``threshold``, returns the ``k`` with the highest recall
-    (the honest best-effort fallback; callers should document the shortfall
-    rather than fake the gate).
+    Restaurant-typed wrapper over
+    :func:`langres.data._benchmark_utils.pick_blocking_k` that defaults
+    ``threshold`` to the Fodors-Zagat :data:`RECALL_GATE` (0.95). If no ``k``
+    reaches it, returns the ``k`` with the highest recall (honest fallback).
 
     Args:
         recalls: Mapping of ``k`` to recall, e.g. from :func:`sweep_blocking_k`.
-        threshold: Minimum acceptable recall.
+        threshold: Minimum acceptable recall (defaults to :data:`RECALL_GATE`).
 
     Returns:
         The chosen ``k``.
@@ -471,12 +385,7 @@ def pick_blocking_k(recalls: dict[int, float], threshold: float = RECALL_GATE) -
     Raises:
         ValueError: If ``recalls`` is empty.
     """
-    if not recalls:
-        raise ValueError("recalls is empty; nothing to pick from")
-    passing = [k for k in sorted(recalls) if recalls[k] >= threshold]
-    if passing:
-        return passing[0]
-    return max(recalls, key=lambda k: recalls[k])
+    return _bu.pick_blocking_k(recalls, threshold)
 
 
 # ---------------------------------------------------------------------------
@@ -522,7 +431,7 @@ def _cross_source_pair_completeness(
     against ``truth_clusters``.
     """
     candidates: list[ERCandidate[RestaurantSchema]] = list(blocker.stream(record_dicts))
-    return evaluate_blocking(_cross_source(candidates), truth_clusters).candidate_recall
+    return evaluate_blocking(_bu.cross_source(candidates), truth_clusters).candidate_recall
 
 
 def evaluate_resolver_bcubed(

--- a/tests/data/test_amazon_google.py
+++ b/tests/data/test_amazon_google.py
@@ -2,13 +2,17 @@
 
 import pytest
 
+from langres.core.benchmark import gold_pairs_from_clusters
+from langres.core.blockers.vector import VectorBlocker
 from langres.core.metrics import evaluate_blocking
 from langres.core.models import ERCandidate
 from langres.data.amazon_google import (
     ACHIEVED_PC_AT_DEFAULT_K,
     AG_RECALL_GATE,
     DEFAULT_AG_BLOCKING_K,
+    DEFAULT_AG_THRESHOLD_GRID,
     GATE_MET,
+    AmazonGoogleBenchmark,
     ProductSchema,
     _clusters_from_pairs,
     _cross_source,
@@ -269,3 +273,66 @@ def test_pair_completeness_is_computable_via_evaluate_blocking() -> None:
     candidates = _cross_source(list(blocker.stream(records)))
     pc = evaluate_blocking(candidates, gold).candidate_recall
     assert pc == pytest.approx(recalls[DEFAULT_AG_BLOCKING_K], abs=5e-3)
+
+
+# --- AmazonGoogleBenchmark conformer: fast contract tests (no embeddings) --------
+
+
+def test_benchmark_exposes_pinned_config() -> None:
+    """The conformer surfaces the dataset-agnostic + blocking-registry contracts."""
+    bench = AmazonGoogleBenchmark()
+    assert bench.name == "amazon_google"
+    assert bench.threshold_grid == DEFAULT_AG_THRESHOLD_GRID
+    assert bench.schema is ProductSchema
+    assert bench.blocking_k == DEFAULT_AG_BLOCKING_K
+
+
+def test_benchmark_load_matches_loader_with_closure_pairs() -> None:
+    """``load`` returns the corpus/partition plus within-cluster (closure) pairs."""
+    bench = AmazonGoogleBenchmark()
+    corpus, gold_clusters, gold_pairs = bench.load()
+
+    base_corpus, base_clusters, _base_pairs = load_amazon_google()
+    assert [r.id for r in corpus] == [r.id for r in base_corpus]
+    assert gold_clusters == base_clusters
+    # Conformer gold_pairs are the within-cluster closure (mirrors FZ), a superset
+    # of the raw labelled pairs because Amazon-Google is many-to-many.
+    assert gold_pairs == gold_pairs_from_clusters(gold_clusters)
+
+
+def test_benchmark_split_is_leakage_free_and_partitions() -> None:
+    """No gold cluster straddles the split; train/test ids are disjoint + complete."""
+    bench = AmazonGoogleBenchmark()
+    corpus, gold_clusters, _pairs = bench.load()
+    train_recs, test_recs, train_cls, test_cls = bench.split(corpus, gold_clusters, seed=0)
+
+    train_ids = {r.id for r in train_recs}
+    test_ids = {r.id for r in test_recs}
+    # Disjoint splits that together cover the whole corpus.
+    assert train_ids.isdisjoint(test_ids)
+    assert train_ids | test_ids == {r.id for r in corpus}
+    # Every returned cluster lives entirely on its own side (no match pair leaks).
+    assert {rid for c in train_cls for rid in c} == train_ids
+    assert {rid for c in test_cls for rid in c} == test_ids
+    # The full gold partition is split whole (many-to-many clusters kept intact).
+    assert len(train_cls) + len(test_cls) == len(gold_clusters)
+
+
+def test_benchmark_split_is_deterministic() -> None:
+    """Same seed → identical split (deterministic shuffle)."""
+    bench = AmazonGoogleBenchmark()
+    corpus, gold_clusters, _pairs = bench.load()
+    a = bench.split(corpus, gold_clusters, seed=0)
+    b = bench.split(corpus, gold_clusters, seed=0)
+    assert [r.id for r in a[0]] == [r.id for r in b[0]]
+    assert [r.id for r in a[1]] == [r.id for r in b[1]]
+
+
+def test_benchmark_build_blocker_returns_fresh_unbuilt_vector_blocker() -> None:
+    """``build_blocker`` yields a fresh VectorBlocker at the requested k each call."""
+    bench = AmazonGoogleBenchmark()
+    b1 = bench.build_blocker(7)
+    b2 = bench.build_blocker(7)
+    assert isinstance(b1, VectorBlocker)
+    assert b1.k_neighbors == 7
+    assert b1 is not b2  # fresh instance per call (independent index)

--- a/tests/examples/test_m3_zero_spend_race.py
+++ b/tests/examples/test_m3_zero_spend_race.py
@@ -1,0 +1,84 @@
+"""End-to-end validation of the full M3 harness with ZERO LLM spend.
+
+Drives the importable core of ``examples/m3_zero_spend_race.py``
+(``run_zero_spend_race``): every zero-spend scorer (rapidfuzz, weighted_average,
+embedding_cosine) raced through ``run_method`` on BOTH ``FodorsZagatBenchmark``
+and ``AmazonGoogleBenchmark`` at seed=0, with real MiniLM embeddings.
+
+This is the gate that the whole protocol — the two dataset conformers, the method
+registry, and the pair+pipeline tracks — works against Amazon-Google before the
+paid W4 race. Asserts every cell yields a fully-populated ``MethodResult`` at zero
+spend, and a discrimination check: on the hard Amazon-Google dataset the three
+scorers' pair-level F1 must SPREAD (a flat result would mean the benchmark cannot
+distinguish methods). Marked ``slow`` (it embeds two corpora) but network-free, so
+it runs in CI.
+"""
+
+import pytest
+
+from examples.m3_zero_spend_race import (
+    _ag_pair_f1_spread,
+    format_detailed_report,
+    run_zero_spend_race,
+)
+from langres.core.benchmark import BenchmarkTable
+from langres.methods import ZERO_SPEND_METHODS
+
+pytestmark = pytest.mark.slow
+
+#: AG is hard but the three scorers must still separate by at least this much
+#: pair-level F1 for the benchmark to be discriminative (observed spread ~0.17).
+_MIN_AG_SPREAD = 0.05
+
+
+@pytest.fixture(scope="module")
+def race_table() -> BenchmarkTable:
+    """Run the full zero-spend race once and share it across this module's tests.
+
+    The race embeds two corpora (minutes), so computing it once and reusing the
+    deterministic ``BenchmarkTable`` keeps the slow suite affordable.
+    """
+    return run_zero_spend_race(seed=0)
+
+
+def test_zero_spend_race_populates_every_cell_at_zero_spend(race_table: BenchmarkTable) -> None:
+    """Both datasets × three scorers each yield a full MethodResult, $0 spent."""
+    table = race_table
+    # One cell per (dataset, scorer): 2 datasets × 3 zero-spend methods.
+    assert len(table.results) == 2 * len(ZERO_SPEND_METHODS)
+
+    datasets = {r.dataset for r in table.results}
+    assert datasets == {"fodors_zagat", "amazon_google"}
+
+    for r in table.results:
+        # Pair track populated (incl. the full PR curve over the threshold grid).
+        assert 0.0 <= r.pair.precision <= 1.0
+        assert 0.0 <= r.pair.recall <= 1.0
+        assert 0.0 <= r.pair.f1 <= 1.0
+        assert r.pair.pr_curve is not None and len(r.pair.pr_curve) > 0
+
+        # Pipeline track populated (BCubed + closure pairwise + floor + Δ).
+        assert 0.0 <= r.pipeline.bcubed_f1 <= 1.0
+        assert 0.0 <= r.pipeline.sanity_floor_f1 <= 1.0
+        assert 0.0 <= r.pipeline.cluster_pairwise_f1 <= 1.0
+        assert r.pipeline.delta_above_floor == pytest.approx(
+            r.pipeline.bcubed_f1 - r.pipeline.sanity_floor_f1
+        )
+
+        # Zero-spend: nothing was charged on any cell.
+        assert r.cost.usd_total == 0.0
+
+    # The detailed report renders one row per cell plus a 2-line header.
+    report = format_detailed_report(table)
+    assert len(report.splitlines()) == len(table.results) + 2
+
+
+def test_amazon_google_discriminates_between_scorers(race_table: BenchmarkTable) -> None:
+    """On the hard AG dataset the three scorers' pair-level F1 visibly spread."""
+    ag_min, ag_max, spread = _ag_pair_f1_spread(race_table)
+
+    assert 0.0 <= ag_min <= ag_max <= 1.0
+    assert spread >= _MIN_AG_SPREAD, (
+        f"Amazon-Google pair-F1 spread {spread:.4f} is below {_MIN_AG_SPREAD}; "
+        "the three zero-spend scorers did not separate (benchmark not discriminative)."
+    )

--- a/tests/examples/test_m3_zero_spend_race.py
+++ b/tests/examples/test_m3_zero_spend_race.py
@@ -68,7 +68,8 @@ def test_zero_spend_race_populates_every_cell_at_zero_spend(race_table: Benchmar
         # Zero-spend: nothing was charged on any cell.
         assert r.cost.usd_total == 0.0
 
-    # The detailed report renders one row per cell plus a 2-line header.
+    # The detailed report renders one row per cell, plus the +2 Markdown header
+    # lines (column-title row + the `--- | ---` separator row).
     report = format_detailed_report(table)
     assert len(report.splitlines()) == len(table.results) + 2
 


### PR DESCRIPTION
## M3 W3.5 — integration-prep: Amazon-Google in the protocol + zero-spend end-to-end validation

Wires Amazon-Google into the benchmark protocol and validates the **full harness end-to-end with ZERO LLM spend** before the paid W4 race. No LLM spend anywhere in this PR.

### Deliverables

**1. `AmazonGoogleBenchmark` conformer** (`src/langres/data/amazon_google.py`) — mirrors `FodorsZagatBenchmark` exactly (`schema=ProductSchema`, `blocking_k=DEFAULT_AG_BLOCKING_K`, `build_blocker → build_product_blocker`, `load() → load_amazon_google()`, `split → stratified_corpus_split`, `name`/`threshold_grid`). `run_method(AmazonGoogleBenchmark(), make_resolver_factory("rapidfuzz", bench), seed=0)` works. Resolves the `# TODO(W3/W4)` note.

**2. Consolidated the W2/W3 duplication** into `src/langres/data/_benchmark_utils.py` — `read_csv_rows`, `cross_source`, `sweep_blocking_k`, `pick_blocking_k`, and `stratified_corpus_split` now live once (generic over the dataset's record type). Both adapters keep their public, schema-typed wrappers, so **no public API change** (distinct defaults — the recall gate — and concrete record types preserved). **FZ parity holds byte-for-byte**: `test_m3_parity_slow` still asserts the exact M2 numbers (BCubed 0.991 / 0.969 / 0.980, floor 0.932).

**3. Zero-spend end-to-end validation** — `examples/m3_zero_spend_race.py` races the three `ZERO_SPEND_METHODS` through `run_method` on **both** datasets at seed=0, collecting a `BenchmarkTable` and printing both tracks. A `@pytest.mark.slow` test asserts every cell yields a fully-populated `MethodResult` at $0 spend and that Amazon-Google discriminates. Reference output committed in `examples/m3_zero_spend_race_output.md`.

### The zero-spend comparison table (seed=0, real MiniLM embeddings, $0)

| dataset | scorer | thr | pair_P | pair_R | pair_F1 | bc_P | bc_R | bc_F1 | clus_F1 | floor_F1 | Δ_floor |
| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
| fodors_zagat | RapidfuzzModule | 0.80 | 0.6857 | 0.7273 | 0.7059 | 0.9922 | 0.9651 | 0.9785 | 0.8136 | 0.9317 | +0.0468 |
| fodors_zagat | weighted_average_judge | 0.80 | 0.6944 | 0.7576 | 0.7246 | 0.9910 | 0.9690 | 0.9799 | 0.8197 | 0.9317 | +0.0482 |
| fodors_zagat | embedding_score_judge | 0.80 | 0.0554 | 1.0000 | 0.1049 | 0.1988 | 1.0000 | 0.3316 | 0.0034 | 0.9317 | -0.6000 |
| amazon_google | RapidfuzzModule | 0.80 | 0.0468 | 0.0976 | 0.0633 | 0.7156 | 0.7642 | 0.7391 | 0.0322 | 0.8545 | -0.1154 |
| amazon_google | weighted_average_judge | 0.80 | 0.1538 | 0.1857 | 0.1683 | 0.8415 | 0.7902 | 0.8151 | 0.1353 | 0.8545 | -0.0394 |
| amazon_google | embedding_score_judge | 0.80 | 0.1358 | 0.9357 | 0.2372 | 0.4538 | 0.9879 | 0.6219 | 0.0248 | 0.8545 | -0.2326 |

### What we learned

- **Amazon-Google discriminates.** The three scorers' pair-level F1 **spread is 0.1740** (rapidfuzz 0.0633 → embedding_cosine 0.2372), far above the 0.05 bar.
- **Best zero-spend AG pair-level F1 = 0.2372 (`embedding_cosine`)** — the bar W4's LLM judge must beat on Amazon-Google.
- **AG pipeline recall is blocking-ceiling-limited.** Blocking Pair-Completeness caps ~0.84 (k=50, gate not met), so every method's BCubed F1 sits at/below the high all-singletons floor (0.8545; AG is mostly singletons). The **pair track** is where methods separate — exactly why the harness reports both. The one method with high AG `bcubed_R` (0.9879) only gets there by over-merging.
- **`embedding_cosine` over-merges at the grid-capped threshold on FZ** (raw cosine > 0.80, the grid's top, so it merges nearly everything → BCubed F1 0.33, below floor). An honest method weakness surfaced by the race, not a wiring bug.
- **FZ parity passed** after consolidation (byte-for-byte M2 numbers).

### Gates
- mypy strict: clean (58 source files) · ruff: clean · **1209 passed, 0 failed** (10 integration deselected) · coverage **99%** (changed files `_benchmark_utils.py`/`amazon_google.py`/`er_benchmarks.py`/`methods.py` all **100%**) · no new deps · no public API changes.

https://claude.ai/code/session_01Qik2ZVTbXtYt6rx2uLkYSd
