### PR TITLE
M4 Wave 0: extract langres.clients.openrouter (cost helpers + SpendMonitor)

### DIFF
--- a/examples/m3_race.py
+++ b/examples/m3_race.py
@@ -82,6 +82,13 @@ from langres.data.amazon_google import (  # noqa: E402
     load_amazon_google_pair_splits,
 )
 from langres.data.er_benchmarks import FodorsZagatBenchmark, RestaurantSchema  # noqa: E402
+from langres.clients.openrouter import (  # noqa: E402
+    make_token_cost_track,
+    no_keepalive_http_client,
+    patch_litellm_prices,
+    per_token_worst_price,
+    register_runtime_model_price,
+)
 from langres.methods import (  # noqa: E402
     ZERO_SPEND_METHODS,
     cascade_cost_track,
@@ -140,18 +147,6 @@ FRONTIER_CANDIDATES: tuple[str, ...] = (
     "openrouter/google/gemini-2.0-flash-001",
 )
 
-#: Published per-1M-token (input, output) USD prices, pinned so cost is honest
-#: even when litellm prices a model at $0. GLM rates are the M1-pinned OpenRouter
-#: anchors; frontier rates are each provider's published list price.
-PRICES_PER_1M: dict[str, tuple[float, float]] = {
-    "openrouter/z-ai/glm-5.2": (0.95, 3.00),
-    "openrouter/z-ai/glm-4.6": (0.60, 2.20),
-    "openrouter/openai/gpt-4o": (2.50, 10.00),
-    "openrouter/anthropic/claude-3.7-sonnet": (3.00, 15.00),
-    "openrouter/anthropic/claude-3.5-sonnet": (3.00, 15.00),
-    "openrouter/google/gemini-2.0-flash-001": (0.10, 0.40),
-}
-
 #: Worst-case total tokens per pair, used to size the pre-flight budget cap.
 WORST_CASE_TOKENS_PER_PAIR = 1500
 
@@ -175,87 +170,8 @@ LLM_NUM_RETRIES = 2
 
 
 # ---------------------------------------------------------------------------
-# Pricing patch + clients
+# Clients
 # ---------------------------------------------------------------------------
-
-
-def patch_litellm_prices(model: str) -> None:
-    """Patch ``litellm.model_cost`` so ``completion_cost`` is honest for ``model``.
-
-    litellm prices many OpenRouter models at $0 (unknown), which would silently
-    report $0 spend and (for the budget tally) hide real cost. We write the pinned
-    per-token price under both the litellm-routing key (``openrouter/...``) and the
-    bare provider key (``z-ai/glm-5.2``) that an OpenAI/OpenRouter response carries
-    in ``response.model``, so both the LiteLLM (llm_judge) and OpenAI-client
-    (cascade) cost paths resolve.
-    """
-    import litellm
-
-    in_per_1m, out_per_1m = PRICES_PER_1M[model]
-    entry = {
-        "input_cost_per_token": in_per_1m / 1_000_000.0,
-        "output_cost_per_token": out_per_1m / 1_000_000.0,
-        "litellm_provider": "openrouter",
-        "mode": "chat",
-    }
-    litellm.model_cost[model] = entry
-    bare = model.split("/", 1)[1] if "/" in model else model
-    litellm.model_cost[bare] = entry
-
-
-def register_runtime_model_price(model: str) -> str | None:
-    """Probe ``model`` once and register its DATED response id into ``model_cost``.
-
-    OpenRouter returns a *dated* model id (e.g. ``z-ai/glm-5.2-20260616``) in
-    ``response.model``, and ``litellm.completion_cost(completion_response=r)`` (the
-    no-override call both ``LLMJudge`` and ``CascadeModule`` make) resolves the
-    price against that dated id — which is absent from litellm's table, so cost
-    silently reports ``$0``. We make ONE cheap call, read the dated id, and pin the
-    published price under it so both cost paths become honest. Returns the dated id
-    (or ``None`` if the probe failed — the caller then tries a fallback model).
-    """
-    import litellm
-
-    if model not in PRICES_PER_1M:
-        return None
-    patch_litellm_prices(model)
-    try:
-        resp = litellm.completion(
-            model=model,
-            messages=[{"role": "user", "content": "ping"}],
-            temperature=0,
-            max_tokens=1,
-        )
-    except Exception as exc:  # noqa: BLE001 — probe; caller falls back on None
-        print(f"[price] probe failed for {model}: {type(exc).__name__}: {exc}")
-        return None
-    dated = str(resp.model)
-    in_per_1m, out_per_1m = PRICES_PER_1M[model]
-    litellm.model_cost[dated] = {
-        "input_cost_per_token": in_per_1m / 1_000_000.0,
-        "output_cost_per_token": out_per_1m / 1_000_000.0,
-        "litellm_provider": "openrouter",
-        "mode": "chat",
-    }
-    print(f"[price] {model}: registered dated id {dated!r} at ${in_per_1m}/${out_per_1m} per 1M")
-    return dated
-
-
-def _no_keepalive_http_client() -> Any:
-    """An httpx client that never reuses a connection (fresh socket per request).
-
-    The first paid attempt wedged because litellm/httpx reused ONE keep-alive
-    socket across thousands of sequential calls; when that socket went stale the
-    whole run stalled (~2 KiB / 24 s) even though fresh calls worked instantly.
-    Disabling keep-alive (``max_keepalive_connections=0``) forces a new connection
-    per call, so a dead socket can never persist and stall the run.
-    """
-    import httpx
-
-    return httpx.Client(
-        limits=httpx.Limits(max_keepalive_connections=0, max_connections=8),
-        timeout=httpx.Timeout(LLM_TIMEOUT_S),
-    )
 
 
 class _OpenAICompletionClient:
@@ -278,7 +194,7 @@ class _OpenAICompletionClient:
             api_key=os.environ["OPENROUTER_API_KEY"],
             timeout=LLM_TIMEOUT_S,
             max_retries=LLM_NUM_RETRIES,
-            http_client=_no_keepalive_http_client(),
+            http_client=no_keepalive_http_client(LLM_TIMEOUT_S),
         )
 
     def completion(self, *, model: str, messages: Any, temperature: float, **_: Any) -> Any:
@@ -304,45 +220,8 @@ def make_openai_client() -> Any:
         api_key=os.environ["OPENROUTER_API_KEY"],
         timeout=LLM_TIMEOUT_S,
         max_retries=LLM_NUM_RETRIES,
-        http_client=_no_keepalive_http_client(),
+        http_client=no_keepalive_http_client(LLM_TIMEOUT_S),
     )
-
-
-def per_token_worst_price(model: str) -> float:
-    """Worst-case per-token price (the dearer of input/output) for the budget cap."""
-    in_per_1m, out_per_1m = PRICES_PER_1M[model]
-    return max(in_per_1m, out_per_1m) / 1_000_000.0
-
-
-def make_token_cost_track(model: str) -> Callable[[list[PairwiseJudgement]], CostTrack]:
-    """A cost function that prices judgements from their captured token counts.
-
-    ``litellm.completion_cost`` returns $0 for OpenRouter responses (their
-    ``response.model`` carries a dated id like ``z-ai/glm-5.2-20260616`` with no
-    provider prefix, so litellm raises "LLM Provider NOT provided" and the judge
-    swallows it to $0). The LLM judge does, however, record ``prompt_tokens`` /
-    ``completion_tokens`` in provenance — so we price the run deterministically from
-    those counts against the pinned per-1M rates. This is the honest, source-of-
-    truth cost for the paid cells (and is what the budget ledger reads back).
-    """
-    in_per_1m, out_per_1m = PRICES_PER_1M[model]
-    in_per_tok, out_per_tok = in_per_1m / 1_000_000.0, out_per_1m / 1_000_000.0
-
-    def track(judgements: list[PairwiseJudgement]) -> CostTrack:
-        usd_total = 0.0
-        for j in judgements:
-            prov = j.provenance
-            usd_total += int(prov.get("prompt_tokens", 0) or 0) * in_per_tok
-            usd_total += int(prov.get("completion_tokens", 0) or 0) * out_per_tok
-        n = len(judgements)
-        per_pair = usd_total / n if n > 0 else 0.0
-        return CostTrack(
-            usd_total=usd_total,
-            usd_per_1k_pairs=per_pair * 1_000.0,
-            est_usd_per_100k=per_pair * 100_000.0,
-        )
-
-    return track
 
 
 # ---------------------------------------------------------------------------
@@ -917,7 +796,7 @@ def main() -> int:
     import litellm
 
     litellm.request_timeout = LLM_TIMEOUT_S
-    litellm.client_session = _no_keepalive_http_client()
+    litellm.client_session = no_keepalive_http_client(LLM_TIMEOUT_S)
 
     if args.smoke:
         return smoke(args.glm_model)

--- a/src/langres/clients/openrouter.py
+++ b/src/langres/clients/openrouter.py
@@ -1,0 +1,290 @@
+"""Reusable OpenRouter cost/pricing helpers + a KISS cumulative-spend monitor.
+
+OpenRouter (via LiteLLM or the OpenAI SDK) is the paid backend for langres
+experiments, but LiteLLM prices most OpenRouter models at ``$0`` (their
+``response.model`` carries a *dated* id like ``z-ai/glm-5.2-20260616`` with no
+provider prefix, so ``completion_cost`` cannot resolve a price). That silently
+reports ``$0`` spend and hides real cost from any budget tally.
+
+This module lifts the *reusable* plumbing that makes cost honest — pinning
+published per-token prices into ``litellm.model_cost`` (including the dated
+runtime id), pricing judgements from their captured token counts, and building a
+no-keep-alive HTTP client that never stalls on a dead socket — out of the
+experiment scripts that first grew it, plus a small :class:`SpendMonitor` for
+budget-aware paid runs.
+
+Experiment *policy* (which models to race, per-cell ledgers, model-selection
+lists) deliberately stays in the calling script: :data:`PRICES_PER_1M` is a
+*default* price table callers may override or extend, not frozen policy.
+"""
+
+from __future__ import annotations
+
+import logging
+from collections.abc import Callable, Mapping
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from langres.core.benchmark import CostTrack
+    from langres.core.models import PairwiseJudgement
+
+logger = logging.getLogger(__name__)
+
+
+#: Default published per-1M-token ``(input, output)`` USD prices, pinned so cost
+#: is honest even when LiteLLM prices a model at ``$0``. This is *data*, not
+#: policy: pass a caller-owned mapping to any helper below to override or extend
+#: it (e.g. to add a new model, or use negotiated rates).
+PRICES_PER_1M: dict[str, tuple[float, float]] = {
+    "openrouter/z-ai/glm-5.2": (0.95, 3.00),
+    "openrouter/z-ai/glm-4.6": (0.60, 2.20),
+    "openrouter/openai/gpt-4o": (2.50, 10.00),
+    "openrouter/anthropic/claude-3.7-sonnet": (3.00, 15.00),
+    "openrouter/anthropic/claude-3.5-sonnet": (3.00, 15.00),
+    "openrouter/google/gemini-2.0-flash-001": (0.10, 0.40),
+}
+
+#: Default per-call timeout (seconds) for the no-keep-alive HTTP client. LiteLLM
+#: ships a 6000s default, so a stalled keep-alive socket can hang a whole
+#: sequential run; a bounded timeout makes a stalled call fail fast and recover.
+DEFAULT_TIMEOUT_S = 60.0
+
+
+# ---------------------------------------------------------------------------
+# Price pinning
+# ---------------------------------------------------------------------------
+
+
+def patch_litellm_prices(
+    model: str, prices: Mapping[str, tuple[float, float]] = PRICES_PER_1M
+) -> None:
+    """Pin ``model``'s per-token price into ``litellm.model_cost`` so cost is honest.
+
+    LiteLLM prices many OpenRouter models at ``$0`` (unknown), which silently
+    reports ``$0`` spend and (for a budget tally) hides real cost. We write the
+    pinned per-token price under **both** the LiteLLM-routing key
+    (``openrouter/...``) and the bare provider key (``z-ai/glm-5.2``) that an
+    OpenAI/OpenRouter response carries in ``response.model``, so both the LiteLLM
+    and OpenAI-client cost paths resolve.
+
+    Args:
+        model: The routing model id (e.g. ``"openrouter/z-ai/glm-5.2"``). Must be
+            a key of ``prices``.
+        prices: Per-1M-token ``(input, output)`` price table. Defaults to
+            :data:`PRICES_PER_1M`; pass your own to override or extend it.
+    """
+    import litellm
+
+    in_per_1m, out_per_1m = prices[model]
+    entry = {
+        "input_cost_per_token": in_per_1m / 1_000_000.0,
+        "output_cost_per_token": out_per_1m / 1_000_000.0,
+        "litellm_provider": "openrouter",
+        "mode": "chat",
+    }
+    litellm.model_cost[model] = entry
+    bare = model.split("/", 1)[1] if "/" in model else model
+    litellm.model_cost[bare] = entry
+
+
+def register_runtime_model_price(
+    model: str, prices: Mapping[str, tuple[float, float]] = PRICES_PER_1M
+) -> str | None:
+    """Probe ``model`` once and pin its *dated* runtime id into ``model_cost``.
+
+    OpenRouter returns a dated model id (e.g. ``z-ai/glm-5.2-20260616``) in
+    ``response.model``, and ``litellm.completion_cost(completion_response=r)``
+    resolves the price against that dated id — which is absent from LiteLLM's
+    table, so cost silently reports ``$0``. We make ONE cheap call, read the
+    dated id, and pin the published price under it so the cost path becomes
+    honest.
+
+    Args:
+        model: The routing model id to probe. Must be a key of ``prices``.
+        prices: Per-1M-token ``(input, output)`` price table. Defaults to
+            :data:`PRICES_PER_1M`.
+
+    Returns:
+        The dated model id, or ``None`` if ``model`` is unknown to ``prices`` or
+        the probe call failed (the caller then tries a fallback model).
+    """
+    import litellm
+
+    if model not in prices:
+        return None
+    patch_litellm_prices(model, prices)
+    try:
+        resp = litellm.completion(
+            model=model,
+            messages=[{"role": "user", "content": "ping"}],
+            temperature=0,
+            max_tokens=1,
+        )
+    except Exception as exc:  # noqa: BLE001 — probe; caller falls back on None
+        logger.warning("price probe failed for %s: %s: %s", model, type(exc).__name__, exc)
+        return None
+    dated = str(resp.model)
+    in_per_1m, out_per_1m = prices[model]
+    litellm.model_cost[dated] = {
+        "input_cost_per_token": in_per_1m / 1_000_000.0,
+        "output_cost_per_token": out_per_1m / 1_000_000.0,
+        "litellm_provider": "openrouter",
+        "mode": "chat",
+    }
+    logger.info(
+        "registered dated id %r for %s at $%s/$%s per 1M", dated, model, in_per_1m, out_per_1m
+    )
+    return dated
+
+
+# ---------------------------------------------------------------------------
+# Cost from token counts
+# ---------------------------------------------------------------------------
+
+
+def per_token_worst_price(
+    model: str, prices: Mapping[str, tuple[float, float]] = PRICES_PER_1M
+) -> float:
+    """Worst-case per-token price (the dearer of input/output), for a budget cap.
+
+    Args:
+        model: The routing model id. Must be a key of ``prices``.
+        prices: Per-1M-token ``(input, output)`` price table. Defaults to
+            :data:`PRICES_PER_1M`.
+    """
+    in_per_1m, out_per_1m = prices[model]
+    return max(in_per_1m, out_per_1m) / 1_000_000.0
+
+
+def make_token_cost_track(
+    model: str, prices: Mapping[str, tuple[float, float]] = PRICES_PER_1M
+) -> Callable[[list[PairwiseJudgement]], CostTrack]:
+    """Build a cost function that prices judgements from their captured token counts.
+
+    ``litellm.completion_cost`` returns ``$0`` for OpenRouter responses (their
+    dated ``response.model`` has no provider prefix, so LiteLLM raises "LLM
+    Provider NOT provided" and the judge swallows it to ``$0``). The judge does,
+    however, record ``prompt_tokens`` / ``completion_tokens`` in provenance — so
+    we price the run deterministically from those counts against the pinned
+    per-1M rates. This is the honest, source-of-truth cost for paid cells.
+
+    Args:
+        model: The routing model id. Must be a key of ``prices``.
+        prices: Per-1M-token ``(input, output)`` price table. Defaults to
+            :data:`PRICES_PER_1M`.
+
+    Returns:
+        A ``track(judgements) -> CostTrack`` closure priced against ``model``.
+    """
+    from langres.core.benchmark import CostTrack
+
+    in_per_1m, out_per_1m = prices[model]
+    in_per_tok, out_per_tok = in_per_1m / 1_000_000.0, out_per_1m / 1_000_000.0
+
+    def track(judgements: list[PairwiseJudgement]) -> CostTrack:
+        usd_total = 0.0
+        for j in judgements:
+            prov = j.provenance
+            usd_total += int(prov.get("prompt_tokens", 0) or 0) * in_per_tok
+            usd_total += int(prov.get("completion_tokens", 0) or 0) * out_per_tok
+        n = len(judgements)
+        per_pair = usd_total / n if n > 0 else 0.0
+        return CostTrack(
+            usd_total=usd_total,
+            usd_per_1k_pairs=per_pair * 1_000.0,
+            est_usd_per_100k=per_pair * 100_000.0,
+        )
+
+    return track
+
+
+# ---------------------------------------------------------------------------
+# HTTP client
+# ---------------------------------------------------------------------------
+
+
+def no_keepalive_http_client(timeout_s: float = DEFAULT_TIMEOUT_S) -> Any:
+    """Build an httpx client that never reuses a connection (fresh socket per request).
+
+    LiteLLM/httpx reusing ONE keep-alive socket across thousands of sequential
+    calls can wedge a whole run: when that socket goes stale the run stalls
+    (~2 KiB / 24 s) even though fresh calls work instantly. Disabling keep-alive
+    (``max_keepalive_connections=0``) forces a new connection per call, so a dead
+    socket can never persist and stall the run.
+
+    Args:
+        timeout_s: Per-request timeout in seconds (default :data:`DEFAULT_TIMEOUT_S`).
+
+    Returns:
+        An ``httpx.Client`` configured with no keep-alive and the given timeout.
+    """
+    import httpx
+
+    return httpx.Client(
+        limits=httpx.Limits(max_keepalive_connections=0, max_connections=8),
+        timeout=httpx.Timeout(timeout_s),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Spend monitor
+# ---------------------------------------------------------------------------
+
+
+class BudgetExceeded(RuntimeError):
+    """Raised by :meth:`SpendMonitor.check` when cumulative spend passes the budget."""
+
+
+class SpendMonitor:
+    """A KISS cumulative-cost ledger for budget-aware paid runs.
+
+    Accumulate the honest cost of each paid call with :meth:`add`, then call
+    :meth:`check` to log a warning once spend passes ``warn_frac * budget_usd``
+    and raise :class:`BudgetExceeded` once it passes ``budget_usd``. This is a
+    monitoring guard, not a hard cap: it never wraps or throttles the LM, it only
+    observes and warns/raises. Pure — no I/O beyond ``logging``.
+    """
+
+    def __init__(self, *, budget_usd: float = 5.0, warn_frac: float = 0.8) -> None:
+        """Initialize the ledger.
+
+        Args:
+            budget_usd: Total spend budget in USD. :meth:`check` raises past it.
+            warn_frac: Fraction of ``budget_usd`` at which :meth:`check` warns.
+        """
+        self._budget_usd = budget_usd
+        self._warn_frac = warn_frac
+        self._spent = 0.0
+
+    def add(self, cost_usd: float) -> None:
+        """Accumulate ``cost_usd`` into the running total."""
+        self._spent += cost_usd
+
+    @property
+    def spent(self) -> float:
+        """Cumulative spend recorded so far (USD)."""
+        return self._spent
+
+    @property
+    def remaining(self) -> float:
+        """Budget left before the cap (USD); negative once over budget."""
+        return self._budget_usd - self._spent
+
+    def check(self) -> None:
+        """Warn past the warn threshold; raise :class:`BudgetExceeded` past the budget.
+
+        Raises:
+            BudgetExceeded: If cumulative spend exceeds ``budget_usd``.
+        """
+        if self._spent > self._budget_usd:
+            raise BudgetExceeded(
+                f"spend ${self._spent:.4f} exceeds budget ${self._budget_usd:.2f}"
+            )
+        if self._spent >= self._warn_frac * self._budget_usd:
+            logger.warning(
+                "spend $%.4f has passed %.0f%% of the $%.2f budget (remaining $%.4f)",
+                self._spent,
+                self._warn_frac * 100.0,
+                self._budget_usd,
+                self.remaining,
+            )

--- a/tests/clients/test_openrouter.py
+++ b/tests/clients/test_openrouter.py
@@ -1,0 +1,191 @@
+"""Tests for langres.clients.openrouter (mock-based, $0 — no network, no spend)."""
+
+import logging
+from unittest.mock import MagicMock, patch
+
+import httpx
+import litellm
+import pytest
+
+from langres.clients.openrouter import (
+    PRICES_PER_1M,
+    BudgetExceeded,
+    SpendMonitor,
+    make_token_cost_track,
+    no_keepalive_http_client,
+    patch_litellm_prices,
+    per_token_worst_price,
+    register_runtime_model_price,
+)
+from langres.core.models import PairwiseJudgement
+
+GLM = "openrouter/z-ai/glm-5.2"
+
+
+def _judgement(prompt_tokens: object, completion_tokens: object) -> PairwiseJudgement:
+    """A minimal LLM-style judgement carrying token counts in provenance."""
+    return PairwiseJudgement(
+        left_id="a",
+        right_id="b",
+        score=0.5,
+        score_type="prob_llm",
+        decision_step="llm_judgment",
+        provenance={"prompt_tokens": prompt_tokens, "completion_tokens": completion_tokens},
+    )
+
+
+class TestPatchLitellmPrices:
+    """patch_litellm_prices writes the pinned price under routing + bare keys."""
+
+    def test_writes_routing_and_bare_keys(self) -> None:
+        with patch.dict(litellm.model_cost, {}, clear=False):
+            patch_litellm_prices(GLM)
+            in_per_1m, out_per_1m = PRICES_PER_1M[GLM]
+            for key in (GLM, "z-ai/glm-5.2"):
+                entry = litellm.model_cost[key]
+                assert entry["input_cost_per_token"] == in_per_1m / 1_000_000.0
+                assert entry["output_cost_per_token"] == out_per_1m / 1_000_000.0
+                assert entry["litellm_provider"] == "openrouter"
+                assert entry["mode"] == "chat"
+
+    def test_custom_prices_and_bare_model_without_slash(self) -> None:
+        # A model id with no "/" exercises the ``bare = model`` branch, and a
+        # caller-supplied table proves ``prices`` overrides the default.
+        prices = {"mymodel": (1.0, 2.0)}
+        with patch.dict(litellm.model_cost, {}, clear=False):
+            patch_litellm_prices("mymodel", prices)
+            assert litellm.model_cost["mymodel"]["input_cost_per_token"] == 1.0 / 1_000_000.0
+            assert litellm.model_cost["mymodel"]["output_cost_per_token"] == 2.0 / 1_000_000.0
+
+
+class TestRegisterRuntimeModelPrice:
+    """register_runtime_model_price pins the dated runtime id from a probe."""
+
+    def test_pins_dated_id(self) -> None:
+        resp = MagicMock()
+        resp.model = "z-ai/glm-5.2-20260616"
+        with (
+            patch.object(litellm, "completion", return_value=resp) as mock_completion,
+            patch.dict(litellm.model_cost, {}, clear=False),
+        ):
+            dated = register_runtime_model_price(GLM)
+            assert dated == "z-ai/glm-5.2-20260616"
+            in_per_1m, out_per_1m = PRICES_PER_1M[GLM]
+            entry = litellm.model_cost["z-ai/glm-5.2-20260616"]
+            assert entry["input_cost_per_token"] == in_per_1m / 1_000_000.0
+            assert entry["output_cost_per_token"] == out_per_1m / 1_000_000.0
+            mock_completion.assert_called_once()
+
+    def test_unknown_model_returns_none_without_probing(self) -> None:
+        with patch.object(litellm, "completion") as mock_completion:
+            assert register_runtime_model_price("openrouter/unknown/model") is None
+            mock_completion.assert_not_called()
+
+    def test_probe_failure_returns_none(self) -> None:
+        with (
+            patch.object(litellm, "completion", side_effect=RuntimeError("boom")),
+            patch.dict(litellm.model_cost, {}, clear=False),
+        ):
+            assert register_runtime_model_price(GLM) is None
+
+
+class TestPerTokenWorstPrice:
+    """per_token_worst_price returns the dearer of input/output, per token."""
+
+    def test_uses_dearer_side(self) -> None:
+        in_per_1m, out_per_1m = PRICES_PER_1M[GLM]
+        expected = max(in_per_1m, out_per_1m) / 1_000_000.0
+        assert per_token_worst_price(GLM) == expected
+
+    def test_custom_prices(self) -> None:
+        assert per_token_worst_price("m", {"m": (5.0, 2.0)}) == 5.0 / 1_000_000.0
+
+
+class TestMakeTokenCostTrack:
+    """make_token_cost_track prices judgements from their provenance token counts."""
+
+    def test_prices_from_token_counts(self) -> None:
+        in_per_1m, out_per_1m = PRICES_PER_1M[GLM]
+        in_tok, out_tok = in_per_1m / 1_000_000.0, out_per_1m / 1_000_000.0
+        track = make_token_cost_track(GLM)
+        judgements = [_judgement(1000, 500), _judgement(200, 100)]
+        expected = (1000 + 200) * in_tok + (500 + 100) * out_tok
+
+        result = track(judgements)
+
+        assert result.usd_total == pytest.approx(expected)
+        per_pair = expected / 2
+        assert result.usd_per_1k_pairs == pytest.approx(per_pair * 1_000.0)
+        assert result.est_usd_per_100k == pytest.approx(per_pair * 100_000.0)
+
+    def test_empty_judgements_is_zero(self) -> None:
+        result = make_token_cost_track(GLM)([])
+        assert result.usd_total == 0.0
+        assert result.usd_per_1k_pairs == 0.0
+        assert result.est_usd_per_100k == 0.0
+
+    def test_missing_or_none_token_counts_count_as_zero(self) -> None:
+        # ``None`` (and absent keys) must coerce to 0 via the ``or 0`` guard.
+        result = make_token_cost_track(GLM)([_judgement(None, None)])
+        assert result.usd_total == 0.0
+
+
+class TestNoKeepaliveHttpClient:
+    """no_keepalive_http_client builds a stall-proof httpx client."""
+
+    def test_builds_client_with_timeout(self) -> None:
+        client = no_keepalive_http_client(5.0)
+        try:
+            assert isinstance(client, httpx.Client)
+            assert client.timeout.read == 5.0
+        finally:
+            client.close()
+
+    def test_default_timeout(self) -> None:
+        client = no_keepalive_http_client()
+        try:
+            assert client.timeout.read == 60.0
+        finally:
+            client.close()
+
+
+class TestSpendMonitor:
+    """SpendMonitor accumulates, warns at the threshold, and raises past budget."""
+
+    def test_accumulates_and_reports_remaining(self) -> None:
+        monitor = SpendMonitor(budget_usd=10.0)
+        monitor.add(1.0)
+        monitor.add(2.5)
+        assert monitor.spent == pytest.approx(3.5)
+        assert monitor.remaining == pytest.approx(6.5)
+
+    def test_check_below_threshold_is_silent(self, caplog: pytest.LogCaptureFixture) -> None:
+        monitor = SpendMonitor(budget_usd=10.0, warn_frac=0.8)
+        monitor.add(5.0)
+        with caplog.at_level(logging.WARNING, logger="langres.clients.openrouter"):
+            monitor.check()
+        assert caplog.records == []
+
+    def test_check_warns_past_warn_fraction(self, caplog: pytest.LogCaptureFixture) -> None:
+        monitor = SpendMonitor(budget_usd=10.0, warn_frac=0.8)
+        monitor.add(8.0)
+        with caplog.at_level(logging.WARNING, logger="langres.clients.openrouter"):
+            monitor.check()
+        assert any("budget" in r.message for r in caplog.records)
+
+    def test_check_at_budget_warns_but_does_not_raise(self) -> None:
+        monitor = SpendMonitor(budget_usd=10.0, warn_frac=0.8)
+        monitor.add(10.0)
+        monitor.check()  # spent == budget is not > budget, so no raise
+        assert monitor.remaining == pytest.approx(0.0)
+
+    def test_check_raises_past_budget(self) -> None:
+        monitor = SpendMonitor(budget_usd=5.0)
+        monitor.add(6.0)
+        with pytest.raises(BudgetExceeded, match="exceeds budget"):
+            monitor.check()
+        assert monitor.remaining == pytest.approx(-1.0)
+
+    def test_defaults(self) -> None:
+        monitor = SpendMonitor()
+        assert monitor.remaining == pytest.approx(5.0)


### PR DESCRIPTION
Part of **M4** (integration branch `feat/m4-foundation`). Extracts the reusable OpenRouter cost/pricing plumbing out of `examples/m3_race.py` into the library, and adds a KISS spend monitor. Unblocks all paid experiments.

## What
- `src/langres/clients/openrouter.py` (new) — `PRICES_PER_1M` (overridable), `patch_litellm_prices`, `register_runtime_model_price` (dated-id pinning), `per_token_worst_price`, `make_token_cost_track`, `no_keepalive_http_client`, and `SpendMonitor` (`add`/`spent`/`remaining`/`check`, warns then raises `BudgetExceeded`). Pure, logging-only — **no LM-wrapping cap machinery** (per the KISS steer: monitor spend, don't over-engineer).
- `examples/m3_race.py` — inline defs replaced with imports; behaviour-preserving. Experiment policy (model tables, `pick_frontier`, cell ledger) stays in the example.
- `tests/clients/test_openrouter.py` (new) — 18 mock-based $0 tests.

## Verification (all $0)
- 18 passed; new file **100%** coverage; full suite 99.04% (gate 95%); `mypy` clean; `ruff` clean; `m3_race.py` parses.

## Deviations (reasonable)
- `print`→`logging` in lifted fns (library T201 rule). `_no_keepalive_http_client`→public `no_keepalive_http_client(timeout_s=)`. Not added to `clients/__init__.py` (keeps import path light).