### PR TITLE
M4 Wave 0: run_methods(...) experiment facade + BenchmarkTable.best()/.rank()

### DIFF
--- a/src/langres/core/benchmark.py
+++ b/src/langres/core/benchmark.py
@@ -29,7 +29,7 @@ import logging
 import math
 import time
 from collections.abc import Callable, Sequence
-from typing import Any, Protocol, TypeVar, runtime_checkable
+from typing import TYPE_CHECKING, Any, Protocol, TypeVar, runtime_checkable
 
 from pydantic import BaseModel, Field
 
@@ -227,13 +227,35 @@ class MethodResult(BaseModel):
     latency: LatencyTrack
 
 
+#: Ranking metrics :meth:`BenchmarkTable.best` / :meth:`~BenchmarkTable.rank`
+#: accept — the decision-relevant headline scores (higher is better for all
+#: three), each a trivial accessor over an existing :class:`MethodResult` field.
+_RANKABLE_METRICS: dict[str, Callable[["MethodResult"], float]] = {
+    "pair_f1": lambda r: r.pair.f1,
+    "bcubed_f1": lambda r: r.pipeline.bcubed_f1,
+    "delta_above_floor": lambda r: r.pipeline.delta_above_floor,
+}
+
+
+def _rank_accessor(by: str) -> Callable[["MethodResult"], float]:
+    """Resolve a ranking-metric name to its accessor, or raise on an unknown one."""
+    try:
+        return _RANKABLE_METRICS[by]
+    except KeyError:
+        raise ValueError(
+            f"unknown ranking metric {by!r}; choose one of {sorted(_RANKABLE_METRICS)}"
+        ) from None
+
+
 class BenchmarkTable(BaseModel):
     """Collects :class:`MethodResult`s and renders a method×dataset×seed table.
 
     A thin, serializable accumulator: append results as runs complete, then call
     :meth:`to_markdown` for a compact headline view (BCubed F1, pair F1, cost,
-    latency). Kept deliberately small — richer reporting (per-track breakdowns,
-    plots) composes on top of the stored ``results`` rather than bloating this.
+    latency), or :meth:`best` / :meth:`rank` for a structured winner an agent
+    driving experiments can read directly. Kept deliberately small — richer
+    reporting (per-track breakdowns, plots) composes on top of the stored
+    ``results`` rather than bloating this.
     """
 
     results: list[MethodResult] = Field(default_factory=list)
@@ -241,6 +263,45 @@ class BenchmarkTable(BaseModel):
     def add(self, result: MethodResult) -> None:
         """Append one method result."""
         self.results.append(result)
+
+    def rank(self, *, by: str = "pair_f1") -> list[MethodResult]:
+        """Return the results sorted by ``by``, best (highest) first.
+
+        The structured counterpart to :meth:`to_markdown`: instead of a rendered
+        string, a list an experiment driver can index. The sort is stable, so ties
+        keep insertion order. An empty table returns ``[]``.
+
+        Args:
+            by: A metric name in :data:`_RANKABLE_METRICS` (``"pair_f1"`` — the
+                scorer-isolating default — ``"bcubed_f1"``, or
+                ``"delta_above_floor"``).
+
+        Returns:
+            The stored results, highest ``by`` first.
+
+        Raises:
+            ValueError: If ``by`` is not a known ranking metric.
+        """
+        accessor = _rank_accessor(by)
+        return sorted(self.results, key=accessor, reverse=True)
+
+    def best(self, *, by: str = "pair_f1") -> MethodResult | None:
+        """Return the single top result by ``by``, or ``None`` for an empty table.
+
+        Args:
+            by: A metric name in :data:`_RANKABLE_METRICS` (default ``"pair_f1"``).
+
+        Returns:
+            The highest-``by`` :class:`MethodResult` (first-added wins ties), or
+            ``None`` when no results have been added.
+
+        Raises:
+            ValueError: If ``by`` is not a known ranking metric.
+        """
+        accessor = _rank_accessor(by)
+        if not self.results:
+            return None
+        return max(self.results, key=accessor)
 
     def to_markdown(self) -> str:
         """Render the collected results as a Markdown table.
@@ -315,6 +376,27 @@ class Benchmark(Protocol[RecordT]):
     ) -> tuple[list[RecordT], list[RecordT], list[set[str]], list[set[str]]]:
         """Split into ``(train_records, test_records, train_clusters, test_clusters)``."""
         ...  # pragma: no cover
+
+
+if TYPE_CHECKING:
+    # ``run_methods`` builds each method's factory via
+    # ``langres.methods.make_resolver_factory``, which needs the *registry*
+    # contract (``BlockingBenchmark``: ``schema`` + ``blocking_k`` +
+    # ``build_blocker``) on top of the harness ``Benchmark`` contract. The two
+    # cannot be a single runtime import here without closing the
+    # ``core.benchmark -> methods -> core.benchmark`` cycle, so the combined
+    # contract is expressed for the type checker only — the annotation is a
+    # forward reference (quoted) and never evaluated at runtime.
+    from langres.methods import BlockingBenchmark
+
+    class _RunnableBenchmark(Benchmark[RecordT], BlockingBenchmark, Protocol):
+        """A benchmark satisfying BOTH the harness and the registry contracts.
+
+        The intersection ``run_methods`` requires — the same shape the two dataset
+        conformers and the test fakes already expose. Mirrors the example's
+        ``_RaceBenchmark`` so one benchmark can drive ``run_method`` (needs
+        ``Benchmark``) and ``make_resolver_factory`` (needs ``BlockingBenchmark``).
+        """
 
 
 # ---------------------------------------------------------------------------
@@ -542,6 +624,62 @@ def run_method(
         cost=cost,
         latency=latency,
     )
+
+
+def run_methods(
+    benchmark: "_RunnableBenchmark[RecordT]",
+    methods: Sequence[str],
+    *,
+    seed: int = 0,
+    budget: float | None = None,
+    **factory_kwargs: Any,
+) -> BenchmarkTable:
+    """Race several named methods on one benchmark into a :class:`BenchmarkTable`.
+
+    The library-level experiment facade: the double loop
+    ``examples/m3_zero_spend_race.py`` hand-coded (``for method: build factory ->
+    run_method -> table.add``) becomes one call. For each name it builds a
+    resolver factory via
+    :func:`~langres.methods.make_resolver_factory(method, benchmark,
+    **factory_kwargs)` and runs it through the existing :func:`run_method`,
+    appending each :class:`MethodResult` in ``methods`` order. A thin orchestration
+    wrapper: it owns no evaluation logic of its own, so both tracks, cost, and
+    latency stay defined in exactly one place (``run_method``).
+
+    ``make_resolver_factory`` lives in :mod:`langres.methods`, which imports
+    ``CostTrack`` / ``_cost_track`` from *this* module. Importing it at module
+    scope would close a ``core.benchmark -> methods -> core.benchmark`` cycle, so
+    it is imported lazily inside the call. ``import langres.core.benchmark`` thus
+    stays free of the method registry (and of ``langres.data``), preserving the
+    harness's dataset-agnostic import graph; the method registry is pulled in only
+    when an experiment is actually run.
+
+    Args:
+        benchmark: A conformer of BOTH the harness :class:`Benchmark` contract and
+            the registry ``BlockingBenchmark`` contract (``schema`` +
+            ``blocking_k`` + ``build_blocker``). The two dataset conformers and the
+            test fakes already satisfy this intersection.
+        methods: Method names to race (e.g. ``("rapidfuzz", "embedding_cosine")``);
+            each must be a name :func:`~langres.methods.make_resolver_factory`
+            accepts (raises ``ValueError`` otherwise).
+        seed: Split seed shared by every method (identical leakage-free split).
+        budget: Per-method spend ceiling forwarded to :func:`run_method`. ``0.0``
+            asserts genuine zero spend (raises if any method is charged); ``None``
+            bounds nothing.
+        **factory_kwargs: Forwarded verbatim to ``make_resolver_factory`` (e.g.
+            ``llm_client``, ``llm_model``) — ignored by the zero-spend methods.
+
+    Returns:
+        A :class:`BenchmarkTable` with one :class:`MethodResult` per method (in
+        ``methods`` order).
+    """
+    from langres.methods import make_resolver_factory
+
+    table = BenchmarkTable()
+    for method in methods:
+        factory = make_resolver_factory(method, benchmark, **factory_kwargs)
+        table.add(run_method(benchmark, factory, seed=seed, budget=budget))
+    return table
 
 
 # ---------------------------------------------------------------------------

--- a/tests/core/test_benchmark.py
+++ b/tests/core/test_benchmark.py
@@ -3,12 +3,15 @@
 Covers the budgeted module runner (preflight cap, budget stop, blind-cost guard,
 per-call isolation, both cost-key paths), the generic ``run_method`` orchestration
 on a fully-deterministic fake benchmark (no embeddings, no LLM), ``BenchmarkTable``
-rendering, and the import-cycle guard (core must not import ``langres.data``).
+rendering, the ``run_methods`` experiment facade + ``BenchmarkTable.best``/``rank``
+structured accessors, and the import-cycle guard (core must not import
+``langres.data``).
 """
 
 import subprocess
 import sys
 from collections.abc import Iterator
+from typing import Any
 
 import pytest
 
@@ -19,20 +22,26 @@ from langres.core.benchmark import (
     BlindCostError,
     BudgetedModuleRunner,
     CostTrack,
+    LatencyTrack,
     MethodResult,
+    PairTrack,
     PipelineTrack,
     _cost_track,
     complete_partition,
     gold_pairs_from_clusters,
     run_method,
+    run_methods,
     tune_threshold_on_train,
 )
 from langres.core.blockers.all_pairs import AllPairsBlocker
+from langres.core.blockers.vector import VectorBlocker
 from langres.core.clusterer import Clusterer
+from langres.core.indexes.vector_index import FakeVectorIndex
 from langres.core.models import CompanySchema, ERCandidate, PairwiseJudgement
 from langres.core.module import Module
 from langres.core.reports import ScoreInspectionReport
 from langres.core.resolver import Resolver
+from langres.methods import ZERO_SPEND_METHODS
 
 # ---------------------------------------------------------------------------
 # Fakes
@@ -545,3 +554,131 @@ def test_import_langres_succeeds() -> None:
         check=False,
     )
     assert proc.returncode == 0, proc.stderr
+
+
+# ---------------------------------------------------------------------------
+# run_methods experiment facade
+# ---------------------------------------------------------------------------
+
+
+def _company_factory(record: dict[str, Any]) -> CompanySchema:
+    return CompanySchema(**{f: record.get(f) for f in CompanySchema.model_fields})
+
+
+class _FakeBlockingBenchmark(_FakeBenchmark):
+    """``_FakeBenchmark`` + the registry ``BlockingBenchmark`` contract.
+
+    Adds ``schema`` + ``blocking_k`` + ``build_blocker`` (a ``FakeVectorIndex``
+    blocker — no real embeddings) so ``make_resolver_factory`` can build the
+    zero-spend methods on the same tiny corpus. This is exactly the intersection
+    ``run_methods`` requires, mirroring the fake in ``tests/test_methods.py``.
+    """
+
+    schema = CompanySchema
+    blocking_k = 2
+
+    def build_blocker(self, k_neighbors: int) -> VectorBlocker[CompanySchema]:
+        return VectorBlocker(
+            schema_factory=_company_factory,
+            text_field_extractor=lambda e: e.name,
+            vector_index=FakeVectorIndex(),
+            k_neighbors=k_neighbors,
+        )
+
+
+def test_run_methods_races_zero_spend_methods_one_row_each() -> None:
+    table = run_methods(_FakeBlockingBenchmark(), ZERO_SPEND_METHODS, seed=0)
+
+    assert isinstance(table, BenchmarkTable)
+    # One populated row per method, all on the same dataset, distinct scorers.
+    assert len(table.results) == len(ZERO_SPEND_METHODS)
+    assert {r.dataset for r in table.results} == {"fake"}
+    assert len({r.method for r in table.results}) == len(ZERO_SPEND_METHODS)
+    # Both tracks populate on every row.
+    assert all(r.pair.pr_curve is not None for r in table.results)
+    assert all(0.0 <= r.pipeline.bcubed_f1 <= 1.0 for r in table.results)
+    assert all(r.seed == 0 for r in table.results)
+
+
+def test_run_methods_budget_zero_asserts_zero_spend() -> None:
+    # budget=0.0 is a hard assertion these methods truly spend nothing.
+    table = run_methods(_FakeBlockingBenchmark(), ZERO_SPEND_METHODS, seed=0, budget=0.0)
+    assert all(r.cost.usd_total == 0.0 for r in table.results)
+
+
+# ---------------------------------------------------------------------------
+# BenchmarkTable.best / rank (structured accessors)
+# ---------------------------------------------------------------------------
+
+
+def _result(
+    method: str, *, pair_f1: float, bcubed_f1: float, delta: float = 0.0
+) -> MethodResult:
+    """A minimal MethodResult carrying only the fields best/rank read."""
+    return MethodResult(
+        method=method,
+        dataset="fake",
+        seed=0,
+        threshold=0.5,
+        pair=PairTrack(precision=pair_f1, recall=pair_f1, f1=pair_f1),
+        pipeline=PipelineTrack(
+            bcubed_p=bcubed_f1,
+            bcubed_r=bcubed_f1,
+            bcubed_f1=bcubed_f1,
+            cluster_pairwise_f1=bcubed_f1,
+            delta_above_floor=delta,
+            sanity_floor_f1=0.0,
+        ),
+        latency=LatencyTrack(seconds_per_pair=0.0),
+    )
+
+
+def _table_with_three() -> BenchmarkTable:
+    # pair_f1 winner is 'b'; bcubed_f1 winner is 'a' — orderings differ so `by` matters.
+    table = BenchmarkTable()
+    table.add(_result("a", pair_f1=0.5, bcubed_f1=0.9))
+    table.add(_result("b", pair_f1=0.8, bcubed_f1=0.4))
+    table.add(_result("c", pair_f1=0.6, bcubed_f1=0.6))
+    return table
+
+
+def test_best_returns_highest_pair_f1_row_by_default() -> None:
+    best = _table_with_three().best()
+    assert best is not None
+    assert best.method == "b"
+
+
+def test_best_by_alternate_metric_switches_winner() -> None:
+    best = _table_with_three().best(by="bcubed_f1")
+    assert best is not None
+    assert best.method == "a"
+
+
+def test_best_by_delta_above_floor() -> None:
+    table = BenchmarkTable()
+    table.add(_result("a", pair_f1=0.1, bcubed_f1=0.1, delta=0.9))
+    table.add(_result("b", pair_f1=0.9, bcubed_f1=0.9, delta=0.1))
+    best = table.best(by="delta_above_floor")
+    assert best is not None
+    assert best.method == "a"
+
+
+def test_best_empty_table_returns_none() -> None:
+    assert BenchmarkTable().best() is None
+
+
+def test_rank_orders_by_metric_best_first() -> None:
+    ranked = _table_with_three().rank(by="pair_f1")
+    assert [r.method for r in ranked] == ["b", "c", "a"]
+
+
+def test_rank_empty_table_is_empty_list() -> None:
+    assert BenchmarkTable().rank() == []
+
+
+def test_best_and_rank_reject_unknown_metric() -> None:
+    table = _table_with_three()
+    with pytest.raises(ValueError, match="unknown ranking metric"):
+        table.best(by="nope")
+    with pytest.raises(ValueError, match="unknown ranking metric"):
+        table.rank(by="nope")


### PR DESCRIPTION
Part of **M4** (integration branch `feat/m4-foundation`). Promotes the one-call experiment loop from `examples/m3_zero_spend_race.py` into the library — the DX + autoresearch heart. Thin wrapper over the existing `run_method` + `BenchmarkTable` (no new god-object).

## What
- `run_methods(benchmark, methods, *, seed=0, budget=None, **factory_kwargs) -> BenchmarkTable` — loops method names via `make_resolver_factory` + existing `run_method`, one `MethodResult` per method. Owns no eval logic.
- `BenchmarkTable.best(by="pair_f1")` / `.rank(by=...)` — structured accessors (best-first) for an agent driving experiments. Metrics: `pair_f1`/`bcubed_f1`/`delta_above_floor`; unknown raises. `to_markdown()` unchanged.

## Import cycle — resolved
`methods.py` imports from `core.benchmark`, so a module-level import back would cycle. Resolved with a function-level lazy import in `run_methods` + a `TYPE_CHECKING`-only protocol. Verified `import langres.core.benchmark` pulls in neither `langres.methods` nor `langres.data`.

## Verification (all $0)
- 36 passed (`-k "benchmark or run_methods or best"`); full suite 99.03% (gate 95%); `mypy` clean; `ruff` clean; facade importable.

Diff is exactly 2 files (+279/−4).