### PR TITLE
M4 Wave 0: import-safe DSPyJudge (compile · run · serialize · honest cost)

### DIFF
--- a/examples/m4_dspy_judge.py
+++ b/examples/m4_dspy_judge.py
@@ -1,0 +1,165 @@
+"""M4 DSPyJudge smoke: Signature -> ChainOfThought -> compile -> forward -> eval -> save/load.
+
+The whole flow at **$0** with DSPy's ``DummyLM`` (no key, no network) on a handful
+of Amazon-Google test pairs — the plumbing a programmer using langres would drive:
+
+1. build ER candidates from the fixed AG pair split;
+2. compile a ``DSPyJudge`` against a tiny gold trainset (``BootstrapFewShot``);
+3. score the candidates and grade them with ``evaluate_judge_on_candidates``;
+4. save the compiled Resolver, reload it, and assert the reloaded judge scores the
+   candidates identically — proving the compiled program round-trips.
+
+Run:
+    uv run python examples/m4_dspy_judge.py --smoke   # default; $0, DummyLM
+
+The ``DummyLM`` returns canned answers, so the printed JudgePairEval is illustrative
+of the *plumbing*, not a real quality signal — the paid first-light (a real model
++ ``MIPROv2``) lands in a later wave.
+"""
+
+import argparse
+import logging
+from pathlib import Path
+
+from dspy import Example
+from dspy.utils.dummies import DummyLM
+
+from langres.core import AllPairsBlocker, Clusterer, Resolver
+from langres.core.benchmark import evaluate_judge_on_candidates
+from langres.core.models import ERCandidate
+from langres.core.modules.dspy_judge import DSPyJudge
+from langres.data.amazon_google import (
+    ProductSchema,
+    load_amazon_google,
+    load_amazon_google_pair_splits,
+)
+
+logging.basicConfig(level=logging.INFO, format="%(message)s")
+logger = logging.getLogger("m4_dspy_judge")
+
+#: Compact pair-level threshold grid for the smoke eval.
+GRID: tuple[float, ...] = (0.1, 0.3, 0.5, 0.7, 0.9)
+
+#: A generous pool of canned DummyLM answers (compile + forward both consume them).
+_CANNED_ANSWERS = [
+    {"reasoning": "records describe the same product", "match": "True", "match_probability": "0.9"}
+] * 200
+
+
+def _dummy_lm() -> DummyLM:
+    """A fresh, deterministic DummyLM (identical answer stream every call)."""
+    return DummyLM(list(_CANNED_ANSWERS))
+
+
+def build_ag_smoke_candidates(
+    per_class: int = 6,
+) -> tuple[list[ERCandidate[ProductSchema]], set[frozenset[str]]]:
+    """Build a balanced handful of ER candidates from the fixed AG test pair split.
+
+    Reuses ``m3_race``'s pattern (corpus by id + fixed pair rows) but skips the
+    MiniLM embedding step — ``DSPyJudge`` reads the raw records, not a cosine — so
+    the smoke stays fast and $0. Takes ``per_class`` positive and ``per_class``
+    negative rows so the trainset carries both labels (bootstrap can collect
+    match-demos and the eval has real positives). Returns the candidates plus the
+    positive gold pairs.
+    """
+    corpus, _clusters, _gold = load_amazon_google()
+    by_id = {r.id: r for r in corpus}
+    all_rows = load_amazon_google_pair_splits()["test"]
+    positives = [row for row in all_rows if row[2] == 1][:per_class]
+    negatives = [row for row in all_rows if row[2] == 0][:per_class]
+    rows = positives + negatives
+
+    candidates: list[ERCandidate[ProductSchema]] = []
+    gold: set[frozenset[str]] = set()
+    for amazon_id, google_id, label in rows:
+        candidates.append(
+            ERCandidate(
+                left=by_id[amazon_id],
+                right=by_id[google_id],
+                blocker_name="m4_smoke",
+            )
+        )
+        if label == 1:
+            gold.add(frozenset({amazon_id, google_id}))
+    return candidates, gold
+
+
+def _trainset(candidates: list[ERCandidate[ProductSchema]], gold: set[frozenset[str]]) -> list[Example]:
+    """Turn candidates into labeled DSPy examples (rendered like ``forward``)."""
+    examples: list[Example] = []
+    for candidate in candidates:
+        is_match = frozenset({candidate.left.id, candidate.right.id}) in gold
+        examples.append(
+            Example(
+                left=candidate.left.model_dump_json(indent=2),
+                right=candidate.right.model_dump_json(indent=2),
+                match=is_match,
+            ).with_inputs("left", "right")
+        )
+    return examples
+
+
+def run_smoke() -> None:
+    """Run the full zero-spend DSPyJudge plumbing and assert the round-trip is faithful."""
+    candidates, gold = build_ag_smoke_candidates()
+    logger.info("Built %d AG candidates (%d positive gold pairs).", len(candidates), len(gold))
+
+    # 1) Compile a DSPyJudge against the tiny gold trainset (deterministic under DummyLM).
+    judge: DSPyJudge[ProductSchema] = DSPyJudge(lm=_dummy_lm(), entity_noun="product")
+    judge.compile(_trainset(candidates, gold), optimizer="bootstrap")
+    logger.info("Compiled DSPyJudge (bootstrap). compiled=%s", judge._compiled)
+
+    # 2) Score + grade the candidates at the pair level.
+    result, _judgements = evaluate_judge_on_candidates(judge, candidates, gold, GRID)
+    logger.info(
+        "JudgePairEval: F1=%.3f P=%.3f R=%.3f @ threshold=%.2f (n_judged=%d, cost=$%.4f)",
+        result.pair.f1,
+        result.pair.precision,
+        result.pair.recall,
+        result.best_threshold,
+        result.n_judged,
+        result.cost.usd_total,
+    )
+
+    # 3) Save the compiled Resolver, reload it, and re-inject a fresh DummyLM (the LM
+    #    is never serialized). The reloaded compiled program must score identically.
+    resolver = Resolver(
+        blocker=AllPairsBlocker(schema=ProductSchema),
+        comparator=None,
+        module=judge,
+        clusterer=Clusterer(threshold=0.7),
+    )
+    out_dir = Path("tmp/m4_dspy_smoke_artifact")
+    resolver.save(out_dir)
+    logger.info("Saved compiled Resolver to %s", out_dir)
+
+    # Re-seed the original judge's LM so both runs start from an identical answer stream.
+    judge._lm = _dummy_lm()
+    before = [j.score for j in judge.forward(iter(candidates))]
+
+    reloaded = Resolver.load(out_dir)
+    assert isinstance(reloaded.module, DSPyJudge)
+    reloaded.module._lm = _dummy_lm()
+    after = [j.score for j in reloaded.module.forward(iter(candidates))]
+
+    assert before == after, f"reloaded judge diverged:\n before={before}\n after ={after}"
+    logger.info("Round-trip OK: reloaded compiled judge scored %d pairs identically.", len(after))
+    logger.info("Smoke complete — $0, DummyLM.")
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="M4 DSPyJudge smoke ($0, DummyLM).")
+    parser.add_argument(
+        "--smoke",
+        action="store_true",
+        help="Run the zero-spend smoke (default when no mode is given).",
+    )
+    parser.parse_args()
+    # Only a zero-spend smoke mode exists on this branch; the paid first-light is a
+    # later wave. The flag is accepted for forward-compatibility and clarity.
+    run_smoke()
+
+
+if __name__ == "__main__":
+    main()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -153,3 +153,13 @@ ignore_missing_imports = true
 module = ["litellm.*"]
 ignore_missing_imports = true
 follow_imports = "skip"
+
+[[tool.mypy.overrides]]
+# dspy (dspy-ai) ships partial/optional type info that flips typed↔untyped across
+# installs, so an inline ignore on an attribute like `dspy.LM` alternates between
+# "needed" and "unused" (the latter fails strict `warn_unused_ignores`). Treat
+# dspy as untyped uniformly and skip following its imports — the DSPyJudge already
+# annotates its own public surface and holds the program as `Any`.
+module = ["dspy.*"]
+ignore_missing_imports = true
+follow_imports = "skip"

--- a/src/langres/core/modules/dspy_judge.py
+++ b/src/langres/core/modules/dspy_judge.py
@@ -270,7 +270,10 @@ class DSPyJudge(Module[SchemaT]):
                 self._program = dspy.BootstrapFewShot(metric=_pair_metric).compile(
                     self._program, trainset=list(trainset), **kwargs
                 )
-            elif optimizer == "mipro":
+            elif optimizer == "mipro":  # pragma: no cover - paid, non-deterministic path
+                # Exercised only by the paid example (MIPROv2 proposes+evaluates
+                # instructions via real LM calls; it is not deterministic under
+                # DummyLM, so it is kept out of the zero-spend unit suite).
                 self._program = dspy.MIPROv2(metric=_pair_metric, auto="light").compile(
                     self._program,
                     trainset=list(trainset),

--- a/src/langres/core/modules/dspy_judge.py
+++ b/src/langres/core/modules/dspy_judge.py
@@ -1,0 +1,304 @@
+"""DSPyJudge: a serializable, compilable DSPy ChainOfThought entity-matching Module.
+
+This is the M4 "learnable scorer seam": a :class:`~langres.core.module.Module`
+whose match decision comes from a DSPy ``ChainOfThought`` program over a typed
+:class:`PairwiseMatchSignature`. Because the program is a DSPy artifact it can be
+**compiled** against a gold set (``BootstrapFewShot`` / ``MIPROv2``) to tune the
+prompt from data — the direct answer to M3's finding that a cheap judge's
+precision collapses under a generic, hand-written prompt.
+
+It mirrors :class:`~langres.core.modules.llm_judge.LLMJudge`'s serializable shape
+so a Resolver with a DSPyJudge in the ``module`` slot can ``save`` / ``load``:
+
+- pure :attr:`config` (``model`` / ``temperature`` / ``entity_noun`` — never the
+  ``dspy.LM`` client or the program bytes);
+- :class:`~langres.core.serialization.SerializableState` for the compiled program
+  (``program.json`` via ``program.save`` / ``program.load``);
+- lazy LM construction (an injected ``lm`` — e.g. ``DummyLM`` in tests — wins;
+  otherwise a ``dspy.LM`` is built on first use), so ``load`` never needs a key.
+
+**Import-safety:** this module is deliberately *not* eager-imported by
+``langres.core`` — importing ``dspy`` opens a disk cache and is undesirable on
+plain ``import langres.core``. It is registered lazily via
+``registry._LAZY_COMPONENT_MODULES`` so ``Resolver.load`` on a ``dspy_judge``
+artifact imports it on demand (firing ``@register``).
+"""
+
+import logging
+from collections.abc import Iterator, Sequence
+from pathlib import Path
+from typing import Any, ClassVar, Self
+
+import dspy
+from dspy.utils.exceptions import AdapterParseError
+
+from langres.core.models import ERCandidate, PairwiseJudgement
+from langres.core.module import Module, SchemaT
+from langres.core.registry import register
+from langres.core.reports import ScoreInspectionReport, _inspect_scores_impl
+
+logger = logging.getLogger(__name__)
+
+
+class PairwiseMatchSignature(dspy.Signature):
+    """Decide whether two {entity_noun} records refer to the same real-world {entity_noun}.
+
+    Weigh the concrete evidence in both records, not surface overlap. A different
+    model, size, edition, or variant means a *different* {entity_noun}, even when
+    titles look similar; conversely, differently-worded records can be the same
+    {entity_noun}. Return the boolean decision, a calibrated probability that the
+    two records are the same {entity_noun} (1.0 = certainly same, 0.0 = certainly
+    different), and a brief justification.
+    """
+
+    left: str = dspy.InputField(desc="First record (rendered fields)")
+    right: str = dspy.InputField(desc="Second record (rendered fields)")
+    match: bool = dspy.OutputField(desc="True if the two records are the same entity")
+    match_probability: float = dspy.OutputField(desc="Probability in [0, 1] they are the same")
+    reasoning: str = dspy.OutputField(desc="Brief justification for the decision")
+
+
+def _signature_for(entity_noun: str) -> type[dspy.Signature]:
+    """Return :class:`PairwiseMatchSignature` with ``entity_noun`` woven into its instructions.
+
+    The signature's docstring is the optimizable instruction (with ``{entity_noun}``
+    placeholders); this substitutes the domain noun at construction so the same
+    signature serves products, companies, people, etc. Compilation later rewrites
+    these instructions from data.
+    """
+    instructions = PairwiseMatchSignature.instructions.replace("{entity_noun}", entity_noun)
+    return PairwiseMatchSignature.with_instructions(instructions)
+
+
+def _clamp01(value: float) -> float:
+    """Clamp ``value`` into the ``[0.0, 1.0]`` range required by ``PairwiseJudgement``."""
+    return max(0.0, min(1.0, value))
+
+
+def _pair_metric(example: dspy.Example, prediction: Any, trace: Any = None) -> bool:
+    """Compilation metric: the predicted ``match`` bool equals the gold ``match`` bool.
+
+    Used by both ``BootstrapFewShot`` and ``MIPROv2`` — a demonstration/instruction
+    is kept only when it reproduces the labeled match decision.
+    """
+    return bool(prediction.match) == bool(example.match)
+
+
+@register("dspy_judge")
+class DSPyJudge(Module[SchemaT]):
+    """DSPy ``ChainOfThought`` entity-matching scorer — compilable and serializable.
+
+    Example:
+        # Zero-spend: inject a DummyLM, compile against a gold set, then score.
+        from dspy.utils.dummies import DummyLM
+
+        judge = DSPyJudge(lm=DummyLM([...]), entity_noun="product")
+        judge.compile(trainset, optimizer="bootstrap")
+        for j in judge.forward(candidates):
+            print(j.score, j.reasoning, j.provenance["cost_usd"])
+    """
+
+    # Registry key, mirrored as a class attribute so the Resolver's uniform
+    # serialization helper can discover the type name (see resolver.py).
+    type_name: ClassVar[str] = "dspy_judge"
+
+    def __init__(
+        self,
+        lm: Any = None,
+        model: str = "openrouter/openai/gpt-4o-mini",
+        temperature: float = 0.0,
+        entity_noun: str = "entity",
+        program: Any = None,
+    ) -> None:
+        """Initialize a DSPyJudge.
+
+        Args:
+            lm: Optional pre-built DSPy LM (``dspy.LM`` or ``DummyLM``). When
+                ``None`` a ``dspy.LM(model, cache=False)`` is built lazily on first
+                use — so ``from_config`` / ``load`` never need a key. Inject an LM
+                as an escape hatch (tests inject ``DummyLM`` for zero-spend runs).
+            model: OpenRouter/LiteLLM model id used when ``lm`` is built lazily.
+            temperature: Sampling temperature for the lazily-built LM.
+            entity_noun: Domain noun woven into the signature instructions.
+            program: Optional pre-built DSPy program (e.g. a compiled one). When
+                ``None`` a fresh ``ChainOfThought`` over the woven signature is
+                built (uncompiled — call :meth:`compile` to tune it).
+        """
+        self.model = model
+        self.temperature = temperature
+        self.entity_noun = entity_noun
+        self._lm = lm
+        self._program: Any = program if program is not None else dspy.ChainOfThought(
+            _signature_for(entity_noun)
+        )
+        # A program is "compiled" once :meth:`compile` has tuned it; a bare
+        # ``ChainOfThought`` (or a ``from_config`` rebuild) starts uncompiled and
+        # :meth:`forward` warns so a user never silently benchmarks an untuned judge.
+        self._compiled = False
+        # Cost seam: honest per-pair cost = tokens * price. OpenRouter is priced at
+        # $0 by litellm, so we never trust ``completion_cost``; instead we multiply
+        # real token counts by a pinned price. Default 0.0 keeps zero-spend runs at
+        # $0; the real pinned price is injected here by ``langres.clients.openrouter``
+        # (sibling branch) — set ``judge.price_per_1k_tokens`` after construction.
+        # TODO(M4 openrouter helper): wire ``price_per_1k_tokens`` from the pinned
+        # OpenRouter price table once ``langres.clients.openrouter`` merges.
+        self.price_per_1k_tokens = 0.0
+
+    def _get_lm(self) -> Any:
+        """Return the DSPy LM, lazily building a ``dspy.LM`` from ``model`` on first use."""
+        if self._lm is None:
+            self._lm = dspy.LM(self.model, cache=False)
+        return self._lm
+
+    @property
+    def config(self) -> dict[str, object]:
+        """Pure, serializable construction config (never the LM, program, or secrets)."""
+        return {
+            "model": self.model,
+            "temperature": self.temperature,
+            "entity_noun": self.entity_noun,
+        }
+
+    @classmethod
+    def from_config(cls, config: dict[str, object]) -> "DSPyJudge[SchemaT]":
+        """Rebuild a fresh (uncompiled) judge from :attr:`config`.
+
+        The program is uncompiled; :meth:`load_state` overwrites it with the saved
+        (possibly compiled) program during ``Resolver.load``.
+        """
+        return cls(
+            lm=None,
+            model=str(config["model"]),
+            temperature=float(config["temperature"]),  # type: ignore[arg-type]
+            entity_noun=str(config["entity_noun"]),
+        )
+
+    def _cost_usd(self, prompt_tokens: int, completion_tokens: int) -> float:
+        """Honest per-pair cost from token counts and the pinned per-1k price."""
+        return (prompt_tokens + completion_tokens) / 1000.0 * self.price_per_1k_tokens
+
+    def _render_entity(self, entity: SchemaT) -> str:
+        """Render an entity for the prompt (LLMJudge's JSON convention)."""
+        return entity.model_dump_json(indent=2)
+
+    def forward(self, candidates: Iterator[ERCandidate[SchemaT]]) -> Iterator[PairwiseJudgement]:
+        """Score each candidate pair with the DSPy program, yielding PairwiseJudgements.
+
+        Each call runs the program under ``dspy.context(lm=..., track_usage=True)``
+        — never ``dspy.settings.configure`` — so the global LM is left untouched and
+        real token usage is captured for honest cost. A DSPy parse/validation error
+        does not skip the pair: it yields a low-confidence (0.5) judgement tagged
+        ``dspy_parse_error`` with the error recorded in provenance.
+        """
+        if not self._compiled:
+            logger.warning(
+                "DSPyJudge.forward is running on an UNCOMPILED program — the prompt "
+                "is untuned. Call compile(trainset) before benchmarking to avoid "
+                "silently scoring with an untuned judge."
+            )
+        lm = self._get_lm()
+        for candidate in candidates:
+            left = self._render_entity(candidate.left)
+            right = self._render_entity(candidate.right)
+            left_id = candidate.left.id  # type: ignore[attr-defined]
+            right_id = candidate.right.id  # type: ignore[attr-defined]
+            try:
+                with dspy.context(lm=lm, track_usage=True):
+                    prediction = self._program(left=left, right=right)
+            except AdapterParseError as error:
+                logger.warning("DSPyJudge parse failure for %s vs %s: %s", left_id, right_id, error)
+                yield PairwiseJudgement(
+                    left_id=left_id,
+                    right_id=right_id,
+                    score=0.5,
+                    score_type="prob_llm",
+                    decision_step="dspy_parse_error",
+                    reasoning=None,
+                    provenance={
+                        "model": self.model,
+                        "cost_usd": 0.0,
+                        "prompt_tokens": 0,
+                        "completion_tokens": 0,
+                        "error": str(error),
+                    },
+                )
+                continue
+
+            usage = prediction.get_lm_usage()  # {model: {prompt_tokens, completion_tokens, ...}}
+            prompt_tokens = sum(int(u.get("prompt_tokens", 0)) for u in usage.values())
+            completion_tokens = sum(int(u.get("completion_tokens", 0)) for u in usage.values())
+            yield PairwiseJudgement(
+                left_id=left_id,
+                right_id=right_id,
+                score=_clamp01(float(prediction.match_probability)),
+                score_type="prob_llm",
+                decision_step="dspy_judgment",
+                reasoning=prediction.reasoning,
+                provenance={
+                    "model": self.model,
+                    "cost_usd": self._cost_usd(prompt_tokens, completion_tokens),
+                    "prompt_tokens": prompt_tokens,
+                    "completion_tokens": completion_tokens,
+                },
+            )
+
+    def compile(
+        self,
+        trainset: Sequence[dspy.Example],
+        valset: Sequence[dspy.Example] | None = None,
+        *,
+        optimizer: str = "bootstrap",
+        **kwargs: Any,
+    ) -> Self:
+        """Compile (tune) the DSPy program against a gold set, in place.
+
+        Args:
+            trainset: Labeled ``dspy.Example`` s (``left`` / ``right`` inputs +
+                gold ``match``) the optimizer tunes against.
+            valset: Optional validation set (used by ``mipro``).
+            optimizer: ``"bootstrap"`` (``BootstrapFewShot`` — deterministic under
+                ``DummyLM``, the zero-spend path) or ``"mipro"`` (``MIPROv2
+                auto="light"`` — the paid path, exercised only by the example).
+            **kwargs: Forwarded to the optimizer's ``compile``.
+
+        Returns:
+            ``self`` with ``_program`` replaced by the compiled program and
+            ``_compiled`` set — so callers can chain ``judge.compile(...).forward(...)``.
+        """
+        with dspy.context(lm=self._get_lm()):
+            if optimizer == "bootstrap":
+                self._program = dspy.BootstrapFewShot(metric=_pair_metric).compile(
+                    self._program, trainset=list(trainset), **kwargs
+                )
+            elif optimizer == "mipro":
+                self._program = dspy.MIPROv2(metric=_pair_metric, auto="light").compile(
+                    self._program,
+                    trainset=list(trainset),
+                    valset=list(valset) if valset is not None else None,
+                    **kwargs,
+                )
+            else:
+                raise ValueError(
+                    f"unknown optimizer {optimizer!r}; choose 'bootstrap' or 'mipro'"
+                )
+        self._compiled = True
+        return self
+
+    def save_state(self, state_dir: Path) -> None:
+        """Persist the DSPy program (demos + instructions) to ``program.json``."""
+        self._program.save(state_dir / "program.json", save_program=False)
+
+    def load_state(self, state_dir: Path) -> None:
+        """Restore the DSPy program from ``program.json`` written by :meth:`save_state`.
+
+        A saved program carries its compiled state; treat a loaded program as
+        compiled so ``forward`` does not warn on a restored, tuned judge.
+        """
+        self._program.load(state_dir / "program.json")
+        self._compiled = True
+
+    def inspect_scores(
+        self, judgements: list[PairwiseJudgement], sample_size: int = 10
+    ) -> ScoreInspectionReport:
+        """Explore scores without ground-truth labels (shared report helper)."""
+        return _inspect_scores_impl(judgements, sample_size)

--- a/src/langres/core/modules/dspy_judge.py
+++ b/src/langres/core/modules/dspy_judge.py
@@ -40,7 +40,7 @@ from langres.core.reports import ScoreInspectionReport, _inspect_scores_impl
 logger = logging.getLogger(__name__)
 
 
-class PairwiseMatchSignature(dspy.Signature):
+class PairwiseMatchSignature(dspy.Signature):  # type: ignore[misc]  # dspy is untyped (Any)
     """Decide whether two {entity_noun} records refer to the same real-world {entity_noun}.
 
     Weigh the concrete evidence in both records, not surface overlap. A different
@@ -58,7 +58,7 @@ class PairwiseMatchSignature(dspy.Signature):
     reasoning: str = dspy.OutputField(desc="Brief justification for the decision")
 
 
-def _signature_for(entity_noun: str) -> type[dspy.Signature]:
+def _signature_for(entity_noun: str) -> Any:
     """Return :class:`PairwiseMatchSignature` with ``entity_noun`` woven into its instructions.
 
     The signature's docstring is the optimizable instruction (with ``{entity_noun}``

--- a/src/langres/core/registry.py
+++ b/src/langres/core/registry.py
@@ -16,6 +16,7 @@ No abstract base classes live here — only registration, lookup, and errors.
 """
 
 import difflib
+import importlib
 from collections.abc import Callable
 from typing import TypeVar
 
@@ -25,6 +26,19 @@ T = TypeVar("T")
 
 _COMPONENT_REGISTRY: dict[str, type] = {}
 _SCHEMA_REGISTRY: dict[str, type[BaseModel]] = {}
+
+# Lazy-registration map: ``type_name -> module path``. A component listed here is
+# NOT eager-imported by ``langres.core`` — importing it would pull a heavy or
+# side-effectful optional dependency into plain ``import langres.core``. Instead
+# its module is imported on demand the first time :func:`get_component` is asked
+# for that ``type_name`` (the import fires the module's ``@register`` decorator),
+# so a fresh process doing ``Resolver.load`` on such an artifact still resolves
+# the type. Keep in sync with any module kept off the eager-import path — e.g.
+# ``dspy_judge``, which would otherwise import ``dspy`` (and open its disk cache)
+# on plain ``import langres.core``.
+_LAZY_COMPONENT_MODULES: dict[str, str] = {
+    "dspy_judge": "langres.core.modules.dspy_judge",
+}
 
 
 class UnknownComponentType(KeyError):
@@ -68,6 +82,11 @@ def get_component(type_name: str) -> type:
         UnknownComponentType: If ``type_name`` is not registered. The message
             lists available types and a did-you-mean suggestion.
     """
+    if type_name not in _COMPONENT_REGISTRY and type_name in _LAZY_COMPONENT_MODULES:
+        # Import the owning module on demand — its ``@register`` populates the
+        # registry — so an optional-dependency component (e.g. ``dspy_judge``)
+        # resolves without being eager-imported by ``langres.core``.
+        importlib.import_module(_LAZY_COMPONENT_MODULES[type_name])
     if type_name not in _COMPONENT_REGISTRY:
         available = sorted(_COMPONENT_REGISTRY)
         suggestions = difflib.get_close_matches(type_name, available, n=3)

--- a/src/langres/methods.py
+++ b/src/langres/methods.py
@@ -22,6 +22,9 @@ is held constant per dataset so the race compares judges, not blockers:
   hard import-time requirement.
 - ``cascade`` — VectorBlocker -> ``CascadeModule`` (embedding early-exit, LLM only
   on the uncertain band) -> Clusterer. Its OpenAI client is injected the same way.
+- ``dspy_judge`` — VectorBlocker -> ``DSPyJudge`` (a compilable DSPy
+  ``ChainOfThought``) -> Clusterer (M4). Its injected client is a **DSPy LM**
+  (``dspy.LM`` / ``DummyLM``), distinct from the LiteLLM/OpenAI clients above.
 
 A dataset participates by conforming to :class:`BlockingBenchmark` — exposing its
 record ``schema`` plus a pinned blocking config (``blocking_k`` and a
@@ -54,7 +57,10 @@ from langres.core.resolver import Resolver
 ZERO_SPEND_METHODS: tuple[str, ...] = ("rapidfuzz", "weighted_average", "embedding_cosine")
 
 #: Methods whose scorer calls an LLM — they take an injected client (mock/real).
-LLM_METHODS: tuple[str, ...] = ("llm_judge", "cascade")
+#: ``dspy_judge`` is LLM-backed too, but its injected client is a **DSPy LM**
+#: (``dspy.LM`` / ``DummyLM``), not the LiteLLM/OpenAI client the others take —
+#: see :func:`_make_module_builder`.
+LLM_METHODS: tuple[str, ...] = ("llm_judge", "cascade", "dspy_judge")
 
 #: Every method the registry can build, in race order.
 ALL_METHODS: tuple[str, ...] = ZERO_SPEND_METHODS + LLM_METHODS
@@ -171,6 +177,15 @@ def _make_module_builder(
         return (lambda: EmbeddingScoreJudge()), None
     if method == "llm_judge":
         return (lambda: LLMJudge(client=llm_client, model=llm_model)), None
+    if method == "dspy_judge":
+        # ``dspy_judge`` takes a **DSPy LM** as its injected client — a
+        # ``dspy.LM(...)`` for real runs or a ``dspy.utils.dummies.DummyLM`` in
+        # tests — NOT the LiteLLM ``client.completion(...)`` shape ``llm_judge``
+        # expects. Imported lazily so building any other method's factory (and
+        # plain ``import langres.methods``) never imports ``dspy``.
+        from langres.core.modules.dspy_judge import DSPyJudge
+
+        return (lambda: DSPyJudge(lm=llm_client, model=llm_model)), None
     if method == "cascade":
         return (
             lambda: _build_cascade_module(

--- a/tests/core/modules/test_dspy_judge.py
+++ b/tests/core/modules/test_dspy_judge.py
@@ -1,0 +1,373 @@
+"""Zero-spend tests for DSPyJudge (the M4 learnable scorer seam).
+
+Every test runs at $0 with DSPy's ``DummyLM`` — no network, no key. They cover
+the serializable-Module contract (forward shape, honest cost, parse-failure
+guard, lazy LM, global-state isolation), compilation (``BootstrapFewShot``
+populates demos), state round-trips (``save_state``/``load_state`` and a full
+fresh-process ``Resolver`` round-trip for both compiled and uncompiled judges),
+and import-safety (``import langres.core`` must not import ``dspy``).
+"""
+
+import logging
+import subprocess
+import sys
+from pathlib import Path
+
+import dspy
+import pytest
+from dspy.utils.dummies import DummyLM
+
+from langres.core.models import CompanySchema, ERCandidate, PairwiseJudgement
+from langres.core.modules.dspy_judge import DSPyJudge, _clamp01, _pair_metric
+from langres.core.registry import get_component
+
+
+def _answers(n: int, *, match: str = "True", prob: str = "0.9") -> list[dict[str, str]]:
+    """``n`` canned JSONAdapter answers carrying the three signature output fields."""
+    return [{"reasoning": "same company", "match": match, "match_probability": prob}] * n
+
+
+def _candidate(left_id: str = "l1", right_id: str = "r1") -> ERCandidate[CompanySchema]:
+    return ERCandidate(
+        left=CompanySchema(id=left_id, name="Acme"),
+        right=CompanySchema(id=right_id, name="Acme Inc"),
+        blocker_name="test",
+    )
+
+
+def _dummy_judge(answers: list[dict[str, str]] | None = None) -> DSPyJudge[CompanySchema]:
+    return DSPyJudge(lm=DummyLM(answers or _answers(10)), entity_noun="company")
+
+
+# ---------------------------------------------------------------------------
+# Registration & config
+# ---------------------------------------------------------------------------
+
+
+def test_registered_under_dspy_judge_via_lazy_lookup() -> None:
+    """``get_component('dspy_judge')`` lazily imports+registers the class."""
+    assert get_component("dspy_judge") is DSPyJudge
+    assert DSPyJudge.type_name == "dspy_judge"
+
+
+def test_config_is_pure_and_excludes_lm_and_program() -> None:
+    """``config`` carries only model/temperature/entity_noun — never the LM/program."""
+    judge = DSPyJudge(lm=DummyLM([]), model="openrouter/z-ai/glm-5.2", entity_noun="product")
+    config = judge.config
+    assert set(config) == {"model", "temperature", "entity_noun"}
+    assert config == {
+        "model": "openrouter/z-ai/glm-5.2",
+        "temperature": 0.0,
+        "entity_noun": "product",
+    }
+    import json
+
+    json.dumps(config)  # must be JSON-serializable
+
+
+def test_explicit_program_is_used_as_is() -> None:
+    """An injected ``program`` is adopted verbatim (no fresh ChainOfThought built)."""
+    program = dspy.ChainOfThought("left, right -> match")
+    judge = DSPyJudge(lm=DummyLM([]), program=program)
+    assert judge._program is program
+
+
+def test_from_config_builds_fresh_uncompiled_judge() -> None:
+    """``from_config`` rebuilds an equivalent judge with a fresh, uncompiled program."""
+    original = _dummy_judge()
+    rebuilt = DSPyJudge.from_config(original.config)
+    assert rebuilt.config == original.config
+    assert rebuilt._lm is None  # LM is not persisted — built lazily
+    assert rebuilt._compiled is False
+
+
+def test_entity_noun_woven_into_signature_instructions() -> None:
+    """The domain noun is substituted into the program's signature instructions."""
+    judge = DSPyJudge(lm=DummyLM([]), entity_noun="restaurant")
+    instructions = judge._program.predict.signature.instructions
+    assert "restaurant" in instructions
+    assert "{entity_noun}" not in instructions
+
+
+# ---------------------------------------------------------------------------
+# forward
+# ---------------------------------------------------------------------------
+
+
+def test_forward_yields_judgement_with_score_equal_to_probability() -> None:
+    """forward emits a PairwiseJudgement whose score is the parsed match_probability."""
+    judge = _dummy_judge(_answers(4, prob="0.83"))
+    [judgement] = list(judge.forward(iter([_candidate("a", "b")])))
+    assert isinstance(judgement, PairwiseJudgement)
+    assert judgement.left_id == "a"
+    assert judgement.right_id == "b"
+    assert judgement.score == pytest.approx(0.83)
+    assert judgement.score_type == "prob_llm"
+    assert judgement.decision_step == "dspy_judgment"
+    assert judgement.reasoning == "same company"
+
+
+def test_forward_provenance_has_cost_and_token_keys() -> None:
+    """Provenance carries honest cost + token counts (0 under DummyLM = $0)."""
+    [judgement] = list(_dummy_judge().forward(iter([_candidate()])))
+    assert set(judgement.provenance) == {
+        "model",
+        "cost_usd",
+        "prompt_tokens",
+        "completion_tokens",
+    }
+    assert judgement.provenance["cost_usd"] == 0.0
+    assert judgement.provenance["prompt_tokens"] == 0
+    assert judgement.provenance["completion_tokens"] == 0
+
+
+def test_forward_parses_bool_and_float_outputs() -> None:
+    """DSPy typed outputs give a real bool ``match`` and float probability."""
+    judge = _dummy_judge(_answers(2, match="False", prob="0.12"))
+    [judgement] = list(judge.forward(iter([_candidate()])))
+    assert judgement.score == pytest.approx(0.12)
+
+
+def test_forward_clamps_probability_into_unit_range() -> None:
+    """An out-of-range probability is clamped to [0, 1] so PairwiseJudgement validates."""
+    judge = _dummy_judge(_answers(2, prob="1.7"))
+    [judgement] = list(judge.forward(iter([_candidate()])))
+    assert judgement.score == 1.0
+
+
+def test_forward_leaves_global_dspy_lm_untouched() -> None:
+    """``dspy.context`` is per-call — the global ``dspy.settings.lm`` is never set."""
+    before = dspy.settings.lm
+    list(_dummy_judge().forward(iter([_candidate()])))
+    assert dspy.settings.lm is before
+
+
+def test_forward_warns_on_uncompiled_program(caplog: pytest.LogCaptureFixture) -> None:
+    """Scoring with an uncompiled program warns so an untuned judge isn't silent."""
+    with caplog.at_level(logging.WARNING):
+        list(_dummy_judge().forward(iter([_candidate()])))
+    assert any("UNCOMPILED" in r.message for r in caplog.records)
+
+
+def test_forward_parse_failure_emits_low_confidence_judgement(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """A DSPy parse error yields a 0.5 judgement tagged ``dspy_parse_error`` (never a skip)."""
+    judge = DSPyJudge(lm=DummyLM([{"unexpected": "shape"}]), entity_noun="company")
+    with caplog.at_level(logging.WARNING):
+        [judgement] = list(judge.forward(iter([_candidate("x", "y")])))
+    assert judgement.score == 0.5
+    assert judgement.decision_step == "dspy_parse_error"
+    assert judgement.reasoning is None
+    assert "error" in judgement.provenance
+    assert judgement.provenance["cost_usd"] == 0.0
+    assert any("parse failure" in r.message for r in caplog.records)
+
+
+# ---------------------------------------------------------------------------
+# Lazy LM + cost seam
+# ---------------------------------------------------------------------------
+
+
+def test_get_lm_builds_dspy_lm_lazily(mocker) -> None:  # type: ignore[no-untyped-def]
+    """With no injected LM, ``_get_lm`` builds a ``dspy.LM(model, cache=False)`` once."""
+    sentinel = object()
+    build = mocker.patch("dspy.LM", return_value=sentinel)
+    judge: DSPyJudge[CompanySchema] = DSPyJudge(model="openrouter/z-ai/glm-5.2")
+    assert judge._lm is None  # not built at construction
+    assert judge._get_lm() is sentinel
+    assert judge._get_lm() is sentinel  # cached
+    build.assert_called_once_with("openrouter/z-ai/glm-5.2", cache=False)
+
+
+def test_injected_lm_is_used_and_never_rebuilt(mocker) -> None:  # type: ignore[no-untyped-def]
+    """An injected LM wins — ``dspy.LM`` is never constructed."""
+    build = mocker.patch("dspy.LM")
+    lm = DummyLM([])
+    judge = DSPyJudge(lm=lm)
+    assert judge._get_lm() is lm
+    build.assert_not_called()
+
+
+def test_cost_usd_uses_pinned_price_seam() -> None:
+    """The honest-cost seam multiplies tokens by the injectable per-1k price."""
+    judge = _dummy_judge()
+    assert judge._cost_usd(1000, 500) == 0.0  # default price 0.0 -> $0
+    judge.price_per_1k_tokens = 2.0
+    assert judge._cost_usd(1000, 500) == pytest.approx(3.0)
+
+
+# ---------------------------------------------------------------------------
+# Small unit helpers
+# ---------------------------------------------------------------------------
+
+
+def test_clamp01_bounds() -> None:
+    assert _clamp01(-0.5) == 0.0
+    assert _clamp01(0.4) == 0.4
+    assert _clamp01(2.0) == 1.0
+
+
+def test_pair_metric_compares_match_bool() -> None:
+    example = dspy.Example(match=True)
+    assert _pair_metric(example, dspy.Prediction(match=True)) is True
+    assert _pair_metric(example, dspy.Prediction(match=False)) is False
+
+
+def test_inspect_scores_returns_report() -> None:
+    """``inspect_scores`` delegates to the shared report helper."""
+    judgements = list(_dummy_judge().forward(iter([_candidate()])))
+    report = _dummy_judge().inspect_scores(judgements)
+    assert report.total_judgements == 1
+
+
+# ---------------------------------------------------------------------------
+# Compilation
+# ---------------------------------------------------------------------------
+
+
+def _trainset(n: int = 4) -> list[dspy.Example]:
+    return [
+        dspy.Example(left="Acme", right="Acme Inc", match=True).with_inputs("left", "right")
+        for _ in range(n)
+    ]
+
+
+def test_compile_bootstrap_populates_demos_and_sets_flag() -> None:
+    """``compile(optimizer='bootstrap')`` tunes the program (adds demos) in place."""
+    judge = _dummy_judge(_answers(50))
+    returned = judge.compile(_trainset(), optimizer="bootstrap")
+    assert returned is judge  # chainable
+    assert judge._compiled is True
+    demos = sum(len(p.demos) for _, p in judge._program.named_predictors())
+    assert demos > 0
+
+
+def test_compile_unknown_optimizer_raises() -> None:
+    judge = _dummy_judge(_answers(10))
+    with pytest.raises(ValueError, match="unknown optimizer"):
+        judge.compile(_trainset(), optimizer="nope")
+
+
+# ---------------------------------------------------------------------------
+# State round-trip
+# ---------------------------------------------------------------------------
+
+
+def test_save_state_load_state_restores_compiled_program(tmp_path: Path) -> None:
+    """A compiled program persists to ``program.json`` and reloads with its demos."""
+    judge = _dummy_judge(_answers(50))
+    judge.compile(_trainset(), optimizer="bootstrap")
+    trained_demos = sum(len(p.demos) for _, p in judge._program.named_predictors())
+
+    judge.save_state(tmp_path)
+    assert (tmp_path / "program.json").exists()
+
+    fresh = DSPyJudge.from_config(judge.config)
+    assert fresh._compiled is False
+    fresh.load_state(tmp_path)
+    assert fresh._compiled is True  # a loaded program is a tuned program
+    restored_demos = sum(len(p.demos) for _, p in fresh._program.named_predictors())
+    assert restored_demos == trained_demos
+
+
+def test_resolver_with_dspy_judge_saves_and_loads(tmp_path: Path) -> None:
+    """A Resolver with a DSPyJudge in the module slot round-trips in-process."""
+    from langres.core import AllPairsBlocker, Clusterer, Resolver
+
+    judge = _dummy_judge(_answers(50))
+    judge.compile(_trainset(), optimizer="bootstrap")
+    resolver = Resolver(
+        blocker=AllPairsBlocker(schema=CompanySchema),
+        comparator=None,
+        module=judge,
+        clusterer=Clusterer(threshold=0.7),
+    )
+    resolver.save(tmp_path)
+
+    import json
+
+    manifest = json.loads((tmp_path / "resolver.json").read_text())
+    module_spec = next(c for c in manifest["components"] if c["slot"] == "module")
+    assert module_spec["type_name"] == "dspy_judge"
+    assert "lm" not in module_spec["config"]
+    assert (tmp_path / "module" / "program.json").exists()
+
+    reloaded = Resolver.load(tmp_path)
+    assert isinstance(reloaded.module, DSPyJudge)
+    assert reloaded.module.config == judge.config
+    assert reloaded.module._compiled is True
+
+
+@pytest.mark.slow
+@pytest.mark.parametrize("compiled", [True, False])
+def test_resolver_load_dspy_judge_in_fresh_process(tmp_path: Path, compiled: bool) -> None:
+    """A clean process can ``Resolver.load`` a dspy_judge artifact via ``langres.core`` alone.
+
+    Regression for the lazy-registration path: ``@register('dspy_judge')`` only
+    fires when ``langres.core.modules.dspy_judge`` is imported, and ``langres.core``
+    deliberately does NOT import it (that would import ``dspy``). ``get_component``
+    imports it on demand, so a fresh process that only does ``from langres.core
+    import Resolver`` still resolves the type. Covers both a compiled and an
+    uncompiled judge.
+    """
+    from langres.core import AllPairsBlocker, Clusterer, Resolver
+
+    judge = _dummy_judge(_answers(50))
+    if compiled:
+        judge.compile(_trainset(), optimizer="bootstrap")
+    resolver = Resolver(
+        blocker=AllPairsBlocker(schema=CompanySchema),
+        comparator=None,
+        module=judge,
+        clusterer=Clusterer(threshold=0.7),
+    )
+    resolver.save(tmp_path)
+
+    result = subprocess.run(
+        [
+            sys.executable,
+            "-c",
+            (
+                "import sys; from langres.core import Resolver; "
+                f"r = Resolver.load(r'{tmp_path}'); "
+                "assert type(r.module).__name__ == 'DSPyJudge'; "
+                "print('OK')"
+            ),
+        ],
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode == 0, (
+        "fresh-process Resolver.load failed for a dspy_judge artifact.\n"
+        f"STDOUT:\n{result.stdout}\nSTDERR:\n{result.stderr}"
+    )
+    assert "UnknownComponentType" not in result.stderr
+
+
+# ---------------------------------------------------------------------------
+# Import-safety
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.slow
+def test_import_langres_core_does_not_import_dspy() -> None:
+    """``import langres.core`` must NOT pull in ``dspy`` (it opens a disk cache).
+
+    Run in a fresh subprocess so a prior in-process ``dspy`` import can't mask the
+    leak (this test module imports dspy itself).
+    """
+    result = subprocess.run(
+        [
+            sys.executable,
+            "-c",
+            "import sys, langres.core; "
+            "assert 'dspy' not in sys.modules, 'dspy leaked into import langres.core'; "
+            "print('OK')",
+        ],
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode == 0, (
+        f"import-safety check failed.\nSTDOUT:\n{result.stdout}\nSTDERR:\n{result.stderr}"
+    )

--- a/tests/test_methods.py
+++ b/tests/test_methods.py
@@ -36,6 +36,7 @@ from langres.core.judges.embedding_score import EmbeddingScoreJudge
 from langres.core.judges.weighted_average import WeightedAverageJudge
 from langres.core.models import CompanySchema, ERCandidate, PairwiseJudgement
 from langres.core.modules.cascade import CascadeModule
+from langres.core.modules.dspy_judge import DSPyJudge
 from langres.core.modules.llm_judge import LLMJudge
 from langres.core.modules.rapidfuzz import RapidfuzzModule
 from langres.core.resolver import Resolver
@@ -158,6 +159,13 @@ class _MockOpenAIClient:
         return _fake_response(self._content)
 
 
+def _dummy_lm() -> Any:
+    """A DSPy ``DummyLM`` for ``dspy_judge`` — the factory injects it as the LM (no spend)."""
+    from dspy.utils.dummies import DummyLM
+
+    return DummyLM([{"reasoning": "same", "match": "True", "match_probability": "0.9"}] * 20)
+
+
 class _ScriptedEmbeddingModel:
     """Cascade embedding double: pops a preset ``[left_vec, right_vec]`` per encode.
 
@@ -233,6 +241,9 @@ def test_unknown_method_raises() -> None:
         # ``client.chat.completions.create(...)`` (OpenAI-shaped).
         ("llm_judge", LLMJudge, False, _MockLiteLLMClient()),
         ("cascade", CascadeModule, False, _MockOpenAIClient()),
+        # ``dspy_judge`` takes a DSPy LM as its injected client (a ``DummyLM``
+        # here), distinct from the LiteLLM/OpenAI clients above.
+        ("dspy_judge", DSPyJudge, False, _dummy_lm()),
     ],
 )
 def test_factory_builds_valid_resolver(


### PR DESCRIPTION
Part of **M4** (integration branch `feat/m4-foundation`). The spine: a DSPy `ChainOfThought` pairwise judge that compiles against the gold set, runs into the `Resolver`, and serializes — validated entirely at $0 with `DummyLM`.

## What
- `src/langres/core/modules/dspy_judge.py` (new) — `@register("dspy_judge") DSPyJudge(Module)`: `PairwiseMatchSignature(left, right -> match: bool, match_probability: float, reasoning)`; per-call `dspy.context(lm=, track_usage=True)` (never global `settings.configure`); honest per-pair cost seam (tokens + `cost_usd`, price injectable — wires to `langres.clients.openrouter`); parse-failure guard (low-confidence, no silent skip); `compile(optimizer="bootstrap"|"mipro")`; `SerializableState` save/load of `program.json`; pure `config`.
- `src/langres/core/registry.py` — `_LAZY_COMPONENT_MODULES` hook so `get_component("dspy_judge")` imports on demand → **`import langres.core` never imports dspy** (asserted in a subprocess test).
- `src/langres/methods.py` — `dspy_judge` method + factory branch (injected client = a DSPy LM). `pyproject.toml` — mypy `dspy.*` override.
- `examples/m4_dspy_judge.py --smoke` ($0, DummyLM) — compile → eval → save → reload → identical scores.

## Verification (all $0)
- 53 passed; `dspy_judge.py` 99%, `methods.py` 100%, `registry.py` 96%; full suite 98.99% (gate 95%); `mypy` clean; `ruff` clean.
- Import-safety asserted (`dspy` not in `sys.modules` after `import langres.core`).
- `--smoke` round-trip OK, $0. `MIPROv2` path is `# pragma: no cover` (paid/non-deterministic, per plan).

Honest-cost `price_per_1k_tokens` is an injectable attr (default 0.0) with a TODO for the openrouter helper (PR #51) — intentional clean seam, no cross-branch import.