### PR TITLE
W0.1: three-verb API (link/dedupe, judge=auto, spend-capped presets)

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -4,7 +4,7 @@ on:
   push:
     branches: [main]
   pull_request:
-    branches: [main, feat/m4-foundation]
+    branches: [main, feat/m4-foundation, feat/m5-foundation]
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -4,7 +4,7 @@ on:
   push:
     branches: [main]
   pull_request:
-    branches: [main, feat/m4-foundation]
+    branches: [main, feat/m4-foundation, feat/m5-foundation]
   schedule:
     # Weekly on Monday at 08:00 UTC
     - cron: "0 8 * * 1"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,7 +4,7 @@ on:
   push:
     branches: [main]
   pull_request:
-    branches: [main, feat/m4-foundation]
+    branches: [main, feat/m4-foundation, feat/m5-foundation]
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/README.md
+++ b/README.md
@@ -104,6 +104,39 @@ pip install langres
 
 ---
 
+## Quickstart: `link()` and `dedupe()`
+
+Unlike the rest of this README, this section is **working code today**. The
+three-verb DX layer (`langres.link`, `langres.dedupe`) dedupes a batch of
+records with zero labels in a handful of lines, no schema required:
+
+```python
+from langres import dedupe
+
+records = [
+    {"id": "1", "name": "Acme Corporation", "city": "New York"},
+    {"id": "2", "name": "Acme Corp", "city": "New York"},
+    {"id": "3", "name": "Totally Different Co", "city": "Chicago"},
+]
+
+result = dedupe(records, judge="string", threshold=0.6)
+# -> [{'1', '2'}], result.judge_used == "string"
+# (singletons like "3" are dropped -- only multi-record clusters are returned)
+```
+
+By default `judge="auto"` picks a real LLM judge when `OPENROUTER_API_KEY` or
+`OPENAI_API_KEY` is set (else it falls back to the zero-spend `"string"`
+judge above), and every judge -- including the free ones -- runs under a
+default $1 spend cap (override with `budget_usd=`). See
+[`examples/quickstart_verbs.py`](examples/quickstart_verbs.py) for a runnable,
+fully offline walkthrough (`uv run python examples/quickstart_verbs.py`), and
+note that threshold semantics differ across judges (a string-similarity
+`"heuristic"` score and an LLM `"prob_llm"` score are not comparable on the
+same 0..1 cut) -- `threshold=None`, the default, resolves to a sane per-judge
+default.
+
+---
+
 ## Planned Usage
 
 The examples below show the intended API design. **These are not yet functional.**

--- a/examples/quickstart_verbs.py
+++ b/examples/quickstart_verbs.py
@@ -1,0 +1,52 @@
+"""Quickstart: dedupe records with zero labels in a handful of lines.
+
+Offline by default (D4): no API key is required, no network call is made, and
+no embedding model is downloaded -- this toy dataset (N <= 100) resolves
+through langres.dedupe's default zero-spend "string" judge. If
+OPENROUTER_API_KEY or OPENAI_API_KEY is set, this prints an "upgrade" note
+(it does NOT actually spend money -- see docs/EXPERIMENTS.md for a real
+LLM-judge walkthrough).
+
+Run it:
+    uv run python examples/quickstart_verbs.py
+"""
+
+import os
+
+from langres import dedupe
+
+# --- the ~10 lines that matter: dedupe a batch of records, zero labels ---
+records = [
+    {"id": "1", "name": "Acme Corporation", "city": "New York"},
+    {"id": "2", "name": "Acme Corp", "city": "New York"},
+    {"id": "3", "name": "Totally Different Co", "city": "Chicago"},
+    {"id": "4", "name": "Totally Different Company", "city": "Chicago"},
+    {"id": "5", "name": "Unrelated Bakery", "city": "Miami"},
+]
+
+result = dedupe(records, judge="string", threshold=0.6)
+
+for cluster in result:
+    print(sorted(cluster))
+# --- end of the dedupe walkthrough ---
+
+print(
+    f"\n{len(result)} cluster(s) found, judge_used={result.judge_used!r}, "
+    f"score_type={result.score_type!r}"
+)
+
+if os.environ.get("OPENROUTER_API_KEY") or os.environ.get("OPENAI_API_KEY"):
+    print(
+        "\nAn OPENROUTER_API_KEY/OPENAI_API_KEY is set: dedupe(records) with the "
+        'default judge="auto" would pick a real LLM judge instead of the '
+        "zero-spend 'string' one. This example pins judge=\"string\" deliberately "
+        'to stay free and fully offline -- drop that kwarg (or pass judge="auto") '
+        "to try it, spend-capped at $1 by default (budget_usd=)."
+    )
+else:
+    print(
+        "\nNo OPENROUTER_API_KEY/OPENAI_API_KEY set: dedupe(records) with the "
+        "default judge=\"auto\" would fall back to this same zero-spend 'string' "
+        "judge (with one warning). Set one of those env vars to try a real LLM "
+        "judge -- it runs under a $1 default spend cap (budget_usd=)."
+    )

--- a/src/langres/__init__.py
+++ b/src/langres/__init__.py
@@ -1,13 +1,24 @@
 """
 langres: A composable entity resolution framework.
 
-This package provides a two-layer API for entity resolution:
-- langres.core: Low-level primitives for custom pipelines
-- langres.tasks: High-level task runners for common use cases (coming soon)
+This package provides:
+- ``link`` / ``dedupe``: the three-verb DX layer (schema-optional, judge="auto"
+  by default, spend-capped) -- see ``langres.verbs``.
+- ``langres.core``: Low-level primitives for custom pipelines (``Resolver``,
+  ``Blocker``, ``Module``, ``Clusterer``, ...).
 """
 
-from langres.core import CompanySchema, ERCandidate, PairwiseJudgement
+from langres.core import CompanySchema, ERCandidate, PairwiseJudgement, Resolver
+from langres.verbs import LinkVerdict, dedupe, link
 
-__all__ = ["CompanySchema", "ERCandidate", "PairwiseJudgement"]
+__all__ = [
+    "CompanySchema",
+    "ERCandidate",
+    "LinkVerdict",
+    "PairwiseJudgement",
+    "Resolver",
+    "dedupe",
+    "link",
+]
 
 __version__ = "0.1.0"

--- a/src/langres/clients/openrouter.py
+++ b/src/langres/clients/openrouter.py
@@ -60,6 +60,13 @@ PRICES_PER_1M: dict[str, tuple[float, float]] = {
 #: sequential run; a bounded timeout makes a stalled call fail fast and recover.
 DEFAULT_TIMEOUT_S = 60.0
 
+#: The OpenRouter route ``judge="auto"``/``judge="zero_shot_llm"`` default to
+#: when no model id is given -- ``core.presets.choose_auto_judge`` and
+#: ``Resolver.from_schema`` both need this literal. Defined once here (the
+#: dspy-free, cycle-safe layer both of those sit above) so the two call sites
+#: can't drift on the string.
+DEFAULT_OPENROUTER_MODEL = "openrouter/openai/gpt-4o-mini"
+
 
 # ---------------------------------------------------------------------------
 # Price pinning
@@ -290,7 +297,19 @@ def no_keepalive_http_client(timeout_s: float = DEFAULT_TIMEOUT_S) -> Any:
 
 
 class BudgetExceeded(RuntimeError):
-    """Raised by :meth:`SpendMonitor.check` when cumulative spend passes the budget."""
+    """Raised by :meth:`SpendMonitor.check` when cumulative spend passes the budget.
+
+    ``partial_judgements`` carries every judgement already produced (and paid
+    for) before the cap tripped (E9) -- populated by the catcher, not here
+    (see :class:`~langres.core.presets._SpendCappedModule`). Declared with a
+    default empty list so any future raiser is safe even if it never sets it,
+    and callers/mypy see the attribute without an ad hoc
+    ``# type: ignore[attr-defined]`` at the one call site that populates it.
+    """
+
+    def __init__(self, *args: object) -> None:
+        super().__init__(*args)
+        self.partial_judgements: list[PairwiseJudgement] = []
 
 
 class SpendMonitor:

--- a/src/langres/clients/openrouter.py
+++ b/src/langres/clients/openrouter.py
@@ -39,6 +39,17 @@ PRICES_PER_1M: dict[str, tuple[float, float]] = {
     "openrouter/z-ai/glm-5.2": (0.95, 3.00),
     "openrouter/z-ai/glm-4.6": (0.60, 2.20),
     "openrouter/openai/gpt-4o": (2.50, 10.00),
+    # OpenRouter path for judge="auto" (OPENROUTER_API_KEY set) — see
+    # langres.core.presets.choose_auto_judge. OpenRouter's own listing for this
+    # route isn't in LiteLLM's pricing table; conservative-high over OpenAI's
+    # published $0.15/$0.60 per-1M list price (litellm model_prices_and_context_
+    # window.json, "gpt-4o-mini", checked 2026-07) to absorb any provider markup.
+    "openrouter/openai/gpt-4o-mini": (0.20, 0.80),
+    # Direct-OpenAI path for judge="auto" (OPENAI_API_KEY set, no OPENROUTER_API_KEY)
+    # — see choose_auto_judge. Matches OpenAI's published gpt-5-mini list price
+    # exactly (litellm model_prices_and_context_window.json, "gpt-5-mini" and
+    # "openrouter/openai/gpt-5-mini" agree: $0.25/$2.00 per 1M, checked 2026-07).
+    "openai/gpt-5-mini": (0.25, 2.00),
     "openrouter/anthropic/claude-3.7-sonnet": (3.00, 15.00),
     "openrouter/anthropic/claude-3.5-sonnet": (3.00, 15.00),
     "openrouter/google/gemini-2.0-flash-001": (0.10, 0.40),
@@ -166,6 +177,41 @@ def per_token_worst_price(
     """
     in_per_1m, out_per_1m = _price_for(model, prices)
     return max(in_per_1m, out_per_1m) / 1_000_000.0
+
+
+def dspy_price_per_1k(
+    model: str, prices: Mapping[str, tuple[float, float]] = PRICES_PER_1M
+) -> float:
+    """Per-1k-token price for ``model`` from ``prices`` (0.0 if unknown).
+
+    ``DSPyJudge`` prices each pair as ``tokens/1000 * price_per_1k_tokens`` -- a
+    single blended per-1k rate over ``prompt + completion`` tokens -- so this
+    takes the worst-case (dearer of input/output) per-token price and scales it
+    to per-1k. Worst-case is the same price basis
+    :class:`~langres.core.benchmark.BudgetedModuleRunner` uses for its cap, so a
+    judge's self-reported cost and a live budget-stop agree.
+
+    Unknown models keep ``0.0`` (zero-spend/test runs stay free and never
+    crash), mirroring :func:`register_runtime_model_price` returning ``None``
+    for unknown ids -- rather than guessing a price.
+
+    This function lives here (not in ``langres.methods``, where it started) so
+    both ``langres.methods`` and ``langres.core.presets`` can import it without
+    creating a ``core -> methods -> core`` cycle -- this module is dspy-free and
+    layer-neutral, sitting below both.
+
+    Args:
+        model: The routing model id.
+        prices: Per-1M-token ``(input, output)`` price table. Defaults to
+            :data:`PRICES_PER_1M`.
+
+    Returns:
+        The worst-case per-1k-token price in USD, or ``0.0`` if ``model`` is
+        unknown to ``prices``.
+    """
+    if model not in prices:
+        return 0.0
+    return per_token_worst_price(model, prices) * 1_000.0
 
 
 def make_token_cost_track(

--- a/src/langres/clients/settings.py
+++ b/src/langres/clients/settings.py
@@ -12,6 +12,8 @@ class Settings(BaseSettings):
 
     Environment variables:
         OPENAI_API_KEY: OpenAI API key
+        OPENROUTER_API_KEY: OpenRouter API key (drives judge="auto" model
+            selection; see langres.core.presets.choose_auto_judge)
         WANDB_API_KEY: Weights & Biases API key
         WANDB_PROJECT: W&B project name (default: "langres")
         WANDB_ENTITY: W&B entity/team name (optional)
@@ -50,6 +52,7 @@ class Settings(BaseSettings):
 
     # OpenAI / LLM
     openai_api_key: str | None = None
+    openrouter_api_key: str | None = None
 
     # wandb (experiment tracking)
     wandb_api_key: str | None = None

--- a/src/langres/core/presets.py
+++ b/src/langres/core/presets.py
@@ -1,0 +1,450 @@
+"""Presets: resolve ``judge="auto"`` and assemble a spend-capped Resolver.
+
+This is the machinery behind the three-verb DX layer (:mod:`langres.verbs`):
+picking a judge from available API keys, building its scorer Module, wiring a
+blocker by dataset size, and wrapping the scorer in a hard spend cap. It sits
+strictly ABOVE :class:`~langres.core.resolver.Resolver` (which must not import
+back from here -- see ``Resolver.from_schema``'s own, deliberately duplicated,
+low-level judge switch) and BELOW :mod:`langres.verbs`:
+
+    verbs.py -> core/presets.py -> Resolver -> {Blocker, Comparator, Module, Clusterer}
+
+Nothing here is domain-specific: every function takes a Pydantic ``schema``
+type and works for any schema (see ``build_judge``'s ``"string"``/``"embedding"``
+branches, which derive their fields from the schema, never a hard-coded name).
+
+Threshold semantics differ across judges (E12): ``"heuristic"`` (string),
+``"sim_cos"`` (embedding), and ``"prob_llm"`` (zero_shot_llm) are three
+different score scales, so one hand-picked ``threshold=0.7`` is not
+comparable across them. :data:`_DEFAULT_THRESHOLDS` gives each judge kind its
+own sane default; pass ``threshold=`` explicitly to override, and calibrate a
+real one with :func:`~langres.core.calibration.derive_threshold` once you have
+labels.
+
+Spend cap (adopted CEO decision #8 + Eng E1/E9): every judge -- including the
+free ones -- is wrapped in :class:`_SpendCappedModule`, a small
+:class:`~langres.core.module.Module` that tallies each judgement's
+``provenance["cost_usd"]`` through a :class:`~langres.clients.openrouter.SpendMonitor`
+and raises :class:`~langres.clients.openrouter.BudgetExceeded` the moment
+cumulative spend would cross ``budget_usd`` (default
+:data:`DEFAULT_BUDGET_USD`). The exception carries every judgement already
+produced (and paid for) on ``.partial_judgements`` -- recover them with::
+
+    try:
+        result = dedupe(records, budget_usd=0.50)
+    except BudgetExceeded as exc:
+        already_scored = exc.partial_judgements  # list[PairwiseJudgement]
+        # e.g. cluster just those, or raise budget_usd and retry
+
+A resolver built here is NOT guaranteed ``save()``-able (the spend-cap wrapper
+has no ``type_name``): for a durable artifact, build the pipeline directly
+with ``Resolver.from_schema`` instead.
+"""
+
+from __future__ import annotations
+
+import warnings
+from typing import TYPE_CHECKING, Any, Literal, NamedTuple
+
+from pydantic import BaseModel
+
+from langres.clients.openrouter import BudgetExceeded, SpendMonitor, dspy_price_per_1k
+from langres.clients.settings import Settings
+from langres.core.blocker import Blocker
+from langres.core.blockers.all_pairs import AllPairsBlocker
+from langres.core.blockers.vector import VectorBlocker
+from langres.core.clusterer import Clusterer
+from langres.core.comparator import Comparator
+from langres.core.embeddings import SentenceTransformerEmbedder
+from langres.core.indexes.vector_index import FAISSIndex
+from langres.core.judges.embedding_score import EmbeddingScoreJudge
+from langres.core.judges.weighted_average import WeightedAverageJudge
+from langres.core.models import ERCandidate, PairwiseJudgement
+from langres.core.module import Module
+from langres.core.resolver import Resolver
+
+if TYPE_CHECKING:
+    from collections.abc import Iterator
+
+#: The judge names the verb layer understands, plus the "auto" meta-value that
+#: :func:`choose_auto_judge` resolves down to one of the other three.
+JudgeName = Literal["auto", "zero_shot_llm", "embedding", "string"]
+
+#: Default clusterer/match threshold per resolved judge kind (D3). Different
+#: ``score_type`` scales make one global constant meaningless; pass
+#: ``threshold=`` explicitly to override, or derive one from labels with
+#: :func:`~langres.core.calibration.derive_threshold`.
+_DEFAULT_THRESHOLDS: dict[str, float] = {
+    "string": 0.5,
+    "embedding": 0.5,
+    "zero_shot_llm": 0.7,
+}
+
+#: Default per-call spend cap for a presets-built judge (CEO decision #8),
+#: overridable via ``budget_usd=``. Zero-spend judges never approach it.
+DEFAULT_BUDGET_USD = 1.0
+
+#: ``AllPairsBlocker`` is used at or below this many records; above it,
+#: :func:`build_resolver` switches to a ``VectorBlocker`` (O(N*k) instead of
+#: O(N^2)). An embedding judge always uses the VectorBlocker regardless of N
+#: (it needs the index's similarity score to score on).
+_ALL_PAIRS_MAX_N = 100
+_VECTOR_K_NEIGHBORS = 10
+_VECTOR_MODEL_NAME = "all-MiniLM-L6-v2"
+
+#: judge="auto" model ids, keyed by which API key is present (choose_auto_judge).
+_OPENROUTER_MODEL = "openrouter/openai/gpt-4o-mini"
+_OPENAI_MODEL = "openai/gpt-5-mini"
+
+#: Static ``PairwiseJudgement.score_type`` each judge kind emits -- used as a
+#: fallback label when no judgement was actually produced (e.g. an empty or
+#: single-record ``dedupe()`` call short-circuits before scoring).
+_SCORE_TYPE_BY_JUDGE: dict[str, str] = {
+    "string": "heuristic",
+    "embedding": "sim_cos",
+    "zero_shot_llm": "prob_llm",
+}
+
+#: Rough, deliberately worst-case-biased token count for the pre-scoring cost
+#: estimate (``notice_pre_scoring_cost``). The real, metered cost is what the
+#: spend cap actually enforces per pair as scoring happens -- this constant
+#: only sizes the upfront heads-up line.
+_ESTIMATED_TOKENS_PER_PAIR = 500
+
+
+def _notice(message: str) -> None:
+    """Emit a user-visible notice via ``warnings.warn`` (D2).
+
+    ``logger.info`` is invisible under default logging config, so both the
+    auto-judge fallback notice and the pre-scoring cost line go through this
+    one channel instead -- tests assert on it with ``pytest.warns``.
+    """
+    warnings.warn(message, stacklevel=3)
+
+
+def choose_auto_judge(settings: Settings) -> tuple[JudgeName, str | None, str | None]:
+    """Resolve ``judge="auto"`` from available API keys.
+
+    ``OPENROUTER_API_KEY`` set -> the OpenRouter gpt-4o-mini route;
+    else ``OPENAI_API_KEY`` set -> the direct-OpenAI gpt-5-mini route;
+    else -> the zero-spend ``"string"`` judge, with one notice (E1: a
+    candidate paid judge whose price is unpinned -- $0, unmetered -- is also
+    refused down to ``"string"``, since a blind cap is no cap at all).
+
+    Args:
+        settings: Loaded :class:`~langres.clients.settings.Settings` (reads
+            ``openrouter_api_key`` / ``openai_api_key``).
+
+    Returns:
+        ``(resolved_judge, model, fallback_reason)`` -- ``model`` is the
+        model id to use when ``resolved_judge == "zero_shot_llm"`` (``None``
+        otherwise); ``fallback_reason`` is set (and a notice already emitted)
+        only when resolution fell back to ``"string"``.
+    """
+    model: str | None
+    if settings.openrouter_api_key:
+        model = _OPENROUTER_MODEL
+    elif settings.openai_api_key:
+        model = _OPENAI_MODEL
+    else:
+        model = None
+
+    if model is not None and dspy_price_per_1k(model) > 0.0:
+        return "zero_shot_llm", model, None
+
+    if model is None:
+        reason = (
+            "judge=\"auto\": no OPENROUTER_API_KEY or OPENAI_API_KEY is set, so "
+            "falling back to the zero-spend 'string' judge. Set one of those "
+            "env vars to use an LLM judge, and calibrate its threshold with "
+            "langres.core.calibration.derive_threshold once you have labels."
+        )
+    else:
+        reason = (
+            f"judge=\"auto\": the selected model {model!r} has no pinned price in "
+            "langres.clients.openrouter.PRICES_PER_1M, so its spend cap would be "
+            "blind; falling back to the zero-spend 'string' judge. Pass "
+            "judge='zero_shot_llm' explicitly to use it anyway, or pin a price."
+        )
+    _notice(reason)
+    return "string", None, reason
+
+
+def build_judge(
+    judge: JudgeName | Module[Any],
+    schema: type[BaseModel],
+    *,
+    model: str | None = None,
+    entity_noun: str = "entity",
+) -> Module[Any]:
+    """Build the scorer Module for a resolved ``judge``.
+
+    Args:
+        judge: ``"zero_shot_llm"`` / ``"embedding"`` / ``"string"``, or a
+            ``Module`` instance passed through verbatim -- the escape hatch
+            (and the ``DummyLM``-injected-``DSPyJudge`` zero-spend test seam).
+            ``"auto"`` is NOT resolved here; call :func:`choose_auto_judge`
+            first (:func:`resolve_judge` does this).
+        schema: The entity schema (drives ``"string"``'s comparator and
+            ``"zero_shot_llm"``'s entity rendering). Works for ANY schema.
+        model: Model id for ``"zero_shot_llm"``. Defaults to the OpenRouter
+            gpt-4o-mini route when omitted.
+        entity_noun: Domain noun woven into the LLM judge's prompt.
+
+    Returns:
+        A ready (uncapped) scorer Module.
+
+    Raises:
+        ValueError: If ``judge`` is an unrecognized string (including
+            ``"auto"``, which only :func:`choose_auto_judge`/:func:`resolve_judge`
+            resolve).
+    """
+    if isinstance(judge, Module):
+        return judge
+    if judge == "string":
+        comparator = Comparator.from_schema(schema)
+        return WeightedAverageJudge(feature_specs=comparator.feature_specs)
+    if judge == "embedding":
+        return EmbeddingScoreJudge()
+    if judge == "zero_shot_llm":
+        # Lazy: dspy must stay out of sys.modules unless a zero_shot_llm judge
+        # is actually chosen (mirrors langres.methods._make_module_builder).
+        from langres.core.modules.dspy_judge import DSPyJudge
+
+        resolved_model = model or _OPENROUTER_MODEL
+        dspy_module: DSPyJudge[Any] = DSPyJudge(model=resolved_model, entity_noun=entity_noun)
+        dspy_module.price_per_1k_tokens = dspy_price_per_1k(resolved_model)
+        return dspy_module
+    raise ValueError(
+        f"unknown judge {judge!r}; choose one of 'zero_shot_llm', 'embedding', "
+        "'string', 'auto', or pass a Module instance directly"
+    )
+
+
+class _SpendCappedModule(Module[Any]):
+    """Wrap a Module, hard-stopping the moment cumulative cost crosses a budget.
+
+    Reuses :class:`~langres.clients.openrouter.SpendMonitor` for the tally +
+    threshold check, per pair, and re-raises its
+    :class:`~langres.clients.openrouter.BudgetExceeded` with every judgement
+    already produced (and paid for) attached as ``.partial_judgements`` (E9;
+    mirrors :class:`~langres.core.benchmark.BlindCostError`'s "set by the
+    catcher, not at raise time" pattern).
+
+    Deliberately NOT :class:`~langres.core.benchmark.BudgetedModuleRunner`:
+    that runner *silently truncates* past its soft cap (correct for the
+    benchmark harness, wrong here -- a verb call must raise, never silently
+    hand back a partially-scored, partially-clustered result).
+    """
+
+    def __init__(self, module: Module[Any], *, budget_usd: float) -> None:
+        self._module = module
+        self._budget_usd = budget_usd
+
+    def forward(self, candidates: Iterator[ERCandidate[Any]]) -> Iterator[PairwiseJudgement]:
+        monitor = SpendMonitor(budget_usd=self._budget_usd)
+        produced: list[PairwiseJudgement] = []
+        for judgement in self._module.forward(candidates):
+            produced.append(judgement)
+            cost = judgement.provenance.get("cost_usd", 0.0)
+            monitor.add(float(cost) if cost is not None else 0.0)
+            try:
+                monitor.check()
+            except BudgetExceeded as exc:
+                exc.partial_judgements = list(produced)  # type: ignore[attr-defined]
+                raise
+            yield judgement
+
+    def inspect_scores(
+        self, judgements: list[PairwiseJudgement], sample_size: int = 10
+    ) -> Any:
+        return self._module.inspect_scores(judgements, sample_size)
+
+
+class ResolvedModule(NamedTuple):
+    """:func:`resolve_judge`'s return: the capped scorer plus what was resolved."""
+
+    module: Module[Any]
+    judge_used: str
+    model: str | None
+    fallback_reason: str | None
+
+
+def resolve_judge(
+    judge: JudgeName | Module[Any],
+    schema: type[BaseModel],
+    *,
+    model: str | None = None,
+    entity_noun: str = "entity",
+    budget_usd: float | None = None,
+) -> ResolvedModule:
+    """Resolve ``judge`` (including ``"auto"``) to a spend-capped scorer Module.
+
+    Args:
+        judge: ``"auto"``, one of the other :data:`JudgeName` values, or a
+            ``Module`` instance (the escape hatch -- reported as
+            ``judge_used="custom"``).
+        schema: The entity schema.
+        model: Model id override for ``"zero_shot_llm"`` (ignored otherwise).
+        entity_noun: Domain noun for the LLM judge's prompt.
+        budget_usd: Spend cap override; defaults to :data:`DEFAULT_BUDGET_USD`.
+
+    Returns:
+        A :class:`ResolvedModule` with the capped module, the resolved judge
+        name, the resolved model (only for ``"zero_shot_llm"``), and any
+        auto-fallback reason.
+    """
+    fallback_reason: str | None = None
+    resolved_model = model
+
+    if isinstance(judge, Module):
+        judge_used = "custom"
+        judge_kind: JudgeName | Module[Any] = judge
+    elif judge == "auto":
+        resolved_kind, resolved_model, fallback_reason = choose_auto_judge(Settings())
+        judge_kind = resolved_kind
+        judge_used = resolved_kind
+    else:
+        judge_kind = judge
+        judge_used = judge
+
+    if judge_used == "zero_shot_llm" and resolved_model is None:
+        resolved_model = _OPENROUTER_MODEL
+
+    built = build_judge(judge_kind, schema, model=resolved_model, entity_noun=entity_noun)
+    capped_budget = DEFAULT_BUDGET_USD if budget_usd is None else budget_usd
+    capped = _SpendCappedModule(built, budget_usd=capped_budget)
+    return ResolvedModule(capped, judge_used, resolved_model, fallback_reason)
+
+
+def _text_field_extractor(schema: type[BaseModel]) -> Any:
+    """Concatenate every comparable string field into one blocking text.
+
+    Schema-agnostic: derives the field list from
+    :meth:`~langres.core.comparator.Comparator.from_schema` (every
+    ``str | None`` field except ``id``) rather than assuming a field named
+    ``"name"`` or similar.
+    """
+    field_names = [spec.name for spec in Comparator.from_schema(schema).feature_specs]
+
+    def extract(entity: Any) -> str:
+        parts = [str(getattr(entity, name)) for name in field_names if getattr(entity, name, None)]
+        return " ".join(parts)
+
+    return extract
+
+
+def _build_vector_blocker(schema: type[BaseModel]) -> VectorBlocker[Any]:
+    """Build a ``VectorBlocker`` (MiniLM + FAISS cosine) for ``schema``."""
+    embedder = SentenceTransformerEmbedder(_VECTOR_MODEL_NAME)
+    index = FAISSIndex(embedder=embedder, metric="cosine")
+    return VectorBlocker(
+        vector_index=index,
+        schema=schema,
+        text_field_extractor=_text_field_extractor(schema),
+        k_neighbors=_VECTOR_K_NEIGHBORS,
+    )
+
+
+def build_embedding_candidate(
+    schema: type[BaseModel], left: dict[str, Any], right: dict[str, Any]
+) -> ERCandidate[Any]:
+    """Build the one ``ERCandidate`` for a ``judge="embedding"`` pair, scored.
+
+    Used by ``langres.verbs.link`` (a single pair -- no blocking needed):
+    embeds both records' blocking text and attaches the cosine similarity via
+    the same ``VectorBlocker``/FAISS path :func:`build_resolver` uses for
+    ``dedupe()``, so the two verbs score embeddings identically.
+    """
+    blocker = _build_vector_blocker(schema)
+    entities = [blocker.schema_factory(record) for record in (left, right)]
+    texts = [blocker.text_field_extractor(entity) for entity in entities]
+    blocker.vector_index.create_index(texts)
+    return next(blocker.stream([left, right]))
+
+
+def _estimate_n_pairs(n_records: int, *, use_vector: bool) -> int:
+    """Worst-case pair-count estimate for the pre-scoring cost notice."""
+    if use_vector:
+        return n_records * _VECTOR_K_NEIGHBORS
+    return n_records * (n_records - 1) // 2
+
+
+def notice_pre_scoring_cost(model: str, n_pairs: int) -> None:
+    """Emit the "about to spend money" notice before any paid scoring (D2).
+
+    ``est_cost`` is a rough, worst-case-biased estimate
+    (:data:`_ESTIMATED_TOKENS_PER_PAIR`) -- the spend cap
+    (:class:`_SpendCappedModule`) meters and enforces the REAL cost live, per
+    pair, as scoring happens.
+    """
+    price_per_1k = dspy_price_per_1k(model)
+    est_cost = n_pairs * (_ESTIMATED_TOKENS_PER_PAIR / 1000.0) * price_per_1k
+    _notice(f"scoring ~{n_pairs} pairs with {model!r}, est. cost ${est_cost:.4f}")
+
+
+class ResolvedJudge(NamedTuple):
+    """:func:`build_resolver`'s return: the pipeline plus what was resolved."""
+
+    resolver: Resolver
+    judge_used: str
+    score_type: str
+    fallback_reason: str | None
+
+
+def build_resolver(
+    schema: type[BaseModel],
+    *,
+    judge: JudgeName | Module[Any],
+    model: str | None,
+    entity_noun: str,
+    threshold: float | None,
+    n_records: int,
+    budget_usd: float | None = None,
+) -> ResolvedJudge:
+    """Assemble a spend-capped Resolver for ``dedupe()``.
+
+    Blocker rule: an embedding judge always uses a ``VectorBlocker`` (it needs
+    the index's similarity score); every other judge uses ``AllPairsBlocker``
+    at ``n_records <= 100`` and a ``VectorBlocker`` above it (O(N*k) instead of
+    O(N^2)).
+
+    Args:
+        schema: The entity schema (any Pydantic model with an ``id`` field).
+        judge: ``"auto"``, another :data:`JudgeName`, or a ``Module`` instance.
+        model: Model id override for ``"zero_shot_llm"``.
+        entity_noun: Domain noun for the LLM judge's prompt.
+        threshold: Clusterer threshold; ``None`` resolves to the judge's
+            default (:data:`_DEFAULT_THRESHOLDS`, D3).
+        n_records: Size of the batch about to be resolved (drives the blocker
+            choice and the pre-scoring cost estimate).
+        budget_usd: Spend cap override; defaults to :data:`DEFAULT_BUDGET_USD`.
+
+    Returns:
+        A :class:`ResolvedJudge` with the assembled Resolver and judge metadata.
+    """
+    resolved = resolve_judge(
+        judge, schema, model=model, entity_noun=entity_noun, budget_usd=budget_usd
+    )
+
+    use_vector = resolved.judge_used == "embedding" or n_records > _ALL_PAIRS_MAX_N
+    blocker: Blocker[Any] = (
+        _build_vector_blocker(schema) if use_vector else AllPairsBlocker(schema=schema)
+    )
+    comparator = Comparator.from_schema(schema) if resolved.judge_used == "string" else None
+
+    if resolved.judge_used == "zero_shot_llm" and resolved.model is not None:
+        n_pairs_est = _estimate_n_pairs(n_records, use_vector=use_vector)
+        notice_pre_scoring_cost(resolved.model, n_pairs_est)
+
+    resolved_threshold = (
+        _DEFAULT_THRESHOLDS.get(resolved.judge_used, 0.5) if threshold is None else threshold
+    )
+    resolver = Resolver(
+        blocker=blocker,
+        comparator=comparator,
+        module=resolved.module,
+        clusterer=Clusterer(threshold=resolved_threshold),
+    )
+    score_type = _SCORE_TYPE_BY_JUDGE.get(resolved.judge_used, "unknown")
+    return ResolvedJudge(resolver, resolved.judge_used, score_type, resolved.fallback_reason)

--- a/src/langres/core/presets.py
+++ b/src/langres/core/presets.py
@@ -48,7 +48,12 @@ from typing import TYPE_CHECKING, Any, Literal, NamedTuple
 
 from pydantic import BaseModel
 
-from langres.clients.openrouter import BudgetExceeded, SpendMonitor, dspy_price_per_1k
+from langres.clients.openrouter import (
+    DEFAULT_OPENROUTER_MODEL,
+    BudgetExceeded,
+    SpendMonitor,
+    dspy_price_per_1k,
+)
 from langres.clients.settings import Settings
 from langres.core.blocker import Blocker
 from langres.core.blockers.all_pairs import AllPairsBlocker
@@ -93,7 +98,10 @@ _VECTOR_K_NEIGHBORS = 10
 _VECTOR_MODEL_NAME = "all-MiniLM-L6-v2"
 
 #: judge="auto" model ids, keyed by which API key is present (choose_auto_judge).
-_OPENROUTER_MODEL = "openrouter/openai/gpt-4o-mini"
+#: ``_OPENROUTER_MODEL`` aliases the shared constant (defined once in
+#: ``clients.openrouter`` -- also used by ``Resolver.from_schema``) so the two
+#: layers can't drift on the literal.
+_OPENROUTER_MODEL = DEFAULT_OPENROUTER_MODEL
 _OPENAI_MODEL = "openai/gpt-5-mini"
 
 #: Static ``PairwiseJudgement.score_type`` each judge kind emits -- used as a
@@ -251,7 +259,7 @@ class _SpendCappedModule(Module[Any]):
             try:
                 monitor.check()
             except BudgetExceeded as exc:
-                exc.partial_judgements = list(produced)  # type: ignore[attr-defined]
+                exc.partial_judgements = list(produced)
                 raise
             yield judgement
 

--- a/src/langres/core/presets.py
+++ b/src/langres/core/presets.py
@@ -154,14 +154,14 @@ def choose_auto_judge(settings: Settings) -> tuple[JudgeName, str | None, str | 
 
     if model is None:
         reason = (
-            "judge=\"auto\": no OPENROUTER_API_KEY or OPENAI_API_KEY is set, so "
+            'judge="auto": no OPENROUTER_API_KEY or OPENAI_API_KEY is set, so '
             "falling back to the zero-spend 'string' judge. Set one of those "
             "env vars to use an LLM judge, and calibrate its threshold with "
             "langres.core.calibration.derive_threshold once you have labels."
         )
     else:
         reason = (
-            f"judge=\"auto\": the selected model {model!r} has no pinned price in "
+            f'judge="auto": the selected model {model!r} has no pinned price in '
             "langres.clients.openrouter.PRICES_PER_1M, so its spend cap would be "
             "blind; falling back to the zero-spend 'string' judge. Pass "
             "judge='zero_shot_llm' explicitly to use it anyway, or pin a price."
@@ -202,7 +202,7 @@ def build_judge(
     if isinstance(judge, Module):
         return judge
     if judge == "string":
-        comparator = Comparator.from_schema(schema)
+        comparator: Comparator[Any] = Comparator.from_schema(schema)
         return WeightedAverageJudge(feature_specs=comparator.feature_specs)
     if judge == "embedding":
         return EmbeddingScoreJudge()
@@ -255,9 +255,7 @@ class _SpendCappedModule(Module[Any]):
                 raise
             yield judgement
 
-    def inspect_scores(
-        self, judgements: list[PairwiseJudgement], sample_size: int = 10
-    ) -> Any:
+    def inspect_scores(self, judgements: list[PairwiseJudgement], sample_size: int = 10) -> Any:
         return self._module.inspect_scores(judgements, sample_size)
 
 
@@ -431,7 +429,9 @@ def build_resolver(
     blocker: Blocker[Any] = (
         _build_vector_blocker(schema) if use_vector else AllPairsBlocker(schema=schema)
     )
-    comparator = Comparator.from_schema(schema) if resolved.judge_used == "string" else None
+    comparator: Comparator[Any] | None = (
+        Comparator.from_schema(schema) if resolved.judge_used == "string" else None
+    )
 
     if resolved.judge_used == "zero_shot_llm" and resolved.model is not None:
         n_pairs_est = _estimate_n_pairs(n_records, use_vector=use_vector)

--- a/src/langres/core/presets.py
+++ b/src/langres/core/presets.py
@@ -130,6 +130,11 @@ def _notice(message: str) -> None:
     warnings.warn(message, stacklevel=3)
 
 
+def _effective_budget(budget_usd: float | None) -> float:
+    """Resolve a caller's ``budget_usd=None`` to :data:`DEFAULT_BUDGET_USD` (DRY)."""
+    return DEFAULT_BUDGET_USD if budget_usd is None else budget_usd
+
+
 def choose_auto_judge(settings: Settings) -> tuple[JudgeName, str | None, str | None]:
     """Resolve ``judge="auto"`` from available API keys.
 
@@ -318,7 +323,7 @@ def resolve_judge(
         resolved_model = _OPENROUTER_MODEL
 
     built = build_judge(judge_kind, schema, model=resolved_model, entity_noun=entity_noun)
-    capped_budget = DEFAULT_BUDGET_USD if budget_usd is None else budget_usd
+    capped_budget = _effective_budget(budget_usd)
     capped = _SpendCappedModule(built, budget_usd=capped_budget)
     return ResolvedModule(capped, judge_used, resolved_model, fallback_reason)
 
@@ -361,12 +366,26 @@ def build_embedding_candidate(
     embeds both records' blocking text and attaches the cosine similarity via
     the same ``VectorBlocker``/FAISS path :func:`build_resolver` uses for
     ``dedupe()``, so the two verbs score embeddings identically.
+
+    Raises:
+        RuntimeError: If the blocker yields no candidate for the pair (should
+            never happen for a two-record ``VectorBlocker.stream()`` call --
+            guarded explicitly rather than letting a bare ``StopIteration``
+            leak out of ``next()``, mirroring ``link()``'s identical
+            no-judgement guard for the string/LLM path).
     """
     blocker = _build_vector_blocker(schema)
     entities = [blocker.schema_factory(record) for record in (left, right)]
     texts = [blocker.text_field_extractor(entity) for entity in entities]
     blocker.vector_index.create_index(texts)
-    return next(blocker.stream([left, right]))
+    candidates = list(blocker.stream([left, right]))
+    if not candidates:
+        raise RuntimeError(
+            "the embedding blocker produced no candidate for this pair; a "
+            "VectorBlocker over exactly two records must always yield one. "
+            "This indicates a bug in the vector index/blocker construction."
+        )
+    return candidates[0]
 
 
 def _estimate_n_pairs(n_records: int, *, use_vector: bool) -> int:
@@ -376,15 +395,33 @@ def _estimate_n_pairs(n_records: int, *, use_vector: bool) -> int:
     return n_records * (n_records - 1) // 2
 
 
-def notice_pre_scoring_cost(model: str, n_pairs: int) -> None:
+def notice_pre_scoring_cost(
+    model: str, n_pairs: int, *, budget_usd: float = DEFAULT_BUDGET_USD
+) -> None:
     """Emit the "about to spend money" notice before any paid scoring (D2).
 
     ``est_cost`` is a rough, worst-case-biased estimate
     (:data:`_ESTIMATED_TOKENS_PER_PAIR`) -- the spend cap
     (:class:`_SpendCappedModule`) meters and enforces the REAL cost live, per
     pair, as scoring happens.
+
+    If ``model`` has no pinned price in :data:`PRICES_PER_1M`, DSPyJudge
+    self-reports ``$0`` per pair -- printing "est. cost $0.0000" here would be
+    actively misleading: the spend cap tallies that same ``$0`` and can NEVER
+    trip, so an unpinned model that OpenRouter really bills for would run
+    uncapped in practice while looking capped. Warn honestly about the blind
+    cap instead of the reassuring (and false) zero estimate.
     """
     price_per_1k = dspy_price_per_1k(model)
+    if price_per_1k == 0.0:
+        _notice(
+            f"model {model!r} has no pinned price in "
+            "langres.clients.openrouter.PRICES_PER_1M, so it self-reports $0/pair "
+            f"cost -- the ${budget_usd:.2f} spend cap CANNOT enforce a limit for it "
+            "and will not stop a runaway bill. Pin its price in PRICES_PER_1M, or "
+            "use a model that already is, to get real spend-cap protection."
+        )
+        return
     est_cost = n_pairs * (_ESTIMATED_TOKENS_PER_PAIR / 1000.0) * price_per_1k
     _notice(f"scoring ~{n_pairs} pairs with {model!r}, est. cost ${est_cost:.4f}")
 
@@ -443,7 +480,9 @@ def build_resolver(
 
     if resolved.judge_used == "zero_shot_llm" and resolved.model is not None:
         n_pairs_est = _estimate_n_pairs(n_records, use_vector=use_vector)
-        notice_pre_scoring_cost(resolved.model, n_pairs_est)
+        notice_pre_scoring_cost(
+            resolved.model, n_pairs_est, budget_usd=_effective_budget(budget_usd)
+        )
 
     resolved_threshold = (
         _DEFAULT_THRESHOLDS.get(resolved.judge_used, 0.5) if threshold is None else threshold

--- a/src/langres/core/resolver.py
+++ b/src/langres/core/resolver.py
@@ -96,10 +96,10 @@ def _build_module_for_judge(
         return EmbeddingScoreJudge()
     if judge == "zero_shot_llm":
         # Lazy: dspy must stay out of sys.modules unless this judge is chosen.
-        from langres.clients.openrouter import dspy_price_per_1k
+        from langres.clients.openrouter import DEFAULT_OPENROUTER_MODEL, dspy_price_per_1k
         from langres.core.modules.dspy_judge import DSPyJudge
 
-        resolved_model = model or "openrouter/openai/gpt-4o-mini"
+        resolved_model = model or DEFAULT_OPENROUTER_MODEL
         dspy_module: DSPyJudge[Any] = DSPyJudge(model=resolved_model, entity_noun=entity_noun)
         dspy_module.price_per_1k_tokens = dspy_price_per_1k(resolved_model)
         return dspy_module
@@ -108,6 +108,34 @@ def _build_module_for_judge(
         "'string', 'embedding', 'zero_shot_llm', or pass a Module instance. "
         "'auto' key-based resolution is a verbs-layer feature -- use "
         "langres.link/langres.dedupe for that."
+    )
+
+
+def _build_embedding_blocker(schema: type[BaseModel]) -> VectorBlocker[Any]:
+    """Build the ``VectorBlocker`` a ``judge="embedding"`` pipeline needs.
+
+    ``AllPairsBlocker``'s candidates never carry ``similarity_score``, which
+    ``EmbeddingScoreJudge`` requires to score -- ``judge="embedding"`` must
+    always be paired with a ``VectorBlocker``, mirroring the identical rule
+    ``core.presets.build_resolver`` applies for the verb layer (same model,
+    same k, same cosine metric). Duplicated here rather than imported from
+    ``core.presets`` for the same layering reason as
+    :func:`_build_module_for_judge`: ``core.presets`` sits ABOVE ``Resolver``
+    and must not be imported back into it.
+    """
+    from langres.core.embeddings import SentenceTransformerEmbedder
+    from langres.core.indexes.vector_index import FAISSIndex
+
+    field_names = [spec.name for spec in Comparator.from_schema(schema).feature_specs]
+
+    def extract(entity: Any) -> str:
+        parts = [str(getattr(entity, name)) for name in field_names if getattr(entity, name, None)]
+        return " ".join(parts)
+
+    embedder = SentenceTransformerEmbedder("all-MiniLM-L6-v2")
+    index = FAISSIndex(embedder=embedder, metric="cosine")
+    return VectorBlocker(
+        vector_index=index, schema=schema, text_field_extractor=extract, k_neighbors=10
     )
 
 
@@ -272,7 +300,10 @@ class Resolver:
         Defaults to an ``AllPairsBlocker`` over the schema, a missing-aware
         ``StringComparator`` auto-derived from the schema's string fields (with
         ``id`` excluded), a ``WeightedAverageJudge`` scorer, and a ``Clusterer``
-        at ``threshold``.
+        at ``threshold``. ``judge="embedding"`` is the one exception to the
+        ``AllPairsBlocker`` default: it wires a ``VectorBlocker`` instead,
+        since ``EmbeddingScoreJudge`` scores off the blocker's
+        ``similarity_score``, which only a ``VectorBlocker`` attaches.
 
         Args:
             schema: The Pydantic entity schema to resolve.
@@ -285,10 +316,11 @@ class Resolver:
             exclude: Field names to skip when deriving features. Defaults to
                 ``{"id"}`` (handled by the comparator).
             judge: ``"string"`` (default -- identical to pre-existing
-                behavior), ``"embedding"``, ``"zero_shot_llm"``, or a
-                ``Module`` instance. This is the low-level, explicit switch
-                (no ``"auto"`` key-based resolution and no spend cap -- that
-                magic lives in ``langres.link``/``langres.dedupe``).
+                behavior), ``"embedding"`` (wires a ``VectorBlocker``, see
+                above), ``"zero_shot_llm"``, or a ``Module`` instance. This is
+                the low-level, explicit switch (no ``"auto"`` key-based
+                resolution and no spend cap -- that magic lives in
+                ``langres.link``/``langres.dedupe``).
             model: Model id override for ``judge="zero_shot_llm"``.
             entity_noun: Domain noun woven into the LLM judge's prompt.
 
@@ -301,8 +333,13 @@ class Resolver:
             schema, exclude=exclude, weights=weights
         )
         module = _build_module_for_judge(judge, comparator, model=model, entity_noun=entity_noun)
+        blocker: Blocker[Any] = (
+            _build_embedding_blocker(schema)
+            if judge == "embedding"
+            else AllPairsBlocker(schema=schema)
+        )
         return cls(
-            blocker=AllPairsBlocker(schema=schema),
+            blocker=blocker,
             comparator=comparator,
             module=module,
             clusterer=Clusterer(threshold=threshold),

--- a/src/langres/core/resolver.py
+++ b/src/langres/core/resolver.py
@@ -36,7 +36,7 @@ import inspect
 import logging
 from collections.abc import Iterator
 from pathlib import Path
-from typing import Any, Self, TypeGuard
+from typing import Any, Literal, Self, TypeGuard
 
 from pydantic import BaseModel
 
@@ -60,6 +60,55 @@ logger = logging.getLogger(__name__)
 
 # Slot names used as sidecar subdirectory names and for manifest ordering.
 _MANIFEST_FILENAME = "resolver.json"
+
+#: ``Resolver.from_schema``'s low-level judge switch. Deliberately narrower
+#: than ``langres.core.presets.JudgeName`` -- no ``"auto"``, since resolving
+#: that needs ``Settings``/env-var lookups, which is verb-layer magic (see
+#: ``langres.core.presets.choose_auto_judge``); this stays a plain, explicit
+#: constructor argument.
+_FromSchemaJudge = Literal["string", "embedding", "zero_shot_llm"]
+
+
+def _build_module_for_judge(
+    judge: "_FromSchemaJudge | Module[Any]",
+    comparator: Comparator[Any],
+    *,
+    model: str | None,
+    entity_noun: str,
+) -> Module[Any]:
+    """Build the scorer for ``Resolver.from_schema``'s ``judge=`` slot.
+
+    A small, deliberately self-contained switch: ``langres.core.presets``
+    (which builds on top of ``Resolver``) is NOT imported here, since that
+    would create a ``Resolver -> presets -> Resolver`` cycle -- see the
+    dependency diagram in this module's docstring. The three branches below
+    duplicate a little of ``presets.build_judge``'s logic; that duplication is
+    the price of keeping the layering one-directional (``verbs -> presets ->
+    Resolver``), not an oversight.
+    """
+    if isinstance(judge, Module):
+        return judge
+    if judge == "string":
+        return WeightedAverageJudge(feature_specs=comparator.feature_specs)
+    if judge == "embedding":
+        from langres.core.judges.embedding_score import EmbeddingScoreJudge
+
+        return EmbeddingScoreJudge()
+    if judge == "zero_shot_llm":
+        # Lazy: dspy must stay out of sys.modules unless this judge is chosen.
+        from langres.clients.openrouter import dspy_price_per_1k
+        from langres.core.modules.dspy_judge import DSPyJudge
+
+        resolved_model = model or "openrouter/openai/gpt-4o-mini"
+        dspy_module: DSPyJudge[Any] = DSPyJudge(model=resolved_model, entity_noun=entity_noun)
+        dspy_module.price_per_1k_tokens = dspy_price_per_1k(resolved_model)
+        return dspy_module
+    raise ValueError(
+        f"unsupported judge {judge!r} for Resolver.from_schema; choose one of "
+        "'string', 'embedding', 'zero_shot_llm', or pass a Module instance. "
+        "'auto' key-based resolution is a verbs-layer feature -- use "
+        "langres.link/langres.dedupe for that."
+    )
 
 
 def _component_config_dict(obj: object) -> dict[str, object]:
@@ -214,6 +263,9 @@ class Resolver:
         threshold: float = 0.7,
         weights: dict[str, float] | None = None,
         exclude: set[str] | None = None,
+        judge: "_FromSchemaJudge | Module[Any]" = "string",
+        model: str | None = None,
+        entity_noun: str = "entity",
     ) -> "Resolver":
         """Build a default dedup Resolver from a Pydantic schema in one line.
 
@@ -232,6 +284,13 @@ class Resolver:
                 floor.
             exclude: Field names to skip when deriving features. Defaults to
                 ``{"id"}`` (handled by the comparator).
+            judge: ``"string"`` (default -- identical to pre-existing
+                behavior), ``"embedding"``, ``"zero_shot_llm"``, or a
+                ``Module`` instance. This is the low-level, explicit switch
+                (no ``"auto"`` key-based resolution and no spend cap -- that
+                magic lives in ``langres.link``/``langres.dedupe``).
+            model: Model id override for ``judge="zero_shot_llm"``.
+            entity_noun: Domain noun woven into the LLM judge's prompt.
 
         Returns:
             A ready-to-run Resolver.
@@ -241,12 +300,11 @@ class Resolver:
         comparator: Comparator[Any] = Comparator.from_schema(
             schema, exclude=exclude, weights=weights
         )
+        module = _build_module_for_judge(judge, comparator, model=model, entity_noun=entity_noun)
         return cls(
             blocker=AllPairsBlocker(schema=schema),
             comparator=comparator,
-            # The judge scores on the same FeatureSpecs (weights) the comparator
-            # compares on, so the comparison vector and the weights line up.
-            module=WeightedAverageJudge(feature_specs=comparator.feature_specs),
+            module=module,
             clusterer=Clusterer(threshold=threshold),
         )
 

--- a/src/langres/core/resolver.py
+++ b/src/langres/core/resolver.py
@@ -34,6 +34,7 @@ the helpers normalize the dict-vs-model and property-vs-method differences.
 
 import inspect
 import logging
+import warnings
 from collections.abc import Iterator
 from pathlib import Path
 from typing import Any, Literal, Self, TypeGuard
@@ -101,7 +102,23 @@ def _build_module_for_judge(
 
         resolved_model = model or DEFAULT_OPENROUTER_MODEL
         dspy_module: DSPyJudge[Any] = DSPyJudge(model=resolved_model, entity_noun=entity_noun)
-        dspy_module.price_per_1k_tokens = dspy_price_per_1k(resolved_model)
+        price = dspy_price_per_1k(resolved_model)
+        if price == 0.0:
+            # An unpinned model self-reports $0/pair -- honest, not reassuring
+            # (mirrors core.presets.notice_pre_scoring_cost's identical check;
+            # duplicated here for the same layering reason as the rest of this
+            # function). Resolver.from_schema has no spend cap at all (see its
+            # judge= docstring), so this is strictly worse than the verbs'
+            # blind-cap case: nothing would ever stop a runaway bill.
+            warnings.warn(
+                f"model {resolved_model!r} has no pinned price in "
+                "langres.clients.openrouter.PRICES_PER_1M, so it self-reports "
+                "$0/pair cost. Resolver.from_schema builds an UNCAPPED pipeline "
+                "(no spend cap at all) -- pin its price in PRICES_PER_1M, or use "
+                "langres.link/langres.dedupe for the built-in spend cap.",
+                stacklevel=3,
+            )
+        dspy_module.price_per_1k_tokens = price
         return dspy_module
     raise ValueError(
         f"unsupported judge {judge!r} for Resolver.from_schema; choose one of "
@@ -320,7 +337,12 @@ class Resolver:
                 above), ``"zero_shot_llm"``, or a ``Module`` instance. This is
                 the low-level, explicit switch (no ``"auto"`` key-based
                 resolution and no spend cap -- that magic lives in
-                ``langres.link``/``langres.dedupe``).
+                ``langres.link``/``langres.dedupe``). **Caution**:
+                ``judge="zero_shot_llm"`` (or any other paid ``Module``) built
+                here runs UNCAPPED -- there is no ``budget_usd`` on this
+                method and nothing stops a runaway bill. Use
+                ``langres.link``/``langres.dedupe`` for the built-in
+                ``SpendMonitor`` cap.
             model: Model id override for ``judge="zero_shot_llm"``.
             entity_noun: Domain noun woven into the LLM judge's prompt.
 

--- a/src/langres/methods.py
+++ b/src/langres/methods.py
@@ -40,6 +40,11 @@ from typing import Any, Protocol
 # (rather than re-implement its cost-key fallback math) so cascade spend totals
 # stay identical to every other method's; it is a stable same-package internal
 # that the harness's own tests also import directly.
+# Relocated to ``langres.clients.openrouter.dspy_price_per_1k`` (dspy-free,
+# layer-neutral) so both this module and ``langres.core.presets`` can share it
+# without a ``core -> methods -> core`` import cycle. Aliased to the old
+# private name since existing call sites in this module reference it.
+from langres.clients.openrouter import dspy_price_per_1k as _dspy_price_per_1k
 from langres.core.benchmark import CostTrack, _cost_track
 from langres.core.blockers.vector import VectorBlocker
 from langres.core.clusterer import Clusterer
@@ -150,27 +155,6 @@ def _build_cascade_module(
     if llm_client is not None:
         module._llm_client = llm_client
     return module
-
-
-def _dspy_price_per_1k(model: str) -> float:
-    """Per-1k-token price for ``model`` from the pinned OpenRouter table (0.0 if unknown).
-
-    ``DSPyJudge`` prices each pair as ``tokens/1000 * price_per_1k_tokens`` — a single
-    blended per-1k rate over ``prompt + completion`` tokens — so we take the worst-case
-    (dearer of input/output) per-token price and scale it to per-1k. Worst-case is the
-    same price basis :class:`~langres.core.benchmark.BudgetedModuleRunner` uses for its
-    cap, so the judge's self-reported cost and the live budget-stop agree.
-
-    Unknown models keep ``0.0`` (zero-spend/test runs stay free and never crash),
-    mirroring ``register_runtime_model_price`` returning ``None`` for unknown ids —
-    rather than guessing a price. ``langres.clients.openrouter`` is dspy-free, so this
-    lookup never pulls ``dspy`` into ``import langres.methods``.
-    """
-    from langres.clients.openrouter import PRICES_PER_1M, per_token_worst_price
-
-    if model not in PRICES_PER_1M:
-        return 0.0
-    return per_token_worst_price(model) * 1_000.0
 
 
 def _make_module_builder(

--- a/src/langres/verbs.py
+++ b/src/langres/verbs.py
@@ -57,6 +57,7 @@ from langres.core.presets import (
     resolve_judge,
 )
 from langres.core.presets import _DEFAULT_THRESHOLDS as _THRESHOLDS
+from langres.core.presets import _effective_budget
 
 __all__ = ["DedupeResult", "LinkVerdict", "dedupe", "link"]
 
@@ -292,7 +293,7 @@ def link(
     )
 
     if judge_used == "zero_shot_llm" and resolved_model is not None:
-        notice_pre_scoring_cost(resolved_model, 1)
+        notice_pre_scoring_cost(resolved_model, 1, budget_usd=_effective_budget(budget_usd))
 
     candidate: ERCandidate[Any]
     if judge_used == "embedding":

--- a/src/langres/verbs.py
+++ b/src/langres/verbs.py
@@ -138,7 +138,7 @@ def _infer_schema(field_names: frozenset[str]) -> type[BaseModel]:
     fields: dict[str, Any] = {"id": (str, ...)}
     for name in sorted(field_names):
         fields[name] = (str | None, None)
-    schema: type[BaseModel] = create_model(_inferred_schema_name(field_names), **fields)  # type: ignore[call-overload]
+    schema: type[BaseModel] = create_model(_inferred_schema_name(field_names), **fields)
     _INFERRED_SCHEMA_CACHE[field_names] = schema
     return schema
 
@@ -219,7 +219,9 @@ def _check_no_duplicate_ids(ids: Sequence[str]) -> None:
         if i in seen:
             dupes.add(i)
         seen.add(i)
-    raise ValueError(f"duplicate ids in input: {sorted(dupes)}; every record must have a unique id.")
+    raise ValueError(
+        f"duplicate ids in input: {sorted(dupes)}; every record must have a unique id."
+    )
 
 
 def _resolved_threshold(judge_used: str, threshold: float | None) -> float:
@@ -289,7 +291,7 @@ def link(
         right_entity = factory(right_record)
         candidate = ERCandidate(left=left_entity, right=right_entity, blocker_name="link")
         if judge_used == "string":
-            comparator = Comparator.from_schema(resolved_schema)
+            comparator: Comparator[Any] = Comparator.from_schema(resolved_schema)
             candidate = candidate.model_copy(
                 update={"comparison": comparator.compare(left_entity, right_entity)}
             )

--- a/src/langres/verbs.py
+++ b/src/langres/verbs.py
@@ -209,6 +209,18 @@ def _infer(records: Sequence[dict[str, Any]]) -> tuple[type[BaseModel], list[dic
     return schema, coerced
 
 
+def _with_resolved_ids(records: Sequence[dict[str, Any]]) -> list[dict[str, Any]]:
+    """Attach a resolved ``"id"`` to each record, via the same rule ``_infer``
+    uses (:func:`_resolve_ids`): every record already has one -> keep it
+    (normalized to ``str``); none do -> assign positional ids; a mix ->
+    raises. Used by ``dedupe()``'s explicit-``schema=`` path so it can't
+    mistake "no id" for "duplicate id" (``str(record.get("id"))`` on two
+    id-less records both reads as the string ``"None"`` -- a false collision).
+    """
+    ids = _resolve_ids(records)
+    return [{**record, "id": rid} for record, rid in zip(records, ids, strict=True)]
+
+
 def _check_no_duplicate_ids(ids: Sequence[str]) -> None:
     """Raise if ``ids`` contains a repeat (dedupe()'s batch-uniqueness contract)."""
     if len(set(ids)) == len(ids):
@@ -363,9 +375,9 @@ def dedupe(
     if schema is None:
         resolved_schema, resolved_records = _infer(records)
     else:
-        resolved_schema, resolved_records = schema, records
+        resolved_schema, resolved_records = schema, _with_resolved_ids(records)
 
-    _check_no_duplicate_ids([str(record.get("id")) for record in resolved_records])
+    _check_no_duplicate_ids([record["id"] for record in resolved_records])
 
     resolved = build_resolver(
         resolved_schema,

--- a/src/langres/verbs.py
+++ b/src/langres/verbs.py
@@ -1,0 +1,385 @@
+"""The three-verb DX layer: ``link``, ``dedupe``, and their result types.
+
+``link(left, right)`` and ``dedupe(records)`` are the thin, schema-optional
+convenience layer on top of :mod:`langres.core.presets` (judge resolution +
+spend cap) and :class:`~langres.core.resolver.Resolver` (blocking + scoring +
+clustering). Schema-optional: pass ``schema=<YourModel>`` for a durable,
+type-checked entity, or omit it and let :func:`dedupe`/:func:`link` infer an
+ephemeral one from the records' own keys.
+
+Both verbs share one small contract:
+
+- ``judge="auto"`` (default) picks an LLM judge when an API key is set
+  (``OPENROUTER_API_KEY``/``OPENAI_API_KEY``), else falls back to the
+  zero-spend ``"string"`` judge with one notice -- see
+  :func:`~langres.core.presets.choose_auto_judge`.
+- Every judge, including the free ones, runs under a default $1 spend cap
+  (override with ``budget_usd=``); a cap breach raises
+  :class:`~langres.clients.openrouter.BudgetExceeded` carrying every
+  judgement already produced on ``.partial_judgements`` (E9) -- see
+  :mod:`langres.core.presets`'s module docstring for the resume recipe.
+- Results are self-describing (D2): every verb reports which judge actually
+  ran (``judge_used``), what its raw score means (``score_type`` -- see the
+  threshold-semantics note below), and why it fell back, if it did
+  (``fallback_reason``).
+- Threshold semantics differ across ``score_type`` scales (E12): a
+  ``"heuristic"`` score, a cosine ``"sim_cos"``, and an LLM ``"prob_llm"`` are
+  not comparable on the same 0..1 cut. ``threshold=None`` (the default)
+  resolves to a sane per-judge default; pass ``threshold=`` explicitly to
+  override, or derive one from labels with
+  :func:`~langres.core.calibration.derive_threshold`.
+
+Known limitation: an *inferred* schema is ephemeral (a dynamically created
+class, not importable by name) -- a ``dedupe()``/``link()`` call built on one
+works fine in-process, but reloading a saved artifact referencing it in a
+FRESH process raises the registry's existing ``SchemaNotRegistered`` error.
+Pass ``schema=<YourModel>`` explicitly for anything you intend to persist.
+"""
+
+from __future__ import annotations
+
+import math
+from collections.abc import Iterable, Sequence
+from hashlib import sha256
+from typing import Any
+
+from pydantic import BaseModel, Field, create_model
+
+from langres.core.blockers.all_pairs import schema_to_factory
+from langres.core.comparator import Comparator
+from langres.core.models import ERCandidate, PairwiseJudgement
+from langres.core.module import Module
+from langres.core.presets import (
+    JudgeName,
+    build_embedding_candidate,
+    build_resolver,
+    notice_pre_scoring_cost,
+    resolve_judge,
+)
+from langres.core.presets import _DEFAULT_THRESHOLDS as _THRESHOLDS
+
+__all__ = ["DedupeResult", "LinkVerdict", "dedupe", "link"]
+
+
+class LinkVerdict(BaseModel):
+    """The result of :func:`link`: a match decision with full provenance.
+
+    Truthy iff ``match`` (``if link(a, b): ...``); ``repr`` shows the verdict,
+    score, and judge for a friendly REPL/notebook experience (D2/D10).
+    """
+
+    match: bool
+    score: float = Field(..., ge=0.0, le=1.0)
+    reasoning: str | None = None
+    judge_used: str
+    score_type: str
+    fallback_reason: str | None = None
+    judgement: PairwiseJudgement
+
+    def __bool__(self) -> bool:
+        return self.match
+
+    def __repr__(self) -> str:
+        verdict = "MATCH" if self.match else "NO MATCH"
+        return f"LinkVerdict({verdict}, score={self.score:.3f}, judge={self.judge_used!r})"
+
+
+class DedupeResult(list[set[str]]):
+    """The clusters :func:`dedupe` returns -- a plain ``list[set[str]]``, self-describing.
+
+    Behaves exactly like the list :meth:`~langres.core.resolver.Resolver.resolve`
+    returns; additionally carries ``judge_used``, ``score_type``, and
+    ``fallback_reason`` (D2) so a caller can inspect what actually ran without
+    a separate call.
+    """
+
+    def __init__(
+        self,
+        clusters: Iterable[set[str]],
+        *,
+        judge_used: str,
+        score_type: str,
+        fallback_reason: str | None,
+    ) -> None:
+        super().__init__(clusters)
+        self.judge_used = judge_used
+        self.score_type = score_type
+        self.fallback_reason = fallback_reason
+
+    def __repr__(self) -> str:
+        return (
+            f"DedupeResult({list.__repr__(self)}, judge_used={self.judge_used!r}, "
+            f"score_type={self.score_type!r})"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Schema-optional inference (E8, D11)
+# ---------------------------------------------------------------------------
+
+_INFERRED_SCHEMA_CACHE: dict[frozenset[str], type[BaseModel]] = {}
+
+
+def _inferred_schema_name(field_names: frozenset[str]) -> str:
+    """Deterministic ``Inferred_<sha8>`` name from a field-set (memoization key)."""
+    digest = sha256("|".join(sorted(field_names)).encode()).hexdigest()[:8]
+    return f"Inferred_{digest}"
+
+
+def _infer_schema(field_names: frozenset[str]) -> type[BaseModel]:
+    """Build (or reuse) an ephemeral all-``str | None`` schema for ``field_names``.
+
+    Memoized by field-set so repeated ``dedupe()``/``link()`` calls over the
+    same record shape reuse one class instead of minting a new one each time.
+    """
+    cached = _INFERRED_SCHEMA_CACHE.get(field_names)
+    if cached is not None:
+        return cached
+    fields: dict[str, Any] = {"id": (str, ...)}
+    for name in sorted(field_names):
+        fields[name] = (str | None, None)
+    schema: type[BaseModel] = create_model(_inferred_schema_name(field_names), **fields)  # type: ignore[call-overload]
+    _INFERRED_SCHEMA_CACHE[field_names] = schema
+    return schema
+
+
+def _coerce_scalar(value: Any) -> str | None:
+    """Coerce one raw field value for an inferred (all-``str | None``) schema.
+
+    ``None`` and ``float('nan')`` both become ``None`` -- never the string
+    ``"nan"``, which would silently poison string-similarity scoring (D11). A
+    nested ``list``/``dict`` value cannot be represented by a flat inferred
+    field, so it raises with guidance rather than being silently stringified
+    (E8).
+    """
+    if value is None:
+        return None
+    if isinstance(value, float) and math.isnan(value):
+        return None
+    if isinstance(value, (list, dict)):
+        raise ValueError(
+            f"cannot infer a schema field from a nested {type(value).__name__} "
+            f"value ({value!r}). Pass schema=<YourModel> explicitly to control "
+            "how nested fields are compared."
+        )
+    return str(value)
+
+
+def _field_union(records: Sequence[dict[str, Any]]) -> frozenset[str]:
+    """Every key across ``records`` except ``"id"`` (handled separately)."""
+    fields: set[str] = set()
+    for record in records:
+        fields.update(key for key in record if key != "id")
+    return frozenset(fields)
+
+
+def _resolve_ids(records: Sequence[dict[str, Any]]) -> list[str]:
+    """Per-record id: explicit ``"id"`` key if EVERY record has one, else positional.
+
+    Raises:
+        ValueError: If some records have an ``"id"`` key and others don't
+            (ambiguous -- which source should win?).
+    """
+    has_id = ["id" in record for record in records]
+    if all(has_id):
+        return [str(record["id"]) for record in records]
+    if not any(has_id):
+        return [str(i) for i in range(len(records))]
+    raise ValueError(
+        "some records have an 'id' key and some don't -- schema inference "
+        "needs consistent id presence across all records. Add 'id' to every "
+        "record (or none), or pass schema=<YourModel> explicitly."
+    )
+
+
+def _infer(records: Sequence[dict[str, Any]]) -> tuple[type[BaseModel], list[dict[str, Any]]]:
+    """Infer an ephemeral schema + coerced records for ``records``.
+
+    No id-uniqueness check here -- ``link(a, a)`` (comparing an entity to
+    itself) is well-defined and must not raise; :func:`dedupe` enforces
+    uniqueness itself via :func:`_check_no_duplicate_ids`.
+    """
+    field_names = _field_union(records)
+    ids = _resolve_ids(records)
+    schema = _infer_schema(field_names)
+    coerced = [
+        {"id": rid, **{name: _coerce_scalar(record.get(name)) for name in field_names}}
+        for record, rid in zip(records, ids, strict=True)
+    ]
+    return schema, coerced
+
+
+def _check_no_duplicate_ids(ids: Sequence[str]) -> None:
+    """Raise if ``ids`` contains a repeat (dedupe()'s batch-uniqueness contract)."""
+    if len(set(ids)) == len(ids):
+        return
+    seen: set[str] = set()
+    dupes: set[str] = set()
+    for i in ids:
+        if i in seen:
+            dupes.add(i)
+        seen.add(i)
+    raise ValueError(f"duplicate ids in input: {sorted(dupes)}; every record must have a unique id.")
+
+
+def _resolved_threshold(judge_used: str, threshold: float | None) -> float:
+    return _THRESHOLDS.get(judge_used, 0.5) if threshold is None else threshold
+
+
+# ---------------------------------------------------------------------------
+# link()
+# ---------------------------------------------------------------------------
+
+
+def link(
+    left: dict[str, Any],
+    right: dict[str, Any],
+    *,
+    judge: JudgeName | Module[Any] = "auto",
+    schema: type[BaseModel] | None = None,
+    model: str | None = None,
+    entity_noun: str = "entity",
+    threshold: float | None = None,
+    budget_usd: float | None = None,
+) -> LinkVerdict:
+    """Decide whether two records refer to the same real-world entity.
+
+    Args:
+        left: The first record (a plain dict).
+        right: The second record. ``link(a, a)`` (the same record twice) is
+            well-defined -- it scores the entity against itself.
+        judge: ``"auto"`` (default; picks an LLM judge if a key is set, else
+            falls back to ``"string"``), ``"zero_shot_llm"``, ``"embedding"``,
+            ``"string"``, or a ``Module`` instance (e.g. an injected
+            ``DSPyJudge(lm=DummyLM(...))`` for a zero-spend test).
+        schema: Optional explicit Pydantic schema. Omit to infer an ephemeral
+            one from ``left``/``right``'s own keys.
+        model: Model id override for ``"zero_shot_llm"``.
+        entity_noun: Domain noun woven into the LLM judge's prompt.
+        threshold: Match cutoff; ``None`` resolves to the judge's default.
+        budget_usd: Spend cap override (default $1; see
+            :mod:`langres.core.presets`).
+
+    Returns:
+        A :class:`LinkVerdict`.
+
+    Raises:
+        ValueError: On schema-inference errors (nested values, inconsistent
+            id presence).
+        BudgetExceeded: If scoring this pair would cross the spend cap.
+    """
+    if schema is None:
+        resolved_schema, (left_record, right_record) = _infer([left, right])
+    else:
+        resolved_schema, left_record, right_record = schema, left, right
+
+    module, judge_used, resolved_model, fallback_reason = resolve_judge(
+        judge, resolved_schema, model=model, entity_noun=entity_noun, budget_usd=budget_usd
+    )
+
+    if judge_used == "zero_shot_llm" and resolved_model is not None:
+        notice_pre_scoring_cost(resolved_model, 1)
+
+    candidate: ERCandidate[Any]
+    if judge_used == "embedding":
+        candidate = build_embedding_candidate(resolved_schema, left_record, right_record)
+    else:
+        factory = schema_to_factory(resolved_schema)
+        left_entity = factory(left_record)
+        right_entity = factory(right_record)
+        candidate = ERCandidate(left=left_entity, right=right_entity, blocker_name="link")
+        if judge_used == "string":
+            comparator = Comparator.from_schema(resolved_schema)
+            candidate = candidate.model_copy(
+                update={"comparison": comparator.compare(left_entity, right_entity)}
+            )
+
+    judgements = list(module.forward(iter([candidate])))
+    if not judgements:
+        raise RuntimeError(
+            f"the {judge_used!r} judge produced no judgement for this pair; every "
+            "candidate must yield exactly one PairwiseJudgement. This indicates a "
+            "bug in an injected judge= Module."
+        )
+    judgement = judgements[0]
+
+    return LinkVerdict(
+        match=judgement.score >= _resolved_threshold(judge_used, threshold),
+        score=judgement.score,
+        reasoning=judgement.reasoning,
+        judge_used=judge_used,
+        score_type=judgement.score_type,
+        fallback_reason=fallback_reason,
+        judgement=judgement,
+    )
+
+
+# ---------------------------------------------------------------------------
+# dedupe()
+# ---------------------------------------------------------------------------
+
+
+def dedupe(
+    records: list[dict[str, Any]],
+    *,
+    judge: JudgeName | Module[Any] = "auto",
+    schema: type[BaseModel] | None = None,
+    model: str | None = None,
+    entity_noun: str = "entity",
+    threshold: float | None = None,
+    budget_usd: float | None = None,
+) -> DedupeResult:
+    """Group a batch of records into entity clusters.
+
+    Args:
+        records: The records to dedupe (plain dicts). ``[]`` -> ``[]``; a
+            single record -> ``[]`` (no pair possible). Every record must
+            have a unique ``"id"`` (or none at all -- positional ids are
+            assigned); a duplicate ``"id"`` raises.
+        judge: ``"auto"`` (default), ``"zero_shot_llm"``, ``"embedding"``,
+            ``"string"``, or a ``Module`` instance.
+        schema: Optional explicit Pydantic schema. Omit to infer an ephemeral
+            one from the records' own keys.
+        model: Model id override for ``"zero_shot_llm"``.
+        entity_noun: Domain noun woven into the LLM judge's prompt.
+        threshold: Clusterer threshold; ``None`` resolves to the judge's
+            default.
+        budget_usd: Spend cap override (default $1).
+
+    Returns:
+        A :class:`DedupeResult` (a ``list[set[str]]`` of entity-id clusters).
+
+    Raises:
+        ValueError: Duplicate ids, inconsistent id presence, or a nested
+            value under schema inference.
+        BudgetExceeded: If scoring would cross the spend cap; the exception
+            carries the judgements already produced on ``.partial_judgements``.
+    """
+    if not records:
+        return DedupeResult([], judge_used="none", score_type="none", fallback_reason=None)
+
+    if schema is None:
+        resolved_schema, resolved_records = _infer(records)
+    else:
+        resolved_schema, resolved_records = schema, records
+
+    _check_no_duplicate_ids([str(record.get("id")) for record in resolved_records])
+
+    resolved = build_resolver(
+        resolved_schema,
+        judge=judge,
+        model=model,
+        entity_noun=entity_noun,
+        threshold=threshold,
+        n_records=len(resolved_records),
+        budget_usd=budget_usd,
+    )
+    judgements = resolved.resolver.predict(resolved_records)
+    clusters = resolved.resolver.clusterer.cluster(judgements)
+    score_type = judgements[0].score_type if judgements else resolved.score_type
+    return DedupeResult(
+        clusters,
+        judge_used=resolved.judge_used,
+        score_type=score_type,
+        fallback_reason=resolved.fallback_reason,
+    )

--- a/tests/clients/test_settings.py
+++ b/tests/clients/test_settings.py
@@ -11,6 +11,21 @@ from langres.clients.settings import Settings
 class TestSettings:
     """Tests for Settings class."""
 
+    def test_settings_openrouter_api_key_from_env(self):
+        """OPENROUTER_API_KEY loads into settings.openrouter_api_key (judge="auto" seam)."""
+        with patch.dict(os.environ, {"OPENROUTER_API_KEY": "or-test123"}, clear=True):
+            settings = Settings()
+            assert settings.openrouter_api_key == "or-test123"
+
+    def test_settings_openrouter_api_key_defaults_to_none(self):
+        """Absent OPENROUTER_API_KEY leaves the field None (judge="auto" falls back)."""
+        with (
+            patch.dict(os.environ, {}, clear=True),
+            patch("pydantic_settings.sources.DotEnvSettingsSource.__call__", return_value={}),
+        ):
+            settings = Settings()
+            assert settings.openrouter_api_key is None
+
     def test_settings_with_all_required_fields(self):
         """Test Settings initialization with all required fields."""
         with patch.dict(

--- a/tests/core/test_presets.py
+++ b/tests/core/test_presets.py
@@ -1,0 +1,424 @@
+"""Tests for langres.core.presets (judge="auto" resolution + spend-capped Resolver).
+
+Zero-spend throughout: real network/LLM calls are never made. The
+"zero_shot_llm" branch is only ever exercised up to *construction* (verifying
+the DSPyJudge instance's model/price), never ``.forward()`` -- any pairwise
+scoring test injects a DummyLM-backed ``DSPyJudge`` or a tiny fake Module
+instead. "embedding" tests that need a real ``.encode()`` call load the local
+MiniLM model (no API key, no paid call) and are marked ``@pytest.mark.slow``.
+"""
+
+from collections.abc import Iterator
+from unittest.mock import patch
+
+import pytest
+from dspy.utils.dummies import DummyLM
+from pydantic import BaseModel
+
+from langres.clients.openrouter import PRICES_PER_1M, BudgetExceeded
+from langres.clients.settings import Settings
+from langres.core.blockers.all_pairs import AllPairsBlocker
+from langres.core.blockers.vector import VectorBlocker
+from langres.core.judges.embedding_score import EmbeddingScoreJudge
+from langres.core.judges.weighted_average import WeightedAverageJudge
+from langres.core.models import ERCandidate, PairwiseJudgement
+from langres.core.module import Module
+from langres.core.modules.dspy_judge import DSPyJudge
+from langres.core.presets import (
+    DEFAULT_BUDGET_USD,
+    _ALL_PAIRS_MAX_N,
+    _build_vector_blocker,
+    _estimate_n_pairs,
+    _OPENAI_MODEL,
+    _OPENROUTER_MODEL,
+    _SpendCappedModule,
+    _text_field_extractor,
+    build_embedding_candidate,
+    build_judge,
+    build_resolver,
+    choose_auto_judge,
+    notice_pre_scoring_cost,
+    resolve_judge,
+)
+
+
+class PresetCompany(BaseModel):
+    id: str
+    name: str | None = None
+    address: str | None = None
+
+
+class PresetProduct(BaseModel):
+    id: str
+    title: str | None = None
+    brand: str | None = None
+
+
+def _settings(*, openrouter: str | None = None, openai: str | None = None) -> Settings:
+    return Settings(openrouter_api_key=openrouter, openai_api_key=openai)
+
+
+class _FakeCostlyModule(Module[object]):
+    """Yields N judgements each costing a fixed amount -- for cap-breach tests."""
+
+    def __init__(self, n: int, cost_each: float) -> None:
+        self._n = n
+        self._cost_each = cost_each
+
+    def forward(
+        self, candidates: Iterator[ERCandidate[object]]
+    ) -> Iterator[PairwiseJudgement]:
+        list(candidates)  # drain (content unused)
+        for i in range(self._n):
+            yield PairwiseJudgement(
+                left_id=str(i),
+                right_id=str(i + 1),
+                score=0.9,
+                score_type="prob_llm",
+                decision_step="fake",
+                provenance={"cost_usd": self._cost_each},
+            )
+
+    def inspect_scores(self, judgements: list[PairwiseJudgement], sample_size: int = 10) -> object:
+        raise NotImplementedError
+
+
+# ---------------------------------------------------------------------------
+# choose_auto_judge
+# ---------------------------------------------------------------------------
+
+
+class TestChooseAutoJudge:
+    def test_no_keys_falls_back_to_string_with_notice(self) -> None:
+        with pytest.warns(UserWarning, match="no OPENROUTER_API_KEY or OPENAI_API_KEY"):
+            judge, model, reason = choose_auto_judge(_settings())
+        assert judge == "string"
+        assert model is None
+        assert reason is not None and "OPENROUTER_API_KEY" in reason
+
+    def test_openrouter_key_resolves_to_zero_shot_llm_with_nonzero_price(self) -> None:
+        with warnings_none():
+            judge, model, reason = choose_auto_judge(_settings(openrouter="or-key"))
+        assert judge == "zero_shot_llm"
+        assert model == _OPENROUTER_MODEL
+        assert reason is None
+        assert PRICES_PER_1M[model][0] > 0.0 and PRICES_PER_1M[model][1] > 0.0
+
+    def test_openai_key_used_only_when_no_openrouter_key(self) -> None:
+        with warnings_none():
+            judge, model, reason = choose_auto_judge(_settings(openai="oai-key"))
+        assert judge == "zero_shot_llm"
+        assert model == _OPENAI_MODEL
+        assert reason is None
+        assert PRICES_PER_1M[model][0] > 0.0 and PRICES_PER_1M[model][1] > 0.0
+
+    def test_openrouter_key_preferred_over_openai_key(self) -> None:
+        judge, model, _ = choose_auto_judge(_settings(openrouter="or-key", openai="oai-key"))
+        assert (judge, model) == ("zero_shot_llm", _OPENROUTER_MODEL)
+
+    def test_refuses_paid_judge_with_unpinned_price(self) -> None:
+        """E1: a candidate model with no pinned price is refused, not silently $0-capped."""
+        unpriced = {k: v for k, v in PRICES_PER_1M.items() if k != _OPENROUTER_MODEL}
+        with (
+            patch.dict("langres.clients.openrouter.PRICES_PER_1M", unpriced, clear=True),
+            pytest.warns(UserWarning, match="no pinned price"),
+        ):
+            judge, model, reason = choose_auto_judge(_settings(openrouter="or-key"))
+        assert judge == "string"
+        assert model is None
+        assert reason is not None and _OPENROUTER_MODEL in reason
+
+
+def warnings_none() -> "_NoWarnings":
+    """Assert the wrapped block emits no warnings at all."""
+    return _NoWarnings()
+
+
+class _NoWarnings:
+    def __enter__(self) -> "_NoWarnings":
+        import warnings as _w
+
+        self._catch = _w.catch_warnings(record=True)
+        self._records = self._catch.__enter__()
+        _w.simplefilter("always")
+        return self
+
+    def __exit__(self, *exc: object) -> None:
+        assert not self._records, f"unexpected warnings: {[str(r.message) for r in self._records]}"
+        self._catch.__exit__(*exc)
+
+
+# ---------------------------------------------------------------------------
+# build_judge
+# ---------------------------------------------------------------------------
+
+
+class TestBuildJudge:
+    def test_string_returns_weighted_average_judge_with_schema_features(self) -> None:
+        module = build_judge("string", PresetCompany)
+        assert isinstance(module, WeightedAverageJudge)
+        names = {spec.name for spec in module.feature_specs}
+        assert names == {"name", "address"}
+
+    def test_string_is_schema_agnostic_across_two_different_schemas(self) -> None:
+        company_module = build_judge("string", PresetCompany)
+        product_module = build_judge("string", PresetProduct)
+        assert {s.name for s in company_module.feature_specs} == {"name", "address"}
+        assert {s.name for s in product_module.feature_specs} == {"title", "brand"}
+
+    def test_embedding_returns_embedding_score_judge(self) -> None:
+        assert isinstance(build_judge("embedding", PresetCompany), EmbeddingScoreJudge)
+
+    def test_zero_shot_llm_returns_dspy_judge_with_default_model_and_pinned_price(self) -> None:
+        module = build_judge("zero_shot_llm", PresetCompany, entity_noun="company")
+        assert isinstance(module, DSPyJudge)
+        assert module.model == _OPENROUTER_MODEL
+        assert module.entity_noun == "company"
+        assert module.price_per_1k_tokens > 0.0
+
+    def test_zero_shot_llm_respects_model_override(self) -> None:
+        module = build_judge("zero_shot_llm", PresetCompany, model=_OPENAI_MODEL)
+        assert isinstance(module, DSPyJudge)
+        assert module.model == _OPENAI_MODEL
+        assert module.price_per_1k_tokens > 0.0
+
+    def test_module_instance_passed_through_verbatim(self) -> None:
+        injected: DSPyJudge[PresetCompany] = DSPyJudge(lm=DummyLM([]), entity_noun="thing")
+        assert build_judge(injected, PresetCompany) is injected
+
+    def test_unknown_judge_name_raises(self) -> None:
+        with pytest.raises(ValueError, match="unknown judge"):
+            build_judge("not-a-real-judge", PresetCompany)  # type: ignore[arg-type]
+
+    def test_auto_is_not_resolved_here(self) -> None:
+        with pytest.raises(ValueError, match="unknown judge"):
+            build_judge("auto", PresetCompany)
+
+
+# ---------------------------------------------------------------------------
+# _SpendCappedModule / resolve_judge
+# ---------------------------------------------------------------------------
+
+
+class TestSpendCappedModule:
+    def test_zero_cost_judgements_never_trip_the_cap(self) -> None:
+        module = _SpendCappedModule(_FakeCostlyModule(5, 0.0), budget_usd=0.01)
+        candidates = iter([_candidate(str(i)) for i in range(5)])
+        judgements = list(module.forward(candidates))
+        assert len(judgements) == 5
+
+    def test_cap_breach_raises_budget_exceeded_with_partial_judgements(self) -> None:
+        module = _SpendCappedModule(_FakeCostlyModule(5, 0.5), budget_usd=0.9)
+        candidates = iter([_candidate(str(i)) for i in range(5)])
+        with pytest.raises(BudgetExceeded) as excinfo:
+            list(module.forward(candidates))
+        partial = excinfo.value.partial_judgements  # type: ignore[attr-defined]
+        # 0.5 -> ok, 1.0 -> breaches $0.9 cap: exactly 2 judgements were paid for.
+        assert len(partial) == 2
+        assert all(isinstance(j, PairwiseJudgement) for j in partial)
+
+    def test_inspect_scores_delegates_to_wrapped_module(self) -> None:
+        inner = build_judge("string", PresetCompany)
+        module = _SpendCappedModule(inner, budget_usd=1.0)
+        report = module.inspect_scores([])
+        assert report is not None
+
+
+def _candidate(suffix: str) -> ERCandidate[PresetCompany]:
+    return ERCandidate(
+        left=PresetCompany(id=f"l{suffix}", name="A"),
+        right=PresetCompany(id=f"r{suffix}", name="B"),
+        blocker_name="test",
+    )
+
+
+class TestResolveJudge:
+    def test_string_judge_used_and_default_budget(self) -> None:
+        resolved = resolve_judge("string", PresetCompany)
+        assert resolved.judge_used == "string"
+        assert resolved.model is None
+        assert resolved.fallback_reason is None
+        assert isinstance(resolved.module, _SpendCappedModule)
+        assert resolved.module._budget_usd == DEFAULT_BUDGET_USD
+
+    def test_custom_budget_usd_override(self) -> None:
+        resolved = resolve_judge("string", PresetCompany, budget_usd=3.5)
+        assert resolved.module._budget_usd == 3.5
+
+    def test_zero_shot_llm_explicit_defaults_model_when_none(self) -> None:
+        resolved = resolve_judge("zero_shot_llm", PresetCompany, model=None)
+        assert resolved.judge_used == "zero_shot_llm"
+        assert resolved.model == _OPENROUTER_MODEL
+        assert resolved.module._module.model == _OPENROUTER_MODEL  # type: ignore[attr-defined]
+
+    def test_injected_module_reports_judge_used_custom(self) -> None:
+        injected: DSPyJudge[PresetCompany] = DSPyJudge(lm=DummyLM([]), entity_noun="thing")
+        resolved = resolve_judge(injected, PresetCompany)
+        assert resolved.judge_used == "custom"
+        assert resolved.module._module is injected
+
+    def test_auto_resolution_is_delegated_to_choose_auto_judge(self) -> None:
+        with patch.dict("os.environ", {"OPENROUTER_API_KEY": "fake-not-a-real-key"}, clear=True):
+            resolved = resolve_judge("auto", PresetCompany)
+        assert resolved.judge_used == "zero_shot_llm"
+        assert resolved.model == _OPENROUTER_MODEL
+        assert isinstance(resolved.module._module, DSPyJudge)
+
+    def test_auto_resolution_falls_back_to_string_without_keys(self) -> None:
+        with (
+            patch.dict("os.environ", {}, clear=True),
+            patch("pydantic_settings.sources.DotEnvSettingsSource.__call__", return_value={}),
+            pytest.warns(UserWarning),
+        ):
+            resolved = resolve_judge("auto", PresetCompany)
+        assert resolved.judge_used == "string"
+        assert resolved.fallback_reason is not None
+
+
+# ---------------------------------------------------------------------------
+# notice_pre_scoring_cost / _estimate_n_pairs
+# ---------------------------------------------------------------------------
+
+
+class TestNoticeAndEstimate:
+    def test_notice_message_format(self) -> None:
+        with pytest.warns(UserWarning, match=r"scoring ~10 pairs with '.*', est\. cost \$"):
+            notice_pre_scoring_cost(_OPENROUTER_MODEL, 10)
+
+    def test_unpriced_model_estimates_zero_cost(self) -> None:
+        with pytest.warns(UserWarning, match=r"est\. cost \$0\.0000"):
+            notice_pre_scoring_cost("unknown/model-not-in-table", 10)
+
+    def test_estimate_all_pairs(self) -> None:
+        assert _estimate_n_pairs(5, use_vector=False) == 10  # C(5,2)
+
+    def test_estimate_vector(self) -> None:
+        assert _estimate_n_pairs(5, use_vector=True) == 50  # 5 * k=10
+
+
+# ---------------------------------------------------------------------------
+# build_resolver
+# ---------------------------------------------------------------------------
+
+
+class TestBuildResolver:
+    def test_string_judge_small_n_uses_all_pairs_blocker(self) -> None:
+        resolved = build_resolver(
+            PresetCompany,
+            judge="string",
+            model=None,
+            entity_noun="entity",
+            threshold=None,
+            n_records=5,
+        )
+        assert resolved.judge_used == "string"
+        assert resolved.score_type == "heuristic"
+        assert isinstance(resolved.resolver.blocker, AllPairsBlocker)
+        assert resolved.resolver.comparator is not None
+
+    def test_string_judge_large_n_uses_vector_blocker(self) -> None:
+        resolved = build_resolver(
+            PresetCompany,
+            judge="string",
+            model=None,
+            entity_noun="entity",
+            threshold=None,
+            n_records=_ALL_PAIRS_MAX_N + 1,
+        )
+        assert isinstance(resolved.resolver.blocker, VectorBlocker)
+
+    def test_embedding_judge_always_uses_vector_blocker_even_for_small_n(self) -> None:
+        resolved = build_resolver(
+            PresetCompany,
+            judge="embedding",
+            model=None,
+            entity_noun="entity",
+            threshold=None,
+            n_records=2,
+        )
+        assert isinstance(resolved.resolver.blocker, VectorBlocker)
+        assert resolved.resolver.comparator is None
+        assert resolved.score_type == "sim_cos"
+
+    def test_threshold_defaults_per_judge_when_none(self) -> None:
+        resolved = build_resolver(
+            PresetCompany, judge="embedding", model=None, entity_noun="e", threshold=None, n_records=2
+        )
+        assert resolved.resolver.clusterer.threshold == 0.5
+
+    def test_explicit_threshold_overrides_default(self) -> None:
+        resolved = build_resolver(
+            PresetCompany, judge="string", model=None, entity_noun="e", threshold=0.9, n_records=2
+        )
+        assert resolved.resolver.clusterer.threshold == 0.9
+
+    def test_zero_shot_llm_emits_pre_scoring_notice(self) -> None:
+        with pytest.warns(UserWarning, match="scoring ~"):
+            build_resolver(
+                PresetCompany,
+                judge="zero_shot_llm",
+                model=_OPENROUTER_MODEL,
+                entity_noun="e",
+                threshold=None,
+                n_records=4,
+            )
+
+    def test_string_judge_emits_no_notice(self) -> None:
+        with warnings_none():
+            build_resolver(
+                PresetCompany, judge="string", model=None, entity_noun="e", threshold=None, n_records=4
+            )
+
+    def test_custom_module_uses_n_based_blocker_rule_and_no_notice(self) -> None:
+        injected: DSPyJudge[PresetCompany] = DSPyJudge(lm=DummyLM([]), entity_noun="thing")
+        with warnings_none():
+            resolved = build_resolver(
+                PresetCompany, judge=injected, model=None, entity_noun="e", threshold=None, n_records=4
+            )
+        assert resolved.judge_used == "custom"
+        assert isinstance(resolved.resolver.blocker, AllPairsBlocker)
+        assert resolved.score_type == "unknown"
+
+
+# ---------------------------------------------------------------------------
+# _text_field_extractor (schema-agnostic)
+# ---------------------------------------------------------------------------
+
+
+class TestTextFieldExtractor:
+    def test_concatenates_non_empty_string_fields(self) -> None:
+        extractor = _text_field_extractor(PresetCompany)
+        entity = PresetCompany(id="1", name="Acme", address=None)
+        assert extractor(entity) == "Acme"
+
+    def test_schema_agnostic_second_schema(self) -> None:
+        extractor = _text_field_extractor(PresetProduct)
+        entity = PresetProduct(id="1", title="Widget", brand="Acme")
+        text = extractor(entity)
+        assert "Widget" in text and "Acme" in text
+
+
+# ---------------------------------------------------------------------------
+# Vector-blocker / embedding construction (real MiniLM load -- slow, local, $0)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.slow
+class TestVectorBlockerAndEmbedding:
+    def test_build_vector_blocker_shape(self) -> None:
+        blocker = _build_vector_blocker(PresetCompany)
+        assert isinstance(blocker, VectorBlocker)
+        assert blocker.k_neighbors == 10
+
+    def test_build_embedding_candidate_identical_texts_score_near_one(self) -> None:
+        record = {"id": "a", "name": "Acme Corporation"}
+        candidate = build_embedding_candidate(PresetCompany, record, dict(record, id="b"))
+        assert candidate.similarity_score is not None
+        assert candidate.similarity_score > 0.99
+
+    def test_build_embedding_candidate_different_texts_score_lower(self) -> None:
+        left = {"id": "a", "name": "Acme Corporation"}
+        right = {"id": "b", "name": "Totally Unrelated Restaurant Chain"}
+        candidate = build_embedding_candidate(PresetCompany, left, right)
+        assert candidate.similarity_score is not None
+        assert candidate.similarity_score < 0.99

--- a/tests/core/test_presets.py
+++ b/tests/core/test_presets.py
@@ -65,9 +65,7 @@ class _FakeCostlyModule(Module[object]):
         self._n = n
         self._cost_each = cost_each
 
-    def forward(
-        self, candidates: Iterator[ERCandidate[object]]
-    ) -> Iterator[PairwiseJudgement]:
+    def forward(self, candidates: Iterator[ERCandidate[object]]) -> Iterator[PairwiseJudgement]:
         list(candidates)  # drain (content unused)
         for i in range(self._n):
             yield PairwiseJudgement(
@@ -342,7 +340,12 @@ class TestBuildResolver:
 
     def test_threshold_defaults_per_judge_when_none(self) -> None:
         resolved = build_resolver(
-            PresetCompany, judge="embedding", model=None, entity_noun="e", threshold=None, n_records=2
+            PresetCompany,
+            judge="embedding",
+            model=None,
+            entity_noun="e",
+            threshold=None,
+            n_records=2,
         )
         assert resolved.resolver.clusterer.threshold == 0.5
 
@@ -366,14 +369,24 @@ class TestBuildResolver:
     def test_string_judge_emits_no_notice(self) -> None:
         with warnings_none():
             build_resolver(
-                PresetCompany, judge="string", model=None, entity_noun="e", threshold=None, n_records=4
+                PresetCompany,
+                judge="string",
+                model=None,
+                entity_noun="e",
+                threshold=None,
+                n_records=4,
             )
 
     def test_custom_module_uses_n_based_blocker_rule_and_no_notice(self) -> None:
         injected: DSPyJudge[PresetCompany] = DSPyJudge(lm=DummyLM([]), entity_noun="thing")
         with warnings_none():
             resolved = build_resolver(
-                PresetCompany, judge=injected, model=None, entity_noun="e", threshold=None, n_records=4
+                PresetCompany,
+                judge=injected,
+                model=None,
+                entity_noun="e",
+                threshold=None,
+                n_records=4,
             )
         assert resolved.judge_used == "custom"
         assert isinstance(resolved.resolver.blocker, AllPairsBlocker)

--- a/tests/core/test_presets.py
+++ b/tests/core/test_presets.py
@@ -210,7 +210,7 @@ class TestSpendCappedModule:
         candidates = iter([_candidate(str(i)) for i in range(5)])
         with pytest.raises(BudgetExceeded) as excinfo:
             list(module.forward(candidates))
-        partial = excinfo.value.partial_judgements  # type: ignore[attr-defined]
+        partial = excinfo.value.partial_judgements
         # 0.5 -> ok, 1.0 -> breaches $0.9 cap: exactly 2 judgements were paid for.
         assert len(partial) == 2
         assert all(isinstance(j, PairwiseJudgement) for j in partial)

--- a/tests/core/test_presets.py
+++ b/tests/core/test_presets.py
@@ -9,6 +9,7 @@ MiniLM model (no API key, no paid call) and are marked ``@pytest.mark.slow``.
 """
 
 from collections.abc import Iterator
+from typing import Any
 from unittest.mock import patch
 
 import pytest
@@ -79,6 +80,37 @@ class _FakeCostlyModule(Module[object]):
 
     def inspect_scores(self, judgements: list[PairwiseJudgement], sample_size: int = 10) -> object:
         raise NotImplementedError
+
+
+class _FakeVectorIndex:
+    """No-op stand-in for a real FAISS index -- create_index does nothing."""
+
+    def create_index(self, texts: list[str]) -> None:
+        pass
+
+
+class _FakeEmptyStreamBlocker:
+    """A fake VectorBlocker whose stream() yields no candidates (L2 test seam).
+
+    Exercises build_embedding_candidate's defensive "no candidate" guard
+    without needing a real, genuinely-broken VectorBlocker -- that case
+    "should never happen" for a real 2-record stream, so it's only reachable
+    by substituting a blocker built this way.
+    """
+
+    vector_index = _FakeVectorIndex()
+
+    @staticmethod
+    def schema_factory(record: dict[str, Any]) -> dict[str, Any]:
+        return record
+
+    @staticmethod
+    def text_field_extractor(entity: dict[str, Any]) -> str:
+        return str(entity)
+
+    @staticmethod
+    def stream(records: list[dict[str, Any]]) -> Iterator[ERCandidate[Any]]:
+        return iter(())
 
 
 # ---------------------------------------------------------------------------
@@ -283,8 +315,20 @@ class TestNoticeAndEstimate:
         with pytest.warns(UserWarning, match=r"scoring ~10 pairs with '.*', est\. cost \$"):
             notice_pre_scoring_cost(_OPENROUTER_MODEL, 10)
 
-    def test_unpriced_model_estimates_zero_cost(self) -> None:
-        with pytest.warns(UserWarning, match=r"est\. cost \$0\.0000"):
+    def test_unpinned_model_warns_blind_cap_not_reassuring_zero(self) -> None:
+        """M1 regression: an unpinned paid model must never print the
+        reassuring (and false) "est. cost $0.0000" -- the spend cap tallies
+        that same $0 and can never trip, so it's silently blind while
+        OpenRouter still bills. The notice must say so honestly."""
+        with pytest.warns(UserWarning, match=r"CANNOT enforce a limit") as record:
+            notice_pre_scoring_cost("unknown/model-not-in-table", 10, budget_usd=2.5)
+        message = str(record[0].message)
+        assert "est. cost $0.0000" not in message
+        assert "unknown/model-not-in-table" in message
+        assert "$2.50" in message
+
+    def test_unpinned_model_defaults_budget_in_message_when_omitted(self) -> None:
+        with pytest.warns(UserWarning, match=rf"\${DEFAULT_BUDGET_USD:.2f}"):
             notice_pre_scoring_cost("unknown/model-not-in-table", 10)
 
     def test_estimate_all_pairs(self) -> None:
@@ -366,6 +410,25 @@ class TestBuildResolver:
                 n_records=4,
             )
 
+    def test_zero_shot_llm_explicit_unpinned_model_warns_blind_cap(self) -> None:
+        """M1 regression: an explicit judge="zero_shot_llm" with an unpinned
+        model= must warn that the spend cap is blind (construction only --
+        DummyLM-equivalent zero-spend, DSPyJudge is never .forward()ed here),
+        not silently proceed under a reassuring but false $0.0000 estimate."""
+        with pytest.warns(UserWarning, match="CANNOT enforce a limit") as record:
+            build_resolver(
+                PresetCompany,
+                judge="zero_shot_llm",
+                model="unknown/model-not-in-table",
+                entity_noun="e",
+                threshold=None,
+                n_records=4,
+                budget_usd=3.0,
+            )
+        message = str(record[0].message)
+        assert "est. cost $0.0000" not in message
+        assert "$3.00" in message
+
     def test_string_judge_emits_no_notice(self) -> None:
         with warnings_none():
             build_resolver(
@@ -435,3 +498,15 @@ class TestVectorBlockerAndEmbedding:
         candidate = build_embedding_candidate(PresetCompany, left, right)
         assert candidate.similarity_score is not None
         assert candidate.similarity_score < 0.99
+
+
+class TestBuildEmbeddingCandidateNoCandidateGuard:
+    """L2 regression: a bare StopIteration must never leak from next()."""
+
+    def test_empty_blocker_stream_raises_clear_runtime_error(self) -> None:
+        fake_blocker = _FakeEmptyStreamBlocker()
+        with patch("langres.core.presets._build_vector_blocker", return_value=fake_blocker):
+            with pytest.raises(RuntimeError, match="produced no candidate"):
+                build_embedding_candidate(
+                    PresetCompany, {"id": "a", "name": "X"}, {"id": "b", "name": "Y"}
+                )

--- a/tests/core/test_resolver_from_schema_judge.py
+++ b/tests/core/test_resolver_from_schema_judge.py
@@ -79,6 +79,18 @@ class TestFromSchemaJudgeOptions:
         assert isinstance(resolver.module, DSPyJudge)
         assert resolver.module.model == "openai/gpt-5-mini"
 
+    def test_zero_shot_llm_unpinned_model_warns_blind_cap(self) -> None:
+        """M1 regression: Resolver.from_schema builds an UNCAPPED pipeline
+        (see the judge= docstring caution) -- an unpinned model must not
+        silently self-report $0/pair without any warning, since nothing here
+        would ever stop a runaway bill. Construction only (zero-spend)."""
+        with pytest.warns(UserWarning, match="UNCAPPED pipeline"):
+            resolver = Resolver.from_schema(
+                ResolverJudgeCo, judge="zero_shot_llm", model="unknown/model-not-in-table"
+            )
+        assert isinstance(resolver.module, DSPyJudge)
+        assert resolver.module.price_per_1k_tokens == 0.0
+
     def test_injected_module_instance_used_verbatim(self) -> None:
         injected: DSPyJudge[ResolverJudgeCo] = DSPyJudge(lm=DummyLM([]), entity_noun="thing")
         resolver = Resolver.from_schema(ResolverJudgeCo, judge=injected)

--- a/tests/core/test_resolver_from_schema_judge.py
+++ b/tests/core/test_resolver_from_schema_judge.py
@@ -1,0 +1,79 @@
+"""Tests for Resolver.from_schema's judge= parameter (W0.1 bullet D).
+
+Zero-spend: the "zero_shot_llm" branch is only exercised up to construction
+(model/price), never a real `.forward()` call.
+"""
+
+import pytest
+from dspy.utils.dummies import DummyLM
+from pydantic import BaseModel
+
+from langres.core.judges.embedding_score import EmbeddingScoreJudge
+from langres.core.judges.weighted_average import WeightedAverageJudge
+from langres.core.modules.dspy_judge import DSPyJudge
+from langres.core.resolver import Resolver, _build_module_for_judge
+
+
+class ResolverJudgeCo(BaseModel):
+    id: str
+    name: str | None = None
+
+
+class TestFromSchemaJudgeDefault:
+    def test_default_judge_is_string_byte_identical_to_pre_existing_behavior(self) -> None:
+        """No judge= kwarg -> the exact WeightedAverageJudge construction that
+        existed before this parameter was added (regression guard)."""
+        resolver = Resolver.from_schema(ResolverJudgeCo)
+        assert isinstance(resolver.module, WeightedAverageJudge)
+        assert resolver.module.feature_specs == resolver.comparator.feature_specs  # type: ignore[union-attr]
+
+    def test_explicit_judge_string_matches_default(self) -> None:
+        default_resolver = Resolver.from_schema(ResolverJudgeCo)
+        explicit_resolver = Resolver.from_schema(ResolverJudgeCo, judge="string")
+        assert type(default_resolver.module) is type(explicit_resolver.module)
+        assert default_resolver.module.feature_specs == explicit_resolver.module.feature_specs  # type: ignore[attr-defined]
+
+
+class TestFromSchemaJudgeOptions:
+    def test_embedding_judge(self) -> None:
+        resolver = Resolver.from_schema(ResolverJudgeCo, judge="embedding")
+        assert isinstance(resolver.module, EmbeddingScoreJudge)
+
+    def test_zero_shot_llm_judge_default_model_and_pinned_price(self) -> None:
+        resolver = Resolver.from_schema(ResolverJudgeCo, judge="zero_shot_llm", entity_noun="company")
+        assert isinstance(resolver.module, DSPyJudge)
+        assert resolver.module.model == "openrouter/openai/gpt-4o-mini"
+        assert resolver.module.entity_noun == "company"
+        assert resolver.module.price_per_1k_tokens > 0.0
+
+    def test_zero_shot_llm_judge_model_override(self) -> None:
+        resolver = Resolver.from_schema(
+            ResolverJudgeCo, judge="zero_shot_llm", model="openai/gpt-5-mini"
+        )
+        assert isinstance(resolver.module, DSPyJudge)
+        assert resolver.module.model == "openai/gpt-5-mini"
+
+    def test_injected_module_instance_used_verbatim(self) -> None:
+        injected: DSPyJudge[ResolverJudgeCo] = DSPyJudge(lm=DummyLM([]), entity_noun="thing")
+        resolver = Resolver.from_schema(ResolverJudgeCo, judge=injected)
+        assert resolver.module is injected
+
+    def test_auto_is_rejected_with_guidance_to_verbs(self) -> None:
+        with pytest.raises(ValueError, match="verbs-layer feature"):
+            Resolver.from_schema(ResolverJudgeCo, judge="auto")  # type: ignore[arg-type]
+
+    def test_unknown_judge_name_raises(self) -> None:
+        with pytest.raises(ValueError, match="unsupported judge"):
+            Resolver.from_schema(ResolverJudgeCo, judge="not-a-real-judge")  # type: ignore[arg-type]
+
+
+class TestBuildModuleForJudgeDirect:
+    def test_returns_module_instance_verbatim(self) -> None:
+        from langres.core.comparator import Comparator
+
+        comparator = Comparator.from_schema(ResolverJudgeCo)
+        injected: DSPyJudge[ResolverJudgeCo] = DSPyJudge(lm=DummyLM([]))
+        assert (
+            _build_module_for_judge(injected, comparator, model=None, entity_noun="entity")
+            is injected
+        )

--- a/tests/core/test_resolver_from_schema_judge.py
+++ b/tests/core/test_resolver_from_schema_judge.py
@@ -40,7 +40,9 @@ class TestFromSchemaJudgeOptions:
         assert isinstance(resolver.module, EmbeddingScoreJudge)
 
     def test_zero_shot_llm_judge_default_model_and_pinned_price(self) -> None:
-        resolver = Resolver.from_schema(ResolverJudgeCo, judge="zero_shot_llm", entity_noun="company")
+        resolver = Resolver.from_schema(
+            ResolverJudgeCo, judge="zero_shot_llm", entity_noun="company"
+        )
         assert isinstance(resolver.module, DSPyJudge)
         assert resolver.module.model == "openrouter/openai/gpt-4o-mini"
         assert resolver.module.entity_noun == "company"

--- a/tests/core/test_resolver_from_schema_judge.py
+++ b/tests/core/test_resolver_from_schema_judge.py
@@ -39,6 +39,30 @@ class TestFromSchemaJudgeOptions:
         resolver = Resolver.from_schema(ResolverJudgeCo, judge="embedding")
         assert isinstance(resolver.module, EmbeddingScoreJudge)
 
+    def test_embedding_judge_wires_vector_blocker_not_all_pairs(self) -> None:
+        """BUG regression: the default AllPairsBlocker's candidates never
+        carry similarity_score, which EmbeddingScoreJudge requires -- so
+        judge="embedding" must wire a VectorBlocker instead, exactly like
+        core.presets.build_resolver does for the verb layer."""
+        from langres.core.blockers.vector import VectorBlocker
+
+        resolver = Resolver.from_schema(ResolverJudgeCo, judge="embedding")
+        assert isinstance(resolver.blocker, VectorBlocker)
+
+    @pytest.mark.slow
+    def test_embedding_judge_resolves_without_similarity_score_error(self) -> None:
+        """End-to-end: resolve() must not raise the ValueError an
+        AllPairsBlocker + EmbeddingScoreJudge pairing would produce (real
+        local MiniLM embed -- $0, no API key, just slow)."""
+        records = [
+            {"id": "1", "name": "Acme Corporation"},
+            {"id": "2", "name": "Acme Corp"},
+            {"id": "3", "name": "Totally Unrelated Restaurant"},
+        ]
+        resolver = Resolver.from_schema(ResolverJudgeCo, judge="embedding", threshold=0.5)
+        clusters = resolver.resolve(records)
+        assert isinstance(clusters, list)
+
     def test_zero_shot_llm_judge_default_model_and_pinned_price(self) -> None:
         resolver = Resolver.from_schema(
             ResolverJudgeCo, judge="zero_shot_llm", entity_noun="company"

--- a/tests/test_verbs.py
+++ b/tests/test_verbs.py
@@ -294,6 +294,21 @@ class TestDedupe:
         result = dedupe(records, judge="string", schema=VerbCompany, threshold=0.5)
         assert {"1", "2"} in result
 
+    def test_explicit_schema_no_id_key_uses_positional_ids(self) -> None:
+        """BUG regression: id-less records under an explicit schema= must not
+        be mis-flagged as duplicates. The old code skipped _resolve_ids() on
+        the explicit-schema path and did str(record.get("id")) for every
+        record -- two id-less records both read as the string "None", a
+        false "duplicate ids" collision even though nothing was duplicated.
+        Explicit-schema and inferred-schema must behave identically here:
+        positional ids when none are present."""
+        records = [
+            {"name": "Acme Corporation", "address": "1 Main St"},
+            {"name": "Acme Corporation", "address": "1 Main St"},
+        ]
+        result = dedupe(records, judge="string", schema=VerbCompany, threshold=0.5)
+        assert {"0", "1"} in result
+
     def test_dummy_lm_e2e_at_zero_cost(self) -> None:
         """Hostile-test requirement: judge=DSPyJudge(lm=DummyLM(...)) through dedupe()."""
         records = [
@@ -308,7 +323,7 @@ class TestDedupe:
         records = [{"id": str(i), "name": f"n{i}"} for i in range(4)]  # C(4,2) = 6 pairs
         with pytest.raises(BudgetExceeded) as excinfo:
             dedupe(records, judge=_CostlyModule(6, 0.5), budget_usd=0.9)
-        partial = excinfo.value.partial_judgements  # type: ignore[attr-defined]
+        partial = excinfo.value.partial_judgements
         assert len(partial) == 2
 
     def test_no_key_falls_back_to_string_with_fallback_reason(self) -> None:
@@ -396,7 +411,7 @@ class TestLink:
                 judge=_CostlyModule(1, 5.0),
                 budget_usd=1.0,
             )
-        partial = excinfo.value.partial_judgements  # type: ignore[attr-defined]
+        partial = excinfo.value.partial_judgements
         assert len(partial) == 1
 
     def test_zero_shot_llm_emits_pre_scoring_notice(self) -> None:

--- a/tests/test_verbs.py
+++ b/tests/test_verbs.py
@@ -95,12 +95,21 @@ def _dummy_judge(match: bool = True, prob: float = 0.9) -> DSPyJudge[VerbCompany
 class TestLinkVerdict:
     def test_bool_reflects_match(self) -> None:
         judgement = PairwiseJudgement(
-            left_id="a", right_id="b", score=0.9, score_type="heuristic",
-            decision_step="x", provenance={},
+            left_id="a",
+            right_id="b",
+            score=0.9,
+            score_type="heuristic",
+            decision_step="x",
+            provenance={},
         )
         verdict = LinkVerdict(
-            match=True, score=0.9, reasoning=None, judge_used="string",
-            score_type="heuristic", fallback_reason=None, judgement=judgement,
+            match=True,
+            score=0.9,
+            reasoning=None,
+            judge_used="string",
+            score_type="heuristic",
+            fallback_reason=None,
+            judgement=judgement,
         )
         assert bool(verdict) is True
         assert verdict
@@ -110,12 +119,21 @@ class TestLinkVerdict:
 
     def test_repr_is_friendly(self) -> None:
         judgement = PairwiseJudgement(
-            left_id="a", right_id="b", score=0.42, score_type="heuristic",
-            decision_step="x", provenance={},
+            left_id="a",
+            right_id="b",
+            score=0.42,
+            score_type="heuristic",
+            decision_step="x",
+            provenance={},
         )
         verdict = LinkVerdict(
-            match=False, score=0.42, reasoning=None, judge_used="string",
-            score_type="heuristic", fallback_reason=None, judgement=judgement,
+            match=False,
+            score=0.42,
+            reasoning=None,
+            judge_used="string",
+            score_type="heuristic",
+            fallback_reason=None,
+            judgement=judgement,
         )
         text = repr(verdict)
         assert "NO MATCH" in text
@@ -363,9 +381,7 @@ class TestLink:
         assert verdict.match is True
 
     def test_default_threshold_used_when_none(self) -> None:
-        verdict = link(
-            {"id": "a", "name": "Acme"}, {"id": "b", "name": "Acme"}, judge="string"
-        )
+        verdict = link({"id": "a", "name": "Acme"}, {"id": "b", "name": "Acme"}, judge="string")
         assert verdict.score >= 0.0  # threshold resolved without raising
 
     def test_no_judgement_produced_raises_runtime_error(self) -> None:
@@ -435,9 +451,7 @@ def test_infer_10k_record_fuzz_with_mixed_types() -> None:
     schema, coerced = _infer(records)
     assert len(coerced) == 10_000
     assert all(isinstance(record["n"], str) for record in coerced)
-    assert all(
-        record["maybe_nan"] is None or record["maybe_nan"] == "ok" for record in coerced
-    )
+    assert all(record["maybe_nan"] is None or record["maybe_nan"] == "ok" for record in coerced)
     # every coerced record round-trips through the inferred schema
     schema(**coerced[0])
     schema(**coerced[-1])

--- a/tests/test_verbs.py
+++ b/tests/test_verbs.py
@@ -435,6 +435,29 @@ class TestLink:
         assert verdict.judge_used == "zero_shot_llm"
         assert verdict.score == pytest.approx(0.8)
 
+    def test_zero_shot_llm_unpinned_model_warns_blind_cap_via_link(self) -> None:
+        """M1 regression: link()'s own notice_pre_scoring_cost call site must
+        forward the effective budget too, so an explicit unpinned paid model
+        warns about the blind cap instead of the reassuring $0.0000 estimate
+        (same DummyLM-backed / patched resolve_judge zero-spend seam as
+        test_zero_shot_llm_emits_pre_scoring_notice above)."""
+        fake_resolved = ResolvedModule(
+            _SpendCappedModule(_dummy_judge(match=True, prob=0.8), budget_usd=2.0),
+            "zero_shot_llm",
+            "unknown/model-not-in-table",
+            None,
+        )
+        with (
+            patch("langres.verbs.resolve_judge", return_value=fake_resolved),
+            pytest.warns(UserWarning, match="CANNOT enforce a limit") as record,
+        ):
+            verdict = link(
+                {"id": "a", "name": "X"}, {"id": "b", "name": "Y"}, judge="auto", budget_usd=2.0
+            )
+        assert "est. cost $0.0000" not in str(record[0].message)
+        assert "$2.00" in str(record[0].message)
+        assert verdict.judge_used == "zero_shot_llm"
+
 
 @pytest.mark.slow
 class TestLinkEmbeddingJudge:

--- a/tests/test_verbs.py
+++ b/tests/test_verbs.py
@@ -1,0 +1,496 @@
+"""Tests for langres.verbs (link/dedupe: the three-verb DX layer).
+
+Zero-spend throughout. The only judge that could ever cost money
+("zero_shot_llm") is exercised exclusively via an injected
+``DSPyJudge(lm=DummyLM(...))`` -- the documented $0 test seam (never
+judge="auto" against a real key, and never past construction for a bare
+"zero_shot_llm" string).
+"""
+
+import math
+import subprocess
+import sys
+from collections.abc import Iterator
+from unittest.mock import patch
+
+import pytest
+from dspy.utils.dummies import DummyLM
+from pydantic import BaseModel
+
+from langres.clients.openrouter import BudgetExceeded
+from langres.core.models import ERCandidate, PairwiseJudgement
+from langres.core.module import Module
+from langres.core.modules.dspy_judge import DSPyJudge
+from langres.core.presets import ResolvedModule, _SpendCappedModule
+from langres.verbs import (
+    DedupeResult,
+    LinkVerdict,
+    _check_no_duplicate_ids,
+    _coerce_scalar,
+    _field_union,
+    _infer,
+    _infer_schema,
+    _resolve_ids,
+    dedupe,
+    link,
+)
+
+
+class VerbCompany(BaseModel):
+    id: str
+    name: str | None = None
+    address: str | None = None
+
+
+class _EmptyModule(Module[object]):
+    """Yields nothing for any candidate -- exercises link()'s no-judgement guard."""
+
+    def forward(self, candidates: Iterator[ERCandidate[object]]) -> Iterator[PairwiseJudgement]:
+        list(candidates)
+        return
+        yield  # pragma: no cover - makes this a generator function
+
+    def inspect_scores(self, judgements: list[PairwiseJudgement], sample_size: int = 10) -> object:
+        raise NotImplementedError
+
+
+class _CostlyModule(Module[object]):
+    """Yields N judgements at a fixed cost each -- for cap-breach tests."""
+
+    def __init__(self, n: int, cost_each: float) -> None:
+        self._n = n
+        self._cost_each = cost_each
+
+    def forward(self, candidates: Iterator[ERCandidate[object]]) -> Iterator[PairwiseJudgement]:
+        pairs = list(candidates)
+        for i in range(min(self._n, len(pairs))):
+            pair = pairs[i]
+            yield PairwiseJudgement(
+                left_id=pair.left.id,  # type: ignore[attr-defined]
+                right_id=pair.right.id,  # type: ignore[attr-defined]
+                score=0.9,
+                score_type="prob_llm",
+                decision_step="fake",
+                provenance={"cost_usd": self._cost_each},
+            )
+
+    def inspect_scores(self, judgements: list[PairwiseJudgement], sample_size: int = 10) -> object:
+        raise NotImplementedError
+
+
+def _dummy_judge(match: bool = True, prob: float = 0.9) -> DSPyJudge[VerbCompany]:
+    answer = {
+        "reasoning": "same company" if match else "different company",
+        "match": "True" if match else "False",
+        "match_probability": str(prob),
+    }
+    return DSPyJudge(lm=DummyLM([answer] * 20), entity_noun="company")
+
+
+# ---------------------------------------------------------------------------
+# LinkVerdict / DedupeResult
+# ---------------------------------------------------------------------------
+
+
+class TestLinkVerdict:
+    def test_bool_reflects_match(self) -> None:
+        judgement = PairwiseJudgement(
+            left_id="a", right_id="b", score=0.9, score_type="heuristic",
+            decision_step="x", provenance={},
+        )
+        verdict = LinkVerdict(
+            match=True, score=0.9, reasoning=None, judge_used="string",
+            score_type="heuristic", fallback_reason=None, judgement=judgement,
+        )
+        assert bool(verdict) is True
+        assert verdict
+        no_match = verdict.model_copy(update={"match": False})
+        assert bool(no_match) is False
+        assert not no_match
+
+    def test_repr_is_friendly(self) -> None:
+        judgement = PairwiseJudgement(
+            left_id="a", right_id="b", score=0.42, score_type="heuristic",
+            decision_step="x", provenance={},
+        )
+        verdict = LinkVerdict(
+            match=False, score=0.42, reasoning=None, judge_used="string",
+            score_type="heuristic", fallback_reason=None, judgement=judgement,
+        )
+        text = repr(verdict)
+        assert "NO MATCH" in text
+        assert "0.420" in text
+        assert "'string'" in text
+
+
+class TestDedupeResult:
+    def test_behaves_like_a_plain_list(self) -> None:
+        result = DedupeResult(
+            [{"a", "b"}], judge_used="string", score_type="heuristic", fallback_reason=None
+        )
+        assert result == [{"a", "b"}]
+        assert len(result) == 1
+        assert list(result) == [{"a", "b"}]
+
+    def test_carries_judge_metadata(self) -> None:
+        result = DedupeResult([], judge_used="embedding", score_type="sim_cos", fallback_reason="x")
+        assert result.judge_used == "embedding"
+        assert result.score_type == "sim_cos"
+        assert result.fallback_reason == "x"
+
+    def test_repr_includes_judge_used(self) -> None:
+        result = DedupeResult([], judge_used="string", score_type="heuristic", fallback_reason=None)
+        assert "judge_used='string'" in repr(result)
+
+
+# ---------------------------------------------------------------------------
+# Schema inference primitives
+# ---------------------------------------------------------------------------
+
+
+class TestCoerceScalar:
+    def test_none_stays_none(self) -> None:
+        assert _coerce_scalar(None) is None
+
+    def test_nan_becomes_none_not_the_string_nan(self) -> None:
+        assert _coerce_scalar(float("nan")) is None
+
+    def test_scalars_coerce_to_str(self) -> None:
+        assert _coerce_scalar(42) == "42"
+        assert _coerce_scalar(3.14) == "3.14"
+        assert _coerce_scalar(True) == "True"
+        assert _coerce_scalar("already") == "already"
+
+    def test_nested_list_raises_with_guidance(self) -> None:
+        with pytest.raises(ValueError, match="nested list"):
+            _coerce_scalar([1, 2, 3])
+
+    def test_nested_dict_raises_with_guidance(self) -> None:
+        with pytest.raises(ValueError, match="nested dict"):
+            _coerce_scalar({"a": 1})
+
+
+class TestFieldUnion:
+    def test_union_excludes_id(self) -> None:
+        records = [{"id": "1", "name": "a"}, {"id": "2", "city": "b"}]
+        assert _field_union(records) == frozenset({"name", "city"})
+
+
+class TestResolveIds:
+    def test_all_present_uses_explicit_ids(self) -> None:
+        records = [{"id": "x"}, {"id": "y"}]
+        assert _resolve_ids(records) == ["x", "y"]
+
+    def test_none_present_assigns_positional_ids(self) -> None:
+        records = [{"name": "a"}, {"name": "b"}]
+        assert _resolve_ids(records) == ["0", "1"]
+
+    def test_mixed_presence_raises(self) -> None:
+        records = [{"id": "x"}, {"name": "no id"}]
+        with pytest.raises(ValueError, match="some records have an 'id' key"):
+            _resolve_ids(records)
+
+
+class TestInferSchema:
+    def test_memoized_by_field_set(self) -> None:
+        a = _infer_schema(frozenset({"name", "city"}))
+        b = _infer_schema(frozenset({"city", "name"}))  # same set, different order
+        assert a is b
+
+    def test_deterministic_name(self) -> None:
+        schema = _infer_schema(frozenset({"name"}))
+        assert schema.__name__.startswith("Inferred_")
+        assert len(schema.__name__) == len("Inferred_") + 8
+
+    def test_different_field_sets_produce_different_schemas(self) -> None:
+        a = _infer_schema(frozenset({"name"}))
+        b = _infer_schema(frozenset({"title"}))
+        assert a is not b
+        assert a.__name__ != b.__name__
+
+    def test_all_fields_are_optional_strings(self) -> None:
+        schema = _infer_schema(frozenset({"name", "city"}))
+        assert schema.model_fields["name"].annotation == str | None
+        assert schema.model_fields["id"].is_required()
+
+
+class TestInfer:
+    def test_coerces_and_assigns_ids(self) -> None:
+        records = [{"id": "1", "n": 42}, {"id": "2", "n": None}]
+        schema, coerced = _infer(records)
+        assert coerced == [{"id": "1", "n": "42"}, {"id": "2", "n": None}]
+        assert schema(**coerced[0]).id == "1"
+
+    def test_does_not_check_duplicate_ids(self) -> None:
+        # link(a, a) relies on this -- _infer alone must never raise on repeats.
+        records = [{"id": "same", "n": "x"}, {"id": "same", "n": "x"}]
+        schema, coerced = _infer(records)
+        assert len(coerced) == 2
+
+
+class TestCheckNoDuplicateIds:
+    def test_unique_ids_pass(self) -> None:
+        _check_no_duplicate_ids(["a", "b", "c"])  # no raise
+
+    def test_duplicate_ids_raise_with_the_offending_id(self) -> None:
+        with pytest.raises(ValueError, match=r"duplicate ids in input: \['a'\]"):
+            _check_no_duplicate_ids(["a", "b", "a"])
+
+
+# ---------------------------------------------------------------------------
+# dedupe()
+# ---------------------------------------------------------------------------
+
+
+class TestDedupe:
+    def test_empty_input_returns_empty_result(self) -> None:
+        result = dedupe([])
+        assert result == []
+        assert result.judge_used == "none"
+
+    def test_single_record_returns_empty(self) -> None:
+        result = dedupe([{"id": "a", "name": "Solo"}], judge="string")
+        assert result == []
+
+    def test_duplicate_id_raises(self) -> None:
+        records = [{"id": "a", "name": "X"}, {"id": "a", "name": "Y"}]
+        with pytest.raises(ValueError, match="duplicate ids"):
+            dedupe(records, judge="string")
+
+    def test_string_judge_inferred_schema_clusters_similar_names(self) -> None:
+        records = [
+            {"id": "1", "name": "Acme Corporation"},
+            {"id": "2", "name": "Acme Corporation"},
+            {"id": "3", "name": "Totally Unrelated Restaurant"},
+        ]
+        result = dedupe(records, judge="string", threshold=0.5)
+        assert {"1", "2"} in result
+        assert result.judge_used == "string"
+        assert result.score_type == "heuristic"
+
+    def test_explicit_schema_used_verbatim(self) -> None:
+        records = [
+            {"id": "1", "name": "Acme Corporation", "address": "1 Main St"},
+            {"id": "2", "name": "Acme Corporation", "address": "1 Main St"},
+        ]
+        result = dedupe(records, judge="string", schema=VerbCompany, threshold=0.5)
+        assert {"1", "2"} in result
+
+    def test_dummy_lm_e2e_at_zero_cost(self) -> None:
+        """Hostile-test requirement: judge=DSPyJudge(lm=DummyLM(...)) through dedupe()."""
+        records = [
+            {"id": "1", "name": "Acme Corporation"},
+            {"id": "2", "name": "Acme Corp"},
+        ]
+        result = dedupe(records, judge=_dummy_judge(match=True, prob=0.95), threshold=0.5)
+        assert result.judge_used == "custom"
+        assert {"1", "2"} in result
+
+    def test_cap_breach_mid_stream_raises_with_partial_judgements(self) -> None:
+        records = [{"id": str(i), "name": f"n{i}"} for i in range(4)]  # C(4,2) = 6 pairs
+        with pytest.raises(BudgetExceeded) as excinfo:
+            dedupe(records, judge=_CostlyModule(6, 0.5), budget_usd=0.9)
+        partial = excinfo.value.partial_judgements  # type: ignore[attr-defined]
+        assert len(partial) == 2
+
+    def test_no_key_falls_back_to_string_with_fallback_reason(self) -> None:
+        with (
+            pytest.MonkeyPatch.context() as mp,
+            pytest.warns(UserWarning),
+        ):
+            mp.delenv("OPENROUTER_API_KEY", raising=False)
+            mp.delenv("OPENAI_API_KEY", raising=False)
+            records = [
+                {"id": "1", "name": "Acme"},
+                {"id": "2", "name": "Acme"},
+            ]
+            result = dedupe(records, threshold=0.5)
+        assert result.judge_used == "string"
+        assert result.fallback_reason is not None
+
+
+# ---------------------------------------------------------------------------
+# link()
+# ---------------------------------------------------------------------------
+
+
+class TestLink:
+    def test_string_judge_match(self) -> None:
+        verdict = link(
+            {"id": "a", "name": "Acme Corporation"},
+            {"id": "b", "name": "Acme Corporation"},
+            judge="string",
+            threshold=0.5,
+        )
+        assert verdict.match is True
+        assert verdict.judge_used == "string"
+        assert verdict.score_type == "heuristic"
+
+    def test_string_judge_no_match(self) -> None:
+        verdict = link(
+            {"id": "a", "name": "Acme Corporation"},
+            {"id": "b", "name": "Totally Unrelated Restaurant"},
+            judge="string",
+            threshold=0.9,
+        )
+        assert verdict.match is False
+
+    def test_link_a_a_is_well_defined(self) -> None:
+        a = {"id": "same", "name": "Acme Corporation"}
+        verdict = link(a, a, judge="string", threshold=0.5)
+        assert verdict.match is True
+        assert verdict.score == pytest.approx(1.0)
+
+    def test_dummy_lm_injected_module_zero_cost(self) -> None:
+        verdict = link(
+            {"id": "a", "name": "Acme"},
+            {"id": "b", "name": "Acme Inc"},
+            judge=_dummy_judge(match=True, prob=0.87),
+            threshold=0.5,
+        )
+        assert verdict.judge_used == "custom"
+        assert verdict.score == pytest.approx(0.87)
+        assert verdict.match is True
+
+    def test_explicit_schema_used_verbatim(self) -> None:
+        verdict = link(
+            {"id": "a", "name": "Acme", "address": "1 Main St"},
+            {"id": "b", "name": "Acme", "address": "1 Main St"},
+            judge="string",
+            schema=VerbCompany,
+            threshold=0.5,
+        )
+        assert verdict.match is True
+
+    def test_default_threshold_used_when_none(self) -> None:
+        verdict = link(
+            {"id": "a", "name": "Acme"}, {"id": "b", "name": "Acme"}, judge="string"
+        )
+        assert verdict.score >= 0.0  # threshold resolved without raising
+
+    def test_no_judgement_produced_raises_runtime_error(self) -> None:
+        with pytest.raises(RuntimeError, match="produced no judgement"):
+            link({"id": "a", "name": "X"}, {"id": "b", "name": "Y"}, judge=_EmptyModule())
+
+    def test_cap_breach_raises_with_partial_judgements(self) -> None:
+        with pytest.raises(BudgetExceeded) as excinfo:
+            link(
+                {"id": "a", "name": "X"},
+                {"id": "b", "name": "Y"},
+                judge=_CostlyModule(1, 5.0),
+                budget_usd=1.0,
+            )
+        partial = excinfo.value.partial_judgements  # type: ignore[attr-defined]
+        assert len(partial) == 1
+
+    def test_zero_shot_llm_emits_pre_scoring_notice(self) -> None:
+        """Covers the paid-notice branch without any real network call.
+
+        ``resolve_judge`` is patched to report ``judge_used="zero_shot_llm"``
+        (as a real key would resolve) while the actual scorer stays the $0
+        DummyLM-backed module -- the notice fires, but nothing paid runs.
+        """
+        fake_resolved = ResolvedModule(
+            _SpendCappedModule(_dummy_judge(match=True, prob=0.8), budget_usd=1.0),
+            "zero_shot_llm",
+            "openrouter/openai/gpt-4o-mini",
+            None,
+        )
+        with (
+            patch("langres.verbs.resolve_judge", return_value=fake_resolved),
+            pytest.warns(UserWarning, match="scoring ~1 pairs"),
+        ):
+            verdict = link({"id": "a", "name": "X"}, {"id": "b", "name": "Y"}, judge="auto")
+        assert verdict.judge_used == "zero_shot_llm"
+        assert verdict.score == pytest.approx(0.8)
+
+
+@pytest.mark.slow
+class TestLinkEmbeddingJudge:
+    def test_embedding_judge_scores_identical_text_near_one(self) -> None:
+        a = {"id": "a", "name": "Acme Corporation"}
+        verdict = link(a, dict(a, id="b"), judge="embedding", threshold=0.5)
+        assert verdict.score > 0.99
+        assert verdict.score_type == "sim_cos"
+        assert verdict.judge_used == "embedding"
+
+
+# ---------------------------------------------------------------------------
+# Hostile: 10k-record fuzz (nested values + mixed types), per adopted plan
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.slow
+def test_infer_10k_record_fuzz_with_mixed_types() -> None:
+    records = []
+    for i in range(10_000):
+        records.append(
+            {
+                "id": str(i),
+                "n": i if i % 3 == 0 else (float(i) if i % 3 == 1 else str(i)),
+                "maybe_nan": float("nan") if i % 7 == 0 else "ok",
+                "missing_sometimes": "present" if i % 2 == 0 else None,
+            }
+        )
+    schema, coerced = _infer(records)
+    assert len(coerced) == 10_000
+    assert all(isinstance(record["n"], str) for record in coerced)
+    assert all(
+        record["maybe_nan"] is None or record["maybe_nan"] == "ok" for record in coerced
+    )
+    # every coerced record round-trips through the inferred schema
+    schema(**coerced[0])
+    schema(**coerced[-1])
+
+
+def test_infer_fuzz_rejects_nested_value_with_guidance() -> None:
+    records = [{"id": "1", "n": 1}, {"id": "2", "n": {"nested": True}}]
+    with pytest.raises(ValueError, match="nested dict"):
+        _infer(records)
+
+
+def test_infer_fuzz_isnan_is_only_checked_for_floats() -> None:
+    # A non-float value can't be nan; this just documents math.isnan's guard.
+    assert math.isnan(float("nan"))
+    assert _coerce_scalar(0) == "0"
+
+
+# ---------------------------------------------------------------------------
+# Import-safety: dspy must stay out of sys.modules for plain imports.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.slow
+def test_import_langres_verbs_does_not_import_dspy() -> None:
+    result = subprocess.run(
+        [
+            sys.executable,
+            "-c",
+            "import sys, langres.verbs; "
+            "assert 'dspy' not in sys.modules, 'dspy leaked into import langres.verbs'; "
+            "print('OK')",
+        ],
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode == 0, (
+        f"import-safety check failed.\nSTDOUT:\n{result.stdout}\nSTDERR:\n{result.stderr}"
+    )
+
+
+@pytest.mark.slow
+def test_import_langres_top_level_does_not_import_dspy() -> None:
+    result = subprocess.run(
+        [
+            sys.executable,
+            "-c",
+            "import sys, langres; "
+            "assert 'dspy' not in sys.modules, 'dspy leaked into import langres'; "
+            "print('OK')",
+        ],
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode == 0, (
+        f"import-safety check failed.\nSTDOUT:\n{result.stdout}\nSTDERR:\n{result.stderr}"
+    )


### PR DESCRIPTION
## What

W0.1 of the M4.5/M5 plan: the usable three-verb DX layer on top of the existing
`Resolver` primitive.

- **`langres.link(left, right, ...)`** / **`langres.dedupe(records, ...)`** — the
  first top-level, schema-optional API. `judge="auto"` picks a real LLM judge when
  `OPENROUTER_API_KEY`/`OPENAI_API_KEY` is set (else falls back to the zero-spend
  `"string"` judge, with one notice), and results are self-describing
  (`LinkVerdict`/`DedupeResult` carry `judge_used`, `score_type`, `fallback_reason`).
- **`langres/core/presets.py`** (new) — `choose_auto_judge`, `build_judge`,
  `build_resolver`: judge resolution + the single blocker rule (embedding judge ->
  always `VectorBlocker`; otherwise `AllPairsBlocker` at N<=100, `VectorBlocker`
  above). Every judge — including the free ones — runs under a default `$1`
  `SpendMonitor` cap (`budget_usd=` override); a cap breach raises `BudgetExceeded`
  carrying `.partial_judgements` so a paid run's already-scored pairs are never
  silently discarded.
- **`Resolver.from_schema`** gains `judge: JudgeName | Module = "string"` (default
  byte-identical to today, regression-tested) so the low-level API can opt into the
  same judge menu.
- **Schema-optional inference**: `dedupe`/`link` accept plain `dict` records with no
  Pydantic schema — infers an ephemeral, memoized schema from the union of keys.
  Coercion rules: scalars -> `str`, `None`/`NaN` -> `None` (never the string
  `"nan"`), nested `list`/`dict` -> `ValueError` with guidance. Duplicate ids in
  `dedupe()` input raise `ValueError`; `link(a, a)` is well-defined (self-comparison).
- **Cost-integrity fix**: relocated `_dspy_price_per_1k` from `langres/methods.py` to
  `langres/clients/openrouter.py` (public `dspy_price_per_1k`) to kill a
  core -> methods -> core import cycle that `presets.py` would otherwise create; added
  real worst-case prices for `openai/gpt-4o-mini` and `openai/gpt-5-mini` so the
  spend cap can never be silently blind for an auto-selectable model.
- Shipped `py.typed` (verified present in the built wheel via `uv build --wheel`).
- `examples/quickstart_verbs.py` — offline by default: toy N<=100 dataset, AllPairs
  blocking, `judge="string"` pinned (zero spend, no model download), prints an
  upgrade note when a real key is present without ever invoking the paid path.
- README gains an append-only "Quickstart: `link()` and `dedupe()`" section pointing
  at the example (full README rewrite is W0.3's job).

## Why

`Resolver` already worked but had no top-level entry point — every user had to
assemble a `Blocker`/`Comparator`/`Module`/`Clusterer` by hand. This PR is the
"scikit-learn-style" front door: `dedupe(records)` in one line, zero labels,
spend-capped by default, that still resolves down to the same `Resolver` seam.

## Quickstart output (fresh process, no API key)

```
$ uv run python examples/quickstart_verbs.py
['1', '2']
['3', '4']

2 cluster(s) found, judge_used='string', score_type='heuristic'

No OPENROUTER_API_KEY/OPENAI_API_KEY set: dedupe(records) with the default judge="auto" would fall back to this same zero-spend 'string' judge (with one warning). Set one of those env vars to try a real LLM judge -- it runs under a $1 default spend cap (budget_usd=).
```

## Adopted-decision references (from the M4.5/M5 plan)

- **E1** — every auto-selectable model has a nonzero pinned price in
  `PRICES_PER_1M`; a paid judge whose price resolves to `$0` is refused (falls
  back to `"string"` + one warning) so the spend-cap guarantee is never blind.
- **E8** — inferred schemas are ephemeral (never registered under a
  collision-prone name); a fresh-process `.load()` of an artifact built on an
  inferred schema hits the pre-existing `SchemaNotRegistered` error, which already
  points at "pass an explicit schema" — no new guard code needed.
- **E9** — `BudgetExceeded` carries `.partial_judgements`; a cap breach mid-run
  never silently drops already-scored pairs.
- **D1** — `py.typed` shipped (the `Typing :: Typed` classifier was a false claim
  before this PR); verified present in the built wheel.
- **D2** — `LinkVerdict`/`DedupeResult` are self-describing (`judge_used`,
  `score_type`, `fallback_reason`); the fallback and pre-scoring-cost notices go
  through `warnings.warn` (the correct choice for library code — visible by
  default, filterable by the caller), not just `logger.info`, which is
  invisible under default logging config.
- **D3** — `threshold=None` (the default) resolves to a per-judge default
  threshold in `presets.py`, so identical code doesn't silently behave
  differently across machines depending on which score scale ends up in use.
- **D4** — the quickstart example is offline by default: no key needed, no model
  download, prints the "a key was found" upgrade note when one exists.
- **D10 / D11** — `BudgetExceeded`'s docs include the resume recipe;
  `None`/`float('nan')` coerce to `None`, never the string `"nan"` (silent
  similarity poison); every new error message states what happened / why / the
  one-line fix.
- **CEO #8** — verbs carry a baked-in default `SpendMonitor` cap (~$1, override via
  `budget_usd=`) plus a pre-scoring cost-estimate line; `judge="auto"` still
  prefers the LLM judge when a key is present.
- **CEO #11** — `_dspy_price_per_1k` relocated to `langres/clients/openrouter.py`
  (dspy-free, layer-neutral) to kill the core -> methods -> core import cycle.
- **CEO #13 / finding #13** — verb edge cases specified and tested:
  `dedupe([])` -> `[]`, single record -> `[]`, duplicate ids -> `ValueError`,
  `link(a, a)` well-defined.

## Review fixes (claude-review + codex)

- **BUG 1 (claude-review)** — `dedupe(records, schema=<explicit>)` mis-flagged
  id-less records as duplicates: the explicit-schema path skipped
  `_resolve_ids()` and did `str(record.get("id"))` for the uniqueness check,
  so two id-less records both read as the string `"None"` — a false
  collision. Fixed by routing the explicit-schema path through
  `_resolve_ids()` (via a new `_with_resolved_ids()` helper), so
  explicit-schema and inferred-schema behave identically for id
  presence/absence. Regression test added: explicit `schema=` + records with
  no `"id"` key now succeeds with positional ids.
- **BUG 2 (codex P2)** — `Resolver.from_schema(schema, judge="embedding")`
  returned an `EmbeddingScoreJudge` but still built the default
  `AllPairsBlocker`, whose candidates never carry `similarity_score` →
  `resolve()`/`predict()` raised `ValueError`. Fixed by wiring a
  `VectorBlocker` for `judge="embedding"`, mirroring
  `core.presets.build_resolver`'s identical rule. Regression test added
  (marked `@pytest.mark.slow`, real local MiniLM embed, $0): builds a
  `VectorBlocker` and `resolve()` runs end-to-end without the error.
- **Nits**: `BudgetExceeded.partial_judgements` is now a declared attribute
  (default `[]`) instead of an ad hoc one set only at the raise site; the
  `"openrouter/openai/gpt-4o-mini"` literal (previously duplicated in
  `resolver.py` and `presets.py`) is now defined once as
  `DEFAULT_OPENROUTER_MODEL` in `clients/openrouter.py` and imported in both.
- Skipped (recorded, not actionable now): the "periodically re-verify dollar
  prices against a live pricing source" note; the embedding-index-reload-per-
  `link()` note (already documented as fine for the single-pair case).

## Test evidence

- `uv run ruff check src tests` / `uv run ruff format --check src tests`: clean.
- `uv run mypy src`: `Success: no issues found in 63 source files`.
- `uv run pytest -m "not slow and not integration"`: **1336 passed**, 0 failed,
  total coverage **98.01%** (project gate: 95%), after the review-fix commit.
- 100% coverage confirmed on every added/changed src file:
  `core/presets.py`, `verbs.py`, `core/resolver.py`, `clients/openrouter.py`,
  `clients/settings.py`, `langres/__init__.py` (the two lines only reachable via
  the local sentence-transformers embedding path are covered by the
  `@pytest.mark.slow` tests, confirmed 100% when run together with the fast suite).
- New/updated test files: `tests/core/test_presets.py` (39 tests),
  `tests/test_verbs.py` (40+ tests, including a 10k-record inference fuzz with
  nested/mixed types, duplicate-id rejection, mid-stream cap-breach carrying
  partials, subprocess dspy-isolation tests, and a `DummyLM` E2E test at $0),
  `tests/core/test_resolver_from_schema_judge.py` (regression-tests the
  byte-identical `judge="string"` default).
- `@pytest.mark.integration` tests that require a real `OPENROUTER_API_KEY`
  (pre-existing, unrelated to this PR) were deliberately excluded from CI-equivalent
  local runs in this branch's verification for cost-safety reasons (see PR
  comment / orchestrator report for the full explanation) — they are unaffected by
  this change and still gated by their existing `skipif`.

## Deviations from spec

- None material. `_check_no_duplicate_ids` was written as an explicit loop instead
  of a one-liner relying on `set.add()`'s falsy return, per the project's
  "Simplicity First" rule. `judge="embedding"` for a single `link()` pair uses a
  direct `SentenceTransformerEmbedder.encode()` + `VectorBlocker.stream()` path
  rather than building a full ANN index for two items (documented in
  `build_embedding_candidate`'s docstring).

