### PR TITLE
W0.2: JudgementLog signal seam (opt-in, boundary component, v:1)

### DIFF
--- a/docs/EXPERIMENTS.md
+++ b/docs/EXPERIMENTS.md
@@ -130,9 +130,46 @@ it does not throttle the LM. For a hard pre-flight cap on the run itself, wrap t
 judge in a `BudgetedModuleRunner` and pass it to `evaluate_judge_on_candidates`. On
 the zero-spend `DummyLM` path both report **$0.00**.
 
+## Signal log — the flywheel inlet (`JudgementLog`)
+
+`link()`/`dedupe()` take an opt-in, keyword-only `log=` (a
+`langres.JudgementLog` or a path — `None` by default, zero overhead):
+
+```python
+from langres import JudgementLog, dedupe
+
+log = JudgementLog("runs/judgements.jsonl")
+result = dedupe(records, judge="string", threshold=0.6, log=log)
+
+rows = log.read()  # round-trips every line written
+```
+
+Every judge call appends one JSON line: pair ids, `score`, `verdict`
+(`score >= threshold`, the same cutoff the verb itself used), `model`,
+`cost_usd`, `decision_step`, `timestamp`, and a schema-version field `"v": 1`
+(so a future format change can branch on it). Record content is **off by
+default** — pass `JudgementLog(path, features=True)` to additionally log
+`reasoning` and the judge's raw `provenance` (comparison levels,
+similarities, token counts, ...): this may contain PII (the record content a
+judge reasoned over), and JSONL is plaintext on disk.
+
+Implementation note: `JudgementLog` is a plain file sink, not a `Module`.
+`log=` wraps the resolved judge in a `LoggingModule` — a small boundary
+component (the same pattern `_SpendCappedModule` uses) that logs each
+`PairwiseJudgement` as it streams past without materializing the whole
+judgement stream. It is intentionally excluded from `Resolver` artifacts —
+`link()`/`dedupe()` never persist their internal resolver, so this isn't a
+durability gap in practice.
+
+This is the flywheel's inlet: a future milestone (W2.4) harvests these logs
+(plus a `corrections.jsonl` contract) into labeled pairs feeding
+`derive_threshold` and `fit()` — see `examples/judgement_log_demo.py` for the
+runnable write-then-read walkthrough.
+
 ## See also
 
 - `examples/m4_experiment_loop.py` — the runnable zero-spend loop documented here.
 - `examples/m4_dspy_judge.py` — DSPyJudge compile + save/load round-trip.
 - `examples/m4_calibration.py` — honest held-out `derive_threshold` lift on AG.
+- `examples/judgement_log_demo.py` — `JudgementLog` write-then-read round-trip.
 - `examples/m3_race.py` / `examples/m3_zero_spend_race.py` — multi-method races.

--- a/examples/judgement_log_demo.py
+++ b/examples/judgement_log_demo.py
@@ -1,0 +1,38 @@
+"""The flywheel inlet: log every judge call, then read the log back.
+
+``log=`` is opt-in on both ``dedupe()`` and ``link()`` (omit it -- the
+default -- for zero overhead). Pass a path (or a ``JudgementLog`` instance
+for more control, e.g. ``features=True``) and every judge call is appended
+as one JSON line: pair ids, score, verdict, model, cost, decision_step,
+timestamp, and a schema-version field ``"v": 1``.
+
+This is the harvest source a future milestone (W2.4) turns into labeled
+training pairs for ``derive_threshold``/``fit()`` -- see the "Signal log"
+section of docs/EXPERIMENTS.md.
+
+Offline and free: the zero-spend "string" judge, no API key needed.
+
+Run it:
+    uv run python examples/judgement_log_demo.py
+"""
+
+import json
+
+from langres import JudgementLog, dedupe
+
+records = [
+    {"id": "1", "name": "Acme Corporation", "city": "New York"},
+    {"id": "2", "name": "Acme Corp", "city": "New York"},
+    {"id": "3", "name": "Totally Different Co", "city": "Chicago"},
+]
+
+log = JudgementLog("tmp/judgement_log_demo.jsonl")
+result = dedupe(records, judge="string", threshold=0.6, log=log)
+
+print(f"{len(result)} cluster(s): {list(result)}")
+
+# --- read the log back (the round-trip) ---
+rows = log.read()
+print(f"\n{len(rows)} judgement(s) logged to {log.path}:")
+for row in rows:
+    print(json.dumps(row))

--- a/src/langres/__init__.py
+++ b/src/langres/__init__.py
@@ -6,14 +6,18 @@ This package provides:
   by default, spend-capped) -- see ``langres.verbs``.
 - ``langres.core``: Low-level primitives for custom pipelines (``Resolver``,
   ``Blocker``, ``Module``, ``Clusterer``, ...).
+- ``JudgementLog``: opt-in JSONL signal log for judge calls, wired via
+  ``log=`` on ``link``/``dedupe`` -- the flywheel inlet (see
+  ``langres.core.judgement_log``).
 """
 
-from langres.core import CompanySchema, ERCandidate, PairwiseJudgement, Resolver
+from langres.core import CompanySchema, ERCandidate, JudgementLog, PairwiseJudgement, Resolver
 from langres.verbs import LinkVerdict, dedupe, link
 
 __all__ = [
     "CompanySchema",
     "ERCandidate",
+    "JudgementLog",
     "LinkVerdict",
     "PairwiseJudgement",
     "Resolver",

--- a/src/langres/core/__init__.py
+++ b/src/langres/core/__init__.py
@@ -37,6 +37,7 @@ from langres.core.indexes import (
     QdrantHybridIndex,
     VectorIndex,
 )
+from langres.core.judgement_log import JudgementLog, LoggingModule
 from langres.core.judges.embedding_score import EmbeddingScoreJudge
 from langres.core.judges.weighted_average import WeightedAverageJudge
 from langres.core.models import (
@@ -100,7 +101,9 @@ __all__ = [
     "get_schema",
     "GLinkerAdapter",
     "GroupwiseModule",
+    "JudgementLog",
     "LLMJudge",
+    "LoggingModule",
     "metrics",
     "Module",
     "optimizers",

--- a/src/langres/core/judgement_log.py
+++ b/src/langres/core/judgement_log.py
@@ -38,6 +38,7 @@ from datetime import UTC, datetime
 from pathlib import Path
 from typing import Any
 
+from langres.clients.openrouter import BudgetExceeded
 from langres.core.models import ERCandidate, PairwiseJudgement
 from langres.core.module import Module
 from langres.core.reports import ScoreInspectionReport
@@ -117,6 +118,17 @@ class LoggingModule(Module[Any]):
     match cutoff the calling verb (``link``/``dedupe``) already resolved for
     its own ``score >= threshold`` decision, so the logged verdict always
     agrees with what the caller acted on.
+
+    Wrapping a spend-capped module (e.g.
+    :class:`~langres.core.presets._SpendCappedModule`, as ``link``/``dedupe``
+    do): the judgement that trips the cap is recorded on the raised
+    ``BudgetExceeded.partial_judgements`` but never yielded (the cap raises
+    *before* yielding it -- E9's "set by the catcher, not at raise time"
+    pattern). A ``LoggingModule`` sitting outside that cap would otherwise
+    silently drop exactly the paid call the flywheel most needs. ``forward``
+    catches ``BudgetExceeded`` and logs any trailing ``partial_judgements``
+    entries not already logged (tracked by count, so nothing is logged
+    twice) before re-raising the exception unmodified.
     """
 
     def __init__(self, module: Module[Any], *, log: JudgementLog, threshold: float) -> None:
@@ -125,9 +137,16 @@ class LoggingModule(Module[Any]):
         self._threshold = threshold
 
     def forward(self, candidates: Iterator[ERCandidate[Any]]) -> Iterator[PairwiseJudgement]:
-        for judgement in self._module.forward(candidates):
-            self._log.append(judgement, verdict=judgement.score >= self._threshold)
-            yield judgement
+        logged = 0
+        try:
+            for judgement in self._module.forward(candidates):
+                self._log.append(judgement, verdict=judgement.score >= self._threshold)
+                logged += 1
+                yield judgement
+        except BudgetExceeded as exc:
+            for judgement in exc.partial_judgements[logged:]:
+                self._log.append(judgement, verdict=judgement.score >= self._threshold)
+            raise
 
     def inspect_scores(
         self, judgements: list[PairwiseJudgement], sample_size: int = 10

--- a/src/langres/core/judgement_log.py
+++ b/src/langres/core/judgement_log.py
@@ -1,0 +1,135 @@
+"""Opt-in JSONL judgement log: the flywheel inlet (harvested by W2.4).
+
+``JudgementLog`` is a small file-backed sink -- it is NOT a ``Module``.
+Wire it via ``log=`` on :func:`langres.link`/:func:`langres.dedupe`; those
+verbs wrap the resolved judge in :class:`LoggingModule` below, which appends
+one JSON line per :class:`~langres.core.models.PairwiseJudgement` **as it
+streams past**. It never buffers or materializes the full judgement stream,
+so laziness and memory behavior are unaffected (Eng finding E10: an explicit
+boundary component wrapping a ``Module``, composed the same way
+:class:`~langres.core.presets._SpendCappedModule` wraps one -- never a
+monkey-patch of ``Module.forward``).
+
+Zero overhead when omitted: ``log=None`` (the default on both verbs) skips
+the wrap entirely -- no file, no extra generator layer, byte-identical to
+pre-W0.2 behavior.
+
+Privacy (adopted DX): record content is OFF by default. Each line carries
+only ids, score, verdict, model, cost, decision_step, timestamp, and the
+schema-version field ``"v": 1`` -- never the underlying record fields or the
+judge's free-text reasoning. Pass ``features=True`` to additionally log
+``reasoning`` and the judge's raw ``provenance`` dict (comparison levels,
+similarities, token counts, ...): **this may contain PII** -- the record
+content a judge reasoned over, verbatim -- and JSONL is plaintext on disk.
+
+Serialization: excluded from Resolver artifacts (decided for W0.2, per E10).
+``LoggingModule`` has no registry ``type_name`` and is applied by the verbs
+layer to an already-built ``Resolver.module`` *after* construction -- it is
+never part of a ``resolver.save()``'d pipeline (``link``/``dedupe`` never
+persist their internal resolver). A future milestone can register it if a
+durable, logging-enabled artifact is ever needed.
+"""
+
+from __future__ import annotations
+
+import json
+from collections.abc import Iterator
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any
+
+from langres.core.models import ERCandidate, PairwiseJudgement
+from langres.core.module import Module
+from langres.core.reports import ScoreInspectionReport
+
+__all__ = ["JudgementLog", "LoggingModule"]
+
+#: Schema-version tag written into every line (CEO #15) -- lets a future
+#: harvester (W2.4) or format-migration branch on it instead of guessing.
+_SCHEMA_VERSION = 1
+
+
+class JudgementLog:
+    """JSONL-file-backed sink for judge-call signals.
+
+    Args:
+        path: Where to append JSON lines. Parent directories are created on
+            first :meth:`append` if missing.
+        features: When ``True``, additionally record ``reasoning`` and the
+            judge's raw ``provenance`` dict on every line -- may contain PII
+            (see module docstring). Default ``False``.
+    """
+
+    def __init__(self, path: str | Path, *, features: bool = False) -> None:
+        self.path = Path(path)
+        self.features = features
+
+    def append(self, judgement: PairwiseJudgement, *, verdict: bool) -> None:
+        """Append one JSON line for ``judgement`` (called by :class:`LoggingModule`)."""
+        row: dict[str, Any] = {
+            "v": _SCHEMA_VERSION,
+            "left_id": judgement.left_id,
+            "right_id": judgement.right_id,
+            "score": judgement.score,
+            "verdict": verdict,
+            "model": judgement.provenance.get("model"),
+            "cost_usd": judgement.provenance.get("cost_usd", 0.0),
+            "decision_step": judgement.decision_step,
+            "timestamp": datetime.now(UTC).isoformat(),
+        }
+        if self.features:
+            row["reasoning"] = judgement.reasoning
+            row["provenance"] = judgement.provenance
+        self.path.parent.mkdir(parents=True, exist_ok=True)
+        with self.path.open("a", encoding="utf-8") as fh:
+            fh.write(json.dumps(row) + "\n")
+
+    def read(self) -> list[dict[str, Any]]:
+        """Reload every line written so far -- the round-trip reader.
+
+        Each line is independently valid JSON (one row per :meth:`append`
+        call); this just parses them back into a list of plain dicts in
+        write order. Returns ``[]`` if the file was never created (e.g. a
+        ``dedupe()``/``link()`` call that scored zero pairs).
+        """
+        if not self.path.exists():
+            return []
+        rows: list[dict[str, Any]] = []
+        with self.path.open("r", encoding="utf-8") as fh:
+            for line in fh:
+                stripped = line.strip()
+                if stripped:
+                    rows.append(json.loads(stripped))
+        return rows
+
+
+class LoggingModule(Module[Any]):
+    """Boundary component: wraps a scorer ``Module``, logging each judgement as it streams past.
+
+    Deliberately NOT a monkey-patch of ``module.forward`` (E10) -- a small
+    wrapper ``Module`` in the same family as
+    :class:`~langres.core.presets._SpendCappedModule`, composing
+    transparently with any ``Module`` -- including a future
+    ``GroupwiseModule`` (W1.0): both yield ``PairwiseJudgement`` one at a
+    time, so wrapping and logging is identical either way.
+
+    ``verdict`` is computed per judgement from ``threshold`` -- the same
+    match cutoff the calling verb (``link``/``dedupe``) already resolved for
+    its own ``score >= threshold`` decision, so the logged verdict always
+    agrees with what the caller acted on.
+    """
+
+    def __init__(self, module: Module[Any], *, log: JudgementLog, threshold: float) -> None:
+        self._module = module
+        self._log = log
+        self._threshold = threshold
+
+    def forward(self, candidates: Iterator[ERCandidate[Any]]) -> Iterator[PairwiseJudgement]:
+        for judgement in self._module.forward(candidates):
+            self._log.append(judgement, verdict=judgement.score >= self._threshold)
+            yield judgement
+
+    def inspect_scores(
+        self, judgements: list[PairwiseJudgement], sample_size: int = 10
+    ) -> ScoreInspectionReport:
+        return self._module.inspect_scores(judgements, sample_size)

--- a/src/langres/verbs.py
+++ b/src/langres/verbs.py
@@ -28,6 +28,12 @@ Both verbs share one small contract:
   resolves to a sane per-judge default; pass ``threshold=`` explicitly to
   override, or derive one from labels with
   :func:`~langres.core.calibration.derive_threshold`.
+- ``log=`` (opt-in, ``None`` by default -- zero overhead) records every judge
+  call to a JSONL file via :class:`~langres.core.judgement_log.JudgementLog`
+  -- the flywheel inlet later harvested (W2.4) into training pairs for
+  :func:`~langres.core.calibration.derive_threshold` and ``fit()``. See
+  :mod:`langres.core.judgement_log` for the record shape and the
+  ``features=True`` opt-in (PII note).
 
 Known limitation: an *inferred* schema is ephemeral (a dynamically created
 class, not importable by name) -- a ``dedupe()``/``link()`` call built on one
@@ -41,12 +47,14 @@ from __future__ import annotations
 import math
 from collections.abc import Iterable, Sequence
 from hashlib import sha256
+from pathlib import Path
 from typing import Any
 
 from pydantic import BaseModel, Field, create_model
 
 from langres.core.blockers.all_pairs import schema_to_factory
 from langres.core.comparator import Comparator
+from langres.core.judgement_log import JudgementLog, LoggingModule
 from langres.core.models import ERCandidate, PairwiseJudgement
 from langres.core.module import Module
 from langres.core.presets import (
@@ -241,6 +249,17 @@ def _resolved_threshold(judge_used: str, threshold: float | None) -> float:
     return _THRESHOLDS.get(judge_used, 0.5) if threshold is None else threshold
 
 
+def _coerce_log(log: JudgementLog | str | Path | None) -> JudgementLog | None:
+    """Normalize ``log=`` to a :class:`JudgementLog` (W0.2): ``None`` stays
+    ``None`` (zero overhead -- no wrap); a path is wrapped in a fresh,
+    default (``features=False``) :class:`JudgementLog`; an existing
+    :class:`JudgementLog` (e.g. constructed with ``features=True``) passes
+    through unchanged."""
+    if log is None or isinstance(log, JudgementLog):
+        return log
+    return JudgementLog(log)
+
+
 # ---------------------------------------------------------------------------
 # link()
 # ---------------------------------------------------------------------------
@@ -256,6 +275,7 @@ def link(
     entity_noun: str = "entity",
     threshold: float | None = None,
     budget_usd: float | None = None,
+    log: JudgementLog | str | Path | None = None,
 ) -> LinkVerdict:
     """Decide whether two records refer to the same real-world entity.
 
@@ -274,6 +294,9 @@ def link(
         threshold: Match cutoff; ``None`` resolves to the judge's default.
         budget_usd: Spend cap override (default $1; see
             :mod:`langres.core.presets`).
+        log: Opt-in signal-log sink -- a :class:`~langres.core.judgement_log.JudgementLog`
+            or a path (wrapped in a default one). ``None`` (default): no
+            logging, zero overhead. See :mod:`langres.core.judgement_log`.
 
     Returns:
         A :class:`LinkVerdict`.
@@ -309,7 +332,13 @@ def link(
                 update={"comparison": comparator.compare(left_entity, right_entity)}
             )
 
-    judgements = list(module.forward(iter([candidate])))
+    resolved_threshold = _resolved_threshold(judge_used, threshold)
+    log_sink = _coerce_log(log)
+    scorer_module: Module[Any] = module
+    if log_sink is not None:
+        scorer_module = LoggingModule(module, log=log_sink, threshold=resolved_threshold)
+
+    judgements = list(scorer_module.forward(iter([candidate])))
     if not judgements:
         raise RuntimeError(
             f"the {judge_used!r} judge produced no judgement for this pair; every "
@@ -319,7 +348,7 @@ def link(
     judgement = judgements[0]
 
     return LinkVerdict(
-        match=judgement.score >= _resolved_threshold(judge_used, threshold),
+        match=judgement.score >= resolved_threshold,
         score=judgement.score,
         reasoning=judgement.reasoning,
         judge_used=judge_used,
@@ -343,6 +372,7 @@ def dedupe(
     entity_noun: str = "entity",
     threshold: float | None = None,
     budget_usd: float | None = None,
+    log: JudgementLog | str | Path | None = None,
 ) -> DedupeResult:
     """Group a batch of records into entity clusters.
 
@@ -360,6 +390,9 @@ def dedupe(
         threshold: Clusterer threshold; ``None`` resolves to the judge's
             default.
         budget_usd: Spend cap override (default $1).
+        log: Opt-in signal-log sink -- a :class:`~langres.core.judgement_log.JudgementLog`
+            or a path (wrapped in a default one). ``None`` (default): no
+            logging, zero overhead. See :mod:`langres.core.judgement_log`.
 
     Returns:
         A :class:`DedupeResult` (a ``list[set[str]]`` of entity-id clusters).
@@ -389,6 +422,13 @@ def dedupe(
         n_records=len(resolved_records),
         budget_usd=budget_usd,
     )
+    log_sink = _coerce_log(log)
+    if log_sink is not None:
+        resolved.resolver.module = LoggingModule(
+            resolved.resolver.module,
+            log=log_sink,
+            threshold=resolved.resolver.clusterer.threshold,
+        )
     judgements = resolved.resolver.predict(resolved_records)
     clusters = resolved.resolver.clusterer.cluster(judgements)
     score_type = judgements[0].score_type if judgements else resolved.score_type

--- a/tests/core/test_judgement_log.py
+++ b/tests/core/test_judgement_log.py
@@ -17,6 +17,7 @@ from typing import Any
 
 import pytest
 
+from langres.clients.openrouter import BudgetExceeded
 from langres.core.judgement_log import JudgementLog, LoggingModule
 from langres.core.models import ERCandidate, PairwiseJudgement
 from langres.core.module import Module
@@ -58,6 +59,30 @@ class _CountingModule(Module[object]):
         for judgement in self._judgements:
             self.pulled += 1
             yield judgement
+
+    def inspect_scores(
+        self, judgements: list[PairwiseJudgement], sample_size: int = 10
+    ) -> ScoreInspectionReport:
+        raise NotImplementedError
+
+
+class _BudgetBreachingModule(Module[object]):
+    """Yields ``yielded``, then raises ``BudgetExceeded`` whose
+    ``partial_judgements`` also carries ``tripping`` -- the judgement that
+    was produced (and paid for) but never yielded, mirroring
+    ``core.presets._SpendCappedModule``'s raise-before-yield behavior on the
+    call that crosses the cap."""
+
+    def __init__(self, yielded: list[PairwiseJudgement], tripping: PairwiseJudgement) -> None:
+        self._yielded = yielded
+        self._tripping = tripping
+
+    def forward(self, candidates: Iterator[ERCandidate[object]]) -> Iterator[PairwiseJudgement]:
+        list(candidates)
+        yield from self._yielded
+        exc = BudgetExceeded("budget exceeded")
+        exc.partial_judgements = [*self._yielded, self._tripping]
+        raise exc
 
     def inspect_scores(
         self, judgements: list[PairwiseJudgement], sample_size: int = 10
@@ -259,3 +284,54 @@ class TestLoggingModule:
         report = wrapped.inspect_scores([_judgement()], sample_size=3)
 
         assert report.total_judgements == 1
+
+
+class TestLoggingModuleBudgetExceeded:
+    """Regression (codex review, PR #62): a paid judgement that trips a
+    ``_SpendCappedModule``'s budget is recorded on ``BudgetExceeded.
+    partial_judgements`` but never yielded (the cap raises before yielding
+    it) -- so a ``LoggingModule`` wrapping the cap must not silently drop it
+    from the log. Every judgement that was actually produced, including the
+    tripping one, must appear in the JSONL exactly once."""
+
+    def test_tripping_judgement_is_logged_before_reraising(self, tmp_path: Path) -> None:
+        yielded = [_judgement("a", "b", 0.9)]
+        tripping = _judgement("c", "d", 0.95)
+        inner = _BudgetBreachingModule(yielded, tripping)
+        log = JudgementLog(tmp_path / "log.jsonl")
+        wrapped = LoggingModule(inner, log=log, threshold=0.5)
+
+        with pytest.raises(BudgetExceeded):
+            list(wrapped.forward(iter([])))
+
+        rows = log.read()
+        assert [(r["left_id"], r["right_id"]) for r in rows] == [("a", "b"), ("c", "d")]
+
+    def test_the_exception_still_carries_partial_judgements_unmodified(
+        self, tmp_path: Path
+    ) -> None:
+        yielded = [_judgement("a", "b", 0.9)]
+        tripping = _judgement("c", "d", 0.95)
+        inner = _BudgetBreachingModule(yielded, tripping)
+        log = JudgementLog(tmp_path / "log.jsonl")
+        wrapped = LoggingModule(inner, log=log, threshold=0.5)
+
+        with pytest.raises(BudgetExceeded) as excinfo:
+            list(wrapped.forward(iter([])))
+
+        assert excinfo.value.partial_judgements == [yielded[0], tripping]
+
+    def test_no_duplicate_rows_when_nothing_was_yielded_before_the_breach(
+        self, tmp_path: Path
+    ) -> None:
+        tripping = _judgement("c", "d", 0.95)
+        inner = _BudgetBreachingModule([], tripping)
+        log = JudgementLog(tmp_path / "log.jsonl")
+        wrapped = LoggingModule(inner, log=log, threshold=0.5)
+
+        with pytest.raises(BudgetExceeded):
+            list(wrapped.forward(iter([])))
+
+        rows = log.read()
+        assert len(rows) == 1
+        assert (rows[0]["left_id"], rows[0]["right_id"]) == ("c", "d")

--- a/tests/core/test_judgement_log.py
+++ b/tests/core/test_judgement_log.py
@@ -130,6 +130,11 @@ class TestJudgementLogAppend:
         row = log.read()[0]
         datetime.fromisoformat(row["timestamp"])  # raises if malformed
 
+    def test_append_creates_missing_parent_directories(self, tmp_path: Path) -> None:
+        log = JudgementLog(tmp_path / "nested" / "run" / "log.jsonl")
+        log.append(_judgement(), verdict=True)
+        assert len(log.read()) == 1
+
     def test_append_default_excludes_reasoning_and_provenance(self, tmp_path: Path) -> None:
         log = JudgementLog(tmp_path / "log.jsonl")
         log.append(

--- a/tests/core/test_judgement_log.py
+++ b/tests/core/test_judgement_log.py
@@ -1,0 +1,256 @@
+"""Tests for langres.core.judgement_log (JudgementLog / LoggingModule).
+
+The opt-in signal-log seam (W0.2): a JSONL sink (``JudgementLog``) plus a
+boundary-component ``Module`` wrapper (``LoggingModule``) that logs each
+``PairwiseJudgement`` as it streams past, without breaking generator
+laziness. Zero-spend throughout -- everything here uses plain fake Modules,
+never a real judge.
+"""
+
+from __future__ import annotations
+
+import json
+from collections.abc import Iterator
+from datetime import datetime
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from langres.core.judgement_log import JudgementLog, LoggingModule
+from langres.core.models import ERCandidate, PairwiseJudgement
+from langres.core.module import Module
+from langres.core.reports import ScoreInspectionReport
+
+
+def _judgement(
+    left_id: str = "a",
+    right_id: str = "b",
+    score: float = 0.9,
+    *,
+    reasoning: str | None = None,
+    provenance: dict[str, Any] | None = None,
+) -> PairwiseJudgement:
+    return PairwiseJudgement(
+        left_id=left_id,
+        right_id=right_id,
+        score=score,
+        score_type="heuristic",
+        decision_step="test_step",
+        reasoning=reasoning,
+        provenance=provenance if provenance is not None else {},
+    )
+
+
+class _CountingModule(Module[object]):
+    """Yields ``judgements`` one at a time, tracking how many were pulled.
+
+    Used to prove ``LoggingModule.forward`` is lazy -- it must not pull more
+    than the caller asked for.
+    """
+
+    def __init__(self, judgements: list[PairwiseJudgement]) -> None:
+        self._judgements = judgements
+        self.pulled = 0
+
+    def forward(self, candidates: Iterator[ERCandidate[object]]) -> Iterator[PairwiseJudgement]:
+        list(candidates)
+        for judgement in self._judgements:
+            self.pulled += 1
+            yield judgement
+
+    def inspect_scores(
+        self, judgements: list[PairwiseJudgement], sample_size: int = 10
+    ) -> ScoreInspectionReport:
+        raise NotImplementedError
+
+
+# ---------------------------------------------------------------------------
+# JudgementLog.append
+# ---------------------------------------------------------------------------
+
+
+class TestJudgementLogAppend:
+    def test_append_writes_one_json_line_per_call(self, tmp_path: Path) -> None:
+        log = JudgementLog(tmp_path / "log.jsonl")
+        log.append(_judgement("a", "b"), verdict=True)
+        log.append(_judgement("c", "d"), verdict=False)
+        lines = (tmp_path / "log.jsonl").read_text().splitlines()
+        assert len(lines) == 2
+        for line in lines:
+            json.loads(line)  # every line is independently valid JSON
+
+    def test_append_includes_schema_version_v1(self, tmp_path: Path) -> None:
+        log = JudgementLog(tmp_path / "log.jsonl")
+        log.append(_judgement(), verdict=True)
+        row = log.read()[0]
+        assert row["v"] == 1
+
+    def test_append_records_pair_ids_score_and_decision_step(self, tmp_path: Path) -> None:
+        log = JudgementLog(tmp_path / "log.jsonl")
+        log.append(_judgement("left1", "right1", 0.73), verdict=True)
+        row = log.read()[0]
+        assert row["left_id"] == "left1"
+        assert row["right_id"] == "right1"
+        assert row["score"] == pytest.approx(0.73)
+        assert row["decision_step"] == "test_step"
+
+    def test_append_verdict_reflects_the_passed_bool(self, tmp_path: Path) -> None:
+        log = JudgementLog(tmp_path / "log.jsonl")
+        log.append(_judgement(), verdict=True)
+        log.append(_judgement(), verdict=False)
+        rows = log.read()
+        assert rows[0]["verdict"] is True
+        assert rows[1]["verdict"] is False
+
+    def test_append_extracts_model_and_cost_from_provenance(self, tmp_path: Path) -> None:
+        log = JudgementLog(tmp_path / "log.jsonl")
+        log.append(
+            _judgement(provenance={"model": "gpt-4o-mini", "cost_usd": 0.0021}), verdict=True
+        )
+        row = log.read()[0]
+        assert row["model"] == "gpt-4o-mini"
+        assert row["cost_usd"] == pytest.approx(0.0021)
+
+    def test_append_missing_model_is_none(self, tmp_path: Path) -> None:
+        log = JudgementLog(tmp_path / "log.jsonl")
+        log.append(_judgement(provenance={}), verdict=True)
+        row = log.read()[0]
+        assert row["model"] is None
+
+    def test_append_missing_cost_defaults_to_zero(self, tmp_path: Path) -> None:
+        log = JudgementLog(tmp_path / "log.jsonl")
+        log.append(_judgement(provenance={}), verdict=True)
+        row = log.read()[0]
+        assert row["cost_usd"] == 0.0
+
+    def test_append_timestamp_is_iso_parseable(self, tmp_path: Path) -> None:
+        log = JudgementLog(tmp_path / "log.jsonl")
+        log.append(_judgement(), verdict=True)
+        row = log.read()[0]
+        datetime.fromisoformat(row["timestamp"])  # raises if malformed
+
+    def test_append_default_excludes_reasoning_and_provenance(self, tmp_path: Path) -> None:
+        log = JudgementLog(tmp_path / "log.jsonl")
+        log.append(
+            _judgement(reasoning="looks like a match", provenance={"similarities": {"name": 1.0}}),
+            verdict=True,
+        )
+        row = log.read()[0]
+        assert "reasoning" not in row
+        assert "provenance" not in row
+
+    def test_features_true_includes_reasoning_and_provenance(self, tmp_path: Path) -> None:
+        log = JudgementLog(tmp_path / "log.jsonl", features=True)
+        log.append(
+            _judgement(reasoning="looks like a match", provenance={"similarities": {"name": 1.0}}),
+            verdict=True,
+        )
+        row = log.read()[0]
+        assert row["reasoning"] == "looks like a match"
+        assert row["provenance"] == {"similarities": {"name": 1.0}}
+
+
+# ---------------------------------------------------------------------------
+# JudgementLog.read (round-trip)
+# ---------------------------------------------------------------------------
+
+
+class TestJudgementLogRead:
+    def test_read_returns_empty_list_when_file_does_not_exist(self, tmp_path: Path) -> None:
+        log = JudgementLog(tmp_path / "missing.jsonl")
+        assert log.read() == []
+
+    def test_read_round_trips_every_appended_row_in_order(self, tmp_path: Path) -> None:
+        log = JudgementLog(tmp_path / "log.jsonl")
+        log.append(_judgement("1", "2", 0.1), verdict=False)
+        log.append(_judgement("3", "4", 0.9), verdict=True)
+        log.append(_judgement("5", "6", 0.5), verdict=False)
+        rows = log.read()
+        assert [r["left_id"] for r in rows] == ["1", "3", "5"]
+        assert [r["score"] for r in rows] == pytest.approx([0.1, 0.9, 0.5])
+
+    def test_read_skips_blank_lines(self, tmp_path: Path) -> None:
+        path = tmp_path / "log.jsonl"
+        path.write_text('{"v": 1, "left_id": "a"}\n\n{"v": 1, "left_id": "b"}\n')
+        log = JudgementLog(path)
+        rows = log.read()
+        assert len(rows) == 2
+
+
+# ---------------------------------------------------------------------------
+# LoggingModule
+# ---------------------------------------------------------------------------
+
+
+class TestLoggingModule:
+    def test_forward_passes_judgements_through_unchanged(self, tmp_path: Path) -> None:
+        judgements = [_judgement("a", "b", 0.9), _judgement("c", "d", 0.1)]
+        inner = _CountingModule(judgements)
+        log = JudgementLog(tmp_path / "log.jsonl")
+        wrapped = LoggingModule(inner, log=log, threshold=0.5)
+
+        result = list(wrapped.forward(iter([])))
+
+        assert result == judgements
+
+    def test_forward_logs_every_judgement_that_streams_past(self, tmp_path: Path) -> None:
+        judgements = [_judgement("a", "b", 0.9), _judgement("c", "d", 0.1)]
+        inner = _CountingModule(judgements)
+        log = JudgementLog(tmp_path / "log.jsonl")
+        wrapped = LoggingModule(inner, log=log, threshold=0.5)
+
+        list(wrapped.forward(iter([])))
+
+        rows = log.read()
+        assert len(rows) == 2
+        assert [r["left_id"] for r in rows] == ["a", "c"]
+
+    def test_forward_computes_verdict_from_threshold(self, tmp_path: Path) -> None:
+        judgements = [_judgement("a", "b", 0.9), _judgement("c", "d", 0.1)]
+        inner = _CountingModule(judgements)
+        log = JudgementLog(tmp_path / "log.jsonl")
+        wrapped = LoggingModule(inner, log=log, threshold=0.5)
+
+        list(wrapped.forward(iter([])))
+
+        rows = log.read()
+        assert rows[0]["verdict"] is True  # 0.9 >= 0.5
+        assert rows[1]["verdict"] is False  # 0.1 < 0.5
+
+    def test_forward_is_lazy_does_not_materialize_the_full_stream(self, tmp_path: Path) -> None:
+        judgements = [_judgement(str(i), str(i + 1), 0.9) for i in range(5)]
+        inner = _CountingModule(judgements)
+        log = JudgementLog(tmp_path / "log.jsonl")
+        wrapped = LoggingModule(inner, log=log, threshold=0.5)
+
+        gen = wrapped.forward(iter([]))
+        next(gen)  # pull exactly one judgement
+
+        assert inner.pulled == 1
+        assert len(log.read()) == 1
+
+    def test_inspect_scores_delegates_to_the_wrapped_module(self, tmp_path: Path) -> None:
+        class _Reporting(Module[object]):
+            def forward(
+                self, candidates: Iterator[ERCandidate[object]]
+            ) -> Iterator[PairwiseJudgement]:
+                return iter([])
+
+            def inspect_scores(
+                self, judgements: list[PairwiseJudgement], sample_size: int = 10
+            ) -> ScoreInspectionReport:
+                return ScoreInspectionReport(
+                    total_judgements=len(judgements),
+                    score_distribution={},
+                    high_scoring_examples=[],
+                    low_scoring_examples=[],
+                    recommendations=[],
+                )
+
+        log = JudgementLog(tmp_path / "log.jsonl")
+        wrapped = LoggingModule(_Reporting(), log=log, threshold=0.5)
+
+        report = wrapped.inspect_scores([_judgement()], sample_size=3)
+
+        assert report.total_judgements == 1

--- a/tests/test_verbs.py
+++ b/tests/test_verbs.py
@@ -7,10 +7,12 @@ judge="auto" against a real key, and never past construction for a bare
 "zero_shot_llm" string).
 """
 
+import inspect
 import math
 import subprocess
 import sys
 from collections.abc import Iterator
+from pathlib import Path
 from unittest.mock import patch
 
 import pytest
@@ -18,6 +20,7 @@ from dspy.utils.dummies import DummyLM
 from pydantic import BaseModel
 
 from langres.clients.openrouter import BudgetExceeded
+from langres.core.judgement_log import JudgementLog
 from langres.core.models import ERCandidate, PairwiseJudgement
 from langres.core.module import Module
 from langres.core.modules.dspy_judge import DSPyJudge
@@ -26,6 +29,7 @@ from langres.verbs import (
     DedupeResult,
     LinkVerdict,
     _check_no_duplicate_ids,
+    _coerce_log,
     _coerce_scalar,
     _field_union,
     _infer,
@@ -467,6 +471,122 @@ class TestLinkEmbeddingJudge:
         assert verdict.score > 0.99
         assert verdict.score_type == "sim_cos"
         assert verdict.judge_used == "embedding"
+
+
+# ---------------------------------------------------------------------------
+# log= (W0.2 JudgementLog signal seam): opt-in, kwarg-only, zero overhead when
+# omitted (E10 boundary-component wrapper -- see langres.core.judgement_log).
+# ---------------------------------------------------------------------------
+
+
+class TestCoerceLog:
+    def test_none_stays_none(self) -> None:
+        assert _coerce_log(None) is None
+
+    def test_judgementlog_instance_passes_through(self, tmp_path: Path) -> None:
+        log = JudgementLog(tmp_path / "log.jsonl")
+        assert _coerce_log(log) is log
+
+    def test_path_or_str_is_wrapped_in_a_judgementlog(self, tmp_path: Path) -> None:
+        coerced = _coerce_log(tmp_path / "log.jsonl")
+        assert isinstance(coerced, JudgementLog)
+        assert coerced.path == tmp_path / "log.jsonl"
+
+
+class TestDedupeWithLog:
+    def test_writes_a_jsonl_log_that_round_trips(self, tmp_path: Path) -> None:
+        records = [
+            {"id": "1", "name": "Acme Corporation"},
+            {"id": "2", "name": "Acme Corporation"},
+            {"id": "3", "name": "Totally Unrelated Restaurant"},
+        ]
+        log_path = tmp_path / "run.jsonl"
+        result = dedupe(records, judge="string", threshold=0.5, log=log_path)
+
+        rows = JudgementLog(log_path).read()
+        assert len(rows) == 3  # C(3,2) all-pairs candidates
+        assert all(row["v"] == 1 for row in rows)
+        assert {"1", "2"} in result
+
+    def test_accepts_a_judgementlog_instance_directly(self, tmp_path: Path) -> None:
+        records = [
+            {"id": "1", "name": "Acme Corporation"},
+            {"id": "2", "name": "Acme Corporation"},
+        ]
+        log = JudgementLog(tmp_path / "run.jsonl")
+        dedupe(records, judge="string", threshold=0.5, log=log)
+        assert len(log.read()) == 1
+
+    def test_verdict_agrees_with_the_resolved_threshold(self, tmp_path: Path) -> None:
+        records = [
+            {"id": "1", "name": "Acme Corporation"},
+            {"id": "2", "name": "Acme Corporation"},
+            {"id": "3", "name": "Totally Unrelated Restaurant"},
+        ]
+        log = JudgementLog(tmp_path / "run.jsonl")
+        dedupe(records, judge="string", threshold=0.5, log=log)
+        rows = {(row["left_id"], row["right_id"]): row for row in log.read()}
+        assert rows[("1", "2")]["verdict"] is True
+        assert rows[("1", "3")]["verdict"] is False
+
+    def test_features_true_includes_the_judge_provenance(self, tmp_path: Path) -> None:
+        records = [
+            {"id": "1", "name": "Acme Corporation"},
+            {"id": "2", "name": "Acme Corporation"},
+        ]
+        log = JudgementLog(tmp_path / "run.jsonl", features=True)
+        dedupe(records, judge="string", threshold=0.5, log=log)
+        row = log.read()[0]
+        assert "similarities" in row["provenance"]
+
+    def test_empty_input_never_touches_the_log(self, tmp_path: Path) -> None:
+        log_path = tmp_path / "run.jsonl"
+        dedupe([], log=log_path)
+        assert not log_path.exists()
+
+    def test_log_omitted_is_identical_to_log_none(self) -> None:
+        records = [
+            {"id": "1", "name": "Acme Corporation"},
+            {"id": "2", "name": "Acme Corporation"},
+            {"id": "3", "name": "Totally Unrelated Restaurant"},
+        ]
+        without_kwarg = dedupe(records, judge="string", threshold=0.5)
+        with_none = dedupe(records, judge="string", threshold=0.5, log=None)
+        assert list(without_kwarg) == list(with_none)
+        assert without_kwarg.judge_used == with_none.judge_used
+        assert without_kwarg.score_type == with_none.score_type
+
+
+class TestLinkWithLog:
+    def test_writes_one_row_matching_the_verdict(self, tmp_path: Path) -> None:
+        log_path = tmp_path / "run.jsonl"
+        verdict = link(
+            {"id": "a", "name": "Acme Corporation"},
+            {"id": "b", "name": "Acme Corporation"},
+            judge="string",
+            threshold=0.5,
+            log=log_path,
+        )
+        rows = JudgementLog(log_path).read()
+        assert len(rows) == 1
+        assert rows[0]["left_id"] == "a"
+        assert rows[0]["right_id"] == "b"
+        assert rows[0]["verdict"] == verdict.match
+
+    def test_log_omitted_is_identical_to_log_none(self) -> None:
+        a = {"id": "a", "name": "Acme Corporation"}
+        b = {"id": "b", "name": "Acme Corporation"}
+        without_kwarg = link(a, b, judge="string", threshold=0.5)
+        with_none = link(a, b, judge="string", threshold=0.5, log=None)
+        assert without_kwarg.match == with_none.match
+        assert without_kwarg.score == pytest.approx(with_none.score)
+
+
+def test_log_param_is_keyword_only_on_both_verbs() -> None:
+    for fn in (link, dedupe):
+        params = inspect.signature(fn).parameters
+        assert "log" in params
+        assert params["log"].kind == inspect.Parameter.KEYWORD_ONLY
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_verbs.py
+++ b/tests/test_verbs.py
@@ -556,6 +556,22 @@ class TestDedupeWithLog:
         assert without_kwarg.judge_used == with_none.judge_used
         assert without_kwarg.score_type == with_none.score_type
 
+    def test_budget_breach_still_logs_the_tripping_judgement(self, tmp_path: Path) -> None:
+        """Regression (codex review, PR #62): LoggingModule wraps the
+        already spend-capped module, so without this fix the paid judgement
+        that trips the cap -- recorded on BudgetExceeded.partial_judgements
+        but never yielded -- would be silently missing from the JSONL."""
+        records = [{"id": str(i), "name": f"n{i}"} for i in range(4)]  # C(4,2) = 6 pairs
+        log = JudgementLog(tmp_path / "run.jsonl")
+        with pytest.raises(BudgetExceeded) as excinfo:
+            dedupe(records, judge=_CostlyModule(6, 0.5), budget_usd=0.9, log=log)
+        partial = excinfo.value.partial_judgements
+        rows = log.read()
+        assert len(rows) == len(partial) == 2
+        assert [(r["left_id"], r["right_id"]) for r in rows] == [
+            (j.left_id, j.right_id) for j in partial
+        ]
+
 
 class TestLinkWithLog:
     def test_writes_one_row_matching_the_verdict(self, tmp_path: Path) -> None:
@@ -580,6 +596,25 @@ class TestLinkWithLog:
         with_none = link(a, b, judge="string", threshold=0.5, log=None)
         assert without_kwarg.match == with_none.match
         assert without_kwarg.score == pytest.approx(with_none.score)
+
+    def test_budget_breach_still_logs_the_tripping_judgement(self, tmp_path: Path) -> None:
+        """Regression (codex review, PR #62) -- see the matching dedupe() test."""
+        log = JudgementLog(tmp_path / "run.jsonl")
+        with pytest.raises(BudgetExceeded) as excinfo:
+            link(
+                {"id": "a", "name": "X"},
+                {"id": "b", "name": "Y"},
+                judge=_CostlyModule(1, 5.0),
+                budget_usd=1.0,
+                log=log,
+            )
+        partial = excinfo.value.partial_judgements
+        rows = log.read()
+        assert len(rows) == len(partial) == 1
+        assert (rows[0]["left_id"], rows[0]["right_id"]) == (
+            partial[0].left_id,
+            partial[0].right_id,
+        )
 
 
 def test_log_param_is_keyword_only_on_both_verbs() -> None:


### PR DESCRIPTION
## What / why

`JudgementLog` is the opt-in signal emitter that is the data flywheel's inlet
(harvested later in W2.4). It records, per judge call: pair ids, score,
verdict, model, cost, decision_step, timestamp, and a schema-version field
`"v": 1` (CEO decision #15 — one field now vs. a harvest-format migration
later). JSONL-file-backed (KISS). Opt-in via a keyword-only `log=` on
`link()`/`dedupe()`; zero overhead when omitted (regression-tested
byte-identical to pre-W0.2 behavior).

## E10 boundary-component rationale

Eng finding E10 (both review voices, independently) ruled out monkey-patching
`Module.forward` — it would silently break generator laziness, composition
with a future `GroupwiseModule` (landing in parallel in W1.0), and thread-
safety. Instead:

- `LoggingModule` is a small `Module` **wrapper**, in the same family as the
  existing `core.presets._SpendCappedModule`: it wraps a scorer `Module` and
  logs each `PairwiseJudgement` **as it streams past** — never materializing
  the full judgement stream. Verified directly: pulling exactly one
  judgement from the wrapped generator logs exactly one JSONL row
  (`test_forward_is_lazy_does_not_materialize_the_full_stream`).
- It composes uniformly with any future `GroupwiseModule` — both just yield
  `PairwiseJudgement` one at a time, so wrapping/logging is identical either
  way. No dependency on W1.0's `GroupwiseModule` landing.
- Wired at the verbs chokepoint (`link()`/`dedupe()`), *after* the judge and
  threshold are already resolved — `core/presets.py` and `core/resolver.py`
  are **untouched**. `verdict` is computed from the same `threshold` the
  calling verb already resolved for its own match decision, so the logged
  verdict always agrees with what the caller acted on.
- Serialization: explicitly **excluded** from Resolver artifacts (decided
  for W0.2, per the plan's explicit "excluded is fine" allowance).
  `LoggingModule` has no registry `type_name` and is applied to an
  already-built `Resolver.module` post-construction — never part of a
  `resolver.save()`'d pipeline, since `link()`/`dedupe()` never persist
  their internal resolver. Documented in the module docstring.

## Privacy: features off by default

Record content is OFF by default — a line carries only ids, score, verdict,
model, cost, decision_step, timestamp, `v`. Opt in with
`JudgementLog(path, features=True)` to additionally log `reasoning` and the
judge's raw `provenance` (comparison levels/similarities, token counts, …).
The docstring calls out explicitly: **this may contain PII** (the record
content a judge reasoned over, verbatim) and JSONL is plaintext on disk.

## Round-trip output (fresh process)

```
$ uv run python examples/judgement_log_demo.py
1 cluster(s): [{'1', '2'}]

3 judgement(s) logged to tmp/judgement_log_demo.jsonl:
{"v": 1, "left_id": "1", "right_id": "2", "score": 0.86, "verdict": true, "model": null, "cost_usd": 0.0, "decision_step": "weighted_average", "timestamp": "2026-07-02T17:18:12.036077+00:00"}
{"v": 1, "left_id": "1", "right_id": "3", "score": 0.20555555555555555, "verdict": false, "model": null, "cost_usd": 0.0, "decision_step": "weighted_average", "timestamp": "2026-07-02T17:18:12.036429+00:00"}
{"v": 1, "left_id": "2", "right_id": "3", "score": 0.1701149425287356, "verdict": false, "model": null, "cost_usd": 0.0, "decision_step": "weighted_average", "timestamp": "2026-07-02T17:18:12.036807+00:00"}
```

## Coverage / quality gates (all green locally)

- `uv run ruff check .` — all checks passed
- `uv run ruff format --check .` — 195 files already formatted
- `uv run mypy src` — no issues found in 64 source files
- `uv run pytest -m "not slow and not integration" --cov=src/langres --cov-report=term-missing` — **1372 passed**, 78 deselected; `src/langres/core/judgement_log.py` **100%** covered; `src/langres/verbs.py` 99% (the one uncovered line, 323, is the pre-existing `judge="embedding"` branch, only exercised by the `@pytest.mark.slow` embedding test — confirmed unrelated to this change: `src/langres/verbs.py` reaches 100% when that slow test runs); total repo coverage 98.09% (gate: 95%).

Never ran a real OpenRouter/OpenAI call — every test uses `DummyLM`/plain fake
`Module`s or the zero-spend `"string"` judge.

## Shared-file impact for parallel branches

**None.** `core/presets.py` and `core/resolver.py` are untouched — the
wrapping happens entirely in `verbs.py`, after `resolve_judge()`/
`build_resolver()` already hand back a fully-assembled module/resolver.
Touched files: `src/langres/core/judgement_log.py` (new),
`src/langres/verbs.py` (added `log=` kwarg + a private `_coerce_log` helper
+ docstring notes — no existing param removed/reordered/retyped),
`src/langres/__init__.py` + `src/langres/core/__init__.py` (added
`JudgementLog`/`LoggingModule` exports, alphabetically inserted), plus new
tests/example/docs. `link()`/`dedupe()` signatures are otherwise byte-for-byte
unchanged (kwarg-only addition, regression-tested).

## Test plan

- [x] `JudgementLog.append`/`.read()` round-trip (ids, score, verdict, model,
      cost, decision_step, timestamp, `v:1`; missing model/cost defaults;
      blank-line tolerance; parent-dir auto-create)
- [x] `features=True` opts into `reasoning`/`provenance`; off by default
- [x] `LoggingModule`: pass-through unchanged, per-judgement logging, lazy
      streaming (proven, not just tested-for-absence-of-crash),
      `inspect_scores` delegation
- [x] `link()`/`dedupe()` `log=`: path-or-`JudgementLog` coercion, verdict
      agrees with the resolved threshold, empty-input never touches the log,
      `features=True` end-to-end, `log=` is keyword-only on both verbs,
      `log` omitted ≡ `log=None` (regression)
- [x] Fresh-process example run (pasted above)

https://claude.ai/code/session_0115MvWbHaCKT1A39PKDWqey