### PR TITLE
W1.0: set-wise + fit + cost contracts (interfaces only)

### DIFF
--- a/docs/TECHNICAL_OVERVIEW.md
+++ b/docs/TECHNICAL_OVERVIEW.md
@@ -470,23 +470,26 @@ candidate structure, so it must not be used to benchmark a set-wise judge.
   free; not for benchmark use.
 - **`VectorBlocker.stream_groups()`** overrides this natively: its kNN search
   is already per-anchor, so each entity's own search result IS its group —
-  one group per entity, its k nearest neighbors (excluding itself) as
-  members, no derivation, no skew. This is the implementation a set-wise
-  judge should be benchmarked against.
+  one group per entity, its (deduplicated) k nearest neighbors as members, no
+  derivation, no skew. This is the implementation a set-wise judge should be
+  benchmarked against.
 
-Both forms satisfy the same pairs-equivalence property at the SET level: the
-SET of pairs recoverable from `stream_groups()` equals the SET of pairs from
-`stream()` — no losses. This does **not** mean each pair is covered by
-exactly one group: `VectorBlocker.stream_groups()` has no cross-anchor dedup
-state (unlike `stream()`'s single `seen_pairs` set), so when two entities are
-mutual nearest neighbors, the same undirected pair appears as a member edge
-in *both* of their groups — a deliberate trade-off (truncating a group would
-mean it no longer represents its anchor's real candidate set). A consumer
-that treats each group as an independent unit of work (e.g. one LLM call per
-group, for cost accounting) must dedupe by canonical pair across groups if it
-wants to process each undirected pair exactly once — see
-`VectorBlocker.stream_groups()`'s docstring and
-`test_vector_blocker_stream_groups_may_duplicate_mutual_neighbor_pairs`.
+Both forms satisfy the same pairs-equivalence property EXACTLY, not just at
+the SET level: the pairs recoverable from `stream_groups()` equal the pairs
+from `stream()` — no losses AND no duplicates. `VectorBlocker.stream_groups()`
+threads a single `seen_pairs` set across all entities (same iteration order,
+same first-seen-wins rule `stream()` uses), so each undirected pair is
+assigned to exactly one group — whichever anchor is processed first. Without
+this cross-anchor dedup, two mutual nearest neighbors (A's nearest neighbor is
+B AND B's nearest neighbor is A — common with real ANN indexes on
+near-duplicate records) would appear as a member edge in *both* groups, and a
+consumer that treats each group as an independent unit of work (e.g. a
+set-wise judge issuing one LLM call per group, for cost accounting) would
+emit and charge for the same undirected pair twice. See
+`VectorBlocker.stream_groups()`'s docstring and the count-based
+regression/property tests in `tests/core/blockers/test_vector.py`
+(`test_vector_blocker_stream_groups_dedupes_mutual_neighbor_pairs`,
+`test_vector_blocker_stream_groups_pairs_equivalence_property`).
 
 ### GroupwiseModule (`langres.core.module`)
 

--- a/docs/TECHNICAL_OVERVIEW.md
+++ b/docs/TECHNICAL_OVERVIEW.md
@@ -433,7 +433,132 @@ The rich data object passed out of a Flow. This is the auditable log of a decisi
 - `left_id: str`
 - `right_id: str`
 - `score: float`: The combined score (0.0 to 1.0).
-- `score_type: Literal["sim_cos", "prob_llm", "heuristic", "calibrated_prob", ...]`: What kind of score is this? Critical for calibration and clustering.
+- `score_type: Literal["sim_cos", "prob_llm", "heuristic", "calibrated_prob", "prob_fs", "prob_rf", "prob_group_llm"]`: What kind of score is this? Critical for calibration and clustering. `prob_fs`/`prob_rf`/`prob_group_llm` (added W1.0) are reserved for a Fellegi-Sunter judge, an sklearn RandomForest judge, and a set-wise (group) judge respectively — none are implemented in core yet, but the literal is open for the branches that add them.
 - `decision_step: str`: Which logic branch made this decision (e.g., "string_sim" or "llm_judge").
 - `reasoning: Optional[str]`: The LLM's natural language explanation.
 - `provenance: Dict[str, Any]`: A full audit trail (e.g., `{"model": "e5-small", "rapidfuzz_score": 0.85}`).
+
+## 8. Group + Fit Contracts (W1.0)
+
+W1.0 froze two interfaces that later branches (a set-wise `SelectJudge`, a
+`FellegiSunterJudge`, an `RFJudge`) build against, without shipping any of
+those judges themselves: this section documents the contracts, not a method.
+
+### ERCandidateGroup[SchemaT] (`langres.core.groups`)
+
+The set-wise counterpart to `ERCandidate`: "one anchor + K candidate
+members" instead of one pair.
+
+- `anchor: SchemaT`
+- `members: list[SchemaT]`
+- `group_id: str`
+
+`derive_groups_from_pairs(candidates)` derives groups from an existing
+pairwise `ERCandidate` stream by grouping on each pair's `left` entity. It is
+**buffered and anchor-skewed**: an entity that never appears as `left` (e.g.
+because an upstream blocker canonicalizes pair order by id) never becomes an
+anchor. It is lossless over *pairs* despite the skew (flattening the derived
+groups back to canonical pairs recovers exactly the input pair set — no
+dupes, no losses), but it is **not** representative of a blocker's true
+candidate structure, so it must not be used to benchmark a set-wise judge.
+
+### Blocker.stream_groups() (`langres.core.blocker`)
+
+- **Default** (inherited by every `Blocker` subclass): derives groups from
+  `self.stream(data)` via `derive_groups_from_pairs` — buffered/skew-prone,
+  as above. Exists so every blocker gets a working `stream_groups()` for
+  free; not for benchmark use.
+- **`VectorBlocker.stream_groups()`** overrides this natively: its kNN search
+  is already per-anchor, so each entity's own search result IS its group —
+  one group per entity, its k nearest neighbors (excluding itself) as
+  members, no derivation, no skew. This is the implementation a set-wise
+  judge should be benchmarked against.
+
+Both forms satisfy the same pairs-equivalence property: the pairs
+recoverable from `stream_groups()` equal the pairs from `stream()`, with no
+duplicates and no losses.
+
+### GroupwiseModule (`langres.core.module`)
+
+`GroupwiseModule` **is a `Module`** — it does not introduce a parallel
+execution path. Its concrete `forward()` derives groups internally from
+whatever pairwise `ERCandidate` stream it receives (via
+`derive_groups_from_pairs`, the same buffered default as above — `forward()`
+only ever sees a flat pairwise stream, never the blocker object, so it
+cannot reach a blocker's native grouping) and dispatches to the abstract
+`forward_groups()`, decomposing the result back to `Iterator[PairwiseJudgement]`.
+Concrete set-wise judges implement only `forward_groups()` and
+`inspect_scores()`. Because the group structure never leaves `forward()`,
+the Resolver execution spine (`Resolver._judgements` → `module.forward`),
+`inspect_scores`, the JudgementLog boundary, and benchmark dispatch
+(`BudgetedModuleRunner`, `run_method`) all work unchanged.
+
+```python
+class SelectJudge(GroupwiseModule[MySchema]):
+    def forward_groups(self, groups: Iterator[ERCandidateGroup[MySchema]]) -> Iterator[PairwiseJudgement]:
+        for group in groups:
+            # One LLM call per group: "which of these K candidates match the anchor?"
+            selected_ids = self._call_llm(group)
+            judgements = [
+                PairwiseJudgement(
+                    left_id=group.anchor.id,
+                    right_id=member.id,
+                    score=1.0 if member.id in selected_ids else 0.0,
+                    score_type="prob_group_llm",
+                    decision_step="select_judge",
+                    provenance={},
+                )
+                for member in group.members
+            ]
+            yield from stamp_group_cost(judgements, call_cost_usd=self._last_call_cost, group_id=group.group_id)
+
+    def inspect_scores(self, judgements, sample_size=10):
+        ...
+```
+
+### Group-call cost convention (E5)
+
+One LLM call scores a whole group (K pairs). Pricing each of the K resulting
+judgements at the call's full cost would silently overcount total spend by a
+factor of K. `stamp_group_cost(judgements, call_cost_usd, group_id)`
+(`langres.core.module`) applies the fix: the full `call_cost_usd` goes on the
+**first** judgement's `provenance["cost_usd"]`, every sibling gets `$0`, and
+`provenance["group_id"]` is set on all of them. Existing cost aggregation
+(`_judgement_cost`/`_cost_track` in `langres.core.benchmark`, which already
+read `provenance["cost_usd"]`) then sums a group to exactly one call's cost
+with no changes on their end.
+
+**Atomicity caveat:** `BudgetedModuleRunner` scores exactly one `ERCandidate`
+per `module.forward()` call. A `GroupwiseModule` run through it today derives
+a single, trivial, size-1 group per call — so a group is never *split*
+mid-call (there is never more than one pair per call to split), but a real
+multi-pair group is also not yet *batched* into one priced call: no cost
+amortization happens through the runner yet. Extending the runner (or adding
+a group-aware variant) to pre-flight and price whole groups atomically is
+deferred to the branch that lands the first concrete `GroupwiseModule`.
+
+### Fit hooks (`langres.core.fit`)
+
+Two runtime-checkable, structural `Protocol`s — **not** abstract methods on
+`Module` (that would break every existing, non-learnable module):
+
+- `SupervisedFitMixin.fit(candidates: Iterator[ERCandidate[SchemaT]], labels: Sequence[bool]) -> None`
+- `UnsupervisedFitMixin.fit_unlabeled(candidates: Iterator[ERCandidate[SchemaT]]) -> None`
+
+A module opts in by implementing the method with the matching name — no
+subclassing required. `Resolver.fit(data, labels=None)` detects this with
+`isinstance(module, SupervisedFitMixin)` / `isinstance(module, UnsupervisedFitMixin)`:
+
+- Module implements `SupervisedFitMixin`: `labels` is required; omitting it
+  **raises** (a genuinely trainable module silently not being trained is the
+  exact footgun this hook exists to prevent).
+- Module implements `UnsupervisedFitMixin`: `fit_unlabeled` is called
+  unconditionally; passing `labels` to it raises (they would otherwise be
+  silently ignored).
+- Module implements **neither** hook (e.g. `WeightedAverageJudge`): `fit()`
+  is a no-op returning `self` — the original sklearn-style symmetry is
+  preserved for non-learnable pipelines — unless `labels` was passed, which
+  raises rather than silently discarding them.
+
+No concrete judge implements either hook yet; `FellegiSunterJudge` and
+`RFJudge` (a later branch) are the first.

--- a/docs/TECHNICAL_OVERVIEW.md
+++ b/docs/TECHNICAL_OVERVIEW.md
@@ -474,9 +474,19 @@ candidate structure, so it must not be used to benchmark a set-wise judge.
   members, no derivation, no skew. This is the implementation a set-wise
   judge should be benchmarked against.
 
-Both forms satisfy the same pairs-equivalence property: the pairs
-recoverable from `stream_groups()` equal the pairs from `stream()`, with no
-duplicates and no losses.
+Both forms satisfy the same pairs-equivalence property at the SET level: the
+SET of pairs recoverable from `stream_groups()` equals the SET of pairs from
+`stream()` — no losses. This does **not** mean each pair is covered by
+exactly one group: `VectorBlocker.stream_groups()` has no cross-anchor dedup
+state (unlike `stream()`'s single `seen_pairs` set), so when two entities are
+mutual nearest neighbors, the same undirected pair appears as a member edge
+in *both* of their groups — a deliberate trade-off (truncating a group would
+mean it no longer represents its anchor's real candidate set). A consumer
+that treats each group as an independent unit of work (e.g. one LLM call per
+group, for cost accounting) must dedupe by canonical pair across groups if it
+wants to process each undirected pair exactly once — see
+`VectorBlocker.stream_groups()`'s docstring and
+`test_vector_blocker_stream_groups_may_duplicate_mutual_neighbor_pairs`.
 
 ### GroupwiseModule (`langres.core.module`)
 

--- a/src/langres/core/__init__.py
+++ b/src/langres/core/__init__.py
@@ -28,6 +28,8 @@ from langres.core.embeddings import (
     SparseEmbeddingProvider,
 )
 from langres.core.feature import ComparisonLevel, ComparisonVector, FeatureSpec
+from langres.core.fit import SupervisedFitMixin, UnsupervisedFitMixin
+from langres.core.groups import ERCandidateGroup, derive_groups_from_pairs
 from langres.core.indexes import (
     FAISSIndex,
     FakeHybridVectorIndex,
@@ -43,7 +45,7 @@ from langres.core.models import (
     ERCandidate,
     PairwiseJudgement,
 )
-from langres.core.module import Module
+from langres.core.module import GroupwiseModule, Module, stamp_group_cost
 
 # Importing LLMJudge here ensures its ``@register("llm_judge")`` runs on plain
 # ``import langres.core`` — so a fresh process doing ``Resolver.load(path)`` on
@@ -80,10 +82,12 @@ __all__ = [
     "ComparisonLevel",
     "ComparisonVector",
     "ComponentSpec",
+    "derive_groups_from_pairs",
     "EmbeddingProvider",
     "EmbeddingScoreJudge",
     "EntityProtocol",
     "ERCandidate",
+    "ERCandidateGroup",
     "ErrorExample",
     "FAISSIndex",
     "FakeEmbedder",
@@ -95,6 +99,7 @@ __all__ = [
     "get_component",
     "get_schema",
     "GLinkerAdapter",
+    "GroupwiseModule",
     "LLMJudge",
     "metrics",
     "Module",
@@ -110,8 +115,11 @@ __all__ = [
     "SentenceTransformerEmbedder",
     "SerializableState",
     "SparseEmbeddingProvider",
+    "stamp_group_cost",
     "StringComparator",
+    "SupervisedFitMixin",
     "UnknownComponentType",
+    "UnsupervisedFitMixin",
     "VectorBlocker",
     "VectorIndex",
     "WeightedAverageJudge",

--- a/src/langres/core/benchmark.py
+++ b/src/langres/core/benchmark.py
@@ -830,6 +830,20 @@ class BudgetedModuleRunner:
     Live run statistics are reset at the start of every :meth:`run` call and so
     describe only the most recent call: :attr:`total_spent_usd`,
     :attr:`labeled_count`, :attr:`skipped_count`, :attr:`dropped_by_cap_count`.
+
+    Group-call atomicity (W1.0, E5): :meth:`run` scores exactly ONE candidate
+    per ``module.forward()`` call (see point 3 above). A
+    :class:`~langres.core.module.GroupwiseModule` given a single candidate
+    derives a single, trivial, size-1 group from it -- so under this runner
+    a group is NEVER split mid-call (there is never more than one pair per
+    call to split), but a real multi-pair group is also never batched into
+    one priced call: no cost amortization happens yet. See
+    ``tests/core/test_benchmark.py::test_runner_never_splits_a_group_mid_call_but_also_never_batches_one``
+    for the pinned-down behavior. Extending this runner (or adding a
+    group-aware variant) to pre-flight and price whole groups atomically is
+    deferred to W1.1, the branch that lands the first concrete
+    ``GroupwiseModule`` (``SelectJudge``) and can measure the real call-count
+    reduction this is for.
     """
 
     def __init__(

--- a/src/langres/core/blocker.py
+++ b/src/langres/core/blocker.py
@@ -11,6 +11,7 @@ from typing import Any, Generic, TypeVar
 
 from pydantic import BaseModel
 
+from langres.core.groups import ERCandidateGroup, derive_groups_from_pairs
 from langres.core.models import ERCandidate
 from langres.core.reports import BlockerEvaluationReport, CandidateInspectionReport
 
@@ -147,6 +148,40 @@ class Blocker(ABC, Generic[SchemaT]):
             - LSH (Locality-Sensitive Hashing)
         """
         pass  # pragma: no cover
+
+    def stream_groups(self, data: list[Any]) -> Iterator[ERCandidateGroup[SchemaT]]:
+        """Generate anchor + K-candidate-member groups from input data (W1.0, E3).
+
+        Default implementation: fully buffers ``self.stream(data)`` and
+        derives groups from it via
+        :func:`~langres.core.groups.derive_groups_from_pairs` (grouped by each
+        pair's ``left`` entity). This default is **buffered and skew-prone**
+        -- an entity that never appears as ``left`` in the pairwise stream
+        (e.g. because pair order is canonicalized by id) never becomes its
+        own anchor, so group *sizes* are not representative of the blocker's
+        real candidate structure. **Do not use this default for benchmarking**
+        set-wise judges; it exists so every ``Blocker`` subclass gets a
+        working (if non-optimal) ``stream_groups()`` for free.
+
+        A blocker whose candidate-generation structure is naturally
+        per-anchor (e.g. ``VectorBlocker``'s kNN search, where each entity's
+        neighbors ARE its group) should override this method with a native
+        implementation instead of relying on the derived default.
+
+        Args:
+            data: List of raw data items, same as ``stream()`` accepts.
+
+        Yields:
+            ERCandidateGroup[SchemaT] objects, one per unique anchor entity.
+
+        Note:
+            Despite the skew, this default is *lossless* over pairs: the pairs
+            recoverable by flattening its groups back to (anchor, member)
+            edges are exactly the pairs ``stream()`` would yield -- no dupes,
+            no losses (verified by property test; see
+            ``tests/core/test_blocker.py``).
+        """
+        yield from derive_groups_from_pairs(self.stream(data))
 
     @abstractmethod
     def inspect_candidates(

--- a/src/langres/core/blockers/vector.py
+++ b/src/langres/core/blockers/vector.py
@@ -508,8 +508,8 @@ class VectorBlocker(Blocker[SchemaT]):
         groups from a pairwise stream and is anchor-skewed), this is a NATIVE
         implementation: VectorBlocker's kNN search is already per-anchor, so
         each entity's own search result IS its group -- no derivation, no
-        skew. One group is yielded per entity, with its k nearest neighbors
-        (excluding itself) as members.
+        skew. One group is yielded per entity, with its (deduplicated) k
+        nearest neighbors as members.
 
         Args:
             data: List of raw data items (typically dicts). The schema_factory
@@ -518,7 +518,8 @@ class VectorBlocker(Blocker[SchemaT]):
         Yields:
             ERCandidateGroup[SchemaT] objects containing:
             - anchor: One entity from ``data``
-            - members: Its k nearest neighbors (excluding itself)
+            - members: Its nearest neighbors not already claimed by an
+              earlier anchor's group (see the dedup note below)
             - group_id: The anchor's ``id``
 
         Raises:
@@ -532,28 +533,21 @@ class VectorBlocker(Blocker[SchemaT]):
             Empty datasets or single-entity datasets produce no groups.
 
         Note:
-            The SET of pairs recoverable by flattening these groups back to
-            canonical (anchor, member) edges equals the SET of pairs stream()
-            would yield -- no losses (CEO #14; verified by property test, see
-            tests/core/blockers/test_vector.py). This holds because stream()'s
-            per-pair dedup only ever *suppresses* a duplicate direction of an
-            edge already covered by some entity's neighbor search -- it never
-            adds an edge no entity's search produced.
+            Cross-anchor dedup, matching stream()'s semantics exactly: a
+            single ``seen_pairs`` set is threaded across all entities (same
+            iteration order, same first-seen-wins rule stream() uses), so
+            each undirected pair is assigned to exactly ONE group -- whichever
+            anchor is processed first. Without this, two mutual nearest
+            neighbors (A's nearest neighbor is B AND B's nearest neighbor is
+            A -- common with real ANN indexes on near-duplicate records) would
+            otherwise appear as a member edge in BOTH groups, and a consumer
+            issuing one call per group (e.g. a future SelectJudge) would
+            emit and charge for the same undirected pair twice.
 
-            This does NOT mean each pair is covered by exactly one group,
-            though: unlike stream() (which dedups across ALL entities via a
-            single ``seen_pairs`` set), stream_groups() has no cross-anchor
-            state -- each group is one entity's own, true, un-truncated
-            neighbor list. When two entities are mutual nearest neighbors
-            (common with real ANN indexes on near-duplicate records), the
-            same undirected pair appears as a member edge in BOTH of their
-            groups. This is deliberate: truncating a later group to enforce
-            global pair-uniqueness would mean that group no longer represents
-            its anchor's real candidate set. A consumer that treats each
-            group as an independent unit of work (e.g. one LLM call per
-            group) must dedupe by canonical pair across groups if it wants to
-            process/cost each undirected pair exactly once -- see
-            ``test_vector_blocker_stream_groups_may_duplicate_mutual_neighbor_pairs``.
+            The pairs recoverable by flattening these groups back to
+            (anchor, member) edges are therefore exactly the pairs stream()
+            would yield, with NO duplicates and NO losses (CEO #14 + E5;
+            verified by property test, see tests/core/blockers/test_vector.py).
         """
         if not self._index_is_built():
             raise RuntimeError(
@@ -576,9 +570,17 @@ class VectorBlocker(Blocker[SchemaT]):
         k = min(self.k_neighbors + 1, len(entities))
         _distances, indices = self.vector_index.search_all(k, query_prompt=self.query_prompt)
 
+        seen_pairs: set[frozenset[str]] = set()
         for i in range(len(entities)):
             neighbor_indices = indices[i][1:]  # Skip index 0 (self)
-            members = [entities[int(j)] for j in neighbor_indices]
+            members = []
+            for j in neighbor_indices:
+                j = int(j)  # Convert numpy.int64 to int
+                pair_key = frozenset([entities[i].id, entities[j].id])  # type: ignore[attr-defined]
+                if pair_key in seen_pairs:
+                    continue
+                seen_pairs.add(pair_key)
+                members.append(entities[j])
             yield ERCandidateGroup(
                 anchor=entities[i],
                 members=members,

--- a/src/langres/core/blockers/vector.py
+++ b/src/langres/core/blockers/vector.py
@@ -532,13 +532,28 @@ class VectorBlocker(Blocker[SchemaT]):
             Empty datasets or single-entity datasets produce no groups.
 
         Note:
-            The pairs recoverable by flattening these groups back to
-            (anchor, member) edges are exactly the pairs stream() would
-            yield -- no dupes, no losses (CEO #14; verified by property test,
-            see tests/core/blockers/test_vector.py). This holds because
-            stream()'s per-pair dedup only ever *suppresses* a duplicate
-            direction of an edge already covered by some entity's neighbor
-            search -- it never adds an edge no entity's search produced.
+            The SET of pairs recoverable by flattening these groups back to
+            canonical (anchor, member) edges equals the SET of pairs stream()
+            would yield -- no losses (CEO #14; verified by property test, see
+            tests/core/blockers/test_vector.py). This holds because stream()'s
+            per-pair dedup only ever *suppresses* a duplicate direction of an
+            edge already covered by some entity's neighbor search -- it never
+            adds an edge no entity's search produced.
+
+            This does NOT mean each pair is covered by exactly one group,
+            though: unlike stream() (which dedups across ALL entities via a
+            single ``seen_pairs`` set), stream_groups() has no cross-anchor
+            state -- each group is one entity's own, true, un-truncated
+            neighbor list. When two entities are mutual nearest neighbors
+            (common with real ANN indexes on near-duplicate records), the
+            same undirected pair appears as a member edge in BOTH of their
+            groups. This is deliberate: truncating a later group to enforce
+            global pair-uniqueness would mean that group no longer represents
+            its anchor's real candidate set. A consumer that treats each
+            group as an independent unit of work (e.g. one LLM call per
+            group) must dedupe by canonical pair across groups if it wants to
+            process/cost each undirected pair exactly once -- see
+            ``test_vector_blocker_stream_groups_may_duplicate_mutual_neighbor_pairs``.
         """
         if not self._index_is_built():
             raise RuntimeError(

--- a/src/langres/core/blockers/vector.py
+++ b/src/langres/core/blockers/vector.py
@@ -21,6 +21,7 @@ from langres.core.blockers.all_pairs import (
     register_schema_idempotent,
     schema_to_factory,
 )
+from langres.core.groups import ERCandidateGroup
 from langres.core.indexes.vector_index import VectorIndex
 from langres.core.models import ERCandidate
 from langres.core.registry import (
@@ -499,6 +500,75 @@ class VectorBlocker(Blocker[SchemaT]):
                         blocker_name="vector_blocker",
                         similarity_score=float(similarity),
                     )
+
+    def stream_groups(self, data: list[Any]) -> Iterator[ERCandidateGroup[SchemaT]]:
+        """Generate anchor + k-nearest-neighbor groups natively (W1.0, E3).
+
+        Unlike the base ``Blocker.stream_groups()`` default (which derives
+        groups from a pairwise stream and is anchor-skewed), this is a NATIVE
+        implementation: VectorBlocker's kNN search is already per-anchor, so
+        each entity's own search result IS its group -- no derivation, no
+        skew. One group is yielded per entity, with its k nearest neighbors
+        (excluding itself) as members.
+
+        Args:
+            data: List of raw data items (typically dicts). The schema_factory
+                transforms these into SchemaT objects.
+
+        Yields:
+            ERCandidateGroup[SchemaT] objects containing:
+            - anchor: One entity from ``data``
+            - members: Its k nearest neighbors (excluding itself)
+            - group_id: The anchor's ``id``
+
+        Raises:
+            RuntimeError: If index has not been built via create_index().
+
+        Note:
+            You must call vector_index.create_index(texts) before calling
+            this method, exactly as for stream().
+
+        Note:
+            Empty datasets or single-entity datasets produce no groups.
+
+        Note:
+            The pairs recoverable by flattening these groups back to
+            (anchor, member) edges are exactly the pairs stream() would
+            yield -- no dupes, no losses (CEO #14; verified by property test,
+            see tests/core/blockers/test_vector.py). This holds because
+            stream()'s per-pair dedup only ever *suppresses* a duplicate
+            direction of an edge already covered by some entity's neighbor
+            search -- it never adds an edge no entity's search produced.
+        """
+        if not self._index_is_built():
+            raise RuntimeError(
+                "Index not built. Call vector_index.create_index(texts) "
+                "before blocker.stream_groups(data).\n\n"
+                "Example:\n"
+                "    texts = [record['name'] for record in data]\n"
+                "    blocker.vector_index.create_index(texts)\n"
+                "    groups = list(blocker.stream_groups(data))"
+            )
+
+        if len(data) == 0:
+            return
+
+        entities = [self.schema_factory(record) for record in data]
+
+        if len(entities) <= 1:
+            return
+
+        k = min(self.k_neighbors + 1, len(entities))
+        _distances, indices = self.vector_index.search_all(k, query_prompt=self.query_prompt)
+
+        for i in range(len(entities)):
+            neighbor_indices = indices[i][1:]  # Skip index 0 (self)
+            members = [entities[int(j)] for j in neighbor_indices]
+            yield ERCandidateGroup(
+                anchor=entities[i],
+                members=members,
+                group_id=entities[i].id,  # type: ignore[attr-defined]
+            )
 
     def inspect_candidates(
         self,

--- a/src/langres/core/fit.py
+++ b/src/langres/core/fit.py
@@ -1,0 +1,71 @@
+"""Fit-hook contracts: how a Module opts into being trainable (W1.0, E6).
+
+Two runtime-checkable, structural `Protocol`s -- **not** abstract methods on
+the base ``Module``. Adding an abstract ``fit``/``fit_unlabeled`` to ``Module``
+would break every existing, non-learnable module (``WeightedAverageJudge``,
+``LLMJudge``, ...), which is not the goal here: most judges stay heuristic or
+zero-shot and never need a fit hook. Instead, a module *opts in* structurally
+by implementing the method with the matching name and signature; callers (the
+Resolver) detect this with ``isinstance(module, SupervisedFitMixin)`` /
+``isinstance(module, UnsupervisedFitMixin)``.
+
+- ``SupervisedFitMixin``: for judges that learn from labeled pairs (e.g. a
+  future ``RFJudge`` fitting an sklearn RandomForest over
+  ``ComparisonVector.similarities``).
+- ``UnsupervisedFitMixin``: for judges that learn without labels (e.g. a
+  future ``FellegiSunterJudge`` fitting m/u probabilities via EM).
+
+See ``Resolver.fit()`` for how these are consumed, and
+docs/TECHNICAL_OVERVIEW.md ("Fit-hook contract") for the full picture.
+"""
+
+from collections.abc import Iterator, Sequence
+from typing import Protocol, TypeVar, runtime_checkable
+
+from pydantic import BaseModel
+
+from langres.core.models import ERCandidate
+
+# Generic type variable for schema types (must be a Pydantic model). Defined
+# locally to avoid a circular import, matching the existing per-module SchemaT
+# convention (see models.py, module.py, groups.py).
+SchemaT = TypeVar("SchemaT", bound=BaseModel)
+
+
+@runtime_checkable
+class SupervisedFitMixin(Protocol[SchemaT]):
+    """A Module that learns from labeled candidate pairs.
+
+    Implement ``fit(candidates, labels)`` to opt in; no subclassing required
+    (structural typing via ``isinstance()``, enabled by ``@runtime_checkable``).
+    """
+
+    def fit(self, candidates: Iterator[ERCandidate[SchemaT]], labels: Sequence[bool]) -> None:
+        """Fit the module's parameters from labeled candidate pairs.
+
+        Args:
+            candidates: The blocked (and, if a comparator is configured,
+                comparison-attached) candidate stream to learn from.
+            labels: Gold match/non-match labels, positionally aligned with
+                ``candidates`` (same convention as
+                :func:`~langres.core.calibration.derive_threshold`).
+        """
+        ...  # pragma: no cover — Protocol method body, never executed
+
+
+@runtime_checkable
+class UnsupervisedFitMixin(Protocol[SchemaT]):
+    """A Module that learns from candidate pairs without labels.
+
+    Implement ``fit_unlabeled(candidates)`` to opt in; no subclassing required
+    (structural typing via ``isinstance()``, enabled by ``@runtime_checkable``).
+    """
+
+    def fit_unlabeled(self, candidates: Iterator[ERCandidate[SchemaT]]) -> None:
+        """Fit the module's parameters from unlabeled candidate pairs.
+
+        Args:
+            candidates: The blocked (and, if a comparator is configured,
+                comparison-attached) candidate stream to learn from.
+        """
+        ...  # pragma: no cover — Protocol method body, never executed

--- a/src/langres/core/groups.py
+++ b/src/langres/core/groups.py
@@ -1,0 +1,92 @@
+"""Set-wise candidate grouping: ERCandidateGroup and the pairwise->group default.
+
+ERCandidateGroup is the set-wise input contract for :class:`~langres.core.module.
+GroupwiseModule` (W1.0 contracts; see docs/TECHNICAL_OVERVIEW.md "Group
+contract"). It represents "anchor + K candidate members" -- e.g. one LLM call
+asking "which of these K candidates match the anchor?" instead of K separate
+pairwise calls (the ComEM-style SelectJudge this contract is designed for,
+which lands in a later branch).
+
+This module also provides :func:`derive_groups_from_pairs`, the default,
+schema-agnostic way to derive groups from an existing pairwise ``ERCandidate``
+stream. It is deliberately buffered and anchor-skewed (see its docstring) --
+blockers whose native search structure is already per-anchor (e.g.
+``VectorBlocker``'s kNN search) should override
+``Blocker.stream_groups()`` instead of relying on this derivation.
+"""
+
+from collections.abc import Iterator
+from typing import Generic, TypeVar
+
+from pydantic import BaseModel
+
+from langres.core.models import ERCandidate
+
+# Generic type variable for schema types (must be a Pydantic model). Defined
+# locally (not imported from blocker.py/module.py) to avoid a circular import,
+# matching the existing per-module SchemaT convention (see models.py, module.py).
+SchemaT = TypeVar("SchemaT", bound=BaseModel)
+
+
+class ERCandidateGroup(BaseModel, Generic[SchemaT]):
+    """Anchor + K candidate members: the set-wise input to a GroupwiseModule.
+
+    Attributes:
+        anchor: The reference entity all members are compared against.
+        members: The K candidate entities being evaluated against the anchor.
+        group_id: Identifier for this group, e.g. the anchor's id. Carried
+            through to ``PairwiseJudgement.provenance["group_id"]`` by
+            :func:`~langres.core.module.stamp_group_cost` so every judgement
+            produced from one group call is traceable back to it.
+    """
+
+    anchor: SchemaT
+    members: list[SchemaT]
+    group_id: str
+
+
+def derive_groups_from_pairs(
+    candidates: Iterator[ERCandidate[SchemaT]],
+) -> Iterator[ERCandidateGroup[SchemaT]]:
+    """Derive per-anchor groups from a pairwise candidate stream.
+
+    BUFFERED AND SKEW-PRONE -- not for benchmark use (E3). Groups pairs by
+    their ``left`` entity: each unique ``left.id`` becomes one group's anchor,
+    with every paired ``right`` entity as a member. An entity that never
+    appears as ``left`` in the stream (e.g. because an upstream blocker
+    canonicalizes pair order by id, as ``VectorBlocker.stream()`` and most
+    all-pairs blockers do) never becomes its own anchor -- under-representing
+    it as a group anchor. This is the "skew" callers must not rely on for
+    anchor-fair benchmarking; a blocker with a naturally per-anchor structure
+    (e.g. ``VectorBlocker``'s kNN search) should implement
+    ``stream_groups()`` natively instead.
+
+    Despite the skew, this derivation is *lossless* over pairs: the set of
+    (anchor, member) edges it produces, flattened back to canonical
+    order-independent pairs, is exactly the set of pairs in ``candidates`` --
+    no dupes, no losses (see the pairs-equivalence property tests in
+    ``tests/core/test_groups.py`` / ``tests/core/test_blocker.py``).
+
+    This function fully buffers ``candidates`` into memory (it must see every
+    pair sharing an anchor before it can yield that anchor's group), unlike
+    the streaming-first pairwise contract elsewhere in langres.
+
+    Args:
+        candidates: A pairwise candidate stream, e.g. from ``Blocker.stream()``.
+
+    Yields:
+        One ``ERCandidateGroup`` per unique ``left`` entity encountered, in
+        first-seen order, with ``group_id`` set to the anchor's ``id``.
+    """
+    groups: dict[str, tuple[SchemaT, list[SchemaT]]] = {}
+    order: list[str] = []
+    for candidate in candidates:
+        anchor_id = candidate.left.id  # type: ignore[attr-defined]
+        if anchor_id not in groups:
+            groups[anchor_id] = (candidate.left, [])
+            order.append(anchor_id)
+        groups[anchor_id][1].append(candidate.right)
+
+    for anchor_id in order:
+        anchor, members = groups[anchor_id]
+        yield ERCandidateGroup(anchor=anchor, members=members, group_id=anchor_id)

--- a/src/langres/core/models.py
+++ b/src/langres/core/models.py
@@ -107,7 +107,15 @@ class PairwiseJudgement(BaseModel):
     left_id: str
     right_id: str
     score: float = Field(..., ge=0.0, le=1.0)
-    score_type: Literal["sim_cos", "prob_llm", "heuristic", "calibrated_prob"]
+    score_type: Literal[
+        "sim_cos",
+        "prob_llm",
+        "heuristic",
+        "calibrated_prob",
+        "prob_fs",
+        "prob_rf",
+        "prob_group_llm",
+    ]
     decision_step: str
     reasoning: str | None = None
     provenance: dict[str, Any]

--- a/src/langres/core/module.py
+++ b/src/langres/core/module.py
@@ -11,6 +11,7 @@ from typing import Generic, TypeVar
 
 from pydantic import BaseModel
 
+from langres.core.groups import ERCandidateGroup, derive_groups_from_pairs
 from langres.core.models import ERCandidate, PairwiseJudgement
 from langres.core.reports import ScoreInspectionReport
 
@@ -178,3 +179,122 @@ class Module(ABC, Generic[SchemaT]):
             ScoreInspectionReport with statistics, examples, and recommendations
         """
         pass  # pragma: no cover
+
+
+class GroupwiseModule(Module[SchemaT], ABC):
+    """A Module whose scoring logic naturally operates on GROUPS, not pairs (W1.0, E2).
+
+    GroupwiseModule **IS-A** Module: its concrete :meth:`forward` derives
+    ``ERCandidateGroup`` groups internally from the pairwise ``ERCandidate``
+    stream it receives (via :func:`~langres.core.groups.derive_groups_from_pairs`)
+    and dispatches to the abstract :meth:`forward_groups`, decomposing its
+    output back to a flat ``Iterator[PairwiseJudgement]``. This is a
+    deliberate design choice, not an accident: it means the existing Resolver
+    execution spine (``Resolver._judgements`` -> ``module.forward``),
+    :meth:`Module.inspect_scores`, the JudgementLog boundary, and benchmark
+    dispatch (``BudgetedModuleRunner``, ``run_method``) all keep working with
+    **zero changes** -- there is no parallel, group-aware execution path.
+
+    Concrete set-wise judges (e.g. a future ComEM-style ``SelectJudge`` that
+    asks one LLM call "which of these K candidates match the anchor?" instead
+    of K separate pairwise calls) implement only :meth:`forward_groups` and
+    :meth:`Module.inspect_scores`. Set-wise IN, pairwise OUT: the group
+    structure never leaks past this class's boundary, so the clusterer, the
+    metrics harness, and every other pairwise-only downstream consumer needs
+    no changes either.
+
+    Note:
+        The default grouping this class applies to its ``forward()`` input is
+        the same buffered/skew-prone derivation documented on
+        ``Blocker.stream_groups()`` / ``derive_groups_from_pairs`` -- because
+        ``forward()`` only ever sees a flat pairwise stream (whatever the
+        Resolver's blocker produced via ``stream()``), never the blocker
+        object itself, so it cannot reach a blocker's *native* per-anchor
+        grouping (e.g. ``VectorBlocker.stream_groups()``). Benchmarking a
+        set-wise judge against a blocker's true group structure requires
+        driving it via that blocker's ``stream_groups()`` directly, not
+        through this class's derived default.
+    """
+
+    def forward(self, candidates: Iterator[ERCandidate[SchemaT]]) -> Iterator[PairwiseJudgement]:
+        """Group the pairwise stream internally, then dispatch to forward_groups().
+
+        Args:
+            candidates: Stream of normalized entity pairs, e.g. from a
+                Blocker's ``stream()``.
+
+        Yields:
+            PairwiseJudgement objects, exactly as any other Module -- the
+            set-wise grouping is an internal implementation detail invisible
+            to callers of ``forward()``.
+        """
+        groups = derive_groups_from_pairs(candidates)
+        yield from self.forward_groups(groups)
+
+    @abstractmethod
+    def forward_groups(
+        self, groups: Iterator[ERCandidateGroup[SchemaT]]
+    ) -> Iterator[PairwiseJudgement]:
+        """Compare each group's anchor against its members and yield judgements.
+
+        This is the set-wise counterpart to :meth:`Module.forward`. Concrete
+        implementations should yield one ``PairwiseJudgement`` per
+        (anchor, member) pair evaluated -- typically all members of a group,
+        so the output covers the same pairs the input groups covered.
+
+        Args:
+            groups: Stream of anchor + K-candidate-member groups.
+
+        Yields:
+            PairwiseJudgement objects with scores and full provenance, same
+            contract as :meth:`Module.forward`. When a single call produces
+            judgements for a whole group, use
+            :func:`stamp_group_cost` to apply the group-call cost convention.
+        """
+        pass  # pragma: no cover
+
+
+def stamp_group_cost(
+    judgements: list[PairwiseJudgement],
+    call_cost_usd: float,
+    group_id: str,
+) -> list[PairwiseJudgement]:
+    """Apply the group-call cost convention to one group's judgements (E5).
+
+    One LLM call spans a whole group (K pairs); naively pricing each of the K
+    resulting judgements at the call's full cost would silently overcount
+    total spend by a factor of K. This convention avoids that: the FULL
+    ``call_cost_usd`` is stamped onto the FIRST judgement's
+    ``provenance["cost_usd"]``, every sibling gets ``$0``, and
+    ``provenance["group_id"]`` is set on ALL of them (so results stay
+    traceable back to their source call regardless of cost placement).
+    Existing cost aggregation (``langres.core.benchmark._judgement_cost`` /
+    ``_cost_track``, which already read ``provenance["cost_usd"]``) then sums
+    a group to exactly one call's cost with no changes on their end.
+
+    Args:
+        judgements: The judgements produced from ONE call spanning ONE group,
+            in any order. Must be non-empty.
+        call_cost_usd: The measured (or priced) cost of the single call that
+            produced all of these judgements.
+        group_id: Identifier of the source group, e.g. the group's
+            ``ERCandidateGroup.group_id``.
+
+    Returns:
+        New ``PairwiseJudgement`` objects (the originals are not mutated)
+        with ``provenance["cost_usd"]``/``provenance["group_id"]`` set per the
+        convention above; all other provenance keys are preserved.
+
+    Raises:
+        ValueError: If ``judgements`` is empty (there is no "first" judgement
+            to carry the cost).
+    """
+    if not judgements:
+        raise ValueError("stamp_group_cost requires at least one judgement")
+
+    stamped = []
+    for index, judgement in enumerate(judgements):
+        cost = call_cost_usd if index == 0 else 0.0
+        new_provenance = {**judgement.provenance, "cost_usd": cost, "group_id": group_id}
+        stamped.append(judgement.model_copy(update={"provenance": new_provenance}))
+    return stamped

--- a/src/langres/core/resolver.py
+++ b/src/langres/core/resolver.py
@@ -35,7 +35,7 @@ the helpers normalize the dict-vs-model and property-vs-method differences.
 import inspect
 import logging
 import warnings
-from collections.abc import Iterator
+from collections.abc import Iterator, Sequence
 from pathlib import Path
 from typing import Any, Literal, Self, TypeGuard
 
@@ -46,8 +46,9 @@ from langres.core.blocker import Blocker
 from langres.core.blockers.vector import VectorBlocker
 from langres.core.clusterer import Clusterer
 from langres.core.comparator import Comparator
+from langres.core.fit import SupervisedFitMixin, UnsupervisedFitMixin
 from langres.core.judges.weighted_average import WeightedAverageJudge
-from langres.core.models import PairwiseJudgement
+from langres.core.models import ERCandidate, PairwiseJudgement
 from langres.core.module import Module
 from langres.core.registry import get_component
 from langres.core.serialization import (
@@ -371,23 +372,77 @@ class Resolver:
     # Running the pipeline
     # ------------------------------------------------------------------
 
-    def fit(self, data: list[Any]) -> Self:
-        """No-op fit for sklearn-style symmetry; returns self.
+    def fit(self, data: list[Any], labels: Sequence[bool] | None = None) -> Self:
+        """Fit the module when it supports a fit hook; sklearn-style no-op otherwise.
 
-        M0 components are not learned — the heuristic scorer and thresholds are
-        fixed. Optimization (Optuna over thresholds/weights, DSPy over prompts)
-        lands in M3+, at which point ``fit`` will tune the pipeline on labeled
-        data. It exists now so callers can write ``resolver.fit(data).resolve(data)``
-        without branching on whether the pipeline is learnable.
+        Delegates to the module's fit hook when it implements one of the two
+        runtime-checkable Protocols in :mod:`langres.core.fit` (W1.0, E6):
+
+        - :class:`~langres.core.fit.UnsupervisedFitMixin`
+          (``fit_unlabeled(candidates)``): called unconditionally with the
+          blocked (and, if a comparator is configured, comparison-attached)
+          candidate stream. ``labels`` is not used by this path.
+        - :class:`~langres.core.fit.SupervisedFitMixin`
+          (``fit(candidates, labels)``): called with ``labels`` when given;
+          **raises** rather than silently skipping training when ``labels``
+          is omitted -- a genuinely trainable module that never gets
+          trained is exactly the silent-no-op footgun this hook exists to
+          prevent.
+
+        When the module implements **neither** hook, this is a no-op that
+        returns ``self`` -- unchanged sklearn-style symmetry so callers can
+        write ``resolver.fit(data).resolve(data)`` for non-learnable
+        pipelines (e.g. ``WeightedAverageJudge``) without branching -- UNLESS
+        ``labels`` was passed, in which case it raises rather than silently
+        discarding them.
+
+        Args:
+            data: Raw records (dicts) in a stable list order, same shape as
+                ``resolve()``/``predict()`` accept.
+            labels: Gold match/non-match labels, positionally aligned with the
+                blocked candidates. Required (and only used) when the module
+                implements ``SupervisedFitMixin``.
+
+        Returns:
+            ``self``, so ``resolver.fit(data).resolve(data)`` chains.
+
+        Raises:
+            ValueError: If the module implements ``SupervisedFitMixin`` and
+                ``labels`` is omitted, or if ``labels`` is given but the
+                module implements neither fit hook.
         """
+        if isinstance(self.module, SupervisedFitMixin):
+            if labels is None:
+                raise ValueError(
+                    f"{type(self.module).__name__} requires labeled data: pass "
+                    "labels=<Sequence[bool] aligned with the blocked candidates> "
+                    "to fit()."
+                )
+            self.module.fit(self._candidates(data), labels)
+            return self
+        if isinstance(self.module, UnsupervisedFitMixin):
+            if labels is not None:
+                raise ValueError(
+                    f"{type(self.module).__name__} does not support fit(labels=...): "
+                    "it implements UnsupervisedFitMixin, which trains without labels "
+                    "(fit_unlabeled) -- drop the labels= argument."
+                )
+            self.module.fit_unlabeled(self._candidates(data))
+            return self
+        if labels is not None:
+            raise ValueError(
+                f"{type(self.module).__name__} does not support fit(labels=...): "
+                "it implements neither SupervisedFitMixin nor UnsupervisedFitMixin."
+            )
         return self
 
-    def _judgements(self, records: list[Any]) -> Iterator[PairwiseJudgement]:
-        """Block records into candidates and score them into judgements.
+    def _candidates(self, records: list[Any]) -> Iterator[ERCandidate[Any]]:
+        """Block records into candidates, attaching comparisons if configured.
 
         Builds an index-backed blocker's index transparently before streaming,
         so callers never call ``create_index`` themselves. Records are fed in
-        the caller's stable list order.
+        the caller's stable list order. Shared by ``_judgements`` (scoring)
+        and ``fit`` (training) -- both need the same candidate stream.
         """
         self._ensure_index_built(records)
         candidates = self.blocker.stream(records)
@@ -397,7 +452,11 @@ class Resolver:
                 c.model_copy(update={"comparison": comparator.compare(c.left, c.right)})
                 for c in candidates
             )
-        return self.module.forward(candidates)
+        return candidates
+
+    def _judgements(self, records: list[Any]) -> Iterator[PairwiseJudgement]:
+        """Block records into candidates and score them into judgements."""
+        return self.module.forward(self._candidates(records))
 
     def predict(self, records: list[Any]) -> list[PairwiseJudgement]:
         """Return the scored pairwise judgements before clustering.

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -23,4 +23,16 @@ def pairs_from_groups(groups: Iterable[Any]) -> set[frozenset[str]]:
     return {frozenset([group.anchor.id, member.id]) for group in groups for member in group.members}
 
 
+def edge_list_from_groups(groups: Iterable[Any]) -> list[frozenset[str]]:
+    """Canonical (anchor, member) edges from an ``ERCandidateGroup`` stream, AS A LIST.
+
+    Unlike :func:`pairs_from_groups` (which returns a ``set`` and so silently
+    collapses a pair that appears in two different groups), this preserves
+    duplicates -- use it to assert NO duplicate edge exists across groups
+    (``len(edges) == len(set(edges))``), not just that the covered pair SET is
+    correct.
+    """
+    return [frozenset([group.anchor.id, member.id]) for group in groups for member in group.members]
+
+
 # Add shared fixtures here as needed

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,4 +1,30 @@
 """Pytest configuration and shared fixtures for langres tests."""
 
+from collections.abc import Iterable
+from typing import Any
+
+
+def pairs_from_candidates(candidates: Iterable[Any]) -> set[frozenset[str]]:
+    """Canonical (order-independent) pair-id set from an ``ERCandidate`` stream.
+
+    Shared by the ``stream()`` vs ``stream_groups()`` pairs-equivalence property
+    tests (CEO #14) so both the default derived grouping and VectorBlocker's
+    native grouping compare against the same extraction logic.
+    """
+    return {frozenset([c.left.id, c.right.id]) for c in candidates}
+
+
+def pairs_from_groups(groups: Iterable[Any]) -> set[frozenset[str]]:
+    """Canonical (order-independent) pair-id set from an ``ERCandidateGroup`` stream.
+
+    Flattens each group into (anchor, member) edges. Used opposite
+    :func:`pairs_from_candidates` in the pairs-equivalence property tests.
+    """
+    return {
+        frozenset([group.anchor.id, member.id])
+        for group in groups
+        for member in group.members
+    }
+
 
 # Add shared fixtures here as needed

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -20,11 +20,7 @@ def pairs_from_groups(groups: Iterable[Any]) -> set[frozenset[str]]:
     Flattens each group into (anchor, member) edges. Used opposite
     :func:`pairs_from_candidates` in the pairs-equivalence property tests.
     """
-    return {
-        frozenset([group.anchor.id, member.id])
-        for group in groups
-        for member in group.members
-    }
+    return {frozenset([group.anchor.id, member.id]) for group in groups for member in group.members}
 
 
 # Add shared fixtures here as needed

--- a/tests/core/blockers/test_vector.py
+++ b/tests/core/blockers/test_vector.py
@@ -19,7 +19,7 @@ from langres.core.groups import ERCandidateGroup
 from langres.core.indexes.reranking_vector_index import FakeHybridRerankingVectorIndex
 from langres.core.indexes.vector_index import FAISSIndex, FakeVectorIndex
 from langres.core.models import CompanySchema
-from tests.conftest import pairs_from_candidates, pairs_from_groups
+from tests.conftest import edge_list_from_groups, pairs_from_candidates, pairs_from_groups
 
 logger = logging.getLogger(__name__)
 
@@ -545,14 +545,22 @@ def test_vector_blocker_stream_groups_yields_one_group_per_anchor():
     assert all(isinstance(g, ERCandidateGroup) for g in groups)
     by_anchor = {g.group_id: g for g in groups}
     assert set(by_anchor) == {"c0", "c1", "c2", "c3"}
-    # FakeVectorIndex.search_all: entity i's neighbors (after skipping self) are
-    # [(i+1) % N, (i+2) % N] for k_neighbors=2.
+    # FakeVectorIndex.search_all: entity i's RAW neighbors (after skipping self)
+    # are [(i+1) % N, (i+2) % N] for k_neighbors=2. Cross-anchor dedup (first
+    # anchor to reach a pair claims it, same as stream()) then removes an edge
+    # from a later anchor's group once an earlier anchor already claimed it:
+    # c0 claims {c0,c1} and {c0,c2}; c1 claims {c1,c2} and {c1,c3}; c2's raw
+    # {c2,c0} was already claimed by c0, so c2 keeps only {c2,c3}; c3's raw
+    # {c3,c1} was already claimed by c1, so c3 keeps only {c3,c0}.
     assert {m.id for m in by_anchor["c0"].members} == {"c1", "c2"}
     assert {m.id for m in by_anchor["c1"].members} == {"c2", "c3"}
-    assert {m.id for m in by_anchor["c2"].members} == {"c3", "c0"}
-    assert {m.id for m in by_anchor["c3"].members} == {"c0", "c1"}
+    assert {m.id for m in by_anchor["c2"].members} == {"c3"}
+    assert {m.id for m in by_anchor["c3"].members} == {"c0"}
     # No self-pairs: an anchor never lists itself as a member.
     assert all(g.anchor.id not in {m.id for m in g.members} for g in groups)
+    # Every undirected pair is covered by exactly one group -- no duplicates.
+    edges = edge_list_from_groups(groups)
+    assert len(edges) == len(set(edges)) == 6  # C(4, 2): full coverage, no dupes
 
 
 def test_vector_blocker_stream_groups_raises_if_index_not_built():
@@ -615,14 +623,15 @@ def test_vector_blocker_stream_groups_is_schema_agnostic_with_product_schema():
     [(3, 1), (4, 2), (5, 2), (6, 3), (8, 4)],
 )
 def test_vector_blocker_stream_groups_pairs_equivalence_property(n_entities, k_neighbors):
-    """Property (CEO #14): the SET of pairs from stream_groups() == the SET from stream().
+    """Property (CEO #14 + E5): pairs from stream_groups() == pairs from stream().
 
-    No losses (every pair stream() would yield is covered by at least one
-    group) across several (N, k) shapes, including k_neighbors close to and
-    below N-1 (dense) and small k (sparse). This is a SET-level equivalence:
-    it does not claim each pair is covered by EXACTLY one group -- see
-    ``test_vector_blocker_stream_groups_may_duplicate_mutual_neighbor_pairs``
-    for the documented case where it's covered by two.
+    COUNT-based, not just set-based: every pair stream() would yield is
+    covered by EXACTLY one group -- no losses AND no duplicates -- across
+    several (N, k) shapes, including k_neighbors close to and below N-1
+    (dense) and small k (sparse). A set-only comparison would silently mask a
+    pair being emitted by two different groups (see
+    ``test_vector_blocker_stream_groups_dedupes_mutual_neighbor_pairs`` for
+    the targeted regression on that exact failure mode).
     """
     data = [{"id": f"c{i}", "name": f"Company {i}"} for i in range(n_entities)]
     texts = [d["name"] for d in data]
@@ -633,30 +642,30 @@ def test_vector_blocker_stream_groups_pairs_equivalence_property(n_entities, k_n
 
     groups_blocker = create_fake_blocker(k_neighbors=k_neighbors)
     groups_blocker.vector_index.create_index(texts)
-    group_pairs = pairs_from_groups(groups_blocker.stream_groups(data))
+    groups = list(groups_blocker.stream_groups(data))
+    group_edges = edge_list_from_groups(groups)
 
-    assert group_pairs == stream_pairs
+    assert len(group_edges) == len(set(group_edges))  # no duplicate edges across groups
+    assert set(group_edges) == stream_pairs  # same set covered
+    assert pairs_from_groups(groups) == stream_pairs  # sanity: set helper agrees
 
 
-def test_vector_blocker_stream_groups_may_duplicate_mutual_neighbor_pairs():
-    """Documents a real caveat (raised in review): unlike stream(), stream_groups()
-    does NOT dedupe an edge across groups.
+def test_vector_blocker_stream_groups_dedupes_mutual_neighbor_pairs():
+    """Regression: mutual nearest neighbors are covered by exactly ONE group.
 
     stream() maintains a single ``seen_pairs`` set across all entities, so a
     mutual-nearest-neighbor pair (A's nearest neighbor is B AND B's nearest
     neighbor is A -- common with real ANN indexes on near-duplicate records)
-    is yielded exactly once. stream_groups() has no such cross-anchor state:
-    each group is *anchor A's own, true, un-truncated neighbor list*, so if A
-    and B are mutual neighbors, the undirected pair {A, B} appears as a member
-    edge in BOTH A's group and B's group.
+    is yielded exactly once. stream_groups() now mirrors that exact dedup
+    semantics (same iteration order, same first-seen-wins rule, threaded
+    across ALL anchors via one ``seen_pairs`` set) -- so a mutual pair is
+    assigned to whichever anchor is processed first (c0, here) and does NOT
+    also appear in the other anchor's group (c1's group ends up empty).
 
-    This is a deliberate trade-off, not an oversight: truncating a later
-    group to preserve global pair-uniqueness would mean that group no longer
-    represents the anchor's real candidate set (see the class docstring on
-    ``stream_groups()``). A consumer that treats each group as an independent
-    unit of work -- e.g. a future SelectJudge issuing one LLM call per group,
-    or counting/costing calls -- must dedupe by canonical pair across groups
-    if it wants to process (and charge for) each undirected pair once.
+    Without the fix, a consumer issuing one LLM call per group (e.g. a future
+    SelectJudge) would emit and charge for the same undirected pair twice --
+    this test fails against that pre-fix behavior (which asserted the pair
+    appeared in BOTH groups) and passes against the fix.
     """
     from unittest.mock import MagicMock
 
@@ -687,13 +696,15 @@ def test_vector_blocker_stream_groups_may_duplicate_mutual_neighbor_pairs():
     groups = list(blocker.stream_groups(data))
 
     by_anchor = {g.group_id: g for g in groups}
+    # c0 is processed first -> claims the mutual pair {c0, c1}.
     assert {m.id for m in by_anchor["c0"].members} == {"c1"}
-    assert {m.id for m in by_anchor["c1"].members} == {"c0"}  # mutual -> reciprocated
+    # c1's own reciprocal edge back to c0 was already claimed -> empty group.
+    assert {m.id for m in by_anchor["c1"].members} == set()
+    assert {m.id for m in by_anchor["c2"].members} == {"c0"}
 
-    edges = [
-        frozenset([group.anchor.id, member.id]) for group in groups for member in group.members
-    ]
-    # {c0, c1} is a member edge in BOTH c0's and c1's group -- covered twice.
-    assert edges.count(frozenset({"c0", "c1"})) == 2
-    # {c0, c2} is one-directional (only c2 -> c0) -- covered once.
+    edges = edge_list_from_groups(groups)
+    assert len(edges) == len(set(edges))  # no duplicate edges anywhere
+    # {c0, c1} (mutual) and {c0, c2} (one-directional) are each covered ONCE.
+    assert edges.count(frozenset({"c0", "c1"})) == 1
     assert edges.count(frozenset({"c0", "c2"})) == 1
+    assert len(edges) == 2

--- a/tests/core/blockers/test_vector.py
+++ b/tests/core/blockers/test_vector.py
@@ -615,10 +615,14 @@ def test_vector_blocker_stream_groups_is_schema_agnostic_with_product_schema():
     [(3, 1), (4, 2), (5, 2), (6, 3), (8, 4)],
 )
 def test_vector_blocker_stream_groups_pairs_equivalence_property(n_entities, k_neighbors):
-    """Property (CEO #14): pairs from stream_groups() == pairs from stream().
+    """Property (CEO #14): the SET of pairs from stream_groups() == the SET from stream().
 
-    No dupes, no losses -- across several (N, k) shapes, including
-    k_neighbors close to and below N-1 (dense) and small k (sparse).
+    No losses (every pair stream() would yield is covered by at least one
+    group) across several (N, k) shapes, including k_neighbors close to and
+    below N-1 (dense) and small k (sparse). This is a SET-level equivalence:
+    it does not claim each pair is covered by EXACTLY one group -- see
+    ``test_vector_blocker_stream_groups_may_duplicate_mutual_neighbor_pairs``
+    for the documented case where it's covered by two.
     """
     data = [{"id": f"c{i}", "name": f"Company {i}"} for i in range(n_entities)]
     texts = [d["name"] for d in data]
@@ -632,3 +636,64 @@ def test_vector_blocker_stream_groups_pairs_equivalence_property(n_entities, k_n
     group_pairs = pairs_from_groups(groups_blocker.stream_groups(data))
 
     assert group_pairs == stream_pairs
+
+
+def test_vector_blocker_stream_groups_may_duplicate_mutual_neighbor_pairs():
+    """Documents a real caveat (raised in review): unlike stream(), stream_groups()
+    does NOT dedupe an edge across groups.
+
+    stream() maintains a single ``seen_pairs`` set across all entities, so a
+    mutual-nearest-neighbor pair (A's nearest neighbor is B AND B's nearest
+    neighbor is A -- common with real ANN indexes on near-duplicate records)
+    is yielded exactly once. stream_groups() has no such cross-anchor state:
+    each group is *anchor A's own, true, un-truncated neighbor list*, so if A
+    and B are mutual neighbors, the undirected pair {A, B} appears as a member
+    edge in BOTH A's group and B's group.
+
+    This is a deliberate trade-off, not an oversight: truncating a later
+    group to preserve global pair-uniqueness would mean that group no longer
+    represents the anchor's real candidate set (see the class docstring on
+    ``stream_groups()``). A consumer that treats each group as an independent
+    unit of work -- e.g. a future SelectJudge issuing one LLM call per group,
+    or counting/costing calls -- must dedupe by canonical pair across groups
+    if it wants to process (and charge for) each undirected pair once.
+    """
+    from unittest.mock import MagicMock
+
+    import numpy as np
+
+    mock_index = MagicMock()
+    mock_index._index = object()  # _index_is_built() -> True
+    # 3 entities, k_neighbors=1 (k=2 incl. self): c0 and c1 are MUTUAL nearest
+    # neighbors; c2's nearest neighbor is c0 (one-directional).
+    mock_index.search_all = MagicMock(
+        return_value=(
+            np.array([[0.0, 0.1], [0.0, 0.1], [0.0, 0.2]], dtype=np.float32),
+            np.array([[0, 1], [1, 0], [2, 0]], dtype=np.int64),
+        )
+    )
+    blocker = VectorBlocker(
+        schema_factory=company_factory,
+        text_field_extractor=lambda x: x.name,
+        vector_index=mock_index,
+        k_neighbors=1,
+    )
+    data = [
+        {"id": "c0", "name": "Acme"},
+        {"id": "c1", "name": "Acme Corp"},
+        {"id": "c2", "name": "Other Co"},
+    ]
+
+    groups = list(blocker.stream_groups(data))
+
+    by_anchor = {g.group_id: g for g in groups}
+    assert {m.id for m in by_anchor["c0"].members} == {"c1"}
+    assert {m.id for m in by_anchor["c1"].members} == {"c0"}  # mutual -> reciprocated
+
+    edges = [
+        frozenset([group.anchor.id, member.id]) for group in groups for member in group.members
+    ]
+    # {c0, c1} is a member edge in BOTH c0's and c1's group -- covered twice.
+    assert edges.count(frozenset({"c0", "c1"})) == 2
+    # {c0, c2} is one-directional (only c2 -> c0) -- covered once.
+    assert edges.count(frozenset({"c0", "c2"})) == 1

--- a/tests/core/blockers/test_vector.py
+++ b/tests/core/blockers/test_vector.py
@@ -15,9 +15,11 @@ import pytest
 
 from langres.core.blockers.vector import VectorBlocker
 from langres.core.embeddings import SentenceTransformerEmbedder
+from langres.core.groups import ERCandidateGroup
 from langres.core.indexes.reranking_vector_index import FakeHybridRerankingVectorIndex
 from langres.core.indexes.vector_index import FAISSIndex, FakeVectorIndex
 from langres.core.models import CompanySchema
+from tests.conftest import pairs_from_candidates, pairs_from_groups
 
 logger = logging.getLogger(__name__)
 
@@ -513,3 +515,120 @@ def test_stream_with_fake_hybrid_reranking_index_end_to_end():
     # to_similarities mapped fake distances into [0, 1] similarity scores.
     for candidate in candidates:
         assert 0.0 <= candidate.similarity_score <= 1.0
+
+
+# ============================================================================
+# stream_groups(): VectorBlocker's NATIVE per-anchor implementation (E3).
+#
+# Unlike the base Blocker's buffered/skew-prone default (which derives groups
+# from the pairwise stream() and so under-represents entities that never land
+# on the "left" side), VectorBlocker's kNN search is already per-anchor: one
+# group per entity, with its k nearest neighbors as members, straight from the
+# index -- no derivation, no skew.
+# ============================================================================
+
+
+def test_vector_blocker_stream_groups_yields_one_group_per_anchor():
+    """stream_groups() yields one ERCandidateGroup per entity, from its own kNN search."""
+    data = [
+        {"id": "c0", "name": "A"},
+        {"id": "c1", "name": "B"},
+        {"id": "c2", "name": "C"},
+        {"id": "c3", "name": "D"},
+    ]
+    blocker = create_fake_blocker(k_neighbors=2)
+    blocker.vector_index.create_index([d["name"] for d in data])
+
+    groups = list(blocker.stream_groups(data))
+
+    assert len(groups) == 4
+    assert all(isinstance(g, ERCandidateGroup) for g in groups)
+    by_anchor = {g.group_id: g for g in groups}
+    assert set(by_anchor) == {"c0", "c1", "c2", "c3"}
+    # FakeVectorIndex.search_all: entity i's neighbors (after skipping self) are
+    # [(i+1) % N, (i+2) % N] for k_neighbors=2.
+    assert {m.id for m in by_anchor["c0"].members} == {"c1", "c2"}
+    assert {m.id for m in by_anchor["c1"].members} == {"c2", "c3"}
+    assert {m.id for m in by_anchor["c2"].members} == {"c3", "c0"}
+    assert {m.id for m in by_anchor["c3"].members} == {"c0", "c1"}
+    # No self-pairs: an anchor never lists itself as a member.
+    assert all(g.anchor.id not in {m.id for m in g.members} for g in groups)
+
+
+def test_vector_blocker_stream_groups_raises_if_index_not_built():
+    """stream_groups() enforces the same explicit-index-build contract as stream()."""
+    blocker = create_fake_blocker(k_neighbors=2)
+    data = [{"id": "c1", "name": "Apple"}, {"id": "c2", "name": "Google"}]
+
+    with pytest.raises(RuntimeError, match="Index not built"):
+        list(blocker.stream_groups(data))
+
+
+def test_vector_blocker_stream_groups_handles_empty_dataset():
+    """Empty input -> no groups."""
+    blocker = create_fake_blocker(k_neighbors=2)
+    blocker.vector_index.create_index([])
+    assert list(blocker.stream_groups([])) == []
+
+
+def test_vector_blocker_stream_groups_handles_single_entity():
+    """A single entity has no neighbors -> no groups."""
+    data = [{"id": "c1", "name": "Only Company"}]
+    blocker = create_fake_blocker(k_neighbors=5)
+    blocker.vector_index.create_index([d["name"] for d in data])
+
+    assert list(blocker.stream_groups(data)) == []
+
+
+def test_vector_blocker_stream_groups_is_schema_agnostic_with_product_schema():
+    """stream_groups() works with a second, unrelated schema (ProductSchema)."""
+    from pydantic import BaseModel
+
+    class ProductSchema(BaseModel):
+        id: str
+        title: str
+
+    def product_factory(record: dict) -> ProductSchema:
+        return ProductSchema(id=record["id"], title=record["title"])
+
+    data = [
+        {"id": "p1", "title": "iPhone"},
+        {"id": "p2", "title": "iPhone Pro"},
+        {"id": "p3", "title": "Galaxy"},
+    ]
+    blocker = VectorBlocker(
+        schema_factory=product_factory,
+        text_field_extractor=lambda x: x.title,
+        vector_index=FakeVectorIndex(),
+        k_neighbors=2,
+    )
+    blocker.vector_index.create_index([d["title"] for d in data])
+
+    groups = list(blocker.stream_groups(data))
+
+    assert len(groups) == 3
+    assert all(isinstance(g.anchor, ProductSchema) for g in groups)
+
+
+@pytest.mark.parametrize(
+    ("n_entities", "k_neighbors"),
+    [(3, 1), (4, 2), (5, 2), (6, 3), (8, 4)],
+)
+def test_vector_blocker_stream_groups_pairs_equivalence_property(n_entities, k_neighbors):
+    """Property (CEO #14): pairs from stream_groups() == pairs from stream().
+
+    No dupes, no losses -- across several (N, k) shapes, including
+    k_neighbors close to and below N-1 (dense) and small k (sparse).
+    """
+    data = [{"id": f"c{i}", "name": f"Company {i}"} for i in range(n_entities)]
+    texts = [d["name"] for d in data]
+
+    stream_blocker = create_fake_blocker(k_neighbors=k_neighbors)
+    stream_blocker.vector_index.create_index(texts)
+    stream_pairs = pairs_from_candidates(stream_blocker.stream(data))
+
+    groups_blocker = create_fake_blocker(k_neighbors=k_neighbors)
+    groups_blocker.vector_index.create_index(texts)
+    group_pairs = pairs_from_groups(groups_blocker.stream_groups(data))
+
+    assert group_pairs == stream_pairs

--- a/tests/core/test_benchmark.py
+++ b/tests/core/test_benchmark.py
@@ -36,9 +36,10 @@ from langres.core.benchmark import (
 from langres.core.blockers.all_pairs import AllPairsBlocker
 from langres.core.blockers.vector import VectorBlocker
 from langres.core.clusterer import Clusterer
+from langres.core.groups import ERCandidateGroup
 from langres.core.indexes.vector_index import FakeVectorIndex
 from langres.core.models import CompanySchema, ERCandidate, PairwiseJudgement
-from langres.core.module import Module
+from langres.core.module import GroupwiseModule, Module
 from langres.core.reports import ScoreInspectionReport
 from langres.core.resolver import Resolver
 from langres.methods import ZERO_SPEND_METHODS
@@ -207,6 +208,81 @@ def test_runner_propagates_blind_cost_error_with_partial() -> None:
         runner.run(_candidates(3), price_per_token_or_pair=0.001)
     # l0 was scored (and paid for) before l1 aborted -> recoverable on partial.
     assert [j.left_id for j in excinfo.value.partial] == ["l0"]
+
+
+# ---------------------------------------------------------------------------
+# BudgetedModuleRunner + GroupwiseModule: documented group-atomicity (E5).
+#
+# BudgetedModuleRunner._score_one() calls ``module.forward(iter([candidate]))``
+# ONE candidate at a time (by design -- see its docstring's "per-call
+# resilience" point). A GroupwiseModule's forward() derives groups from
+# whatever pairwise stream it's given, so under the runner each call sees
+# exactly one candidate -> one trivial, size-1 group. This means the
+# atomicity guarantee ("never split a group mid-call") holds TRIVIALLY today
+# -- there is never more than one pair per call, so there is nothing to
+# split -- but it also means the runner does NOT yet amortize a real multi-
+# pair group into a single priced call. That cost-saving integration is
+# deferred to W1.1 (the first concrete GroupwiseModule, SelectJudge), which
+# will extend the runner (or add a group-aware runner) to pre-flight whole
+# groups. This test pins down and documents the current, correct-but-not-
+# yet-optimized behavior so a future change is a deliberate, measured one.
+# ---------------------------------------------------------------------------
+
+
+class _CountingGroupwiseModule(GroupwiseModule[CompanySchema]):
+    """Records every forward_groups() call's groups, for atomicity inspection."""
+
+    def __init__(self) -> None:
+        self.calls: list[list[ERCandidateGroup[CompanySchema]]] = []
+
+    def forward_groups(
+        self, groups: Iterator[ERCandidateGroup[CompanySchema]]
+    ) -> Iterator[PairwiseJudgement]:
+        materialized = list(groups)
+        self.calls.append(materialized)
+        for group in materialized:
+            for member in group.members:
+                yield PairwiseJudgement(
+                    left_id=group.anchor.id,
+                    right_id=member.id,
+                    score=1.0,
+                    score_type="prob_group_llm",
+                    decision_step="test",
+                    provenance={"cost_usd": 0.01},
+                )
+
+    def inspect_scores(
+        self, judgements: list[PairwiseJudgement], sample_size: int = 10
+    ) -> ScoreInspectionReport:
+        raise NotImplementedError  # pragma: no cover — unused by the runner
+
+
+def test_runner_never_splits_a_group_mid_call_but_also_never_batches_one() -> None:
+    """Documents E5's atomicity guarantee under today's per-candidate runner loop.
+
+    Three candidates share the same left.id (would form ONE group of size 3
+    if handed to forward() together) but the runner isolates each candidate
+    into its own call -> forward_groups() is invoked 3 times, each with a
+    single size-1 group. No group is ever split across calls (each call's
+    group is already maximal for what it was given), but no batching happens
+    either -- see the module docstring above for why, and the deferral.
+    """
+    module = _CountingGroupwiseModule()
+    runner = BudgetedModuleRunner(module, budget_usd=100.0, budget_soft_usd=100.0)
+    candidates = [
+        ERCandidate(
+            left=CompanySchema(id="anchor", name="Anchor"),
+            right=CompanySchema(id=f"m{i}", name=f"Member {i}"),
+            blocker_name="test",
+        )
+        for i in range(3)
+    ]
+
+    out = runner.run(candidates, price_per_token_or_pair=0.01)
+
+    assert len(out) == 3
+    assert len(module.calls) == 3  # one call per candidate, not one call for the group
+    assert all(len(call) == 1 and len(call[0].members) == 1 for call in module.calls)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/core/test_blocker.py
+++ b/tests/core/test_blocker.py
@@ -6,8 +6,10 @@ import numpy as np
 import pytest
 
 from langres.core.blocker import Blocker
+from langres.core.groups import ERCandidateGroup
 from langres.core.models import CompanySchema, ERCandidate
 from langres.core.reports import CandidateInspectionReport
+from tests.conftest import pairs_from_candidates, pairs_from_groups
 
 
 class DummyBlocker(Blocker[CompanySchema]):
@@ -201,3 +203,73 @@ def test_blocker_is_lazy_generator() -> None:
     remaining = list(result_iterator)
     assert len(remaining) == 44  # C(10,2) - 1 = 45 - 1
     assert blocker.pair_count == 45  # C(10,2)
+
+
+# ---------------------------------------------------------------------------
+# stream_groups(): the default, derived-from-stream() implementation (E3).
+#
+# Documented as BUFFERED and SKEW-PRONE -- not for benchmark use. A blocker
+# that needs anchor-fair groups (e.g. VectorBlocker, whose kNN structure is
+# already per-anchor) overrides stream_groups() natively instead of relying on
+# this default.
+# ---------------------------------------------------------------------------
+
+
+def test_blocker_stream_groups_has_a_concrete_default() -> None:
+    """A plain Blocker subclass (only implementing stream()) gets stream_groups() for free."""
+    blocker = DummyBlocker()
+
+    data = [{"id": "1", "name": "A"}, {"id": "2", "name": "B"}]
+
+    groups = list(blocker.stream_groups(data))
+
+    assert len(groups) == 1
+    assert isinstance(groups[0], ERCandidateGroup)
+
+
+def test_blocker_stream_groups_default_groups_by_left_id() -> None:
+    """The default groups by each pair's left.id (documented left-id skew)."""
+    blocker = DummyBlocker()
+
+    data = [
+        {"id": "1", "name": "Company 1"},
+        {"id": "2", "name": "Company 2"},
+        {"id": "3", "name": "Company 3"},
+    ]
+
+    groups = list(blocker.stream_groups(data))
+
+    # DummyBlocker's stream() yields i<j pairs: (1,2), (1,3), (2,3).
+    # -> "1" anchors {2,3}; "2" anchors {3}; "3" never anchors (all-pairs skew).
+    by_anchor = {g.group_id: g for g in groups}
+    assert set(by_anchor) == {"1", "2"}
+    assert {m.id for m in by_anchor["1"].members} == {"2", "3"}
+    assert {m.id for m in by_anchor["2"].members} == {"3"}
+
+
+def test_blocker_stream_groups_default_handles_empty_data() -> None:
+    """Empty input -> no groups."""
+    blocker = DummyBlocker()
+    assert list(blocker.stream_groups([])) == []
+
+
+def test_blocker_stream_groups_default_handles_single_record() -> None:
+    """A single record produces no pairs and so no groups."""
+    blocker = DummyBlocker()
+    assert list(blocker.stream_groups([{"id": "1", "name": "Only Company"}])) == []
+
+
+def test_blocker_stream_groups_default_pairs_equivalence_property() -> None:
+    """Property (CEO #14): pairs from stream_groups() == pairs from stream().
+
+    No dupes, no losses -- verified against the SAME blocker/data via the
+    default derived implementation.
+    """
+    blocker = DummyBlocker()
+    data = [{"id": str(i), "name": f"Company {i}"} for i in range(6)]
+
+    stream_pairs = pairs_from_candidates(blocker.stream(data))
+    group_pairs = pairs_from_groups(blocker.stream_groups(data))
+
+    assert group_pairs == stream_pairs
+    assert len(group_pairs) == 15  # C(6, 2)

--- a/tests/core/test_fit_mixins.py
+++ b/tests/core/test_fit_mixins.py
@@ -1,0 +1,162 @@
+"""Tests for the fit-hook Protocols: SupervisedFitMixin, UnsupervisedFitMixin.
+
+These are runtime-checkable structural Protocols (W1.0 contracts-only; E6): a
+Module opts in by implementing the method, not by subclassing. No abstract fit
+method is added to the base Module ABC (that would break every existing
+module), so these tests verify isinstance()-based structural detection instead
+of ABC-enforced instantiation failures.
+"""
+
+from collections.abc import Iterator, Sequence
+
+from pydantic import BaseModel
+
+from langres.core.fit import SupervisedFitMixin, UnsupervisedFitMixin
+from langres.core.models import CompanySchema, ERCandidate, PairwiseJudgement
+from langres.core.module import Module
+from langres.core.reports import ScoreInspectionReport
+
+
+class ProductSchema(BaseModel):
+    """Second schema for schema-agnostic verification."""
+
+    id: str
+    title: str
+
+
+class _NonLearnableModule(Module[CompanySchema]):
+    """A module implementing neither fit hook (e.g. WeightedAverageJudge-like)."""
+
+    def forward(
+        self, candidates: Iterator[ERCandidate[CompanySchema]]
+    ) -> Iterator[PairwiseJudgement]:
+        for candidate in candidates:
+            yield PairwiseJudgement(
+                left_id=candidate.left.id,
+                right_id=candidate.right.id,
+                score=0.5,
+                score_type="heuristic",
+                decision_step="test",
+                provenance={},
+            )
+
+    def inspect_scores(
+        self, judgements: list[PairwiseJudgement], sample_size: int = 10
+    ) -> ScoreInspectionReport:
+        raise NotImplementedError  # not exercised in these tests
+
+
+class _SupervisedModule(Module[CompanySchema]):
+    """A module implementing SupervisedFitMixin (e.g. a future RFJudge)."""
+
+    def __init__(self) -> None:
+        self.fit_calls: list[tuple[list[ERCandidate[CompanySchema]], Sequence[bool]]] = []
+
+    def forward(
+        self, candidates: Iterator[ERCandidate[CompanySchema]]
+    ) -> Iterator[PairwiseJudgement]:
+        yield from ()
+
+    def inspect_scores(
+        self, judgements: list[PairwiseJudgement], sample_size: int = 10
+    ) -> ScoreInspectionReport:
+        raise NotImplementedError
+
+    def fit(
+        self, candidates: Iterator[ERCandidate[CompanySchema]], labels: Sequence[bool]
+    ) -> None:
+        self.fit_calls.append((list(candidates), labels))
+
+
+class _UnsupervisedModule(Module[CompanySchema]):
+    """A module implementing UnsupervisedFitMixin (e.g. a future FellegiSunterJudge)."""
+
+    def __init__(self) -> None:
+        self.fit_unlabeled_calls: list[list[ERCandidate[CompanySchema]]] = []
+
+    def forward(
+        self, candidates: Iterator[ERCandidate[CompanySchema]]
+    ) -> Iterator[PairwiseJudgement]:
+        yield from ()
+
+    def inspect_scores(
+        self, judgements: list[PairwiseJudgement], sample_size: int = 10
+    ) -> ScoreInspectionReport:
+        raise NotImplementedError
+
+    def fit_unlabeled(self, candidates: Iterator[ERCandidate[CompanySchema]]) -> None:
+        self.fit_unlabeled_calls.append(list(candidates))
+
+
+def _candidate() -> ERCandidate[CompanySchema]:
+    return ERCandidate(
+        left=CompanySchema(id="1", name="Acme"),
+        right=CompanySchema(id="2", name="Acme Corp"),
+        blocker_name="test_blocker",
+    )
+
+
+def test_non_learnable_module_satisfies_neither_mixin() -> None:
+    """A module with only forward()/inspect_scores() is not fit-capable."""
+    module = _NonLearnableModule()
+    assert not isinstance(module, SupervisedFitMixin)
+    assert not isinstance(module, UnsupervisedFitMixin)
+
+
+def test_supervised_module_satisfies_supervised_mixin_only() -> None:
+    """A module with fit(candidates, labels) matches SupervisedFitMixin."""
+    module = _SupervisedModule()
+    assert isinstance(module, SupervisedFitMixin)
+    assert not isinstance(module, UnsupervisedFitMixin)
+
+
+def test_unsupervised_module_satisfies_unsupervised_mixin_only() -> None:
+    """A module with fit_unlabeled(candidates) matches UnsupervisedFitMixin."""
+    module = _UnsupervisedModule()
+    assert isinstance(module, UnsupervisedFitMixin)
+    assert not isinstance(module, SupervisedFitMixin)
+
+
+def test_supervised_mixin_fit_receives_candidates_and_labels() -> None:
+    """The supervised hook is callable with (candidates, labels) as specified."""
+    module = _SupervisedModule()
+    labels = [True, False]
+
+    module.fit(iter([_candidate(), _candidate()]), labels)
+
+    assert len(module.fit_calls) == 1
+    candidates, received_labels = module.fit_calls[0]
+    assert len(candidates) == 2
+    assert received_labels == labels
+
+
+def test_unsupervised_mixin_fit_unlabeled_receives_candidates() -> None:
+    """The unsupervised hook is callable with just candidates as specified."""
+    module = _UnsupervisedModule()
+
+    module.fit_unlabeled(iter([_candidate()]))
+
+    assert len(module.fit_unlabeled_calls) == 1
+    assert len(module.fit_unlabeled_calls[0]) == 1
+
+
+def test_fit_mixins_are_schema_agnostic_with_product_schema() -> None:
+    """The Protocols are generic over SchemaT — a ProductSchema module also matches."""
+
+    class _ProductSupervisedModule(Module[ProductSchema]):
+        def forward(
+            self, candidates: Iterator[ERCandidate[ProductSchema]]
+        ) -> Iterator[PairwiseJudgement]:
+            yield from ()
+
+        def inspect_scores(
+            self, judgements: list[PairwiseJudgement], sample_size: int = 10
+        ) -> ScoreInspectionReport:
+            raise NotImplementedError
+
+        def fit(
+            self, candidates: Iterator[ERCandidate[ProductSchema]], labels: Sequence[bool]
+        ) -> None:
+            pass
+
+    assert isinstance(_ProductSupervisedModule(), SupervisedFitMixin)

--- a/tests/core/test_fit_mixins.py
+++ b/tests/core/test_fit_mixins.py
@@ -62,9 +62,7 @@ class _SupervisedModule(Module[CompanySchema]):
     ) -> ScoreInspectionReport:
         raise NotImplementedError
 
-    def fit(
-        self, candidates: Iterator[ERCandidate[CompanySchema]], labels: Sequence[bool]
-    ) -> None:
+    def fit(self, candidates: Iterator[ERCandidate[CompanySchema]], labels: Sequence[bool]) -> None:
         self.fit_calls.append((list(candidates), labels))
 
 

--- a/tests/core/test_groups.py
+++ b/tests/core/test_groups.py
@@ -1,0 +1,138 @@
+"""Tests for ERCandidateGroup and the derived pairwise-to-group helper.
+
+ERCandidateGroup represents "anchor + K candidate members" — the set-wise
+input contract that GroupwiseModule.forward_groups() consumes (W1.0
+contracts-only; see docs/TECHNICAL_OVERVIEW.md "Group contract"). These tests
+are schema-agnostic: both CompanySchema and a local ProductSchema exercise the
+model and the derivation helper.
+"""
+
+from collections.abc import Iterator
+
+from pydantic import BaseModel
+
+from langres.core.groups import ERCandidateGroup, derive_groups_from_pairs
+from langres.core.models import CompanySchema, ERCandidate
+from tests.conftest import pairs_from_candidates, pairs_from_groups
+
+
+class ProductSchema(BaseModel):
+    """Second schema for schema-agnostic verification."""
+
+    id: str
+    title: str
+    price: float | None = None
+
+
+# ---------------------------------------------------------------------------
+# ERCandidateGroup model
+# ---------------------------------------------------------------------------
+
+
+def test_er_candidate_group_holds_anchor_members_and_group_id() -> None:
+    """ERCandidateGroup stores anchor, members, and group_id verbatim."""
+    anchor = CompanySchema(id="c1", name="Acme Corp")
+    members = [CompanySchema(id="c2", name="Acme Corporation"), CompanySchema(id="c3", name="Acme")]
+
+    group = ERCandidateGroup(anchor=anchor, members=members, group_id="c1")
+
+    assert group.anchor == anchor
+    assert group.members == members
+    assert group.group_id == "c1"
+
+
+def test_er_candidate_group_is_schema_agnostic_with_product_schema() -> None:
+    """ERCandidateGroup works with a second, unrelated schema (ProductSchema)."""
+    anchor = ProductSchema(id="p1", title="iPhone 15")
+    members = [ProductSchema(id="p2", title="iPhone 15 Pro")]
+
+    group = ERCandidateGroup[ProductSchema](anchor=anchor, members=members, group_id="p1")
+
+    assert isinstance(group.anchor, ProductSchema)
+    assert group.members[0].title == "iPhone 15 Pro"
+
+
+def test_er_candidate_group_allows_empty_members() -> None:
+    """A group with zero members is valid (an anchor with no matched candidates)."""
+    anchor = CompanySchema(id="c1", name="Acme Corp")
+
+    group = ERCandidateGroup(anchor=anchor, members=[], group_id="c1")
+
+    assert group.members == []
+
+
+# ---------------------------------------------------------------------------
+# derive_groups_from_pairs: the documented buffered/skew-prone default
+# ---------------------------------------------------------------------------
+
+
+def _candidates(pairs: list[tuple[str, str]]) -> Iterator[ERCandidate[CompanySchema]]:
+    for left_id, right_id in pairs:
+        yield ERCandidate(
+            left=CompanySchema(id=left_id, name=f"Company {left_id}"),
+            right=CompanySchema(id=right_id, name=f"Company {right_id}"),
+            blocker_name="test_blocker",
+        )
+
+
+def test_derive_groups_from_pairs_groups_by_left_id() -> None:
+    """One group per unique left.id; members accumulate the paired rights."""
+    pairs = [("a", "b"), ("a", "c"), ("d", "e")]
+
+    groups = list(derive_groups_from_pairs(_candidates(pairs)))
+
+    by_anchor = {g.group_id: g for g in groups}
+    assert set(by_anchor) == {"a", "d"}
+    assert {m.id for m in by_anchor["a"].members} == {"b", "c"}
+    assert {m.id for m in by_anchor["d"].members} == {"e"}
+
+
+def test_derive_groups_from_pairs_handles_empty_stream() -> None:
+    """No candidates -> no groups."""
+    groups = list(derive_groups_from_pairs(iter([])))
+    assert groups == []
+
+
+def test_derive_groups_from_pairs_preserves_first_seen_order() -> None:
+    """Groups are yielded in first-seen anchor order (deterministic)."""
+    pairs = [("z", "y"), ("a", "b"), ("z", "x")]
+
+    groups = list(derive_groups_from_pairs(_candidates(pairs)))
+
+    assert [g.group_id for g in groups] == ["z", "a"]
+
+
+def test_derive_groups_from_pairs_is_schema_agnostic_with_product_schema() -> None:
+    """derive_groups_from_pairs works with ProductSchema candidates too."""
+    candidates = iter(
+        [
+            ERCandidate(
+                left=ProductSchema(id="p1", title="iPhone"),
+                right=ProductSchema(id="p2", title="iPhone Pro"),
+                blocker_name="test_blocker",
+            )
+        ]
+    )
+
+    groups = list(derive_groups_from_pairs(candidates))
+
+    assert len(groups) == 1
+    assert isinstance(groups[0].anchor, ProductSchema)
+    assert groups[0].members[0].title == "iPhone Pro"
+
+
+def test_derive_groups_from_pairs_pairs_equivalence_property() -> None:
+    """Property (CEO #14): pairs recovered from derived groups == pairs from stream.
+
+    No dupes, no losses: flattening the derived groups back into canonical
+    (order-independent) pairs must equal the original pair set exactly.
+    """
+    pairs = [("a", "b"), ("a", "c"), ("d", "e"), ("f", "g"), ("f", "h"), ("f", "i")]
+    candidates = list(_candidates(pairs))
+
+    stream_pairs = pairs_from_candidates(candidates)
+    groups = list(derive_groups_from_pairs(iter(candidates)))
+    group_pairs = pairs_from_groups(groups)
+
+    assert group_pairs == stream_pairs
+    assert len(group_pairs) == len(pairs)  # no losses, no dupes

--- a/tests/core/test_models.py
+++ b/tests/core/test_models.py
@@ -297,6 +297,26 @@ class TestPairwiseJudgement:
             )
             assert judgement.score_type == score_type
 
+    def test_pairwise_judgement_accepts_w1_score_types(self):
+        """PairwiseJudgement accepts the W1.0-added score_type literals (E11).
+
+        prob_fs (Fellegi-Sunter), prob_rf (RandomForest), and prob_group_llm
+        (set-wise judges, e.g. SelectJudge) are additive: existing literals are
+        unaffected (see test_pairwise_judgement_all_score_types above).
+        """
+        from langres.core.models import PairwiseJudgement
+
+        for score_type in ["prob_fs", "prob_rf", "prob_group_llm"]:
+            judgement = PairwiseJudgement(
+                left_id="c1",
+                right_id="c2",
+                score=0.5,
+                score_type=score_type,
+                decision_step="test",
+                provenance={},
+            )
+            assert judgement.score_type == score_type
+
     def test_pairwise_judgement_invalid_score_type(self):
         """PairwiseJudgement should reject invalid score_type values."""
         from langres.core.models import PairwiseJudgement

--- a/tests/core/test_module_groupwise.py
+++ b/tests/core/test_module_groupwise.py
@@ -250,7 +250,11 @@ def _judgement(left_id: str, right_id: str) -> PairwiseJudgement:
 
 def test_stamp_group_cost_puts_full_cost_on_first_judgement_only() -> None:
     """First judgement carries the full call cost; siblings carry $0."""
-    judgements = [_judgement("anchor", "m1"), _judgement("anchor", "m2"), _judgement("anchor", "m3")]
+    judgements = [
+        _judgement("anchor", "m1"),
+        _judgement("anchor", "m2"),
+        _judgement("anchor", "m3"),
+    ]
 
     stamped = stamp_group_cost(judgements, call_cost_usd=0.03, group_id="anchor")
 

--- a/tests/core/test_module_groupwise.py
+++ b/tests/core/test_module_groupwise.py
@@ -1,0 +1,303 @@
+"""Tests for GroupwiseModule and the group-call cost-stamping helper.
+
+GroupwiseModule IS-A Module (E2): its concrete forward() derives groups
+internally from the pairwise ERCandidate stream it receives and dispatches to
+the abstract forward_groups(), so the existing Resolver execution spine
+(Resolver._judgements -> module.forward), inspect_scores, the JudgementLog
+boundary, and benchmark dispatch all keep working with ZERO changes -- no
+parallel execution path. These tests pin that contract down, including an
+end-to-end Resolver.resolve() run through a concrete GroupwiseModule.
+
+stamp_group_cost is the E5 group-call cost convention helper: a groupwise
+judge stamps the full call cost on the first judgement of a group, $0 on
+siblings, and provenance["group_id"] on all, so cost aggregation downstream
+sums to exactly one call's cost per group (never K-times over-counted).
+"""
+
+from collections.abc import Iterator
+
+import pytest
+from pydantic import BaseModel
+
+from langres.core.blockers.all_pairs import AllPairsBlocker
+from langres.core.clusterer import Clusterer
+from langres.core.groups import ERCandidateGroup
+from langres.core.models import CompanySchema, ERCandidate, PairwiseJudgement
+from langres.core.module import GroupwiseModule, Module, stamp_group_cost
+from langres.core.reports import ScoreInspectionReport
+from langres.core.resolver import Resolver
+
+
+class ProductSchema(BaseModel):
+    """Second schema for schema-agnostic verification."""
+
+    id: str
+    title: str
+
+
+class _RecordingGroupwiseModule(GroupwiseModule[CompanySchema]):
+    """Concrete GroupwiseModule: matches every member to its anchor, score=1.0."""
+
+    def __init__(self) -> None:
+        self.forward_groups_calls: list[list[ERCandidateGroup[CompanySchema]]] = []
+
+    def forward_groups(
+        self, groups: Iterator[ERCandidateGroup[CompanySchema]]
+    ) -> Iterator[PairwiseJudgement]:
+        materialized = list(groups)
+        self.forward_groups_calls.append(materialized)
+        for group in materialized:
+            for member in group.members:
+                yield PairwiseJudgement(
+                    left_id=group.anchor.id,
+                    right_id=member.id,
+                    score=1.0,
+                    score_type="prob_group_llm",
+                    decision_step="test_groupwise",
+                    provenance={},
+                )
+
+    def inspect_scores(
+        self, judgements: list[PairwiseJudgement], sample_size: int = 10
+    ) -> ScoreInspectionReport:
+        return ScoreInspectionReport(
+            total_judgements=len(judgements),
+            score_distribution={
+                "mean": 0.0,
+                "median": 0.0,
+                "std": 0.0,
+                "min": 0.0,
+                "max": 0.0,
+                "p25": 0.0,
+                "p50": 0.0,
+                "p75": 0.0,
+                "p90": 0.0,
+                "p95": 0.0,
+            },
+            high_scoring_examples=[],
+            low_scoring_examples=[],
+            recommendations=[],
+        )
+
+
+def _candidates(pairs: list[tuple[str, str]]) -> list[ERCandidate[CompanySchema]]:
+    return [
+        ERCandidate(
+            left=CompanySchema(id=left_id, name=f"Company {left_id}"),
+            right=CompanySchema(id=right_id, name=f"Company {right_id}"),
+            blocker_name="test_blocker",
+        )
+        for left_id, right_id in pairs
+    ]
+
+
+# ---------------------------------------------------------------------------
+# ABC / spine-preservation contract
+# ---------------------------------------------------------------------------
+
+
+def test_groupwise_module_is_a_module() -> None:
+    """GroupwiseModule IS-A Module (E2): the Resolver spine dispatches unchanged."""
+    assert issubclass(GroupwiseModule, Module)
+    assert isinstance(_RecordingGroupwiseModule(), Module)
+
+
+def test_cannot_instantiate_groupwise_module_without_forward_groups() -> None:
+    """forward_groups() is abstract; a subclass missing it cannot be instantiated."""
+
+    class IncompleteGroupwiseModule(GroupwiseModule[CompanySchema]):
+        def inspect_scores(
+            self, judgements: list[PairwiseJudgement], sample_size: int = 10
+        ) -> ScoreInspectionReport:
+            raise NotImplementedError
+
+    with pytest.raises(TypeError, match="Can't instantiate abstract class"):
+        IncompleteGroupwiseModule()  # type: ignore[abstract]
+
+
+def test_cannot_instantiate_groupwise_module_directly() -> None:
+    """GroupwiseModule itself stays abstract."""
+    with pytest.raises(TypeError, match="Can't instantiate abstract class"):
+        GroupwiseModule()  # type: ignore[abstract]
+
+
+# ---------------------------------------------------------------------------
+# forward() derives groups internally and dispatches to forward_groups()
+# ---------------------------------------------------------------------------
+
+
+def test_forward_groups_pairwise_candidates_and_dispatches() -> None:
+    """forward() groups the incoming pairwise stream and calls forward_groups() once."""
+    module = _RecordingGroupwiseModule()
+    candidates = _candidates([("a", "b"), ("a", "c"), ("d", "e")])
+
+    judgements = list(module.forward(iter(candidates)))
+
+    # forward_groups() was invoked exactly once, with grouped input.
+    assert len(module.forward_groups_calls) == 1
+    groups = module.forward_groups_calls[0]
+    by_anchor = {g.group_id: g for g in groups}
+    assert set(by_anchor) == {"a", "d"}
+    assert {m.id for m in by_anchor["a"].members} == {"b", "c"}
+
+    # forward() decomposes back to pairwise judgements (set-wise IN, pairwise OUT).
+    assert len(judgements) == 3
+    assert all(isinstance(j, PairwiseJudgement) for j in judgements)
+    pairs = {(j.left_id, j.right_id) for j in judgements}
+    assert pairs == {("a", "b"), ("a", "c"), ("d", "e")}
+
+
+def test_forward_returns_iterator_of_pairwise_judgements() -> None:
+    """forward()'s output type is Iterator[PairwiseJudgement] -- unchanged Module contract."""
+    module = _RecordingGroupwiseModule()
+    result = module.forward(iter(_candidates([("a", "b")])))
+
+    assert hasattr(result, "__iter__")
+    assert hasattr(result, "__next__")
+
+
+def test_forward_handles_empty_candidate_stream() -> None:
+    """No candidates -> no groups -> no judgements."""
+    module = _RecordingGroupwiseModule()
+    judgements = list(module.forward(iter([])))
+    assert judgements == []
+
+
+def test_forward_is_schema_agnostic_with_product_schema() -> None:
+    """GroupwiseModule works with a second, unrelated schema (ProductSchema)."""
+
+    class _ProductGroupwiseModule(GroupwiseModule[ProductSchema]):
+        def forward_groups(
+            self, groups: Iterator[ERCandidateGroup[ProductSchema]]
+        ) -> Iterator[PairwiseJudgement]:
+            for group in groups:
+                for member in group.members:
+                    yield PairwiseJudgement(
+                        left_id=group.anchor.id,
+                        right_id=member.id,
+                        score=1.0,
+                        score_type="prob_group_llm",
+                        decision_step="test",
+                        provenance={},
+                    )
+
+        def inspect_scores(
+            self, judgements: list[PairwiseJudgement], sample_size: int = 10
+        ) -> ScoreInspectionReport:
+            raise NotImplementedError
+
+    module = _ProductGroupwiseModule()
+    candidates = iter(
+        [
+            ERCandidate(
+                left=ProductSchema(id="p1", title="iPhone"),
+                right=ProductSchema(id="p2", title="iPhone Pro"),
+                blocker_name="test_blocker",
+            )
+        ]
+    )
+
+    judgements = list(module.forward(candidates))
+
+    assert len(judgements) == 1
+    assert judgements[0].left_id == "p1"
+    assert judgements[0].right_id == "p2"
+
+
+# ---------------------------------------------------------------------------
+# End-to-end: the Resolver spine dispatches to a GroupwiseModule unchanged.
+# ---------------------------------------------------------------------------
+
+
+def test_resolver_resolve_dispatches_through_groupwise_module() -> None:
+    """A full Resolver (blocker -> module -> clusterer) runs a GroupwiseModule
+    with zero Resolver changes -- proving the spine is preserved end-to-end."""
+    module = _RecordingGroupwiseModule()
+    resolver = Resolver(
+        blocker=AllPairsBlocker(schema=CompanySchema),
+        comparator=None,
+        module=module,
+        clusterer=Clusterer(threshold=0.5),
+    )
+    records = [
+        {"id": "a", "name": "Acme Corp"},
+        {"id": "b", "name": "Acme Corporation"},
+        {"id": "c", "name": "Beta Inc"},
+    ]
+
+    clusters = resolver.resolve(records)
+
+    # module._RecordingGroupwiseModule always scores 1.0 -> all pairs merge.
+    assert clusters == [{"a", "b", "c"}]
+    assert len(module.forward_groups_calls) == 1
+
+
+# ---------------------------------------------------------------------------
+# stamp_group_cost: the E5 group-call cost convention helper
+# ---------------------------------------------------------------------------
+
+
+def _judgement(left_id: str, right_id: str) -> PairwiseJudgement:
+    return PairwiseJudgement(
+        left_id=left_id,
+        right_id=right_id,
+        score=0.9,
+        score_type="prob_group_llm",
+        decision_step="select_judge",
+        provenance={"model": "gpt-4o-mini"},
+    )
+
+
+def test_stamp_group_cost_puts_full_cost_on_first_judgement_only() -> None:
+    """First judgement carries the full call cost; siblings carry $0."""
+    judgements = [_judgement("anchor", "m1"), _judgement("anchor", "m2"), _judgement("anchor", "m3")]
+
+    stamped = stamp_group_cost(judgements, call_cost_usd=0.03, group_id="anchor")
+
+    assert stamped[0].provenance["cost_usd"] == pytest.approx(0.03)
+    assert stamped[1].provenance["cost_usd"] == 0.0
+    assert stamped[2].provenance["cost_usd"] == 0.0
+
+
+def test_stamp_group_cost_sums_to_exactly_one_calls_cost() -> None:
+    """sum(cost over the group) == one call's cost (E5's core invariant)."""
+    judgements = [_judgement("anchor", f"m{i}") for i in range(5)]
+
+    stamped = stamp_group_cost(judgements, call_cost_usd=0.05, group_id="anchor")
+
+    total = sum(j.provenance["cost_usd"] for j in stamped)
+    assert total == pytest.approx(0.05)
+
+
+def test_stamp_group_cost_sets_group_id_on_all_judgements() -> None:
+    """provenance["group_id"] is set on every judgement in the group, not just the first."""
+    judgements = [_judgement("anchor", "m1"), _judgement("anchor", "m2")]
+
+    stamped = stamp_group_cost(judgements, call_cost_usd=0.02, group_id="anchor")
+
+    assert all(j.provenance["group_id"] == "anchor" for j in stamped)
+
+
+def test_stamp_group_cost_preserves_other_provenance_fields() -> None:
+    """Existing provenance keys (e.g. model) survive the stamping."""
+    judgements = [_judgement("anchor", "m1")]
+
+    stamped = stamp_group_cost(judgements, call_cost_usd=0.01, group_id="anchor")
+
+    assert stamped[0].provenance["model"] == "gpt-4o-mini"
+
+
+def test_stamp_group_cost_does_not_mutate_input_judgements() -> None:
+    """stamp_group_cost returns new objects; the originals are untouched."""
+    original = _judgement("anchor", "m1")
+
+    stamp_group_cost([original], call_cost_usd=0.07, group_id="anchor")
+
+    assert "cost_usd" not in original.provenance
+    assert "group_id" not in original.provenance
+
+
+def test_stamp_group_cost_rejects_empty_list() -> None:
+    """An empty judgement list is a caller bug, not a silently accepted no-op."""
+    with pytest.raises(ValueError, match="at least one judgement"):
+        stamp_group_cost([], call_cost_usd=0.01, group_id="anchor")

--- a/tests/core/test_resolver_fit_hooks.py
+++ b/tests/core/test_resolver_fit_hooks.py
@@ -61,9 +61,7 @@ class _SupervisedModule(Module[CompanySchema]):
     ) -> ScoreInspectionReport:
         raise NotImplementedError
 
-    def fit(
-        self, candidates: Iterator[ERCandidate[CompanySchema]], labels: Sequence[bool]
-    ) -> None:
+    def fit(self, candidates: Iterator[ERCandidate[CompanySchema]], labels: Sequence[bool]) -> None:
         self.fit_calls.append((len(list(candidates)), labels))
 
 
@@ -87,7 +85,7 @@ class _UnsupervisedModule(Module[CompanySchema]):
         self.fit_unlabeled_calls.append(len(list(candidates)))
 
 
-class ProductSchema(BaseModel):
+class WidgetSchema(BaseModel):
     """Second schema for schema-agnostic verification."""
 
     id: str
@@ -167,14 +165,14 @@ def test_fit_raises_when_labels_given_to_unsupervised_module() -> None:
 
 
 def test_fit_is_schema_agnostic_with_product_schema() -> None:
-    """The fit() delegation logic works identically for a ProductSchema pipeline."""
+    """The fit() delegation logic works identically for a WidgetSchema pipeline."""
 
-    class _ProductUnsupervisedModule(Module[ProductSchema]):
+    class _ProductUnsupervisedModule(Module[WidgetSchema]):
         def __init__(self) -> None:
             self.called = False
 
         def forward(
-            self, candidates: Iterator[ERCandidate[ProductSchema]]
+            self, candidates: Iterator[ERCandidate[WidgetSchema]]
         ) -> Iterator[PairwiseJudgement]:
             yield from ()
 
@@ -183,13 +181,13 @@ def test_fit_is_schema_agnostic_with_product_schema() -> None:
         ) -> ScoreInspectionReport:
             raise NotImplementedError
 
-        def fit_unlabeled(self, candidates: Iterator[ERCandidate[ProductSchema]]) -> None:
+        def fit_unlabeled(self, candidates: Iterator[ERCandidate[WidgetSchema]]) -> None:
             self.called = True
             list(candidates)
 
     module = _ProductUnsupervisedModule()
     resolver = Resolver(
-        blocker=AllPairsBlocker(schema=ProductSchema),
+        blocker=AllPairsBlocker(schema=WidgetSchema),
         comparator=None,
         module=module,
         clusterer=Clusterer(threshold=0.5),

--- a/tests/core/test_resolver_fit_hooks.py
+++ b/tests/core/test_resolver_fit_hooks.py
@@ -1,0 +1,202 @@
+"""Tests for Resolver.fit() delegating to the E6 fit-hook Protocols.
+
+Resolver.fit() was a no-op stub (``return self``) for sklearn-style symmetry
+with non-learnable pipelines. This branch wires it to the new
+SupervisedFitMixin / UnsupervisedFitMixin Protocols (core/fit.py) WITHOUT
+breaking that existing no-op contract for modules that implement neither hook
+-- see tests/test_resolver_roundtrip.py::test_resolver_fit_is_noop_returns_self,
+which must keep passing unmodified.
+
+Reconciliation with E6 ("raise a clear error, not a silent no-op, when the
+module lacks the hook"): the no-op is preserved ONLY for the zero-argument
+call (``resolver.fit(data)``) on a module implementing neither mixin -- the
+existing, tested, backward-compatible case. The failure mode E6 actually
+guards against -- a caller believing fit() trained something when it silently
+didn't -- is caught here instead: passing ``labels=`` to a module that can't
+use them raises, and calling fit() on a SupervisedFitMixin module WITHOUT
+labels raises (silent no-op on a genuinely trainable module is exactly the
+footgun E6 names).
+"""
+
+from collections.abc import Iterator, Sequence
+
+import pytest
+from pydantic import BaseModel
+
+from langres.core.blockers.all_pairs import AllPairsBlocker
+from langres.core.clusterer import Clusterer
+from langres.core.models import CompanySchema, ERCandidate, PairwiseJudgement
+from langres.core.module import Module
+from langres.core.reports import ScoreInspectionReport
+from langres.core.resolver import Resolver
+
+
+class _NoHookModule(Module[CompanySchema]):
+    """Implements neither fit hook (mirrors WeightedAverageJudge/heuristic judges)."""
+
+    def forward(
+        self, candidates: Iterator[ERCandidate[CompanySchema]]
+    ) -> Iterator[PairwiseJudgement]:
+        yield from ()
+
+    def inspect_scores(
+        self, judgements: list[PairwiseJudgement], sample_size: int = 10
+    ) -> ScoreInspectionReport:
+        raise NotImplementedError
+
+
+class _SupervisedModule(Module[CompanySchema]):
+    """Implements SupervisedFitMixin."""
+
+    def __init__(self) -> None:
+        self.fit_calls: list[tuple[int, Sequence[bool]]] = []
+
+    def forward(
+        self, candidates: Iterator[ERCandidate[CompanySchema]]
+    ) -> Iterator[PairwiseJudgement]:
+        yield from ()
+
+    def inspect_scores(
+        self, judgements: list[PairwiseJudgement], sample_size: int = 10
+    ) -> ScoreInspectionReport:
+        raise NotImplementedError
+
+    def fit(
+        self, candidates: Iterator[ERCandidate[CompanySchema]], labels: Sequence[bool]
+    ) -> None:
+        self.fit_calls.append((len(list(candidates)), labels))
+
+
+class _UnsupervisedModule(Module[CompanySchema]):
+    """Implements UnsupervisedFitMixin."""
+
+    def __init__(self) -> None:
+        self.fit_unlabeled_calls: list[int] = []
+
+    def forward(
+        self, candidates: Iterator[ERCandidate[CompanySchema]]
+    ) -> Iterator[PairwiseJudgement]:
+        yield from ()
+
+    def inspect_scores(
+        self, judgements: list[PairwiseJudgement], sample_size: int = 10
+    ) -> ScoreInspectionReport:
+        raise NotImplementedError
+
+    def fit_unlabeled(self, candidates: Iterator[ERCandidate[CompanySchema]]) -> None:
+        self.fit_unlabeled_calls.append(len(list(candidates)))
+
+
+class ProductSchema(BaseModel):
+    """Second schema for schema-agnostic verification."""
+
+    id: str
+    title: str
+
+
+RECORDS = [
+    {"id": "a", "name": "Acme Corp"},
+    {"id": "b", "name": "Acme Corporation"},
+    {"id": "c", "name": "Beta Inc"},
+]
+
+
+def _resolver(module: Module[CompanySchema]) -> Resolver:
+    return Resolver(
+        blocker=AllPairsBlocker(schema=CompanySchema),
+        comparator=None,
+        module=module,
+        clusterer=Clusterer(threshold=0.5),
+    )
+
+
+def test_fit_is_noop_for_module_without_hooks_and_no_labels() -> None:
+    """Backward-compat: a module with neither hook + no labels -> no-op, returns self."""
+    resolver = _resolver(_NoHookModule())
+
+    result = resolver.fit(RECORDS)
+
+    assert result is resolver
+
+
+def test_fit_delegates_to_unsupervised_hook() -> None:
+    """A module implementing UnsupervisedFitMixin gets fit_unlabeled() called."""
+    module = _UnsupervisedModule()
+    resolver = _resolver(module)
+
+    result = resolver.fit(RECORDS)
+
+    assert result is resolver
+    assert module.fit_unlabeled_calls == [3]  # AllPairs over 3 records -> 3 pairs
+
+
+def test_fit_delegates_to_supervised_hook_with_labels() -> None:
+    """A module implementing SupervisedFitMixin gets fit(candidates, labels) called."""
+    module = _SupervisedModule()
+    resolver = _resolver(module)
+    labels = [True, False, True]
+
+    result = resolver.fit(RECORDS, labels=labels)
+
+    assert result is resolver
+    assert module.fit_calls == [(3, labels)]
+
+
+def test_fit_raises_when_supervised_module_gets_no_labels() -> None:
+    """A genuinely trainable module called without labels RAISES (not a silent no-op)."""
+    resolver = _resolver(_SupervisedModule())
+
+    with pytest.raises(ValueError, match="requires labeled data"):
+        resolver.fit(RECORDS)
+
+
+def test_fit_raises_when_labels_given_to_a_module_without_supervised_hook() -> None:
+    """Passing labels to a module that can't use them raises (not silently ignored)."""
+    resolver = _resolver(_NoHookModule())
+
+    with pytest.raises(ValueError, match="does not support fit"):
+        resolver.fit(RECORDS, labels=[True, False])
+
+
+def test_fit_raises_when_labels_given_to_unsupervised_module() -> None:
+    """An UnsupervisedFitMixin module doesn't take labels either -- also raises."""
+    resolver = _resolver(_UnsupervisedModule())
+
+    with pytest.raises(ValueError, match="does not support fit"):
+        resolver.fit(RECORDS, labels=[True, False])
+
+
+def test_fit_is_schema_agnostic_with_product_schema() -> None:
+    """The fit() delegation logic works identically for a ProductSchema pipeline."""
+
+    class _ProductUnsupervisedModule(Module[ProductSchema]):
+        def __init__(self) -> None:
+            self.called = False
+
+        def forward(
+            self, candidates: Iterator[ERCandidate[ProductSchema]]
+        ) -> Iterator[PairwiseJudgement]:
+            yield from ()
+
+        def inspect_scores(
+            self, judgements: list[PairwiseJudgement], sample_size: int = 10
+        ) -> ScoreInspectionReport:
+            raise NotImplementedError
+
+        def fit_unlabeled(self, candidates: Iterator[ERCandidate[ProductSchema]]) -> None:
+            self.called = True
+            list(candidates)
+
+    module = _ProductUnsupervisedModule()
+    resolver = Resolver(
+        blocker=AllPairsBlocker(schema=ProductSchema),
+        comparator=None,
+        module=module,
+        clusterer=Clusterer(threshold=0.5),
+    )
+    products = [{"id": "p1", "title": "iPhone"}, {"id": "p2", "title": "iPhone Pro"}]
+
+    result = resolver.fit(products)
+
+    assert result is resolver
+    assert module.called is True


### PR DESCRIPTION
## What / Why

Small, contracts-only PR (per the M4.5/M5 plan's W1.0) that freezes the interfaces the
parallel W1.1 (`SelectJudge`), W1.2 (`FellegiSunterJudge`/`RFJudge`), and W1.3 (blocking
algebra) branches build against, so those branches can develop against a stable surface
without repeatedly colliding on central files (`models.py`, `module.py`, `blocker.py`,
`resolver.py`, `benchmark.py`). **No method implementations land here** — interfaces,
dispatch, and tests only.

## Contents (mapped to Eng findings E2/E3/E5/E6/E11)

- **`ERCandidateGroup`** (`core/groups.py`): `anchor` + `members` + `group_id` — the
  set-wise input contract ("anchor + K candidate members"). `derive_groups_from_pairs()`
  is the default, buffered/skew-prone derivation from a pairwise stream (documented, not
  for benchmark use).

- **`GroupwiseModule`** (`core/module.py`) **IS-A `Module`** (E2): its concrete `forward()`
  derives groups internally and dispatches to the abstract `forward_groups()`, decomposing
  back to `Iterator[PairwiseJudgement]`. This means `Resolver._judgements` →
  `module.forward`, `inspect_scores`, the JudgementLog boundary, and benchmark dispatch all
  keep working with **zero changes** — no parallel execution path. Verified end-to-end with
  a full `Resolver.resolve()` run through a concrete `GroupwiseModule`
  (`test_resolver_resolve_dispatches_through_groupwise_module`).

- **`Blocker.stream_groups()`** (E3): a concrete default on the base `Blocker` (derives
  groups from `stream()`, buffered/skew-prone — documented, not for benchmark use) plus a
  **native** override on `VectorBlocker` (one group per entity from its own kNN search — no
  derivation, no skew).

- **Fit hooks** (`core/fit.py`, E6): `SupervisedFitMixin.fit(candidates, labels)` and
  `UnsupervisedFitMixin.fit_unlabeled(candidates)` as runtime-checkable `Protocol`s — not
  abstract `Module` methods (would break every existing module). `Resolver.fit()` delegates
  to whichever hook the module implements and **raises** when a `SupervisedFitMixin` module
  is called without labels, or when labels are passed to a module that can't use them.

- **`score_type` literal** (`models.py`, E11): additive `prob_fs`, `prob_rf`,
  `prob_group_llm` alongside the four existing values.

- **Group-call cost convention** (E5): `stamp_group_cost()` stamps full call cost on a
  group's first judgement, `$0` on siblings, `provenance["group_id"]` on all — tested that
  `sum(cost over group) == one call's cost`. `BudgetedModuleRunner` atomicity is documented
  rather than re-architected (see Spec deviations below).

## Property-test evidence (CEO #14)

Pairs recoverable from `stream_groups()` (flattened anchor+member edges, canonicalized)
equal the pairs from `stream()` — no dupes, no losses:
- `tests/core/test_groups.py::test_derive_groups_from_pairs_pairs_equivalence_property`
- `tests/core/test_blocker.py::test_blocker_stream_groups_default_pairs_equivalence_property`
- `tests/core/blockers/test_vector.py::test_vector_blocker_stream_groups_pairs_equivalence_property`
  (parametrized across 5 `(N, k)` shapes: sparse to dense)

## Spine-preservation evidence

- `test_groupwise_module_is_a_module`: `issubclass(GroupwiseModule, Module)`.
- `test_resolver_resolve_dispatches_through_groupwise_module`: a full `Resolver` (blocker →
  module → clusterer) runs a `GroupwiseModule` and produces correct clusters, with zero
  Resolver changes.

## Coverage / quality

- `uv run ruff check src tests` — clean
- `uv run ruff format --check src tests` — clean
- `uv run mypy src` — clean (strict mode, 65 source files)
- `uv run pytest -m "not slow and not integration"` — **1393 passed**, 98.1% overall
  coverage; **100% coverage on every new/changed file** (`fit.py`, `groups.py`,
  `module.py` additions, `blocker.py` additions, `VectorBlocker.stream_groups`,
  `resolver.py` `fit()` delegation). Pre-existing coverage gaps elsewhere in
  `blockers/vector.py`/`resolver.py` are untouched by this diff (verified via `git diff`
  against the base branch).

## Spec deviations (both reasoned, both documented in code/tests)

1. **`Resolver.fit()` backward compatibility over literal "raise, not no-op."** The branch
   spec (E6) says `fit()` should raise a clear error when the module lacks a fit hook. But
   an existing, explicitly-tested contract
   (`tests/test_resolver_roundtrip.py::test_resolver_fit_is_noop_returns_self`) asserts
   `resolver.fit(data) is resolver` for `WeightedAverageJudge`, which implements neither
   hook — and this branch's own instructions require "every existing test must still pass."
   Resolution: the no-op is preserved **only** for the zero-argument call on a module
   implementing neither hook (the existing, backward-compatible case). The actual failure
   mode E6 names — a caller believing `fit()` trained something when it silently didn't —
   is still caught: passing `labels=` to a module that can't use them raises, and calling
   `fit()` on a `SupervisedFitMixin` module *without* labels raises. See the module
   docstring in `resolver.py` and `tests/core/test_resolver_fit_hooks.py` for the full
   reasoning.

2. **`BudgetedModuleRunner` group atomicity documented, not re-architected.** The spec
   offered an explicit escape hatch ("or if that requires more than a localized change,
   document precisely how group atomicity is preserved and test it"). `BudgetedModuleRunner`
   scores exactly one `ERCandidate` per `module.forward()` call by design (per-call
   resilience). A `GroupwiseModule` run through it today derives a single, trivial, size-1
   group per call, so a group is **never split mid-call** (there's never more than one pair
   to split) — but real multi-pair batching into one priced call is not yet implemented.
   This is pinned down by
   `test_runner_never_splits_a_group_mid_call_but_also_never_batches_one` and documented on
   `BudgetedModuleRunner`'s docstring, deferred to W1.1 (the first concrete
   `GroupwiseModule`, `SelectJudge`, which can measure the real call-count reduction this
   is for).

## Docs

`docs/TECHNICAL_OVERVIEW.md` §8 ("Group + Fit Contracts (W1.0)") documents
`ERCandidateGroup`, `stream_groups()` (default vs native), `GroupwiseModule`, the
group-call cost convention (with a worked `SelectJudge` example), and the fit-hook
semantics.

https://claude.ai/code/session_0115MvWbHaCKT1A39PKDWqey