### PR TITLE
W0.4: extras split + lazy heavy imports + spend-safe test gating

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -24,7 +24,11 @@ jobs:
           enable-cache: true
 
       - name: Install dependencies
-        run: uv sync
+        # --all-extras: mypy must resolve the [semantic]/[llm]/[trained]
+        # symbols that W0.4 made lazy (still statically type-checked via
+        # TYPE_CHECKING imports) -- a core-only `uv sync` wouldn't have
+        # torch/faiss/litellm/scikit-learn installed for it to check against.
+        run: uv sync --all-extras
 
       - name: Run ruff check
         run: uv run ruff check .

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -30,7 +30,9 @@ jobs:
           enable-cache: true
 
       - name: Install dependencies
-        run: uv sync
+        # --all-extras: scan the [semantic]/[llm] extras' dependencies (torch,
+        # litellm, faiss, ...) too, not just the core-only dependency set.
+        run: uv sync --all-extras
 
       # pip-audit and guarddog are ADVISORY signals, not merge gates. The hard
       # supply-chain controls are the exclude-newer 7-day quarantine (pyproject)

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -30,7 +30,11 @@ jobs:
           enable-cache: true
 
       - name: Install dependencies
-        run: uv sync
+        # --all-extras: the full non-integration suite exercises VectorBlocker/
+        # LLMJudge/RFJudge/etc. (the [semantic]/[llm]/[trained] extras), which
+        # W0.4 made optional at runtime but which CI still needs installed to
+        # run those tests.
+        run: uv sync --all-extras
 
       - name: Run unit tests and collect coverage
         run: uv run pytest -m "not integration"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -47,3 +47,35 @@ jobs:
     #       file: ./coverage.xml
     #     env:
     #       CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
+
+  test-core-only:
+    # W0.4: proves the [semantic]/[llm] extras boundary against a genuinely
+    # core-only install, not just a simulated one -- `test` above always runs
+    # with --all-extras, so tests/test_import_budget.py's real (un-monkeypatched)
+    # ImportError-on-missing-dependency assertions only ever exercise their
+    # `pytest.importorskip`-guarded skip branch there. Runs bare `uv sync` (no
+    # extras; the "dev" dependency group -- pytest et al -- still installs by
+    # default) so torch/litellm/faiss/sentence-transformers are genuinely
+    # absent, then a *targeted* subset: the full test suite can't even collect
+    # here (many test files import those packages directly to mock them), so
+    # this only runs the import-budget file plus a quickstart smoke check.
+    runs-on: blacksmith-4vcpu-ubuntu-2404
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+
+      - name: Set up uv
+        uses: astral-sh/setup-uv@v7
+        with:
+          version: "0.11.24"
+          python-version: "3.13"
+          enable-cache: true
+
+      - name: Install dependencies (core only -- no [semantic]/[llm] extras)
+        run: uv sync
+
+      - name: Run import-budget tests against the real core-only install
+        run: uv run pytest tests/test_import_budget.py -o addopts="-v -m 'not integration'"
+
+      - name: Verify the core-only string-judge dedupe() path still works
+        run: uv run python examples/quickstart_verbs.py

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -71,7 +71,14 @@ modules, `Canonicalizer`, a general `Optimizer`, a synthetic data generator.
 
 ## Dependencies
 
-**Core stack**: Pydantic (validation), Optuna (hyperparameter optimization), DSPy (prompt optimization), sentence-transformers (embeddings), rapidfuzz (string similarity), networkx (graph clustering), PyTorch (learnable components).
+**Core** (always installed, `uv sync`): Pydantic + pydantic-settings (validation), rapidfuzz (string similarity), networkx (graph clustering), numpy. The string-judge/`AllPairsBlocker` path works with only these.
+
+**Extras** (opt-in, `uv sync --all-extras` or `pip install langres[semantic,llm,trained]`):
+- `[semantic]` — sentence-transformers, torch, faiss-cpu, onnxruntime/optimum, qdrant-client (`VectorBlocker`, embeddings, vector indexes).
+- `[llm]` — litellm, dspy-ai, openai (`LLMJudge`, DSPy-compiled judges).
+- `[trained]` — scikit-learn (`RFJudge`, the W1.2 trained-family judge, and `core.calibration.derive_threshold`).
+
+These heavy/optional symbols resolve lazily (PEP 562 `__getattr__` in `langres/core/__init__.py` and `langres/clients/__init__.py`) so a bare `import langres` never pulls torch/litellm/faiss/scikit-learn into `sys.modules` — see `tests/test_import_budget.py`. Optuna/wandb/langfuse/ranx are dev-only (`[dependency-groups] dev`), for eval tooling, not the production `link()`/`dedupe()` path (scikit-learn is duplicated in the dev group too, so the repo's own test suite doesn't need `--all-extras` for a bare `uv sync`).
 
 **Dev tools**: ruff (format + lint), pytest + pytest-cov (tests), mypy (strict-mode type checking).
 

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the
+      purposes of this License, Derivative Works shall not include works
+      that remain separable from, or merely link (or bind by name) to the
+      interfaces of, the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/NOTICE
+++ b/NOTICE
@@ -1,0 +1,5 @@
+langres
+Copyright 2026 David Graf
+
+This product is licensed under the Apache License, Version 2.0.
+See the LICENSE file for the full license text.

--- a/README.md
+++ b/README.md
@@ -44,21 +44,32 @@ see [docs/ROADMAP.md](docs/ROADMAP.md); for current scope, [docs/POC.md](docs/PO
 ```bash
 git clone https://github.com/raisesquad/langres.git
 cd langres
-uv sync            # installs langres + dev tooling into a local .venv
+uv sync            # core only -- string-judge dedupe/link, no ML deps
 uv run python examples/quickstart_verbs.py
 ```
 
-> **Target install layout (in progress, not final).** The dependency tree is
-> being split into optional extras so the core install stays lean:
+Once published, the same split will apply to `pip install`:
+
+```bash
+pip install langres              # core: string-judge dedupe/link only
+pip install langres[semantic]    # + VectorBlocker / embeddings (sentence-transformers, faiss, torch)
+pip install langres[llm]         # + LLMJudge / DSPy-compiled judges (litellm, dspy-ai)
+pip install langres[trained]     # + RFJudge (scikit-learn)
+```
+
+> **Extras layout.** The dependency tree is split into optional extras so the
+> core install stays lean:
 >
 > | Install | Pulls in | Enables |
 > |---|---|---|
-> | `pip install langres` | pydantic, rapidfuzz, networkx | the `"string"` judge — full dedupe/link with **no ML dependencies** |
-> | `pip install langres[semantic]` | sentence-transformers, FAISS, torch | the `"embedding"` judge + vector blocking |
-> | `pip install langres[llm]` | litellm, dspy | the `"zero_shot_llm"` judge |
+> | `uv sync` / `pip install langres` | pydantic, rapidfuzz, networkx, numpy | the `"string"` judge — full dedupe/link with **no ML dependencies** |
+> | `[semantic]` (`uv sync --all-extras` or `pip install langres[semantic]`) | sentence-transformers, FAISS, torch | the `"embedding"` judge + vector blocking |
+> | `[llm]` | litellm, dspy-ai | the `"zero_shot_llm"` judge |
+> | `[trained]` | scikit-learn | `RFJudge` (trained-family, W1.2) |
 >
-> This extras split is **not yet wired** — today `uv sync` installs the full
-> stack. The table above describes the target UX so you know where it's headed.
+> A bare `import langres`/`import langres.core` never imports torch/litellm/
+> faiss/scikit-learn — those resolve lazily the first time you actually touch
+> a symbol that needs them (`tests/test_import_budget.py` proves it).
 
 **Requirements:** Python >= 3.12.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -64,6 +64,13 @@ llm = [
     "litellm>=1.79.0",
     "openai>=2.6.1",
 ]
+# The trained-judge stack -- RFJudge (W1.2's sklearn RandomForest judge) and
+# core.calibration.derive_threshold (sklearn.metrics.roc_curve). Also present
+# in the dev group below (unrelated eval tooling depends on it too, and the
+# repo's own test suite needs it without requiring --all-extras locally).
+trained = [
+    "scikit-learn>=1.7.2",
+]
 
 [build-system]
 requires = ["hatchling"]
@@ -72,10 +79,12 @@ build-backend = "hatchling.build"
 [dependency-groups]
 dev = [
     # Experimentation/eval tooling (BCubed harness via ranx, hyperparameter
-    # tuning via optuna, threshold calibration via scikit-learn) plus
-    # experiment-tracking integrations (wandb, langfuse) -- not needed by the
-    # production link()/dedupe() path, so they live in the dev group (not a
-    # pip-installable extra) rather than core `dependencies`.
+    # tuning via optuna) plus experiment-tracking integrations (wandb,
+    # langfuse) -- not needed by the production link()/dedupe() path, so they
+    # live in the dev group (not a pip-installable extra) rather than core
+    # `dependencies`. scikit-learn is also duplicated in the `[trained]`
+    # extra above (RFJudge, core.calibration) -- kept here too so the repo's
+    # own test suite doesn't need --all-extras for a bare `uv sync`.
     "guarddog>=1.3.0",
     "langfuse>=4,<5",
     "mypy>=1.18.2",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,6 +3,8 @@ name = "langres"
 version = "0.1.0"
 description = "A two-layer entity resolution framework with optimization, blocking, and human-in-the-loop capabilities"
 readme = "README.md"
+license = "Apache-2.0"
+license-files = ["LICENSE", "NOTICE"]
 authors = [
     { name = "David Graf", email = "david@raisesquad.com" }
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,27 +11,13 @@ maintainers = [
 ]
 requires-python = ">=3.12"
 dependencies = [
-    "dspy-ai>=3.0.3",
-    "faiss-cpu>=1.12.0",
-    "fastembed>=0.7.3",
-    "langfuse>=4,<5",
-    "litellm>=1.79.0",
     "networkx>=3.5",
-    "onnxruntime>=1.23.2",
-    "openai>=2.6.1",
-    "optimum[onnxruntime]>=2.0.0",
-    "optuna>=4.5.0",
-    "optuna-integration[wandb]>=4.5.0",
+    "numpy>=2.4.6",
     "pydantic>=2.12.3",
     "pydantic-settings>=2.11.0",
-    "qdrant-client>=1.15.1",
-    "ranx>=0.3.21",
     "rapidfuzz>=3.14.1",
-    "scikit-learn>=1.7.2",
-    "sentence-transformers>=5.1.2",
-    "tenacity>=9.1.2",
-    "wandb>=0.22.3",
 ]
+
 keywords = [
     "entity-resolution",
     "record-linkage",
@@ -58,23 +44,55 @@ Repository = "https://github.com/raisesquad/langres"
 Issues = "https://github.com/raisesquad/langres/issues"
 Changelog = "https://github.com/raisesquad/langres/blob/main/CHANGELOG.md"
 
+[project.optional-dependencies]
+# The embedding/vector stack -- VectorBlocker, embeddings.py, indexes.py
+# (FAISS + Qdrant). Required for judge="embedding" and the VectorBlocker
+# scaling path (dedupe() above ~100 records).
+semantic = [
+    "faiss-cpu>=1.12.0",
+    "fastembed>=0.7.3",
+    "onnxruntime>=1.23.2",
+    "optimum[onnxruntime]>=2.0.0",
+    "qdrant-client>=1.15.1",
+    "sentence-transformers>=5.1.2",
+    "torch>=2.12.1",
+]
+# The LLM/judge stack -- LLMJudge, DSPyJudge, CascadeModule's OpenAI client.
+# Required for judge="zero_shot_llm" / judge="auto" with a key set.
+llm = [
+    "dspy-ai>=3.0.3",
+    "litellm>=1.79.0",
+    "openai>=2.6.1",
+]
+
 [build-system]
 requires = ["hatchling"]
 build-backend = "hatchling.build"
 
 [dependency-groups]
 dev = [
+    # Experimentation/eval tooling (BCubed harness via ranx, hyperparameter
+    # tuning via optuna, threshold calibration via scikit-learn) plus
+    # experiment-tracking integrations (wandb, langfuse) -- not needed by the
+    # production link()/dedupe() path, so they live in the dev group (not a
+    # pip-installable extra) rather than core `dependencies`.
     "guarddog>=1.3.0",
+    "langfuse>=4,<5",
     "mypy>=1.18.2",
+    "optuna>=4.5.0",
+    "optuna-integration[wandb]>=4.5.0",
     "pip-audit>=2.9.0",
     "pre-commit>=4.3.0",
     "pytest>=8.4.2",
     "pytest-asyncio>=1.3.0",
     "pytest-cov>=7.0.0",
     "pytest-mock>=3.15.1",
+    "ranx>=0.3.21",
     "ruff>=0.15.2",
+    "scikit-learn>=1.7.2",
     "testcontainers[qdrant]>=4.13.2",
     "types-networkx>=3.5.0.20251001",
+    "wandb>=0.22.3",
 ]
 
 [tool.uv]
@@ -87,7 +105,7 @@ exclude-newer = "2026-06-18"
 
 [tool.pytest.ini_options]
 minversion = "6.0"
-addopts = "-v --cov=langres --cov-report=term-missing --cov-report=html --cov-fail-under=95"
+addopts = "-v --cov=langres --cov-report=term-missing --cov-report=html --cov-fail-under=95 -m 'not integration'"
 testpaths = ["tests"]
 pythonpath = ["src"]
 markers = [

--- a/src/langres/__init__.py
+++ b/src/langres/__init__.py
@@ -2,7 +2,7 @@
 langres: A composable entity resolution framework.
 
 This package provides:
-- ``link`` / ``dedupe``: the three-verb DX layer (schema-optional, judge="auto"
+- ``link`` / ``dedupe``: the two-verb DX layer (schema-optional, judge="auto"
   by default, spend-capped) -- see ``langres.verbs``.
 - ``langres.core``: Low-level primitives for custom pipelines (``Resolver``,
   ``Blocker``, ``Module``, ``Clusterer``, ...).

--- a/src/langres/bootstrap/labelers.py
+++ b/src/langres/bootstrap/labelers.py
@@ -324,10 +324,11 @@ class TeacherLabeler(Labeler):
     ) -> "TeacherLabeler":
         """Build a teacher with an LLM judge constructed from the environment.
 
-        The judge's client is built with ``enable_langfuse=False`` so the
-        teacher never depends on Langfuse credentials (design-review B4): the
-        usual ``LLMJudge.from_env`` enables Langfuse by default, which raises
-        without ``LANGFUSE_*`` env vars.
+        The judge's client is built with ``enable_langfuse=False`` (explicit,
+        though it's also ``create_llm_client``'s default since W0.4 -- see
+        design-review B4) so the teacher never depends on Langfuse
+        credentials or the langfuse package (dev-group only, not part of the
+        ``[llm]`` extra).
 
         Args:
             price_per_1m_prompt_tokens: See :meth:`__init__`.

--- a/src/langres/clients/__init__.py
+++ b/src/langres/clients/__init__.py
@@ -4,14 +4,44 @@ langres.clients: Client configuration and factories for external services.
 This module provides centralized configuration and client factories for:
 - LLM providers (OpenAI, LiteLLM with Langfuse tracing)
 - Experiment tracking (wandb)
+
+W0.4: ``create_llm_client``/``create_wandb_tracker`` are resolved lazily (PEP
+562) -- ``langres.clients.llm`` imports ``litellm`` at module level, and
+litellm's own import runs ``load_dotenv()`` as a side effect, silently
+populating ``OPENROUTER_API_KEY``/etc. from any ``.env`` on the path (the
+SPEND-SAFETY footgun this branch closes). Eager-importing it here (a side
+effect of importing ANY submodule of this package, e.g.
+``langres.clients.settings``) meant plain ``import langres`` triggered that
+side effect unconditionally. ``create_wandb_tracker`` (``wandb``, dev-only)
+gets the same treatment for consistency and import weight. ``Settings`` stays
+eager -- it's pydantic-settings only.
 """
 
-from langres.clients.llm import create_llm_client
+import importlib
+from typing import TYPE_CHECKING, Any
+
 from langres.clients.settings import Settings
-from langres.clients.tracking import create_wandb_tracker
+
+if TYPE_CHECKING:
+    from langres.clients.llm import create_llm_client
+    from langres.clients.tracking import create_wandb_tracker
 
 __all__ = [
     "Settings",
     "create_llm_client",
     "create_wandb_tracker",
 ]
+
+_LAZY: dict[str, str] = {
+    "create_llm_client": "langres.clients.llm",
+    "create_wandb_tracker": "langres.clients.tracking",
+}
+
+
+def __getattr__(name: str) -> Any:
+    module_path = _LAZY.get(name)
+    if module_path is None:
+        raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+    value = getattr(importlib.import_module(module_path), name)
+    globals()[name] = value  # cache: subsequent access skips __getattr__
+    return value

--- a/src/langres/clients/llm.py
+++ b/src/langres/clients/llm.py
@@ -10,7 +10,7 @@ from langres.clients.settings import Settings
 logger = logging.getLogger(__name__)
 
 
-def create_llm_client(settings: Settings | None = None, enable_langfuse: bool = True) -> Any:
+def create_llm_client(settings: Settings | None = None, enable_langfuse: bool = False) -> Any:
     """Create LiteLLM client with optional Langfuse tracing.
 
     This function configures LiteLLM with the Langfuse OpenTelemetry callback
@@ -21,14 +21,23 @@ def create_llm_client(settings: Settings | None = None, enable_langfuse: bool = 
 
     Args:
         settings: Optional Settings object. If None, loads from environment.
-        enable_langfuse: If True, configure Langfuse tracing (requires LANGFUSE_* env vars).
-                        If False, no tracing is configured.
+        enable_langfuse: If True, configure Langfuse tracing (requires LANGFUSE_*
+                        env vars *and* the ``langfuse`` package -- it's dev-group
+                        only, not part of the ``[llm]`` extra's install promise,
+                        see the Note below). Defaults to False: tracing is an
+                        explicit opt-in, so ``LLMJudge``'s internal
+                        ``create_llm_client(Settings())`` calls (and every other
+                        caller that doesn't pass this kwarg) work on a plain
+                        ``pip install langres[llm]`` with no langfuse installed.
 
     Returns:
         The litellm module configured with optional Langfuse callbacks.
 
     Raises:
         ValueError: If enable_langfuse=True but required Langfuse env vars are missing.
+        ImportError: If enable_langfuse=True but the ``langfuse`` package isn't
+            installed -- with a one-line fix (``pip install langres[dev]`` or
+            disable tracing).
 
     Environment variables (when enable_langfuse=True):
         LANGFUSE_PUBLIC_KEY: Langfuse public API key (required)
@@ -42,11 +51,11 @@ def create_llm_client(settings: Settings | None = None, enable_langfuse: bool = 
         AZURE_API_VERSION: Azure OpenAI API version
 
     Example:
-        # With Langfuse tracing (requires LANGFUSE_* env vars)
-        client = create_llm_client(enable_langfuse=True)
+        # Default: no tracing, no langfuse required (just [llm])
+        client = create_llm_client()
 
-        # Without tracing (no env vars required)
-        client = create_llm_client(enable_langfuse=False)
+        # With Langfuse tracing (requires LANGFUSE_* env vars + langfuse installed)
+        client = create_llm_client(enable_langfuse=True)
 
         # Use with Azure OpenAI (reads from AZURE_API_* env vars)
         response = client.completion(
@@ -62,6 +71,13 @@ def create_llm_client(settings: Settings | None = None, enable_langfuse: bool = 
         For Azure OpenAI, use model names with "azure/" prefix:
         - "azure/gpt-5-mini" (your deployment name)
         - LiteLLM reads AZURE_API_BASE, AZURE_API_KEY, AZURE_API_VERSION from environment
+
+    Note:
+        ``langfuse`` lives in the dev dependency group (experiment-tracking
+        tooling), not the ``[llm]`` extra -- a production ``pip install
+        langres[llm]`` install has litellm but not langfuse. Tracing therefore
+        defaults to off; pass ``enable_langfuse=True`` only when langfuse is
+        actually installed (dev environments, or ``pip install langres[dev]``).
     """
     if settings is None:
         settings = Settings()  # Loads from env vars
@@ -70,9 +86,21 @@ def create_llm_client(settings: Settings | None = None, enable_langfuse: bool = 
     if enable_langfuse:
         # W0.4: langfuse moved to the dev dependency group (experiment-tracking
         # tooling, not part of the [llm] extra's install promise) -- imported
-        # here, lazily, so `create_llm_client(enable_langfuse=False)` works
-        # with just [llm] installed and no langfuse present.
-        from langfuse import Langfuse
+        # here, lazily, so the default (enable_langfuse=False) works with just
+        # [llm] installed and no langfuse present. A caller that explicitly
+        # asks for tracing without langfuse installed gets an actionable
+        # ImportError instead of a raw "No module named 'langfuse'" traceback.
+        try:
+            from langfuse import Langfuse
+        except ImportError as e:
+            raise ImportError(
+                "create_llm_client(enable_langfuse=True) requires the 'langfuse' "
+                "package, which is not installed. langfuse is a dev/observability "
+                "dependency, not part of the langres[llm] extra. Fix: "
+                "pip install 'langres[dev]' (or uv add --dev langfuse). "
+                "Or call create_llm_client(enable_langfuse=False) (the default) "
+                "to disable tracing."
+            ) from e
 
         # Validate Langfuse env vars are present
         if not settings.langfuse_public_key:

--- a/src/langres/clients/llm.py
+++ b/src/langres/clients/llm.py
@@ -4,7 +4,6 @@ import logging
 from typing import Any
 
 import litellm
-from langfuse import Langfuse
 
 from langres.clients.settings import Settings
 
@@ -69,6 +68,12 @@ def create_llm_client(settings: Settings | None = None, enable_langfuse: bool = 
 
     # Configure Langfuse callbacks if enabled
     if enable_langfuse:
+        # W0.4: langfuse moved to the dev dependency group (experiment-tracking
+        # tooling, not part of the [llm] extra's install promise) -- imported
+        # here, lazily, so `create_llm_client(enable_langfuse=False)` works
+        # with just [llm] installed and no langfuse present.
+        from langfuse import Langfuse
+
         # Validate Langfuse env vars are present
         if not settings.langfuse_public_key:
             raise ValueError(

--- a/src/langres/core/__init__.py
+++ b/src/langres/core/__init__.py
@@ -192,8 +192,7 @@ _LAZY_SYMBOLS: dict[str, str] = {
 #: either ``[llm]`` (LLMJudge) or ``[semantic]`` (embeddings/vector index/
 #: VectorBlocker).
 _EXTRA_BY_SYMBOL: dict[str, str] = {
-    name: {"LLMJudge": "llm", "RFJudge": "trained"}.get(name, "semantic")
-    for name in _LAZY_SYMBOLS
+    name: {"LLMJudge": "llm", "RFJudge": "trained"}.get(name, "semantic") for name in _LAZY_SYMBOLS
 }
 
 

--- a/src/langres/core/__init__.py
+++ b/src/langres/core/__init__.py
@@ -3,15 +3,32 @@ langres.core: Low-level API for entity resolution.
 
 This module provides the foundational primitives for building custom
 entity resolution pipelines.
+
+Import weight (W0.4): most names below are cheap (pydantic/rapidfuzz/networkx,
+the core dependencies) and stay eager. A handful pull an optional, heavy
+dependency -- the embedding/vector stack (torch/sentence-transformers/faiss/
+qdrant-client, the ``[semantic]`` extra), the LLM stack (litellm, the ``[llm]``
+extra), the trained-judge stack (scikit-learn, the ``[trained]`` extra --
+:class:`~langres.core.modules.rf_judge.RFJudge`), or dev/eval tooling
+(ranx/optuna/wandb) -- and are resolved lazily via PEP 562 ``__getattr__``
+(see :data:`_LAZY_SUBMODULES` / :data:`_LAZY_SYMBOLS` below): ``from
+langres.core import VectorBlocker`` still works, but the actual ``import`` of
+``faiss``/``torch``/etc. only happens the first time ``VectorBlocker`` (or
+another lazy name) is actually accessed -- so plain ``import langres`` stays
+fast and never touches ``sys.modules`` for a dependency the caller hasn't
+asked for. Accessing a ``[semantic]``/``[llm]``/``[trained]`` symbol without
+that extra installed raises a clear ``ImportError`` naming the extra to
+install.
 """
 
-from langres.core import benchmark, metrics, optimizers
+import importlib
+from typing import TYPE_CHECKING, Any
+
 from langres.core.adapters.glinker import GLinkerAdapter
 from langres.core.blocker import Blocker
 from langres.core.blockers.all_pairs import AllPairsBlocker
 from langres.core.blockers.composite import CompositeBlocker
 from langres.core.blockers.key import KeyBlocker
-from langres.core.blockers.vector import VectorBlocker
 from langres.core.clusterer import Clusterer
 from langres.core.clusterers.correlation import CorrelationClusterer
 from langres.core.comparator import Comparator, StringComparator
@@ -22,24 +39,9 @@ from langres.core.debugging import (
     PipelineDebugger,
     ScoreStats,
 )
-from langres.core.embeddings import (
-    EmbeddingProvider,
-    FakeEmbedder,
-    FakeSparseEmbedder,
-    FastEmbedSparseEmbedder,
-    SentenceTransformerEmbedder,
-    SparseEmbeddingProvider,
-)
 from langres.core.feature import ComparisonLevel, ComparisonVector, FeatureSpec
 from langres.core.fit import SupervisedFitMixin, UnsupervisedFitMixin
 from langres.core.groups import ERCandidateGroup, derive_groups_from_pairs
-from langres.core.indexes import (
-    FAISSIndex,
-    FakeHybridVectorIndex,
-    FakeVectorIndex,
-    QdrantHybridIndex,
-    VectorIndex,
-)
 from langres.core.judgement_log import JudgementLog, LoggingModule
 from langres.core.judges.embedding_score import EmbeddingScoreJudge
 from langres.core.judges.fellegi_sunter import FellegiSunterJudge
@@ -51,13 +53,6 @@ from langres.core.models import (
     PairwiseJudgement,
 )
 from langres.core.module import GroupwiseModule, Module, stamp_group_cost
-
-# Importing LLMJudge here ensures its ``@register("llm_judge")`` runs on plain
-# ``import langres.core`` — so a fresh process doing ``Resolver.load(path)`` on
-# an LLMJudge artifact finds the type in the registry (mirrors WeightedAverageJudge
-# above). It also makes ``from langres.core import LLMJudge`` work.
-from langres.core.modules.llm_judge import LLMJudge
-from langres.core.modules.rf_judge import RFJudge
 from langres.core.registry import (
     SchemaNotRegistered,
     UnknownComponentType,
@@ -73,6 +68,29 @@ from langres.core.serialization import (
     ComponentSpec,
     SerializableState,
 )
+
+if TYPE_CHECKING:
+    # Only reached by mypy (never at runtime) -- keeps every lazy name visible
+    # to `mypy --strict` without executing the heavy imports below.
+    from langres.core import benchmark, metrics, optimizers
+    from langres.core.blockers.vector import VectorBlocker
+    from langres.core.embeddings import (
+        EmbeddingProvider,
+        FakeEmbedder,
+        FakeSparseEmbedder,
+        FastEmbedSparseEmbedder,
+        SentenceTransformerEmbedder,
+        SparseEmbeddingProvider,
+    )
+    from langres.core.indexes import (
+        FAISSIndex,
+        FakeHybridVectorIndex,
+        FakeVectorIndex,
+        QdrantHybridIndex,
+        VectorIndex,
+    )
+    from langres.core.modules.llm_judge import LLMJudge
+    from langres.core.modules.rf_judge import RFJudge
 
 __all__ = [
     "ARTIFACT_VERSION",
@@ -137,3 +155,69 @@ __all__ = [
     "VectorIndex",
     "WeightedAverageJudge",
 ]
+
+#: Names resolved to a *submodule of this package* on first access -- unlike
+#: :data:`_LAZY_SYMBOLS`, the value ``__getattr__`` binds is the imported
+#: module itself (``langres.core.benchmark``, not an attribute of it). All
+#: three eventually need ranx (``metrics``, and ``benchmark`` which imports
+#: it) or optuna/wandb (``optimizers``) -- dev/eval tooling, not part of the
+#: link()/dedupe() runtime path.
+_LAZY_SUBMODULES: frozenset[str] = frozenset({"benchmark", "metrics", "optimizers"})
+
+#: ``name -> owning module`` for symbols resolved on first access. Each entry
+#: needs an optional extra installed; see :data:`_EXTRA_BY_SYMBOL` for the
+#: ``pip install langres[<extra>]`` hint a missing dependency should surface.
+_LAZY_SYMBOLS: dict[str, str] = {
+    "VectorBlocker": "langres.core.blockers.vector",
+    "EmbeddingProvider": "langres.core.embeddings",
+    "FakeEmbedder": "langres.core.embeddings",
+    "FakeSparseEmbedder": "langres.core.embeddings",
+    "FastEmbedSparseEmbedder": "langres.core.embeddings",
+    "SentenceTransformerEmbedder": "langres.core.embeddings",
+    "SparseEmbeddingProvider": "langres.core.embeddings",
+    "FAISSIndex": "langres.core.indexes",
+    "FakeHybridVectorIndex": "langres.core.indexes",
+    "FakeVectorIndex": "langres.core.indexes",
+    "QdrantHybridIndex": "langres.core.indexes",
+    "VectorIndex": "langres.core.indexes",
+    "LLMJudge": "langres.core.modules.llm_judge",
+    "RFJudge": "langres.core.modules.rf_judge",
+}
+
+#: ``name -> extra`` for the lazy symbols a ``pip install langres[<extra>]``
+#: actually fixes -- everything in :data:`_LAZY_SYMBOLS` except the three
+#: submodules (dev/eval tooling, not distributed as a pip extra; see
+#: :data:`_LAZY_SUBMODULES`'s docstring). ``RFJudge`` needs scikit-learn (the
+#: ``[trained]`` extra, W1.2's trained-family judge); everything else needs
+#: either ``[llm]`` (LLMJudge) or ``[semantic]`` (embeddings/vector index/
+#: VectorBlocker).
+_EXTRA_BY_SYMBOL: dict[str, str] = {
+    name: {"LLMJudge": "llm", "RFJudge": "trained"}.get(name, "semantic")
+    for name in _LAZY_SYMBOLS
+}
+
+
+def __getattr__(name: str) -> Any:
+    """PEP 562: resolve a heavy/optional name the first time it's accessed.
+
+    Raises:
+        AttributeError: ``name`` isn't a known attribute of this module.
+        ImportError: The owning module's dependency isn't installed --
+            re-raised with a ``pip install langres[<extra>]`` hint instead of
+            the raw ``ModuleNotFoundError`` (:data:`_EXTRA_BY_SYMBOL`).
+    """
+    if name in _LAZY_SUBMODULES:
+        value: Any = importlib.import_module(f"{__name__}.{name}")
+    elif name in _LAZY_SYMBOLS:
+        try:
+            value = getattr(importlib.import_module(_LAZY_SYMBOLS[name]), name)
+        except ImportError as exc:
+            extra = _EXTRA_BY_SYMBOL[name]
+            raise ImportError(
+                f"langres.core.{name} requires the {extra!r} extra: "
+                f"pip install 'langres[{extra}]' (or uv add 'langres[{extra}]')"
+            ) from exc
+    else:
+        raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+    globals()[name] = value  # cache: subsequent access skips __getattr__
+    return value

--- a/src/langres/core/blockers/__init__.py
+++ b/src/langres/core/blockers/__init__.py
@@ -1,8 +1,27 @@
-"""Blocker implementations for candidate pair generation."""
+"""Blocker implementations for candidate pair generation.
+
+``VectorBlocker`` needs faiss (the ``[semantic]`` extra, see
+``langres.core``'s module docstring for the W0.4 rationale) -- resolved lazily
+via PEP 562 so importing this package (a side effect of e.g.
+``from langres.core.blockers.all_pairs import AllPairsBlocker``) never pulls
+faiss in for a caller who only wants the light blocker.
+"""
+
+from typing import TYPE_CHECKING, Any
 
 from langres.core.blockers.all_pairs import AllPairsBlocker
 from langres.core.blockers.composite import CompositeBlocker
 from langres.core.blockers.key import KeyBlocker
-from langres.core.blockers.vector import VectorBlocker
+
+if TYPE_CHECKING:
+    from langres.core.blockers.vector import VectorBlocker
 
 __all__ = ["AllPairsBlocker", "CompositeBlocker", "KeyBlocker", "VectorBlocker"]
+
+
+def __getattr__(name: str) -> Any:
+    if name == "VectorBlocker":
+        from langres.core.blockers.vector import VectorBlocker
+
+        return VectorBlocker
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")

--- a/src/langres/core/blockers/__init__.py
+++ b/src/langres/core/blockers/__init__.py
@@ -23,5 +23,6 @@ def __getattr__(name: str) -> Any:
     if name == "VectorBlocker":
         from langres.core.blockers.vector import VectorBlocker
 
+        globals()[name] = VectorBlocker  # cache: subsequent access skips __getattr__
         return VectorBlocker
     raise AttributeError(f"module {__name__!r} has no attribute {name!r}")

--- a/src/langres/core/modules/__init__.py
+++ b/src/langres/core/modules/__init__.py
@@ -1,7 +1,43 @@
-"""Module implementations for entity comparison."""
+"""Module implementations for entity comparison.
 
-from langres.core.modules.cascade import CascadeModule
-from langres.core.modules.llm_judge import LLMJudge, LLMJudgeModule
+``LLMJudge``/``LLMJudgeModule`` need litellm (the ``[llm]`` extra) and
+``CascadeModule`` additionally needs sentence-transformers (``[semantic]``) --
+resolved lazily via PEP 562 so importing this package (a side effect of e.g.
+``from langres.core.modules.rapidfuzz import RapidfuzzModule``) never pulls
+those in for a caller who only wants the light module. See
+``langres.core``'s module docstring for the W0.4 rationale.
+"""
+
+import importlib
+from typing import TYPE_CHECKING, Any
+
 from langres.core.modules.rapidfuzz import RapidfuzzModule
 
+if TYPE_CHECKING:
+    from langres.core.modules.cascade import CascadeModule
+    from langres.core.modules.llm_judge import LLMJudge, LLMJudgeModule
+
 __all__ = ["RapidfuzzModule", "LLMJudge", "LLMJudgeModule", "CascadeModule"]
+
+_LAZY: dict[str, tuple[str, str]] = {
+    "LLMJudge": ("langres.core.modules.llm_judge", "pip install 'langres[llm]'"),
+    "LLMJudgeModule": ("langres.core.modules.llm_judge", "pip install 'langres[llm]'"),
+    "CascadeModule": (
+        "langres.core.modules.cascade",
+        "pip install 'langres[llm,semantic]'",
+    ),
+}
+
+
+def __getattr__(name: str) -> Any:
+    if name not in _LAZY:
+        raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+    module_path, install_hint = _LAZY[name]
+    try:
+        value = getattr(importlib.import_module(module_path), name)
+    except ImportError as exc:
+        raise ImportError(
+            f"langres.core.modules.{name} requires an optional dependency: {install_hint}"
+        ) from exc
+    globals()[name] = value  # cache: subsequent access skips __getattr__
+    return value

--- a/src/langres/core/modules/llm_judge.py
+++ b/src/langres/core/modules/llm_judge.py
@@ -169,9 +169,12 @@ class LLMJudge(Module[SchemaT]):
 
     The client is optional. When omitted, it is lazily built from the
     environment with ``create_llm_client(Settings())`` on first use, enabling:
-    - Automatic Langfuse tracing for observability
     - Support for multiple LLM providers (OpenAI, Azure, etc.)
     - Serialization without persisting any secret
+    - Optional Langfuse tracing for observability (opt-in: pass
+      ``client=create_llm_client(Settings(), enable_langfuse=True)`` -- off by
+      default since langfuse is a dev-only dependency, not part of the
+      ``[llm]`` extra)
 
     Example:
         # Happy path: build the client from environment.

--- a/src/langres/core/presets.py
+++ b/src/langres/core/presets.py
@@ -1,6 +1,6 @@
 """Presets: resolve ``judge="auto"`` and assemble a spend-capped Resolver.
 
-This is the machinery behind the three-verb DX layer (:mod:`langres.verbs`):
+This is the machinery behind the two-verb DX layer (:mod:`langres.verbs`):
 picking a judge from available API keys, building its scorer Module, wiring a
 blocker by dataset size, and wrapping the scorer in a hard spend cap. It sits
 strictly ABOVE :class:`~langres.core.resolver.Resolver` (which must not import

--- a/src/langres/core/presets.py
+++ b/src/langres/core/presets.py
@@ -57,11 +57,8 @@ from langres.clients.openrouter import (
 from langres.clients.settings import Settings
 from langres.core.blocker import Blocker
 from langres.core.blockers.all_pairs import AllPairsBlocker
-from langres.core.blockers.vector import VectorBlocker
 from langres.core.clusterer import Clusterer
 from langres.core.comparator import Comparator
-from langres.core.embeddings import SentenceTransformerEmbedder
-from langres.core.indexes.vector_index import FAISSIndex
 from langres.core.judges.embedding_score import EmbeddingScoreJudge
 from langres.core.judges.weighted_average import WeightedAverageJudge
 from langres.core.models import ERCandidate, PairwiseJudgement
@@ -70,6 +67,14 @@ from langres.core.resolver import Resolver
 
 if TYPE_CHECKING:
     from collections.abc import Iterator
+
+    # [semantic] extra (faiss/sentence-transformers/torch) -- imported lazily
+    # inside _build_vector_blocker (W0.4) so a core-only `import langres`
+    # never pulls faiss/torch in for a caller who never picks judge="embedding"
+    # or crosses the AllPairsBlocker -> VectorBlocker size threshold.
+    from langres.core.blockers.vector import VectorBlocker
+    from langres.core.embeddings import SentenceTransformerEmbedder
+    from langres.core.indexes.vector_index import FAISSIndex
 
 #: The judge names the verb layer understands, plus the "auto" meta-value that
 #: :func:`choose_auto_judge` resolves down to one of the other three.
@@ -347,6 +352,13 @@ def _text_field_extractor(schema: type[BaseModel]) -> Any:
 
 def _build_vector_blocker(schema: type[BaseModel]) -> VectorBlocker[Any]:
     """Build a ``VectorBlocker`` (MiniLM + FAISS cosine) for ``schema``."""
+    # Lazy: faiss/sentence-transformers ([semantic] extra) must stay out of
+    # sys.modules unless a VectorBlocker is actually built (mirrors the
+    # zero_shot_llm branch's lazy dspy import right below).
+    from langres.core.blockers.vector import VectorBlocker
+    from langres.core.embeddings import SentenceTransformerEmbedder
+    from langres.core.indexes.vector_index import FAISSIndex
+
     embedder = SentenceTransformerEmbedder(_VECTOR_MODEL_NAME)
     index = FAISSIndex(embedder=embedder, metric="cosine")
     return VectorBlocker(

--- a/src/langres/core/registry.py
+++ b/src/langres/core/registry.py
@@ -37,20 +37,32 @@ _SCHEMA_REGISTRY: dict[str, type[BaseModel]] = {}
 # ``dspy_judge``, which would otherwise import ``dspy`` (and open its disk cache)
 # on plain ``import langres.core``.
 #
-# ``key_blocker``/``composite_blocker``/``correlation_clusterer`` are ALSO
-# eager-imported today (``core/__init__.py``, mirroring ``AllPairsBlocker``/
-# ``VectorBlocker``/``LLMJudge``), so this entry is currently redundant for
-# them -- it exists so a saved artifact referencing these types keeps resolving
-# once those eager imports are trimmed (planned packaging-dx work), the same
-# safety net ``select_judge``/``dspy_judge`` already rely on.
+# ``key_blocker``/``composite_blocker``/``correlation_clusterer``/
+# ``fellegi_sunter_judge``/``rf_judge`` were added to this map so a saved
+# artifact referencing these types keeps resolving once W0.4's lazy-import
+# refactor trimmed ``core/__init__.py``'s eager imports -- the same safety net
+# ``select_judge``/``dspy_judge`` already relied on.
+#
+# W0.4 (extras split): ``llm_judge``/``vector_blocker``/``faiss_index``/
+# ``sentence_transformer_embedder``/``fake_embedder`` joined this map when
+# ``langres.core.__init__`` stopped eager-importing litellm (``llm_judge``) and
+# faiss/sentence-transformers (``vector_blocker``, ``faiss_index``,
+# ``*_embedder``) — those packages are now optional (``pip install
+# langres[llm]`` / ``langres[semantic]``), so importing them must be deferred
+# to the first actual access, exactly like ``dspy_judge``.
 _LAZY_COMPONENT_MODULES: dict[str, str] = {
     "composite_blocker": "langres.core.blockers.composite",
     "correlation_clusterer": "langres.core.clusterers.correlation",
     "dspy_judge": "langres.core.modules.dspy_judge",
+    "faiss_index": "langres.core.indexes.vector_index",
+    "fake_embedder": "langres.core.embeddings",
     "fellegi_sunter_judge": "langres.core.judges.fellegi_sunter",
     "key_blocker": "langres.core.blockers.key",
+    "llm_judge": "langres.core.modules.llm_judge",
     "rf_judge": "langres.core.modules.rf_judge",
     "select_judge": "langres.core.modules.select_judge",
+    "sentence_transformer_embedder": "langres.core.embeddings",
+    "vector_blocker": "langres.core.blockers.vector",
 }
 
 

--- a/src/langres/core/resolver.py
+++ b/src/langres/core/resolver.py
@@ -37,14 +37,13 @@ import logging
 import warnings
 from collections.abc import Iterator, Sequence
 from pathlib import Path
-from typing import Any, Literal, Self, TypeGuard
+from typing import TYPE_CHECKING, Any, Literal, Self, TypeGuard, cast
 
 from pydantic import BaseModel
 
 import langres
 from langres.core.blocker import Blocker
 from langres.core.blockers.composite import CompositeBlocker
-from langres.core.blockers.vector import VectorBlocker
 from langres.core.clusterer import Clusterer
 from langres.core.comparator import Comparator
 from langres.core.fit import SupervisedFitMixin, UnsupervisedFitMixin
@@ -58,6 +57,13 @@ from langres.core.serialization import (
     ComponentSpec,
     SerializableState,
 )
+
+if TYPE_CHECKING:
+    # [semantic] extra (faiss/sentence-transformers/torch) -- imported lazily
+    # inside _build_embedding_blocker and _ensure_index_built (W0.4) so a
+    # core-only `import langres` never pulls faiss/torch in for a Resolver
+    # that never uses judge="embedding".
+    from langres.core.blockers.vector import VectorBlocker
 
 logger = logging.getLogger(__name__)
 
@@ -130,7 +136,7 @@ def _build_module_for_judge(
     )
 
 
-def _build_embedding_blocker(schema: type[BaseModel]) -> VectorBlocker[Any]:
+def _build_embedding_blocker(schema: type[BaseModel]) -> "VectorBlocker[Any]":
     """Build the ``VectorBlocker`` a ``judge="embedding"`` pipeline needs.
 
     ``AllPairsBlocker``'s candidates never carry ``similarity_score``, which
@@ -142,6 +148,7 @@ def _build_embedding_blocker(schema: type[BaseModel]) -> VectorBlocker[Any]:
     :func:`_build_module_for_judge`: ``core.presets`` sits ABOVE ``Resolver``
     and must not be imported back into it.
     """
+    from langres.core.blockers.vector import VectorBlocker
     from langres.core.embeddings import SentenceTransformerEmbedder
     from langres.core.indexes.vector_index import FAISSIndex
 
@@ -158,7 +165,7 @@ def _build_embedding_blocker(schema: type[BaseModel]) -> VectorBlocker[Any]:
     )
 
 
-def _iter_vector_blockers(blocker: object) -> Iterator[VectorBlocker[Any]]:
+def _iter_vector_blockers(blocker: object) -> "Iterator[VectorBlocker[Any]]":
     """Yield every ``VectorBlocker`` reachable from ``blocker``.
 
     A plain ``VectorBlocker`` yields itself. A ``CompositeBlocker`` (the
@@ -168,9 +175,18 @@ def _iter_vector_blockers(blocker: object) -> Iterator[VectorBlocker[Any]]:
     recall-first pattern ``CompositeBlocker([KeyBlocker(...), VectorBlocker(...)],
     op="union")``. Index-free blockers (``AllPairsBlocker``, ``KeyBlocker``,
     ``GLinkerAdapter``) contribute nothing.
+
+    Checks ``type_name`` rather than ``isinstance(blocker, VectorBlocker)``
+    deliberately (W0.4, mirrors :meth:`Resolver._ensure_index_built`'s own
+    docstring): this walks the blocker tree on every ``resolve()``/
+    ``predict()`` call, so an ``isinstance`` check would need ``VectorBlocker``
+    imported unconditionally, pulling faiss/sentence-transformers (the
+    ``[semantic]`` extra) into a plain ``AllPairsBlocker``/``KeyBlocker``
+    pipeline. ``CompositeBlocker`` itself has no heavy dependency, so it's
+    safe to ``isinstance``-check directly.
     """
-    if isinstance(blocker, VectorBlocker):
-        yield blocker
+    if getattr(blocker, "type_name", None) == "vector_blocker":
+        yield cast("VectorBlocker[Any]", blocker)
     elif isinstance(blocker, CompositeBlocker):
         for child in blocker.children:
             yield from _iter_vector_blockers(child)
@@ -514,6 +530,14 @@ class Resolver:
         re-embed, so restore + same-records round-trips are cheap); different
         -> rebuild (so reusing the Resolver on a new record list scores
         against the right corpus rather than a stale one).
+
+        No ``isinstance(..., VectorBlocker)`` anywhere in this walk (W0.4): see
+        :func:`_iter_vector_blockers`'s docstring for why -- this method runs
+        on every ``resolve()``/``predict()`` call regardless of blocker, so an
+        ``isinstance`` check would need ``VectorBlocker`` imported
+        unconditionally, pulling faiss/sentence-transformers (the
+        ``[semantic]`` extra) into a plain ``AllPairsBlocker``/``KeyBlocker``
+        pipeline.
         """
         for vector_blocker in _iter_vector_blockers(self.blocker):
             entities = [vector_blocker.schema_factory(record) for record in records]

--- a/src/langres/verbs.py
+++ b/src/langres/verbs.py
@@ -1,4 +1,4 @@
-"""The three-verb DX layer: ``link``, ``dedupe``, and their result types.
+"""The two-verb DX layer: ``link``, ``dedupe``, and their result types.
 
 ``link(left, right)`` and ``dedupe(records)`` are the thin, schema-optional
 convenience layer on top of :mod:`langres.core.presets` (judge resolution +

--- a/tests/clients/test_llm.py
+++ b/tests/clients/test_llm.py
@@ -1,6 +1,7 @@
 """Tests for langres.clients.llm module."""
 
 import os
+import sys
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -22,7 +23,7 @@ class TestCreateLLMClient:
     """Tests for create_llm_client factory function."""
 
     def test_create_llm_client_with_settings(self):
-        """Test create_llm_client configures litellm with Langfuse."""
+        """Test create_llm_client configures litellm with Langfuse (explicit opt-in)."""
         settings = Settings(
             openai_api_key="sk-test",
             wandb_api_key="wb-test",
@@ -41,7 +42,7 @@ class TestCreateLLMClient:
             mock_langfuse_instance.auth_check.return_value = True
             mock_langfuse_class.return_value = mock_langfuse_instance
 
-            client = create_llm_client(settings)
+            client = create_llm_client(settings, enable_langfuse=True)
 
             # Verify Langfuse client was initialized
             mock_langfuse_class.assert_called_once_with(
@@ -58,7 +59,7 @@ class TestCreateLLMClient:
             assert client is mock_litellm
 
     def test_create_llm_client_without_settings_loads_from_env(self):
-        """Test create_llm_client without settings loads from env vars."""
+        """Test create_llm_client without settings loads from env vars (Langfuse opt-in)."""
         with patch.dict(
             os.environ,
             {
@@ -79,7 +80,7 @@ class TestCreateLLMClient:
                 mock_langfuse_instance.auth_check.return_value = True
                 mock_langfuse_class.return_value = mock_langfuse_instance
 
-                client = create_llm_client()
+                client = create_llm_client(enable_langfuse=True)
 
                 # Verify Langfuse initialized with env vars
                 mock_langfuse_class.assert_called_once()
@@ -108,7 +109,7 @@ class TestCreateLLMClient:
             mock_langfuse_instance.auth_check.return_value = True
             mock_langfuse_class.return_value = mock_langfuse_instance
 
-            client = create_llm_client(settings)
+            client = create_llm_client(settings, enable_langfuse=True)
 
             # Verify Langfuse initialized with default host
             mock_langfuse_class.assert_called_once_with(
@@ -147,7 +148,7 @@ class TestCreateLLMClient:
             mock_langfuse_instance.auth_check.return_value = True
             mock_langfuse_class.return_value = mock_langfuse_instance
 
-            client = create_llm_client(settings)
+            client = create_llm_client(settings, enable_langfuse=True)
 
             # Verify Langfuse initialized
             mock_langfuse_class.assert_called_once()
@@ -165,7 +166,7 @@ class TestCreateLLMClient:
             assert client is mock_litellm
 
     def test_create_llm_client_without_langfuse(self):
-        """Test create_llm_client with Langfuse disabled."""
+        """Test create_llm_client with Langfuse explicitly disabled."""
         with patch("langres.clients.llm.litellm") as mock_litellm:
             client = create_llm_client(enable_langfuse=False)
 
@@ -174,6 +175,45 @@ class TestCreateLLMClient:
 
             # Verify litellm module is returned
             assert client is mock_litellm
+
+    def test_create_llm_client_default_does_not_require_langfuse_installed(self, monkeypatch):
+        """The [llm]-only contract: enable_langfuse now defaults to False, so
+        create_llm_client(Settings()) -- exactly what LLMJudge.from_env()/
+        LLMJudge._get_client() call internally -- must succeed even when
+        langfuse isn't installed (it's dev-group only, not part of [llm]).
+
+        Simulates absence by making ``langfuse`` unimportable (the standard
+        "set sys.modules[name] = None" trick forces the next `import`/`from
+        ... import` to raise ImportError), since langfuse IS installed in
+        this dev environment and can't be genuinely uninstalled for the test.
+        """
+        monkeypatch.setitem(sys.modules, "langfuse", None)
+        with patch("langres.clients.llm.litellm") as mock_litellm:
+            client = create_llm_client(Settings())
+
+            assert client is mock_litellm
+            assert mock_litellm.callbacks != ["langfuse_otel"]
+
+    def test_create_llm_client_no_args_default_does_not_require_langfuse_installed(
+        self, monkeypatch
+    ):
+        """Same contract as above, but via the no-Settings call LLMJudge's
+        ``forward_async`` path (langres/core/modules/llm_judge.py:370) uses."""
+        monkeypatch.setitem(sys.modules, "langfuse", None)
+        with patch("langres.clients.llm.litellm") as mock_litellm:
+            client = create_llm_client()
+
+            assert client is mock_litellm
+            assert mock_litellm.callbacks != ["langfuse_otel"]
+
+    def test_create_llm_client_enable_langfuse_raises_actionable_import_error_when_absent(
+        self, monkeypatch
+    ):
+        """Explicitly requesting tracing without langfuse installed must raise
+        a helpful ImportError (what/why/fix), not a raw ModuleNotFoundError."""
+        monkeypatch.setitem(sys.modules, "langfuse", None)
+        with pytest.raises(ImportError, match=r"langres\[dev\]"):
+            create_llm_client(Settings(), enable_langfuse=True)
 
     def test_create_llm_client_raises_error_if_langfuse_keys_missing(self):
         """Test create_llm_client raises ValueError if Langfuse keys missing."""
@@ -214,7 +254,7 @@ class TestCreateLLMClient:
             mock_langfuse_instance.auth_check.return_value = True
             mock_langfuse_class.return_value = mock_langfuse_instance
 
-            client = create_llm_client(settings)
+            client = create_llm_client(settings, enable_langfuse=True)
 
             # Verify Langfuse initialized
             mock_langfuse_class.assert_called_once()

--- a/tests/clients/test_llm.py
+++ b/tests/clients/test_llm.py
@@ -35,7 +35,7 @@ class TestCreateLLMClient:
 
         with (
             patch("langres.clients.llm.litellm") as mock_litellm,
-            patch("langres.clients.llm.Langfuse") as mock_langfuse_class,
+            patch("langfuse.Langfuse") as mock_langfuse_class,
         ):
             mock_langfuse_instance = MagicMock()
             mock_langfuse_instance.auth_check.return_value = True
@@ -73,7 +73,7 @@ class TestCreateLLMClient:
         ):
             with (
                 patch("langres.clients.llm.litellm") as mock_litellm,
-                patch("langres.clients.llm.Langfuse") as mock_langfuse_class,
+                patch("langfuse.Langfuse") as mock_langfuse_class,
             ):
                 mock_langfuse_instance = MagicMock()
                 mock_langfuse_instance.auth_check.return_value = True
@@ -102,7 +102,7 @@ class TestCreateLLMClient:
 
         with (
             patch("langres.clients.llm.litellm") as mock_litellm,
-            patch("langres.clients.llm.Langfuse") as mock_langfuse_class,
+            patch("langfuse.Langfuse") as mock_langfuse_class,
         ):
             mock_langfuse_instance = MagicMock()
             mock_langfuse_instance.auth_check.return_value = True
@@ -141,7 +141,7 @@ class TestCreateLLMClient:
 
         with (
             patch("langres.clients.llm.litellm") as mock_litellm,
-            patch("langres.clients.llm.Langfuse") as mock_langfuse_class,
+            patch("langfuse.Langfuse") as mock_langfuse_class,
         ):
             mock_langfuse_instance = MagicMock()
             mock_langfuse_instance.auth_check.return_value = True
@@ -208,7 +208,7 @@ class TestCreateLLMClient:
 
         with (
             patch("langres.clients.llm.litellm") as mock_litellm,
-            patch("langres.clients.llm.Langfuse") as mock_langfuse_class,
+            patch("langfuse.Langfuse") as mock_langfuse_class,
         ):
             mock_langfuse_instance = MagicMock()
             mock_langfuse_instance.auth_check.return_value = True
@@ -233,7 +233,7 @@ class TestCreateLLMClient:
             langfuse_secret_key="sk-lf-test",
         )
 
-        with patch("langres.clients.llm.Langfuse") as mock_langfuse_class:
+        with patch("langfuse.Langfuse") as mock_langfuse_class:
             # Simulate Langfuse initialization failure
             mock_langfuse_class.side_effect = Exception("Connection failed")
 
@@ -247,7 +247,7 @@ class TestCreateLLMClient:
             langfuse_secret_key="sk-lf-test",
         )
 
-        with patch("langres.clients.llm.Langfuse") as mock_langfuse_class:
+        with patch("langfuse.Langfuse") as mock_langfuse_class:
             mock_langfuse_instance = MagicMock()
             # auth_check returns False -> invalid credentials/host
             mock_langfuse_instance.auth_check.return_value = False

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,7 +1,23 @@
 """Pytest configuration and shared fixtures for langres tests."""
 
+import os
 from collections.abc import Iterable
 from typing import Any
+
+# W0.4 SPEND-SAFETY: the handful of @pytest.mark.integration tests that make a
+# real, billed OpenRouter call must never run by accident. A key alone used to
+# be enough to trigger them -- and litellm's import-time load_dotenv() side
+# effect (fixed in W0.4, see tests/test_import_budget.py) could populate that
+# key from an unrelated .env even when the developer never intended a paid
+# run, which is exactly how this already cost real spend once. Both gates now
+# require this explicit opt-in on TOP OF a key being present.
+PAID_TESTS_ENABLED = (
+    bool(os.getenv("OPENROUTER_API_KEY")) and os.getenv("LANGRES_RUN_PAID_TESTS") == "1"
+)
+PAID_TEST_SKIP_REASON = (
+    "requires OPENROUTER_API_KEY AND LANGRES_RUN_PAID_TESTS=1 (explicit "
+    "opt-in for a real, billed OpenRouter call)"
+)
 
 
 def pairs_from_candidates(candidates: Iterable[Any]) -> set[frozenset[str]]:

--- a/tests/core/blockers/test_vector.py
+++ b/tests/core/blockers/test_vector.py
@@ -19,9 +19,20 @@ from langres.core.groups import ERCandidateGroup
 from langres.core.indexes.reranking_vector_index import FakeHybridRerankingVectorIndex
 from langres.core.indexes.vector_index import FAISSIndex, FakeVectorIndex
 from langres.core.models import CompanySchema
+from langres.core.registry import get_component
 from tests.conftest import edge_list_from_groups, pairs_from_candidates, pairs_from_groups
 
 logger = logging.getLogger(__name__)
+
+
+def test_registered_under_vector_blocker_via_lazy_lookup() -> None:
+    """``get_component('vector_blocker')`` lazily imports+registers the class.
+
+    (W0.4: faiss/sentence-transformers are optional, so ``vector_blocker``
+    joined ``_LAZY_COMPONENT_MODULES`` alongside ``dspy_judge``.)
+    """
+    assert get_component("vector_blocker") is VectorBlocker
+    assert VectorBlocker.type_name == "vector_blocker"
 
 
 # Helper functions for test construction

--- a/tests/core/indexes/test_vector_index.py
+++ b/tests/core/indexes/test_vector_index.py
@@ -12,8 +12,19 @@ from langres.core.indexes.vector_index import (
     clip_scores_to_similarities,
     inverse_distances_to_similarities,
 )
+from langres.core.registry import get_component
 
 logger = logging.getLogger(__name__)
+
+
+def test_registered_under_faiss_index_via_lazy_lookup() -> None:
+    """``get_component('faiss_index')`` lazily imports+registers the class.
+
+    (W0.4: faiss is optional, so ``faiss_index`` joined
+    ``_LAZY_COMPONENT_MODULES`` alongside ``dspy_judge``.)
+    """
+    assert get_component("faiss_index") is FAISSIndex
+    assert FAISSIndex.type_name == "faiss_index"
 
 
 class TestFAISSIndex:

--- a/tests/core/modules/test_llm_judge.py
+++ b/tests/core/modules/test_llm_judge.py
@@ -12,9 +12,20 @@ from openai.types.chat import ChatCompletion, ChatCompletionMessage
 from openai.types.chat.chat_completion import Choice
 
 from langres.core.models import CompanySchema, ERCandidate, PairwiseJudgement
-from langres.core.modules.llm_judge import LLMJudgeModule
+from langres.core.modules.llm_judge import LLMJudge, LLMJudgeModule
+from langres.core.registry import get_component
 
 logger = logging.getLogger(__name__)
+
+
+def test_registered_under_llm_judge_via_lazy_lookup() -> None:
+    """``get_component('llm_judge')`` lazily imports+registers the class.
+
+    (W0.4: litellm is optional, so ``llm_judge`` joined
+    ``_LAZY_COMPONENT_MODULES`` alongside ``dspy_judge``.)
+    """
+    assert get_component("llm_judge") is LLMJudge
+    assert LLMJudge.type_name == "llm_judge"
 
 
 @pytest.fixture

--- a/tests/core/test_embeddings.py
+++ b/tests/core/test_embeddings.py
@@ -10,8 +10,24 @@ from langres.core.embeddings import (
     FakeEmbedder,
     SentenceTransformerEmbedder,
 )
+from langres.core.registry import get_component
 
 logger = logging.getLogger(__name__)
+
+
+def test_registered_under_sentence_transformer_embedder_via_lazy_lookup() -> None:
+    """``get_component(...)`` lazily imports+registers the class.
+
+    (W0.4: sentence-transformers is optional, so these joined
+    ``_LAZY_COMPONENT_MODULES`` alongside ``dspy_judge``.)
+    """
+    assert get_component("sentence_transformer_embedder") is SentenceTransformerEmbedder
+    assert SentenceTransformerEmbedder.type_name == "sentence_transformer_embedder"
+
+
+def test_registered_under_fake_embedder_via_lazy_lookup() -> None:
+    assert get_component("fake_embedder") is FakeEmbedder
+    assert FakeEmbedder.type_name == "fake_embedder"
 
 
 class TestSentenceTransformerEmbedder:

--- a/tests/core/test_w1_3_registry_wiring.py
+++ b/tests/core/test_w1_3_registry_wiring.py
@@ -141,3 +141,101 @@ def test_resolver_fresh_process_roundtrip_with_composite_key_vector_blocker(
         f"STDOUT:\n{result.stdout}\nSTDERR:\n{result.stderr}"
     )
     assert "OK" in result.stdout
+
+
+@pytest.mark.slow
+def test_resolver_fresh_process_roundtrip_with_key_blocker_alone(tmp_path: Path) -> None:
+    """Fresh-process save/load/resolve for a Resolver whose *sole* blocker is
+    ``KeyBlocker`` (not nested inside a ``CompositeBlocker``).
+
+    The composite roundtrip test above only exercises ``key_blocker`` as a
+    composite CHILD -- ``Resolver.load`` reconstructs a composite's children
+    via the same generic ``_rebuild_component``, so that already proves
+    ``get_component("key_blocker")`` resolves. This test additionally proves
+    ``key_blocker`` resolves when it's the Resolver's top-level blocker slot
+    (W0.4 exit check: every ``_LAZY_COMPONENT_MODULES`` entry must survive a
+    fresh-process ``Resolver.load``, not just as an incidental nested case).
+    """
+    from langres.core import Clusterer, Comparator, KeyBlocker, Resolver, WeightedAverageJudge
+    from langres.core.models import CompanySchema
+    from tests.fixtures.companies import COMPANY_RECORDS
+
+    blocker: KeyBlocker[CompanySchema] = KeyBlocker(schema=CompanySchema, key_field="address")
+    comparator = Comparator.from_schema(CompanySchema)
+    resolver = Resolver(
+        blocker=blocker,
+        comparator=comparator,
+        module=WeightedAverageJudge(feature_specs=comparator.feature_specs),
+        clusterer=Clusterer(threshold=0.7),
+    )
+    resolver.resolve(COMPANY_RECORDS)
+    resolver.save(tmp_path)
+
+    script = (
+        "from langres.core import Resolver\n"
+        "from tests.fixtures.companies import COMPANY_RECORDS\n"
+        f"reloaded = Resolver.load({str(tmp_path)!r})\n"
+        "clusters = reloaded.resolve(COMPANY_RECORDS)\n"
+        "assert isinstance(clusters, list)\n"
+        "print('OK')\n"
+    )
+    result = subprocess.run(
+        [sys.executable, "-c", script],
+        capture_output=True,
+        text=True,
+        timeout=60,
+    )
+
+    assert result.returncode == 0, (
+        f"fresh-process key-blocker roundtrip failed.\nSTDOUT:\n{result.stdout}\n"
+        f"STDERR:\n{result.stderr}"
+    )
+    assert "OK" in result.stdout
+
+
+@pytest.mark.slow
+def test_resolver_fresh_process_roundtrip_with_correlation_clusterer(tmp_path: Path) -> None:
+    """Fresh-process save/load/resolve for a Resolver whose clusterer slot is
+    ``CorrelationClusterer`` (the merge-resistant pivot-algorithm variant).
+
+    No existing test round-trips ``correlation_clusterer`` as an actual
+    Resolver slot through a fresh subprocess -- only ``get_component`` alone
+    (above) and an in-process ``config``/``from_config`` round trip
+    (``tests/core/clusterers/test_correlation_clusterer.py``). This closes
+    that gap for the W0.4 exit check.
+    """
+    from langres.core import AllPairsBlocker, Comparator, CorrelationClusterer, Resolver
+    from langres.core.judges.weighted_average import WeightedAverageJudge
+    from langres.core.models import CompanySchema
+    from tests.fixtures.companies import COMPANY_RECORDS
+
+    comparator = Comparator.from_schema(CompanySchema)
+    resolver = Resolver(
+        blocker=AllPairsBlocker(schema=CompanySchema),
+        comparator=comparator,
+        module=WeightedAverageJudge(feature_specs=comparator.feature_specs),
+        clusterer=CorrelationClusterer(threshold=0.7),
+    )
+    resolver.resolve(COMPANY_RECORDS)
+    resolver.save(tmp_path)
+
+    script = (
+        "from langres.core import Resolver\n"
+        "from tests.fixtures.companies import COMPANY_RECORDS\n"
+        f"reloaded = Resolver.load({str(tmp_path)!r})\n"
+        "clusters = reloaded.resolve(COMPANY_RECORDS)\n"
+        "assert isinstance(clusters, list)\n"
+        "print('OK')\n"
+    )
+    result = subprocess.run(
+        [sys.executable, "-c", script],
+        capture_output=True,
+        text=True,
+        timeout=60,
+    )
+
+    assert result.returncode == 0, (
+        f"fresh-process correlation-clusterer roundtrip failed.\nSTDOUT:\n{result.stdout}\n"
+        f"STDERR:\n{result.stderr}"
+    )
+    assert "OK" in result.stdout

--- a/tests/examples/test_person_resolution.py
+++ b/tests/examples/test_person_resolution.py
@@ -11,8 +11,6 @@ The live path (one real OpenRouter call) is gated behind ``OPENROUTER_API_KEY``.
 
 from __future__ import annotations
 
-import os
-
 import pytest
 
 from examples.person_resolution import (
@@ -27,6 +25,7 @@ from examples.person_resolution import (
 from langres.core import Resolver
 from langres.core.blockers.vector import VectorBlocker
 from langres.core.metrics import evaluate_blocking
+from tests.conftest import PAID_TEST_SKIP_REASON, PAID_TESTS_ENABLED
 
 
 def _canonical(clusters: list[set[str]]) -> frozenset[frozenset[str]]:
@@ -118,10 +117,7 @@ def test_serialized_blocker_recovers_blocking(tmp_path) -> None:  # type: ignore
 
 
 @pytest.mark.integration
-@pytest.mark.skipif(
-    not os.getenv("OPENROUTER_API_KEY"),
-    reason="requires OPENROUTER_API_KEY for a real LLM call",
-)
+@pytest.mark.skipif(not PAID_TESTS_ENABLED, reason=PAID_TEST_SKIP_REASON)
 def test_live_smoke_single_pair() -> None:
     """One real OpenRouter pair returns a usable judgement (gated on a key)."""
     from langres.core.models import ERCandidate

--- a/tests/test_import_budget.py
+++ b/tests/test_import_budget.py
@@ -1,0 +1,298 @@
+"""Import weight + spend-safety tests (W0.4: extras split + lazy heavy imports).
+
+Two concerns, both closed by making ``langres/__init__.py``'s import chain --
+``langres.core``, ``langres.clients``, ``langres.core.blockers``,
+``langres.core.modules`` -- resolve heavy/optional-dependency symbols lazily
+(PEP 562 ``__getattr__``) instead of eager top-level imports:
+
+1. **Import weight**: a bare ``import langres`` must not pull torch, litellm,
+   faiss, or sentence-transformers into ``sys.modules`` (the ``[semantic]``/
+   ``[llm]`` extras) -- these are now optional dependencies, not installed in
+   a core-only environment, and even when installed should not slow down or
+   bloat a plain import.
+2. **Spend safety**: ``litellm`` calls ``load_dotenv()`` as an import side
+   effect, silently populating ``OPENROUTER_API_KEY``/etc. from any ``.env``
+   on the path -- independent of whether a judge is ever chosen. A bare
+   ``import langres`` must never trigger this (this already cost real
+   OpenRouter spend once this session, before this fix).
+
+Subprocess-based (mirrors the existing dspy import-safety pattern in
+``tests/test_verbs.py``/``tests/core/modules/test_dspy_judge.py``) since the
+whole point is a *fresh* process/import state -- ``sys.modules`` in the
+current pytest process is already polluted by other tests.
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+import time
+from pathlib import Path
+
+import pytest
+
+# ---------------------------------------------------------------------------
+# Import weight: heavy/optional deps must stay out of sys.modules.
+# ---------------------------------------------------------------------------
+
+_HEAVY_MODULES = ["torch", "litellm", "faiss", "sentence_transformers"]
+
+_CHECK_SCRIPT = (
+    "import sys; import langres; "
+    "leaked = [m for m in {modules!r} if m in sys.modules]; "
+    "assert not leaked, f'heavy modules leaked into sys.modules: {{leaked}}'; "
+    "print('OK')"
+).format(modules=_HEAVY_MODULES)
+
+
+def test_import_langres_excludes_heavy_modules_from_sys_modules() -> None:
+    """Plain ``import langres`` must not import torch/litellm/faiss/sentence-transformers."""
+    result = subprocess.run(
+        [sys.executable, "-c", _CHECK_SCRIPT],
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode == 0, (
+        f"import-budget check failed.\nSTDOUT:\n{result.stdout}\nSTDERR:\n{result.stderr}"
+    )
+
+
+def test_import_langres_is_fast() -> None:
+    """Soft timing budget: a warm ``import langres`` should be well under a second.
+
+    Not a hard CI gate (machine-dependent) -- records the actual number on
+    failure so a regression is visible rather than silently tolerated.
+    """
+    script = (
+        "import time; t0 = time.perf_counter(); import langres; print(time.perf_counter() - t0)"
+    )
+    # Warm-up run (module bytecode cache, filesystem cache) so the measured
+    # run reflects steady-state import cost, not first-ever compilation.
+    subprocess.run([sys.executable, "-c", "import langres"], capture_output=True, text=True)
+    result = subprocess.run([sys.executable, "-c", script], capture_output=True, text=True)
+    assert result.returncode == 0, result.stderr
+    elapsed = float(result.stdout.strip())
+    assert elapsed < 2.0, f"import langres took {elapsed:.3f}s (budget: 2.0s)"
+
+
+# ---------------------------------------------------------------------------
+# Spend safety: import must never populate OPENROUTER_API_KEY/etc. from a
+# nearby .env (the litellm load_dotenv() footgun).
+# ---------------------------------------------------------------------------
+
+
+def test_import_langres_does_not_leak_env_from_dotenv(tmp_path: Path) -> None:
+    """A ``.env`` with a real-looking key must not leak into ``os.environ``.
+
+    Reproduces the actual footgun: litellm's import runs ``load_dotenv()``,
+    which walks up the directory tree from cwd looking for a ``.env`` file
+    and populates ``os.environ`` from it -- independent of any judge= choice.
+    Runs the subprocess with cwd set to a directory containing exactly that
+    kind of ``.env``; since litellm must stay out of sys.modules (previous
+    test), the key must never appear.
+
+    Explicitly strips ``OPENROUTER_API_KEY`` from the child's inherited
+    environment first: an *earlier* test in this suite legitimately importing
+    litellm (e.g. to test ``LLMJudge`` directly) can itself trigger
+    ``load_dotenv()`` in THIS pytest process, populating the real key from the
+    repo's own ``.env`` a few directories up -- that's a pre-existing fact of
+    running this suite locally with a real key configured, not a regression
+    this test is checking for. Isolating it here keeps the assertion about
+    ``import langres`` specifically, not about the ambient dev environment.
+    """
+    (tmp_path / ".env").write_text("OPENROUTER_API_KEY=sk-test-canary-should-not-leak\n")
+    child_env = {k: v for k, v in os.environ.items() if k != "OPENROUTER_API_KEY"}
+    script = (
+        "import os; import langres; "
+        "assert 'OPENROUTER_API_KEY' not in os.environ, "
+        "'OPENROUTER_API_KEY leaked into os.environ via import langres'; "
+        "print('OK')"
+    )
+    result = subprocess.run(
+        [sys.executable, "-c", script],
+        capture_output=True,
+        text=True,
+        cwd=tmp_path,
+        env=child_env,
+    )
+    assert result.returncode == 0, (
+        f"spend-safety check failed.\nSTDOUT:\n{result.stdout}\nSTDERR:\n{result.stderr}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Lazy attribute resolution (PEP 562 __getattr__) -- in-process, exercising
+# the actual resolution/caching/error paths of each __getattr__.
+# ---------------------------------------------------------------------------
+
+
+class TestCoreLazyGetattr:
+    """``langres.core.__getattr__`` for the [semantic]/[llm] symbols + submodules."""
+
+    def test_vector_blocker_resolves_and_caches(self) -> None:
+        import langres.core as core
+
+        vb = core.VectorBlocker
+        from langres.core.blockers.vector import VectorBlocker
+
+        assert vb is VectorBlocker
+        # Cached on the module namespace -- a second access must not re-hit
+        # __getattr__ (it's now a plain module attribute).
+        assert core.__dict__["VectorBlocker"] is VectorBlocker
+
+    def test_llm_judge_resolves(self) -> None:
+        import langres.core as core
+
+        from langres.core.modules.llm_judge import LLMJudge
+
+        assert core.LLMJudge is LLMJudge
+
+    def test_embeddings_and_indexes_symbols_resolve(self) -> None:
+        import langres.core as core
+
+        from langres.core.embeddings import SentenceTransformerEmbedder
+        from langres.core.indexes.vector_index import FAISSIndex
+
+        assert core.SentenceTransformerEmbedder is SentenceTransformerEmbedder
+        assert core.FAISSIndex is FAISSIndex
+
+    def test_submodules_resolve_to_the_module_object(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Attribute access resolves each submodule via ``__getattr__``.
+
+        Python's import machinery binds ``core.benchmark`` as a plain
+        attribute the moment *anything* does ``import langres.core.benchmark``
+        directly, bypassing ``__getattr__`` entirely -- and the wider test
+        suite legitimately does exactly that elsewhere (its own tests import
+        these submodules directly). Clearing the cached attribute first (same
+        pattern as the missing-dependency tests below) forces this access to
+        actually go through ``__getattr__``'s ``_LAZY_SUBMODULES`` branch
+        regardless of what already ran earlier in the suite.
+        """
+        import langres.core as core
+        import langres.core.benchmark as benchmark_mod
+        import langres.core.metrics as metrics_mod
+        import langres.core.optimizers as optimizers_mod
+
+        monkeypatch.delitem(vars(core), "benchmark", raising=False)
+        monkeypatch.delitem(vars(core), "metrics", raising=False)
+        monkeypatch.delitem(vars(core), "optimizers", raising=False)
+
+        assert core.benchmark is benchmark_mod
+        assert core.metrics is metrics_mod
+        assert core.optimizers is optimizers_mod
+
+    def test_unknown_attribute_raises_attribute_error(self) -> None:
+        import langres.core as core
+
+        with pytest.raises(AttributeError, match="not_a_real_attribute"):
+            core.not_a_real_attribute  # noqa: B018
+
+    def test_missing_dependency_raises_actionable_import_error(self, monkeypatch) -> None:
+        """A missing [semantic]/[llm] package surfaces a 'pip install' hint, not a raw traceback."""
+        import importlib
+
+        import langres.core as core
+
+        # __getattr__ caches a successful resolution onto the module namespace
+        # (see its docstring) -- an earlier test in this file may have already
+        # resolved and cached FAISSIndex, which would make this access skip
+        # __getattr__ entirely. Clear it so the patched import is actually hit.
+        monkeypatch.delitem(vars(core), "FAISSIndex", raising=False)
+
+        real_import_module = importlib.import_module
+
+        def _fail_for_faiss(name: str, *args: object, **kwargs: object) -> object:
+            if name == "langres.core.indexes":
+                raise ModuleNotFoundError("No module named 'faiss'")
+            return real_import_module(name, *args, **kwargs)
+
+        monkeypatch.setattr(core.importlib, "import_module", _fail_for_faiss)
+        with pytest.raises(ImportError, match=r"langres\.core\.FAISSIndex.*langres\[semantic\]"):
+            core.FAISSIndex  # noqa: B018
+
+
+class TestClientsLazyGetattr:
+    """``langres.clients.__getattr__`` for ``create_llm_client``/``create_wandb_tracker``."""
+
+    def test_create_llm_client_resolves(self) -> None:
+        import langres.clients as clients
+
+        from langres.clients.llm import create_llm_client
+
+        assert clients.create_llm_client is create_llm_client
+
+    def test_create_wandb_tracker_resolves(self) -> None:
+        import langres.clients as clients
+
+        from langres.clients.tracking import create_wandb_tracker
+
+        assert clients.create_wandb_tracker is create_wandb_tracker
+
+    def test_unknown_attribute_raises_attribute_error(self) -> None:
+        import langres.clients as clients
+
+        with pytest.raises(AttributeError, match="not_a_real_attribute"):
+            clients.not_a_real_attribute  # noqa: B018
+
+
+class TestBlockersPackageLazyGetattr:
+    """``langres.core.blockers.__getattr__`` for ``VectorBlocker``."""
+
+    def test_vector_blocker_resolves_via_package_path(self) -> None:
+        import langres.core.blockers as blockers
+
+        from langres.core.blockers.vector import VectorBlocker
+
+        assert blockers.VectorBlocker is VectorBlocker
+
+    def test_unknown_attribute_raises_attribute_error(self) -> None:
+        import langres.core.blockers as blockers
+
+        with pytest.raises(AttributeError, match="not_a_real_attribute"):
+            blockers.not_a_real_attribute  # noqa: B018
+
+
+class TestModulesPackageLazyGetattr:
+    """``langres.core.modules.__getattr__`` for LLMJudge/LLMJudgeModule/CascadeModule."""
+
+    def test_llm_judge_resolves_via_package_path(self) -> None:
+        import langres.core.modules as modules_pkg
+
+        from langres.core.modules.llm_judge import LLMJudge
+
+        assert modules_pkg.LLMJudge is LLMJudge
+
+    def test_llm_judge_module_resolves_via_package_path(self) -> None:
+        import langres.core.modules as modules_pkg
+
+        from langres.core.modules.llm_judge import LLMJudgeModule
+
+        assert modules_pkg.LLMJudgeModule is LLMJudgeModule
+
+    def test_cascade_module_resolves_via_package_path(self) -> None:
+        import langres.core.modules as modules_pkg
+
+        from langres.core.modules.cascade import CascadeModule
+
+        assert modules_pkg.CascadeModule is CascadeModule
+
+    def test_unknown_attribute_raises_attribute_error(self) -> None:
+        import langres.core.modules as modules_pkg
+
+        with pytest.raises(AttributeError, match="not_a_real_attribute"):
+            modules_pkg.not_a_real_attribute  # noqa: B018
+
+    def test_missing_dependency_raises_actionable_import_error(self, monkeypatch) -> None:
+        import langres.core.modules as modules_pkg
+
+        # See the analogous comment in TestCoreLazyGetattr: clear any cached
+        # resolution from an earlier test so __getattr__ actually runs.
+        monkeypatch.delitem(vars(modules_pkg), "LLMJudge", raising=False)
+
+        def _fail(name: str) -> object:
+            raise ModuleNotFoundError("No module named 'litellm'")
+
+        monkeypatch.setattr(modules_pkg.importlib, "import_module", _fail)
+        with pytest.raises(ImportError, match=r"langres\.core\.modules\.LLMJudge.*llm"):
+            modules_pkg.LLMJudge  # noqa: B018

--- a/tests/test_import_budget.py
+++ b/tests/test_import_budget.py
@@ -6,10 +6,10 @@ Two concerns, both closed by making ``langres/__init__.py``'s import chain --
 (PEP 562 ``__getattr__``) instead of eager top-level imports:
 
 1. **Import weight**: a bare ``import langres`` must not pull torch, litellm,
-   faiss, or sentence-transformers into ``sys.modules`` (the ``[semantic]``/
-   ``[llm]`` extras) -- these are now optional dependencies, not installed in
-   a core-only environment, and even when installed should not slow down or
-   bloat a plain import.
+   faiss, sentence-transformers, or scikit-learn into ``sys.modules`` (the
+   ``[semantic]``/``[llm]``/``[trained]`` extras) -- these are now optional
+   dependencies, not installed in a core-only environment, and even when
+   installed should not slow down or bloat a plain import.
 2. **Spend safety**: ``litellm`` calls ``load_dotenv()`` as an import side
    effect, silently populating ``OPENROUTER_API_KEY``/etc. from any ``.env``
    on the path -- independent of whether a judge is ever chosen. A bare
@@ -43,7 +43,7 @@ def _import_ok(module_name: str) -> bool:
 # Import weight: heavy/optional deps must stay out of sys.modules.
 # ---------------------------------------------------------------------------
 
-_HEAVY_MODULES = ["torch", "litellm", "faiss", "sentence_transformers"]
+_HEAVY_MODULES = ["torch", "litellm", "faiss", "sentence_transformers", "sklearn"]
 
 _CHECK_SCRIPT = (
     "import sys; import langres; "
@@ -157,6 +157,14 @@ class TestCoreLazyGetattr:
 
         assert core.LLMJudge is LLMJudge
 
+    def test_rf_judge_resolves(self) -> None:
+        pytest.importorskip("sklearn", reason="requires the [trained] extra")
+        import langres.core as core
+
+        from langres.core.modules.rf_judge import RFJudge
+
+        assert core.RFJudge is RFJudge
+
     def test_embeddings_and_indexes_symbols_resolve(self) -> None:
         pytest.importorskip("sentence_transformers", reason="requires the [semantic] extra")
         pytest.importorskip("faiss", reason="requires the [semantic] extra")
@@ -192,6 +200,15 @@ class TestCoreLazyGetattr:
 
         with pytest.raises(ImportError, match=r"langres\.core\.LLMJudge.*langres\[llm\]"):
             core.LLMJudge  # noqa: B018
+
+    def test_rf_judge_raises_actionable_import_error_when_trained_absent(self) -> None:
+        """Core-only install (no [trained]): a real, un-simulated ImportError (see above)."""
+        if _import_ok("sklearn"):
+            pytest.skip("scikit-learn is installed ([trained] extra present) -- nothing to observe")
+        import langres.core as core
+
+        with pytest.raises(ImportError, match=r"langres\.core\.RFJudge.*langres\[trained\]"):
+            core.RFJudge  # noqa: B018
 
     def test_submodules_resolve_to_the_module_object(self, monkeypatch: pytest.MonkeyPatch) -> None:
         """Attribute access resolves each submodule via ``__getattr__``.

--- a/tests/test_import_budget.py
+++ b/tests/test_import_budget.py
@@ -24,6 +24,7 @@ current pytest process is already polluted by other tests.
 
 from __future__ import annotations
 
+import importlib.util
 import os
 import subprocess
 import sys
@@ -31,6 +32,12 @@ import time
 from pathlib import Path
 
 import pytest
+
+
+def _import_ok(module_name: str) -> bool:
+    """True if ``module_name`` is importable, without actually importing it."""
+    return importlib.util.find_spec(module_name) is not None
+
 
 # ---------------------------------------------------------------------------
 # Import weight: heavy/optional deps must stay out of sys.modules.
@@ -131,6 +138,7 @@ class TestCoreLazyGetattr:
     """``langres.core.__getattr__`` for the [semantic]/[llm] symbols + submodules."""
 
     def test_vector_blocker_resolves_and_caches(self) -> None:
+        pytest.importorskip("faiss", reason="requires the [semantic] extra")
         import langres.core as core
 
         vb = core.VectorBlocker
@@ -142,6 +150,7 @@ class TestCoreLazyGetattr:
         assert core.__dict__["VectorBlocker"] is VectorBlocker
 
     def test_llm_judge_resolves(self) -> None:
+        pytest.importorskip("litellm", reason="requires the [llm] extra")
         import langres.core as core
 
         from langres.core.modules.llm_judge import LLMJudge
@@ -149,6 +158,8 @@ class TestCoreLazyGetattr:
         assert core.LLMJudge is LLMJudge
 
     def test_embeddings_and_indexes_symbols_resolve(self) -> None:
+        pytest.importorskip("sentence_transformers", reason="requires the [semantic] extra")
+        pytest.importorskip("faiss", reason="requires the [semantic] extra")
         import langres.core as core
 
         from langres.core.embeddings import SentenceTransformerEmbedder
@@ -156,6 +167,31 @@ class TestCoreLazyGetattr:
 
         assert core.SentenceTransformerEmbedder is SentenceTransformerEmbedder
         assert core.FAISSIndex is FAISSIndex
+
+    def test_vector_blocker_raises_actionable_import_error_when_semantic_absent(self) -> None:
+        """Core-only install (no [semantic]): a real, un-simulated ImportError.
+
+        Unlike ``test_missing_dependency_raises_actionable_import_error``
+        below (which *simulates* absence via monkeypatching so it also runs
+        when the extra IS installed), this exercises the genuine failure path
+        -- meaningful only in a core-only environment, so it skips itself when
+        faiss is actually importable.
+        """
+        if _import_ok("faiss"):
+            pytest.skip("faiss is installed ([semantic] extra present) -- nothing to observe")
+        import langres.core as core
+
+        with pytest.raises(ImportError, match=r"langres\.core\.VectorBlocker.*langres\[semantic\]"):
+            core.VectorBlocker  # noqa: B018
+
+    def test_llm_judge_raises_actionable_import_error_when_llm_absent(self) -> None:
+        """Core-only install (no [llm]): a real, un-simulated ImportError (see above)."""
+        if _import_ok("litellm"):
+            pytest.skip("litellm is installed ([llm] extra present) -- nothing to observe")
+        import langres.core as core
+
+        with pytest.raises(ImportError, match=r"langres\.core\.LLMJudge.*langres\[llm\]"):
+            core.LLMJudge  # noqa: B018
 
     def test_submodules_resolve_to_the_module_object(self, monkeypatch: pytest.MonkeyPatch) -> None:
         """Attribute access resolves each submodule via ``__getattr__``.
@@ -216,6 +252,7 @@ class TestClientsLazyGetattr:
     """``langres.clients.__getattr__`` for ``create_llm_client``/``create_wandb_tracker``."""
 
     def test_create_llm_client_resolves(self) -> None:
+        pytest.importorskip("litellm", reason="requires the [llm] extra")
         import langres.clients as clients
 
         from langres.clients.llm import create_llm_client
@@ -240,6 +277,7 @@ class TestBlockersPackageLazyGetattr:
     """``langres.core.blockers.__getattr__`` for ``VectorBlocker``."""
 
     def test_vector_blocker_resolves_via_package_path(self) -> None:
+        pytest.importorskip("faiss", reason="requires the [semantic] extra")
         import langres.core.blockers as blockers
 
         from langres.core.blockers.vector import VectorBlocker
@@ -260,6 +298,7 @@ class TestModulesPackageLazyGetattr:
     """``langres.core.modules.__getattr__`` for LLMJudge/LLMJudgeModule/CascadeModule."""
 
     def test_llm_judge_resolves_via_package_path(self) -> None:
+        pytest.importorskip("litellm", reason="requires the [llm] extra")
         import langres.core.modules as modules_pkg
 
         from langres.core.modules.llm_judge import LLMJudge
@@ -267,6 +306,7 @@ class TestModulesPackageLazyGetattr:
         assert modules_pkg.LLMJudge is LLMJudge
 
     def test_llm_judge_module_resolves_via_package_path(self) -> None:
+        pytest.importorskip("litellm", reason="requires the [llm] extra")
         import langres.core.modules as modules_pkg
 
         from langres.core.modules.llm_judge import LLMJudgeModule
@@ -274,6 +314,8 @@ class TestModulesPackageLazyGetattr:
         assert modules_pkg.LLMJudgeModule is LLMJudgeModule
 
     def test_cascade_module_resolves_via_package_path(self) -> None:
+        pytest.importorskip("litellm", reason="requires the [llm] extra")
+        pytest.importorskip("sentence_transformers", reason="requires the [semantic] extra")
         import langres.core.modules as modules_pkg
 
         from langres.core.modules.cascade import CascadeModule

--- a/tests/test_import_budget.py
+++ b/tests/test_import_budget.py
@@ -245,6 +245,9 @@ class TestBlockersPackageLazyGetattr:
         from langres.core.blockers.vector import VectorBlocker
 
         assert blockers.VectorBlocker is VectorBlocker
+        # Cached on the module namespace -- a second access must not re-hit
+        # __getattr__ (matches core/clients/modules' lazy loaders).
+        assert blockers.__dict__["VectorBlocker"] is VectorBlocker
 
     def test_unknown_attribute_raises_attribute_error(self) -> None:
         import langres.core.blockers as blockers

--- a/tests/test_methods.py
+++ b/tests/test_methods.py
@@ -17,7 +17,6 @@ The un-fakeable real-network LLM glue lives behind an ``OPENROUTER_API_KEY``
 skipif, so ``--cov`` stays green without a live key.
 """
 
-import os
 from types import SimpleNamespace
 from typing import Any
 
@@ -52,6 +51,7 @@ from langres.methods import (
     make_resolver_factory,
 )
 from langres.core.blockers.vector import VectorBlocker
+from tests.conftest import PAID_TEST_SKIP_REASON, PAID_TESTS_ENABLED
 
 # ---------------------------------------------------------------------------
 # Synthetic, embedding-free benchmark (FakeVectorIndex) for fast tests
@@ -677,10 +677,7 @@ def test_slow_fodors_zagat_race(method: str) -> None:
 
 
 @pytest.mark.integration
-@pytest.mark.skipif(
-    not os.getenv("OPENROUTER_API_KEY"),
-    reason="needs OPENROUTER_API_KEY for a real LLM call",
-)
+@pytest.mark.skipif(not PAID_TESTS_ENABLED, reason=PAID_TEST_SKIP_REASON)
 def test_llm_judge_real_network_smoke() -> None:  # pragma: no cover - requires live key
     """A single real LLM judgement via the injected env client (W4 path)."""
     from langres.clients import Settings, create_llm_client


### PR DESCRIPTION
## Summary

Highest-blast-radius branch of Wave 0: makes langres light to install/import and closes the litellm spend footgun. No PyPI publish.

1. **Extras split** (`pyproject.toml`): core deps shrink to `pydantic`, `pydantic-settings`, `rapidfuzz`, `networkx`, `numpy`. `[semantic]` = sentence-transformers, faiss-cpu, torch, onnxruntime, optimum, qdrant-client. `[llm]` = litellm, dspy-ai, openai. Eval/research tooling (optuna, wandb, langfuse, scikit-learn, ranx) moved to `[dependency-groups] dev` — not needed by the production `link()`/`dedupe()` path, and this placement means a bare `uv sync` keeps installing them for local dev without `--all-extras`. `tenacity` dropped (confirmed unused).

2. **Lazy imports** (PEP 562 module-level `__getattr__`): heavy/optional symbols resolve on first access instead of eagerly. `__all__` unchanged; `TYPE_CHECKING` imports keep mypy strict seeing every name. Accessing a `[semantic]`/`[llm]` symbol without the extra raises a clear `ImportError("... requires the 'semantic' extra: pip install 'langres[semantic]'")`.

3. **Import-budget test** (`tests/test_import_budget.py`, new): subprocess-based proof that `import langres` excludes torch/litellm/faiss/sentence_transformers from `sys.modules`, a soft timing budget, plus in-process coverage of every `__getattr__` branch.

4. **Spend-safety hardening**: `test_live_smoke_single_pair` and `test_llm_judge_real_network_smoke` now require `LANGRES_RUN_PAID_TESTS=1` **in addition to** the API key (a key alone used to be enough — and litellm's own `load_dotenv()` import-time side effect could populate that key from an unrelated `.env` even without intending a paid run). `pytest` `addopts` now exclude the `integration` marker by default, so bare `uv run pytest` never runs paid tests.

## Before/after proof

```
$ uv run python -c "import sys, langres; print('torch' in sys.modules, 'litellm' in sys.modules)"
False False
```

Fresh-process import time: **~0.18s** (previously eager-imported torch/litellm/faiss/sentence-transformers).

Core-only fresh venv (`uv venv` + `uv pip install -e .`, no extras) installs **11 packages** total (pydantic stack + rapidfuzz + networkx + numpy), and `examples/quickstart_verbs.py` (string-judge `dedupe()` path) runs end-to-end with zero heavy deps installed.

## Extras layout

```toml
[project.optional-dependencies]
semantic = ["faiss-cpu", "fastembed", "onnxruntime", "optimum[onnxruntime]", "qdrant-client", "sentence-transformers", "torch"]
llm = ["dspy-ai", "litellm", "openai"]
```

`[dependency-groups] dev` gains optuna, optuna-integration[wandb], wandb, langfuse, scikit-learn, ranx (already-installed-by-default via bare `uv sync`, just no longer counted as "core").

## Blast-radius: 6 files, not 2

The task named `langres/__init__.py` and `langres/core/__init__.py` as the localized fix. In practice, achieving the actual "torch/litellm/faiss/sentence_transformers excluded from `sys.modules`" requirement required the same PEP-562 pattern in **6 files**, because importing any submodule always runs its parent package's `__init__.py` first:

- `langres/core/__init__.py`, `langres/clients/__init__.py`, `langres/core/blockers/__init__.py`, `langres/core/modules/__init__.py` — package aggregators, same lazy-`__getattr__` pattern.
- `langres/core/presets.py`, `langres/core/resolver.py` — leaf modules with their own top-level heavy imports, localized into the functions that build a vector-backed pipeline.

`langres/clients/__init__.py` turned out to be the actual root cause of the SPEND-SAFETY footgun (`langres.clients.llm` eager-imports litellm, whose import runs `load_dotenv()`).

`langres/__init__.py` was deliberately **left untouched**: none of its exported names (`CompanySchema`, `ERCandidate`, `LinkVerdict`, `PairwiseJudgement`, `Resolver`, `dedupe`, `link`) are actually heavy once `presets.py`/`resolver.py` were fixed, so adding vacuous PEP-562 machinery there would be dead ceremony.

All six fixes are the same small, mechanical pattern (defer an import, add a `TYPE_CHECKING` alias, cache on first access) — not sprawl into disparate call sites.

`core/resolver.py`'s `_ensure_index_built()` runs on *every* `resolve()`/`predict()` call regardless of blocker type, so it duck-types via `blocker.type_name == "vector_blocker"` instead of `isinstance(..., VectorBlocker)` — an `isinstance` check would force-import faiss even for pure `AllPairsBlocker`/string-judge pipelines, defeating the whole extras split.

## Coverage / mypy / ruff / tests

```
uv run ruff check src tests          -> All checks passed!
uv run ruff format --check src tests -> 163 files already formatted
uv run mypy src                      -> Success: no issues found in 63 source files
uv run pytest -m "not slow and not integration" --cov=src/langres --cov-report=term-missing
  -> 1365 passed, 78 deselected
  -> TOTAL coverage 98.08% (>= 95% floor)
  -> src/langres/core/__init__.py: 100%
  -> src/langres/clients/__init__.py: 100%
  -> src/langres/core/blockers/__init__.py: 100%
  -> src/langres/core/modules/__init__.py: 100%
```

Remaining sub-100% files (`resolver.py` 156-157, `presets.py` 400, `registry.py` 102, `blockers/vector.py`, `embeddings.py`, `indexes/vector_index.py`, etc.) are pre-existing coverage-tool artifacts from pytest's eager test-collection pre-populating registries/caches before the specific lazy-lookup test runs, or lines only exercised by `@pytest.mark.slow` tests — verified via `git show origin/feat/m5-foundation:...` comparisons against unchanged closure code; not introduced by this change.

Also updated (same change, per CLAUDE.md's "keep docs in sync"): `.github/workflows/{lint,test,security}.yml` now `uv sync --all-extras` (a bare `uv sync` no longer installs `[semantic]`/`[llm]`, but mypy/full-suite/security-scan need them installed to check against); `CLAUDE.md`'s Dependencies section and the README install snippet now describe the core/`[semantic]`/`[llm]` split.

## Test plan

- [x] `uv run ruff check src tests && uv run ruff format --check src tests && uv run mypy src` all green
- [x] `uv run pytest -m "not slow and not integration" --cov=src/langres --cov-report=term-missing` — 1365 passed, 98.08% coverage
- [x] `import sys, langres; print('torch' in sys.modules, 'litellm' in sys.modules)` -> `False False`
- [x] Core-only fresh venv (`uv venv` + `uv pip install -e .`, no `--all-extras`) installs only 11 core packages
- [x] `examples/quickstart_verbs.py` runs end-to-end in that core-only venv

https://claude.ai/code/session_0115MvWbHaCKT1A39PKDWqey