### PR TITLE
W1.3: blocking algebra (Key/Composite ∪∩−) + merge-resistant clusterer (C6)

### DIFF
--- a/docs/TECHNICAL_OVERVIEW.md
+++ b/docs/TECHNICAL_OVERVIEW.md
@@ -596,3 +596,68 @@ subclassing required. `Resolver.fit(data, labels=None)` detects this with
 
 No concrete judge implements either hook yet; `FellegiSunterJudge` and
 `RFJudge` (a later branch) are the first.
+
+## 9. Blocking Algebra + Merge-Resistant Clustering (W1.3)
+
+### KeyBlocker (`langres.core.blockers.key`)
+
+Buckets records by a configurable key and emits all pairs within each bucket.
+Mirrors `AllPairsBlocker`'s declarative/callable split: `key_field=` (a schema
+attribute name, serializable) or `key_fn=` (full callable control, not
+serializable), same mutual-exclusion rule as `schema=`/`schema_factory=`.
+`normalize=True` (default) lowercases + strips non-`None` keys before
+bucketing. A record whose key extracts to `None` gets no candidates from this
+blocker — trading recall for precision/speed, by design; compose with a
+recall-oriented blocker (e.g. `VectorBlocker`) via `CompositeBlocker` to
+recover it.
+
+### CompositeBlocker (`langres.core.blockers.composite`)
+
+Set algebra over 2+ child `Blocker`s: `op="union"` (default,
+recall-maximizing — a pairs-superset of every child), `"intersection"`
+(pairs in every child), or `"difference"` (`children[0]` minus the rest).
+Dedups by the canonical undirected pair key with first-seen semantics (the
+same guarantee every base blocker already gives). `blocker_name` on each
+surviving candidate is rewritten to
+`"composite_{op}(label1+label2+...)"`, naming exactly which child(ren)
+produced *that* pair — real per-pair provenance, not just "this came from a
+composite." Necessarily buffers every child in full (set membership must be
+known across all children before a pair can be kept or dropped) — like
+`derive_groups_from_pairs`, this trades the streaming-first contract for
+correctness. Relies on the inherited `Blocker.stream_groups()` default
+(no native per-anchor override): composite pair sets, especially under
+intersection/difference across heterogeneous children, have no natural
+single-anchor structure the way `VectorBlocker`'s kNN search does.
+Registered (`"composite_blocker"`) and config-serializable as long as every
+child is too (a child with out-of-band state, e.g. a built `VectorBlocker`
+index, is not preserved through a composite's `config`/`from_config`
+round-trip — persist such a pipeline via the `Resolver` artifact instead).
+
+Measured on Fodors-Zagat + Amazon-Google (Pair-Completeness / Reduction-Ratio,
+composite vs. each dataset's pinned `VectorBlocker` alone):
+`examples/w1_blocking_algebra_output.md`.
+
+### CorrelationClusterer (`langres.core.clusterers.correlation`, "C6")
+
+A `Clusterer` subclass (drop-in for the `clusterer=` slot; inherits
+`config`/`from_config`/`evaluate`/`inspect_clusters` unchanged, overrides only
+`cluster()`). The base `Clusterer` builds a graph from edges `>= threshold`
+and takes connected components — full transitive closure, so a chain of
+edges (A-B, B-C) with no direct A-C edge still merges all three (the
+documented M3 −0.63 BCubed over-merge failure mode). `CorrelationClusterer`
+implements the *pivot algorithm* for correlation clustering (Ailon, Charikar
+& Newman, JACM 2008): process nodes highest-confidence-edge-first
+(deterministic, ties broken by id); each pivot's cluster is itself plus only
+its *direct* neighbours `>= threshold`. A node with only an indirect path to
+a cluster is never pulled in by transitivity alone — merge-resistant relative
+to the base `Clusterer` — while a genuinely well-connected clique (every pair
+directly compared and matched) still merges fully under both.
+
+**Not the default.** Benchmarked head-to-head against the base `Clusterer` on
+Fodors-Zagat + Amazon-Google (same blocking + judge pipeline, only the
+clusterer differs): a wash on Fodors-Zagat (+0.0006 BCubed F1), a clear win
+on Amazon-Google (+0.0324 BCubed F1, +0.0715 precision at −0.016 recall) —
+see `examples/w1_blocking_algebra_output.md` for the full tables and the
+default-flip decision (kept opt-in; recommended for harder/messier
+entity-resolution problems, not flipped globally on a single hard-dataset
+win).

--- a/examples/w1_blocking_algebra.py
+++ b/examples/w1_blocking_algebra.py
@@ -1,0 +1,233 @@
+"""W1.3 blocking-algebra + clusterer benchmark (Fodors-Zagat + Amazon-Google).
+
+Zero-spend ($0, no LLM calls anywhere): blocking is KeyBlocker/VectorBlocker,
+scoring is WeightedAverageJudge. Two independent measurements:
+
+1. **Composite blocking.** Does UNIONing a cheap, exact-key ``KeyBlocker``
+   with each dataset's existing pinned ``VectorBlocker`` improve
+   Pair-Completeness (PC = recall of the blocking stage) over the
+   ``VectorBlocker`` alone, and at what Reduction-Ratio (RR) cost? RR is
+   measured against the cross-source product (both benchmarks are linkage
+   tasks whose true matches are all cross-source; see
+   ``langres.data._benchmark_utils.cross_source``), matching the
+   already-established PC methodology in ``er_benchmarks.py``/
+   ``amazon_google.py`` (``ACHIEVED_PC_AT_DEFAULT_K`` etc.) so these numbers
+   are directly comparable to the pinned baselines.
+
+2. **C6 (CorrelationClusterer) vs the base Clusterer.** Head-to-head BCubed
+   P/R/F1 on the SAME blocking + judge pipeline for both -- only the
+   clusterer differs -- to isolate the over-merge fix's effect. The threshold
+   (0.80) reuses the value already tuned for WeightedAverageJudge in
+   ``examples/m3_zero_spend_race_output.md``, so the base-Clusterer row here
+   should reproduce those numbers.
+
+Reproduce with:
+    uv run python examples/w1_blocking_algebra.py
+"""
+
+import logging
+from typing import Any
+
+from pydantic import BaseModel
+
+from langres.core.benchmark import complete_partition
+from langres.core.blockers.composite import CompositeBlocker
+from langres.core.blockers.key import KeyBlocker
+from langres.core.blockers.vector import VectorBlocker
+from langres.core.clusterer import Clusterer
+from langres.core.clusterers.correlation import CorrelationClusterer
+from langres.core.comparator import Comparator
+from langres.core.judges.weighted_average import WeightedAverageJudge
+from langres.core.metrics import calculate_bcubed_metrics, evaluate_blocking
+from langres.core.models import ERCandidate
+from langres.data import _benchmark_utils as _bu
+from langres.data.amazon_google import (
+    DEFAULT_AG_BLOCKING_K,
+    ProductSchema,
+    build_product_blocker,
+    load_amazon_google,
+)
+from langres.data.er_benchmarks import (
+    DEFAULT_BLOCKING_K,
+    RestaurantSchema,
+    build_restaurant_blocker,
+    load_fodors_zagat,
+)
+
+logging.basicConfig(level=logging.INFO, format="%(message)s")
+logger = logging.getLogger(__name__)
+
+# Reused, not re-tuned: the WeightedAverageJudge threshold already established
+# in examples/m3_zero_spend_race_output.md (both FZ and AG).
+THRESHOLD = 0.80
+
+
+def _build_vector_candidates(
+    blocker: VectorBlocker[Any], corpus: list[Any], records: list[dict[str, Any]]
+) -> list[ERCandidate[Any]]:
+    """Build a VectorBlocker's FAISS index over ``embed_text`` and stream it."""
+    texts = [r.embed_text for r in corpus]
+    blocker.vector_index.create_index(texts)
+    return list(blocker.stream(records))
+
+
+def _pc_rr(
+    candidates: list[ERCandidate[Any]],
+    gold_clusters: list[set[str]],
+    cross_source_denominator: int,
+) -> tuple[float, float, int]:
+    """Cross-source Pair-Completeness + Reduction-Ratio for one candidate set."""
+    filtered = _bu.cross_source(candidates)
+    pc = evaluate_blocking(filtered, gold_clusters).candidate_recall
+    rr = 1.0 - (len(filtered) / cross_source_denominator)
+    return pc, rr, len(filtered)
+
+
+def run_blocking_comparison() -> list[dict[str, Any]]:
+    """Composite (KeyBlocker UNION VectorBlocker) vs VectorBlocker-alone PC/RR."""
+    rows: list[dict[str, Any]] = []
+
+    # --- Fodors-Zagat: block by normalized city ---
+    fz_corpus, fz_gold = load_fodors_zagat()
+    fz_records = [r.model_dump() for r in fz_corpus]
+    n_fodors = sum(1 for r in fz_corpus if r.source == "fodors")
+    n_zagat = sum(1 for r in fz_corpus if r.source == "zagat")
+    fz_denom = n_fodors * n_zagat
+
+    fz_vector = build_restaurant_blocker(DEFAULT_BLOCKING_K)
+    fz_vector_candidates = _build_vector_candidates(fz_vector, fz_corpus, fz_records)
+
+    # Reuse fz_vector's already-built index (same k, same corpus) as the
+    # composite's second child -- avoids a redundant embedding pass.
+    fz_key = KeyBlocker(schema=RestaurantSchema, key_field="city")
+    fz_composite = CompositeBlocker(children=[fz_key, fz_vector], op="union")
+    fz_composite_candidates = list(fz_composite.stream(fz_records))
+
+    for label, cands in [
+        (f"VectorBlocker only (k={DEFAULT_BLOCKING_K}, pinned)", fz_vector_candidates),
+        ("KeyBlocker(city) UNION VectorBlocker", fz_composite_candidates),
+    ]:
+        pc, rr, n = _pc_rr(cands, fz_gold, fz_denom)
+        rows.append(
+            {"dataset": "fodors_zagat", "blocker": label, "n_candidates": n, "pc": pc, "rr": rr}
+        )
+        logger.info("fodors_zagat | %-42s | n=%5d | PC=%.4f | RR=%.4f", label, n, pc, rr)
+
+    # --- Amazon-Google: block by normalized manufacturer ---
+    ag_corpus, ag_gold, _ag_pairs = load_amazon_google()
+    ag_records = [r.model_dump() for r in ag_corpus]
+    n_amazon = sum(1 for r in ag_corpus if r.source == "amazon")
+    n_google = sum(1 for r in ag_corpus if r.source == "google")
+    ag_denom = n_amazon * n_google
+
+    ag_vector = build_product_blocker(DEFAULT_AG_BLOCKING_K)
+    ag_vector_candidates = _build_vector_candidates(ag_vector, ag_corpus, ag_records)
+
+    ag_key = KeyBlocker(schema=ProductSchema, key_field="manufacturer")
+    ag_composite = CompositeBlocker(children=[ag_key, ag_vector], op="union")
+    ag_composite_candidates = list(ag_composite.stream(ag_records))
+
+    for label, cands in [
+        (f"VectorBlocker only (k={DEFAULT_AG_BLOCKING_K}, pinned)", ag_vector_candidates),
+        ("KeyBlocker(manufacturer) UNION VectorBlocker", ag_composite_candidates),
+    ]:
+        pc, rr, n = _pc_rr(cands, ag_gold, ag_denom)
+        rows.append(
+            {"dataset": "amazon_google", "blocker": label, "n_candidates": n, "pc": pc, "rr": rr}
+        )
+        logger.info("amazon_google | %-42s | n=%5d | PC=%.4f | RR=%.4f", label, n, pc, rr)
+
+    return rows
+
+
+def _judged_candidates(
+    blocker: VectorBlocker[Any], corpus: list[Any], schema: type[BaseModel]
+) -> list[Any]:
+    """Block + attach comparison + score with WeightedAverageJudge (no clustering)."""
+    records = [r.model_dump() for r in corpus]
+    candidates = _build_vector_candidates(blocker, corpus, records)
+
+    comparator: Comparator[Any] = Comparator.from_schema(schema)
+    judge: WeightedAverageJudge[Any] = WeightedAverageJudge(feature_specs=comparator.feature_specs)
+
+    compared = [
+        c.model_copy(update={"comparison": comparator.compare(c.left, c.right)}) for c in candidates
+    ]
+    return list(judge.forward(iter(compared)))
+
+
+def run_clusterer_comparison() -> list[dict[str, Any]]:
+    """CorrelationClusterer (C6) vs the base Clusterer, same pipeline otherwise."""
+    rows: list[dict[str, Any]] = []
+
+    fz_corpus, fz_gold = load_fodors_zagat()
+    ag_corpus, ag_gold, _ = load_amazon_google()
+
+    datasets: list[tuple[str, list[Any], list[set[str]], VectorBlocker[Any], type[BaseModel]]] = [
+        (
+            "fodors_zagat",
+            fz_corpus,
+            fz_gold,
+            build_restaurant_blocker(DEFAULT_BLOCKING_K),
+            RestaurantSchema,
+        ),
+        (
+            "amazon_google",
+            ag_corpus,
+            ag_gold,
+            build_product_blocker(DEFAULT_AG_BLOCKING_K),
+            ProductSchema,
+        ),
+    ]
+
+    for name, corpus, gold, blocker, schema in datasets:
+        judgements = _judged_candidates(blocker, corpus, schema)
+        all_ids = [r.id for r in corpus]
+
+        for clusterer_name, clusterer in [
+            ("Clusterer (default, transitive closure)", Clusterer(threshold=THRESHOLD)),
+            (
+                "CorrelationClusterer (C6, pivot algorithm)",
+                CorrelationClusterer(threshold=THRESHOLD),
+            ),
+        ]:
+            predicted = clusterer.cluster(judgements)
+            completed = complete_partition(predicted, all_ids)
+            metrics = calculate_bcubed_metrics(completed, gold)
+            rows.append(
+                {
+                    "dataset": name,
+                    "clusterer": clusterer_name,
+                    "bc_p": metrics["precision"],
+                    "bc_r": metrics["recall"],
+                    "bc_f1": metrics["f1"],
+                }
+            )
+            logger.info(
+                "%s | %-42s | bc_P=%.4f | bc_R=%.4f | bc_F1=%.4f",
+                name,
+                clusterer_name,
+                metrics["precision"],
+                metrics["recall"],
+                metrics["f1"],
+            )
+
+    return rows
+
+
+def main() -> int:
+    logger.info("=== Composite blocking: Pair-Completeness / Reduction-Ratio ===")
+    blocking_rows = run_blocking_comparison()
+
+    logger.info("")
+    logger.info("=== Clusterer comparison: base Clusterer vs CorrelationClusterer (C6) ===")
+    clusterer_rows = run_clusterer_comparison()
+
+    logger.info("")
+    logger.info("blocking_rows=%s", blocking_rows)
+    logger.info("clusterer_rows=%s", clusterer_rows)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/examples/w1_blocking_algebra_output.md
+++ b/examples/w1_blocking_algebra_output.md
@@ -1,0 +1,122 @@
+# W1.3 blocking algebra + C6 clusterer — reference output
+
+Reference run of `examples/w1_blocking_algebra.py` on Fodors-Zagat (FZ) and
+Amazon-Google (AG), **zero LLM spend** (blocking is `KeyBlocker`/`VectorBlocker`,
+scoring is `WeightedAverageJudge` — no LLM calls anywhere). Embedding/FAISS
+nondeterminism moves the low-order digits slightly across machines; the
+headline conclusions are stable. Reproduce with:
+
+```
+uv run python examples/w1_blocking_algebra.py
+```
+
+## 1. Composite blocking: Pair-Completeness (PC) / Reduction-Ratio (RR)
+
+PC = cross-source recall of the blocking stage (`evaluate_blocking(...).candidate_recall`
+after filtering to cross-source pairs, matching the methodology already
+pinned in `er_benchmarks.py`/`amazon_google.py`). RR = `1 - n_candidates /
+(n_source_a * n_source_b)` (cross-source product denominator — both
+benchmarks are linkage tasks whose true matches are all cross-source).
+
+| dataset | blocker | n_candidates | PC | RR |
+| --- | --- | --- | --- | --- |
+| fodors_zagat | VectorBlocker only (k=5, pinned) | 1,381 | 0.9911 | 0.9922 |
+| fodors_zagat | **KeyBlocker(city) UNION VectorBlocker** | 10,901 | **1.0000** | 0.9382 |
+| amazon_google | VectorBlocker only (k=50, pinned) | 60,502 | 0.8388 | 0.9862 |
+| amazon_google | KeyBlocker(manufacturer) UNION VectorBlocker | 61,439 | 0.8388 | 0.9860 |
+
+### Read-out
+
+- **Fodors-Zagat: composite blocking closes the recall gap.** The pinned
+  `VectorBlocker` alone misses exactly one gold pair (`f640`/`z325`,
+  "masa's") — a documented, structural edge case where both sources have
+  *identical* `embed_text`, so `VectorBlocker`'s position-based self-skip
+  drops the one neighbour that would have surfaced it (see
+  `er_benchmarks.py`'s `DEFAULT_BLOCKING_K` comment). `KeyBlocker(city)`
+  recovers it: two records with identical text obviously share a city, so
+  the UNION surfaces the pair the vector search structurally cannot. PC
+  goes to a clean 1.0000, at a real RR cost (0.9922 → 0.9382 — still a
+  93.8% reduction vs. brute-force `C(864,2)`, just less aggressive).
+- **Amazon-Google: composite blocking does NOT lift the documented 0.8388
+  ceiling.** `manufacturer` is missing on **62.5% of AG records**
+  (2,870/4,589) — `KeyBlocker`'s standard "exclude records with no key"
+  semantics means most of the corpus never gets a chance to contribute a
+  candidate through this key, so the union adds ~937 extra candidates
+  without recovering any *new* true match the vector search hadn't already
+  found. This is an honest negative result for this specific key choice: a
+  field-selectivity problem, not a `KeyBlocker`/`CompositeBlocker`
+  correctness problem. A denser or composite key (e.g. normalized title
+  n-grams, or `manufacturer` OR normalized-price) would likely do better —
+  left for future work / #55, not required by this exit criterion (PC/RR
+  *measured*, not *maximized*).
+- **Recall-first union does no *harm*** in either case: PC never drops
+  below the `VectorBlocker`-alone baseline (`union` is provably a
+  pairs-superset per `CompositeBlocker`'s own test suite), consistent with
+  its "recall-maximizing default" design intent.
+
+## 2. Clusterer comparison: base `Clusterer` vs `CorrelationClusterer` (C6)
+
+Same blocking (`VectorBlocker`, pinned k) + same `WeightedAverageJudge` +
+same threshold (0.80, reused from `examples/m3_zero_spend_race_output.md`)
+for both rows — **only the clusterer differs**, isolating its effect.
+
+| dataset | clusterer | bc_P | bc_R | bc_F1 |
+| --- | --- | --- | --- | --- |
+| fodors_zagat | Clusterer (default, transitive closure) | 0.9888 | 0.9583 | 0.9733 |
+| fodors_zagat | CorrelationClusterer (C6, pivot algorithm) | 0.9911 | 0.9572 | 0.9739 |
+| amazon_google | Clusterer (default, transitive closure) | 0.6746 | 0.7978 | 0.7311 |
+| amazon_google | **CorrelationClusterer (C6, pivot algorithm)** | **0.7461** | 0.7818 | **0.7635** |
+
+### Read-out
+
+- **Fodors-Zagat: a wash.** ΔbcF1 = +0.0006 (0.9733 → 0.9739) — both land
+  within measurement noise of each other. FZ is small, near-saturated, and
+  its match clusters are almost all size-2 (one Fodor's + one Zagat record),
+  so there's little chaining structure for the base `Clusterer`'s transitive
+  closure to over-merge in the first place.
+- **Amazon-Google: C6 clearly wins.** ΔbcF1 = **+0.0324** (0.7311 → 0.7635,
+  a 4.4% relative improvement), driven by **+0.0715 precision** (0.6746 →
+  0.7461) at a modest **-0.0160 recall** cost (0.7978 → 0.7818). This is
+  exactly the over-merge signature the base `Clusterer`'s transitive closure
+  is known to produce on the harder, chattier dataset (M3's documented
+  −0.63 BCubed regression on `embedding_cosine` was the extreme version of
+  this same failure mode) — `CorrelationClusterer` requires a *direct* edge
+  to a cluster's pivot rather than any transitive path, so it declines to
+  chain-merge borderline pairs the base `Clusterer` would.
+- **The synthetic unit tests** (`tests/core/clusterers/test_correlation_clusterer.py`)
+  show the mechanism directly: on a 3-node chain (A-B, B-C, no direct A-C
+  edge) the base `Clusterer` merges `{A, B, C}` into one cluster;
+  `CorrelationClusterer` produces `{A, B}, {C}` — while a fully-connected
+  triangle (every pair directly compared and matched) still merges fully
+  under both, so C6 is not simply "more conservative everywhere," only where
+  the evidence is actually indirect.
+
+### Default-flip decision: **NOT flipped — C6 stays opt-in**
+
+Per the exit criterion ("only flip the clusterer default if C6 clearly wins
+on the benchmark; otherwise keep it opt-in and report why"): C6 wins clearly
+on Amazon-Google (the harder, more chain-prone dataset) but is a wash on
+Fodors-Zagat. Two datasets, one showing a clear win and one showing no
+differentiation, is not the "clearly wins" bar a *global default* change
+needs — flipping the default would be extrapolating a hard-dataset win onto
+every user, including the easy/well-behaved cases where it buys nothing.
+`CorrelationClusterer` (registered as `"correlation_clusterer"`) is shipped
+as a pluggable, opt-in alternative:
+
+```python
+from langres.core.clusterers.correlation import CorrelationClusterer
+
+resolver = Resolver(
+    blocker=...,
+    module=...,
+    clusterer=CorrelationClusterer(threshold=0.7),  # opt-in, not the default
+)
+```
+
+**Recommendation:** prefer `CorrelationClusterer` for harder/messier
+entity-resolution problems (long, noisy fields; many borderline-similarity
+records — Amazon-Google-shaped data) where the base `Clusterer`'s transitive
+closure has real chaining risk. Keep the base `Clusterer` for small,
+well-behaved, mostly-clean datasets (Fodors-Zagat-shaped data) where the two
+are equivalent and the base clusterer's simplicity is one less thing to
+reason about.

--- a/src/langres/core/__init__.py
+++ b/src/langres/core/__init__.py
@@ -9,8 +9,11 @@ from langres.core import benchmark, metrics, optimizers
 from langres.core.adapters.glinker import GLinkerAdapter
 from langres.core.blocker import Blocker
 from langres.core.blockers.all_pairs import AllPairsBlocker
+from langres.core.blockers.composite import CompositeBlocker
+from langres.core.blockers.key import KeyBlocker
 from langres.core.blockers.vector import VectorBlocker
 from langres.core.clusterer import Clusterer
+from langres.core.clusterers.correlation import CorrelationClusterer
 from langres.core.comparator import Comparator, StringComparator
 from langres.core.debugging import (
     CandidateStats,
@@ -83,6 +86,8 @@ __all__ = [
     "ComparisonLevel",
     "ComparisonVector",
     "ComponentSpec",
+    "CompositeBlocker",
+    "CorrelationClusterer",
     "derive_groups_from_pairs",
     "EmbeddingProvider",
     "EmbeddingScoreJudge",
@@ -102,6 +107,7 @@ __all__ = [
     "GLinkerAdapter",
     "GroupwiseModule",
     "JudgementLog",
+    "KeyBlocker",
     "LLMJudge",
     "LoggingModule",
     "metrics",

--- a/src/langres/core/blockers/__init__.py
+++ b/src/langres/core/blockers/__init__.py
@@ -1,6 +1,8 @@
 """Blocker implementations for candidate pair generation."""
 
 from langres.core.blockers.all_pairs import AllPairsBlocker
+from langres.core.blockers.composite import CompositeBlocker
+from langres.core.blockers.key import KeyBlocker
 from langres.core.blockers.vector import VectorBlocker
 
-__all__ = ["AllPairsBlocker", "VectorBlocker"]
+__all__ = ["AllPairsBlocker", "CompositeBlocker", "KeyBlocker", "VectorBlocker"]

--- a/src/langres/core/blockers/composite.py
+++ b/src/langres/core/blockers/composite.py
@@ -1,0 +1,277 @@
+"""CompositeBlocker implementation: set algebra over child blockers.
+
+Composes 2+ child :class:`~langres.core.blocker.Blocker` instances' candidate
+pair-sets via a set operation (``"union"`` / ``"intersection"`` /
+``"difference"``), deduping by the canonical undirected pair key with
+first-seen semantics (the same guarantee every base blocker already gives:
+each unordered pair appears at most once). ``"union"`` is the recall-maximizing
+default -- composing a cheap, high-precision :class:`~langres.core.blockers.
+key.KeyBlocker` with a recall-oriented :class:`~langres.core.blockers.vector.
+VectorBlocker` recovers the recall a single blocking key alone would miss.
+"""
+
+from collections.abc import Iterator, Sequence
+from typing import Any, ClassVar, Literal
+
+from langres.core.blocker import Blocker, SchemaT
+from langres.core.models import ERCandidate
+from langres.core.registry import get_component, register
+from langres.core.reports import CandidateInspectionReport
+
+CompositeOp = Literal["union", "intersection", "difference"]
+
+_VALID_OPS: tuple[CompositeOp, ...] = ("union", "intersection", "difference")
+
+
+def _pair_key(candidate: ERCandidate[Any]) -> frozenset[str]:
+    """Canonical undirected pair key for dedup (matches the base blockers' guarantee)."""
+    return frozenset((candidate.left.id, candidate.right.id))
+
+
+@register("composite_blocker")
+class CompositeBlocker(Blocker[SchemaT]):
+    """Set algebra (union/intersection/difference) over child blockers.
+
+    Each child is fully materialized into a ``{pair_key: candidate}`` map (set
+    operations need to know a pair's full membership across children, so this
+    -- like :func:`~langres.core.groups.derive_groups_from_pairs` -- is
+    necessarily buffered, unlike the streaming-first single-blocker contract).
+    The retained ``ERCandidate`` for a kept pair is the first child's own
+    candidate object (preserving its ``left``/``right`` orientation), with
+    ``blocker_name`` replaced to carry provenance: which child(ren) actually
+    produced that specific pair.
+
+    - ``"union"`` (default, recall-maximizing): every pair produced by ANY
+      child.
+    - ``"intersection"``: only pairs produced by EVERY child.
+    - ``"difference"``: pairs produced by the FIRST child and by no other
+      child (``children[0] - (children[1] | children[2] | ...)``).
+
+    ``stream_groups()`` is NOT overridden: it relies on the inherited
+    ``Blocker`` default (buffered derivation from ``stream()``), which is
+    already proven pairs-equivalent for any blocker (see
+    ``test_blocker_stream_groups_default_pairs_equivalence_property`` and this
+    module's own equivalence tests). CompositeBlocker's own pair generation
+    already fully buffers every child, and its pair sets (especially for
+    intersection/difference across heterogeneous children) have no natural
+    single "anchor" structure, so a native per-anchor override -- the
+    treatment ``VectorBlocker`` gets, per W1.0 -- would add complexity without
+    a corresponding benefit here.
+
+    Example:
+        # Recall-first: cheap key blocking backstopped by semantic search.
+        composite = CompositeBlocker(
+            children=[
+                KeyBlocker(schema=CompanySchema, key_field="postal_code"),
+                VectorBlocker(schema=CompanySchema, text_field="name", ...),
+            ],
+            op="union",
+        )
+        candidates = list(composite.stream(company_records))
+
+    Note:
+        Serialization (``config``/``from_config``) only supports children
+        whose own ``config`` is plain data (e.g. ``KeyBlocker``,
+        ``AllPairsBlocker``, another ``CompositeBlocker`` of such children). A
+        child with out-of-band state (e.g. a built ``VectorBlocker`` index)
+        is not preserved through a composite's save/load round-trip -- persist
+        such a pipeline via the ``Resolver`` artifact instead, which already
+        handles that state explicitly.
+    """
+
+    # Registry key, mirrored as a class attribute so the Resolver's uniform
+    # serialization helper can discover the type name (see resolver.py).
+    type_name: ClassVar[str] = "composite_blocker"
+
+    def __init__(self, children: Sequence[Blocker[SchemaT]], op: CompositeOp = "union"):
+        """Initialize CompositeBlocker.
+
+        Args:
+            children: 2+ child blockers to compose. All must normalize to the
+                same entity schema (they compose over the same input ``data``).
+            op: The set operation: ``"union"`` (default), ``"intersection"``,
+                or ``"difference"`` (first child minus the rest).
+
+        Raises:
+            ValueError: If fewer than 2 children are given, or ``op`` is not
+                one of ``"union"``, ``"intersection"``, ``"difference"``.
+        """
+        if len(children) < 2:
+            raise ValueError(
+                f"CompositeBlocker requires at least 2 child blockers (got {len(children)})."
+            )
+        if op not in _VALID_OPS:
+            raise ValueError(f"Unknown composite op {op!r}; expected one of {_VALID_OPS}.")
+
+        self.children = list(children)
+        self.op: CompositeOp = op
+
+    def _label(self, child: Blocker[SchemaT]) -> str:
+        """Provenance label for a child: its registry type_name, or class name."""
+        return str(getattr(child, "type_name", type(child).__name__))
+
+    def _child_pair_maps(self, data: list[Any]) -> list[dict[frozenset[str], ERCandidate[SchemaT]]]:
+        """Fully materialize each child's candidates into a pair-key -> candidate map."""
+        maps: list[dict[frozenset[str], ERCandidate[SchemaT]]] = []
+        for child in self.children:
+            pair_map: dict[frozenset[str], ERCandidate[SchemaT]] = {}
+            for candidate in child.stream(data):
+                key = _pair_key(candidate)
+                if key not in pair_map:
+                    pair_map[key] = candidate
+            maps.append(pair_map)
+        return maps
+
+    def _keep(self, key: frozenset[str], maps: list[dict[frozenset[str], Any]]) -> bool:
+        """Whether ``key`` survives this composite's set operation."""
+        if self.op == "union":
+            return True  # reached only if present in at least one map
+        if self.op == "intersection":
+            return all(key in pm for pm in maps)
+        # difference: in the first child, and in no other child.
+        return key in maps[0] and not any(key in pm for pm in maps[1:])
+
+    def stream(self, data: list[Any]) -> Iterator[ERCandidate[SchemaT]]:
+        """Generate candidate pairs by combining children via ``self.op``.
+
+        Args:
+            data: List of raw data items, passed through unchanged to every
+                child's ``stream()``.
+
+        Yields:
+            ERCandidate[SchemaT] objects surviving the set operation, each
+            pair exactly once, in first-seen order across children (in
+            ``self.children`` order, then each child's own stream order).
+            ``blocker_name`` is rewritten to
+            ``"composite_{op}(label1+label2+...)"`` listing the child(ren)
+            that actually produced that pair.
+        """
+        maps = self._child_pair_maps(data)
+        labels = [self._label(child) for child in self.children]
+
+        seen: set[frozenset[str]] = set()
+        for pair_map in maps:
+            for key, candidate in pair_map.items():
+                if key in seen:
+                    continue
+                seen.add(key)
+                if not self._keep(key, maps):
+                    continue
+                contributing = [label for pm, label in zip(maps, labels, strict=True) if key in pm]
+                name = f"composite_{self.op}({'+'.join(contributing)})"
+                yield candidate.model_copy(update={"blocker_name": name})
+
+    @property
+    def config(self) -> dict[str, object]:
+        """Serializable construction config for the registry.
+
+        Returns:
+            ``{"op": ..., "children": [{"type_name": ..., "config": ...}, ...]}``.
+
+        Raises:
+            ValueError: If any child has no registry ``type_name``, or any
+                child's own ``config`` raises (e.g. it was built from a
+                non-serializable callable).
+        """
+        child_specs: list[dict[str, object]] = []
+        for child in self.children:
+            child_type_name = getattr(child, "type_name", None)
+            if child_type_name is None:
+                raise ValueError(
+                    f"CompositeBlocker child {child!r} has no registry 'type_name'; "
+                    "construct with a registered Blocker subclass to persist."
+                )
+            child_config: Any = child.config  # type: ignore[attr-defined]
+            child_specs.append({"type_name": child_type_name, "config": child_config})
+        return {"op": self.op, "children": child_specs}
+
+    @classmethod
+    def from_config(cls, config: dict[str, object]) -> "CompositeBlocker[SchemaT]":
+        """Rebuild a CompositeBlocker from its serialized config.
+
+        Args:
+            config: A mapping with ``"op"`` and ``"children"`` (see
+                :attr:`config`).
+
+        Returns:
+            A blocker equivalent to the one that produced ``config``.
+        """
+        children: list[Blocker[SchemaT]] = []
+        child_specs: Any = config["children"]
+        for spec in child_specs:
+            child_cls: Any = get_component(str(spec["type_name"]))
+            children.append(child_cls.from_config(spec["config"]))
+        return cls(children=children, op=config["op"])  # type: ignore[arg-type]
+
+    def inspect_candidates(
+        self,
+        candidates: list[ERCandidate[SchemaT]],
+        entities: list[SchemaT],
+        sample_size: int = 10,
+    ) -> CandidateInspectionReport:
+        """Explore CompositeBlocker candidates without ground truth.
+
+        Args:
+            candidates: List of generated candidate pairs.
+            entities: Original list of entities.
+            sample_size: Number of example pairs to include in report.
+
+        Returns:
+            CandidateInspectionReport with totals, per-entity distribution,
+            samples, and a recommendation naming the composite's op.
+        """
+        n = len(entities)
+        total_candidates = len(candidates)
+        avg_candidates_per_entity = (2 * total_candidates / n) if n > 0 else 0.0
+
+        counts: dict[str, int] = {str(getattr(e, "id", id(e))): 0 for e in entities}
+        for cand in candidates:
+            left_id = str(getattr(cand.left, "id", id(cand.left)))
+            right_id = str(getattr(cand.right, "id", id(cand.right)))
+            counts[left_id] = counts.get(left_id, 0) + 1
+            counts[right_id] = counts.get(right_id, 0) + 1
+
+        distribution: dict[str, int] = {}
+        for count in counts.values():
+            key = str(count)
+            distribution[key] = distribution.get(key, 0) + 1
+
+        examples: list[dict[str, str]] = []
+        for cand in candidates[:sample_size]:
+            examples.append(
+                {
+                    "left_id": str(getattr(cand.left, "id", id(cand.left))),
+                    "right_id": str(getattr(cand.right, "id", id(cand.right))),
+                    "left_text": self._extract_text(cand.left),
+                    "right_text": self._extract_text(cand.right),
+                }
+            )
+
+        recommendations: list[str] = [
+            f"CompositeBlocker(op={self.op!r}) over {len(self.children)} children "
+            f"generated {total_candidates:,} candidates "
+            f"(avg {avg_candidates_per_entity:.1f} per entity, n={n}). "
+            + (
+                "'union' maximizes recall at the cost of more candidates; "
+                "'intersection'/'difference' trade recall for precision -- "
+                "measure Pair-Completeness against a labeled sample before relying on them."
+                if self.op == "union"
+                else "Verify Pair-Completeness against a labeled sample: "
+                "'intersection'/'difference' can silently drop true matches "
+                "that only one child's blocking strategy would have found."
+            )
+        ]
+
+        return CandidateInspectionReport(
+            total_candidates=total_candidates,
+            avg_candidates_per_entity=avg_candidates_per_entity,
+            candidate_distribution=distribution,
+            examples=examples,
+            recommendations=recommendations,
+        )
+
+    def _extract_text(self, entity: SchemaT) -> str:
+        """Extract human-readable text from entity."""
+        if hasattr(entity, "name"):
+            return str(entity.name)
+        return str(entity)

--- a/src/langres/core/blockers/key.py
+++ b/src/langres/core/blockers/key.py
@@ -1,0 +1,293 @@
+"""KeyBlocker implementation for exact/normalized-key candidate generation.
+
+This blocker buckets records by a configurable key (a declared schema field or
+a full callable) and emits all pairs within each bucket. It is schema-agnostic
+via the same ``schema``/``schema_factory`` mutual-exclusion pattern used by
+``AllPairsBlocker``/``VectorBlocker``.
+"""
+
+from collections.abc import Callable, Iterator
+from typing import Any, ClassVar
+
+from langres.core.blocker import Blocker, SchemaT
+from langres.core.blockers.all_pairs import register_schema_idempotent, schema_to_factory
+from langres.core.models import ERCandidate
+from langres.core.registry import get_schema, register
+from langres.core.reports import CandidateInspectionReport
+
+
+def _field_key_fn(field: str) -> Callable[[Any], str | None]:
+    """Build a key-extraction function that reads ``field`` off an entity."""
+
+    def _fn(entity: Any) -> str | None:
+        value = getattr(entity, field)
+        return None if value is None else str(value)
+
+    return _fn
+
+
+@register("key_blocker")
+class KeyBlocker(Blocker[SchemaT]):
+    """Schema-agnostic blocker that pairs records sharing an (normalized) key.
+
+    Records are bucketed by a key extracted from each entity; every pair
+    within a bucket becomes a candidate (a bucket of size B contributes
+    B*(B-1)/2 pairs). Records whose key extraction is ``None`` (e.g. a missing
+    field) are excluded entirely -- they get no candidates from this blocker.
+
+    The key can come from either:
+
+    - ``key_field=`` (declarative): ``getattr(entity, key_field)``, serializable.
+    - ``key_fn=`` (callable): full control over key extraction, not serializable.
+
+    ``normalize=True`` (default) applies ``.strip().lower()`` to non-``None``
+    keys before bucketing, regardless of which path produced the key -- this is
+    what makes "Zurich" and "  ZURICH  " land in the same bucket.
+
+    Example:
+        # Block companies by normalized city
+        blocker = KeyBlocker(schema=CompanySchema, key_field="city")
+        candidates = list(blocker.stream(company_records))
+
+        # Custom key: first letter of the name
+        blocker = KeyBlocker(
+            schema=CompanySchema,
+            key_fn=lambda c: c.name[0] if c.name else None,
+        )
+
+    Note:
+        A single exact-key blocker trades recall for precision/speed: two
+        matching records with slightly different key values (typos, different
+        formatting) land in different buckets and are missed. Compose with a
+        recall-oriented blocker (e.g. ``VectorBlocker``) via
+        :class:`~langres.core.blockers.composite.CompositeBlocker` (union) to
+        recover that recall.
+    """
+
+    # Registry key, mirrored as a class attribute so the Resolver's uniform
+    # serialization helper can discover the type name (see resolver.py).
+    type_name: ClassVar[str] = "key_blocker"
+
+    def __init__(
+        self,
+        schema_factory: Callable[[dict[str, Any]], SchemaT] | None = None,
+        schema: type[SchemaT] | None = None,
+        *,
+        key_field: str | None = None,
+        key_fn: Callable[[SchemaT], str | None] | None = None,
+        normalize: bool = True,
+    ):
+        """Initialize KeyBlocker.
+
+        Provide exactly one of ``schema``/``schema_factory`` (entity
+        normalization) and exactly one of ``key_field``/``key_fn`` (key
+        extraction).
+
+        Args:
+            schema_factory: Callable that transforms a raw dict into a Pydantic
+                schema object (SchemaT). Mutually exclusive with ``schema``.
+            schema: Pydantic schema class for declarative reconstruction.
+                Mutually exclusive with ``schema_factory``.
+            key_field: Name of a schema field to use as the blocking key
+                (declarative, serializable). Mutually exclusive with ``key_fn``.
+            key_fn: Callable extracting a key (or ``None``) from an entity
+                (full control, not serializable). Mutually exclusive with
+                ``key_field``.
+            normalize: If ``True`` (default), lowercase + strip non-``None``
+                keys before bucketing.
+
+        Raises:
+            ValueError: If both or neither of ``schema``/``schema_factory`` are
+                given, or if both or neither of ``key_field``/``key_fn`` are
+                given.
+        """
+        if (schema is None) == (schema_factory is None):
+            raise ValueError(
+                "KeyBlocker requires exactly one of 'schema' or "
+                "'schema_factory' (got both or neither)."
+            )
+        if (key_field is None) == (key_fn is None):
+            raise ValueError(
+                "KeyBlocker requires exactly one of 'key_field' or 'key_fn' (got both or neither)."
+            )
+
+        self._schema_type_name: str | None = None
+        if schema is not None:
+            self._schema_type_name = register_schema_idempotent(schema)
+            self.schema_factory = schema_to_factory(schema)
+        else:
+            assert schema_factory is not None  # narrowed by the guard above
+            self.schema_factory = schema_factory
+
+        self._key_field_name: str | None = key_field
+        if key_field is not None:
+            self.key_fn: Callable[[SchemaT], str | None] = _field_key_fn(key_field)
+        else:
+            assert key_fn is not None  # narrowed by the guard above
+            self.key_fn = key_fn
+
+        self.normalize = normalize
+
+    @property
+    def config(self) -> dict[str, object]:
+        """Serializable construction config for the registry.
+
+        Returns:
+            ``{"schema_type_name": ..., "key_field": ..., "normalize": ...}``.
+
+        Raises:
+            ValueError: If this blocker was constructed with ``schema_factory``
+                or ``key_fn`` (opaque callables that cannot be serialized).
+        """
+        if self._schema_type_name is None:
+            raise ValueError(
+                "KeyBlocker built with 'schema_factory' is not serializable "
+                "(a callable cannot round-trip through config); construct with "
+                "schema= to persist."
+            )
+        if self._key_field_name is None:
+            raise ValueError(
+                "KeyBlocker built with 'key_fn' is not serializable (a callable "
+                "cannot round-trip through config); construct with key_field= "
+                "to persist."
+            )
+        return {
+            "schema_type_name": self._schema_type_name,
+            "key_field": self._key_field_name,
+            "normalize": self.normalize,
+        }
+
+    @classmethod
+    def from_config(cls, config: dict[str, object]) -> "KeyBlocker[SchemaT]":
+        """Rebuild a KeyBlocker from its serialized config.
+
+        Args:
+            config: A mapping with ``"schema_type_name"``, ``"key_field"``, and
+                ``"normalize"`` (see :attr:`config`).
+
+        Returns:
+            A blocker equivalent to the one that produced ``config``.
+        """
+        schema = get_schema(str(config["schema_type_name"]))
+        return cls(
+            schema=schema,  # type: ignore[arg-type]
+            key_field=str(config["key_field"]),
+            normalize=bool(config["normalize"]),
+        )
+
+    def _extract_key(self, entity: SchemaT) -> str | None:
+        """Extract and (optionally) normalize this entity's blocking key."""
+        raw = self.key_fn(entity)
+        if raw is None:
+            return None
+        return raw.strip().lower() if self.normalize else raw
+
+    def stream(self, data: list[Any]) -> Iterator[ERCandidate[SchemaT]]:
+        """Generate candidate pairs for records sharing a (normalized) key.
+
+        Args:
+            data: List of raw data items (typically dicts). The schema_factory
+                transforms these into SchemaT objects.
+
+        Yields:
+            ERCandidate[SchemaT] objects for every pair of records within the
+            same key bucket, in first-seen bucket order (blocker_name:
+            "key_blocker").
+        """
+        entities = [self.schema_factory(record) for record in data]
+
+        buckets: dict[str, list[SchemaT]] = {}
+        order: list[str] = []
+        for entity in entities:
+            key = self._extract_key(entity)
+            if key is None:
+                continue
+            if key not in buckets:
+                buckets[key] = []
+                order.append(key)
+            buckets[key].append(entity)
+
+        for key in order:
+            bucket = buckets[key]
+            for i, left in enumerate(bucket):
+                for right in bucket[i + 1 :]:
+                    yield ERCandidate(left=left, right=right, blocker_name="key_blocker")
+
+    def inspect_candidates(
+        self,
+        candidates: list[ERCandidate[SchemaT]],
+        entities: list[SchemaT],
+        sample_size: int = 10,
+    ) -> CandidateInspectionReport:
+        """Explore KeyBlocker candidates without ground truth.
+
+        Unlike AllPairsBlocker, KeyBlocker's candidate distribution is NOT
+        uniform (it depends on bucket sizes), so this computes the real
+        per-entity candidate count from ``candidates`` rather than assuming
+        n-1.
+
+        Args:
+            candidates: List of generated candidate pairs.
+            entities: Original list of entities.
+            sample_size: Number of example pairs to include in report.
+
+        Returns:
+            CandidateInspectionReport with totals, distribution, samples, and
+            key-selectivity recommendations.
+        """
+        n = len(entities)
+        total_candidates = len(candidates)
+        avg_candidates_per_entity = (2 * total_candidates / n) if n > 0 else 0.0
+
+        counts: dict[str, int] = {str(getattr(e, "id", id(e))): 0 for e in entities}
+        for cand in candidates:
+            left_id = str(getattr(cand.left, "id", id(cand.left)))
+            right_id = str(getattr(cand.right, "id", id(cand.right)))
+            counts[left_id] = counts.get(left_id, 0) + 1
+            counts[right_id] = counts.get(right_id, 0) + 1
+
+        distribution: dict[str, int] = {}
+        for count in counts.values():
+            key = str(count)
+            distribution[key] = distribution.get(key, 0) + 1
+
+        examples: list[dict[str, str]] = []
+        for cand in candidates[:sample_size]:
+            examples.append(
+                {
+                    "left_id": str(getattr(cand.left, "id", id(cand.left))),
+                    "right_id": str(getattr(cand.right, "id", id(cand.right))),
+                    "left_text": self._extract_text(cand.left),
+                    "right_text": self._extract_text(cand.right),
+                }
+            )
+
+        recommendations: list[str] = []
+        if total_candidates == 0:
+            recommendations.append(
+                "⚠️ No candidates generated -- no two records share a (normalized) "
+                "key. Check the key field/function, or compose with a "
+                "recall-oriented blocker (e.g. VectorBlocker) via CompositeBlocker."
+            )
+        else:
+            recommendations.append(
+                f"✅ KeyBlocker generated {total_candidates:,} candidates "
+                f"(avg {avg_candidates_per_entity:.1f} per entity, n={n}). "
+                f"A coarse key (few, huge buckets) approaches AllPairs cost; a "
+                f"fine key (many singleton buckets) risks missing near-matches "
+                f"whose key values differ slightly."
+            )
+
+        return CandidateInspectionReport(
+            total_candidates=total_candidates,
+            avg_candidates_per_entity=avg_candidates_per_entity,
+            candidate_distribution=distribution,
+            examples=examples,
+            recommendations=recommendations,
+        )
+
+    def _extract_text(self, entity: SchemaT) -> str:
+        """Extract human-readable text from entity."""
+        if hasattr(entity, "name"):
+            return str(entity.name)
+        return str(entity)

--- a/src/langres/core/clusterers/__init__.py
+++ b/src/langres/core/clusterers/__init__.py
@@ -4,3 +4,7 @@
 connected-components); this package holds alternative clustering strategies
 that plug into the same ``Blocker``/``blockers/`` split convention.
 """
+
+from langres.core.clusterers.correlation import CorrelationClusterer
+
+__all__ = ["CorrelationClusterer"]

--- a/src/langres/core/clusterers/__init__.py
+++ b/src/langres/core/clusterers/__init__.py
@@ -1,0 +1,6 @@
+"""Pluggable Clusterer variants.
+
+``langres.core.clusterer`` holds the base ``Clusterer`` (transitive-closure /
+connected-components); this package holds alternative clustering strategies
+that plug into the same ``Blocker``/``blockers/`` split convention.
+"""

--- a/src/langres/core/clusterers/correlation.py
+++ b/src/langres/core/clusterers/correlation.py
@@ -1,0 +1,111 @@
+"""CorrelationClusterer (C6): a merge-resistant Clusterer variant.
+
+The base :class:`~langres.core.clusterer.Clusterer` builds a graph from edges
+scoring >= threshold and takes connected components -- i.e. FULL transitive
+closure. A chain of edges (A-B, B-C) with no direct A-C edge still merges A,
+B, and C into one cluster, because connectivity alone (not direct evidence)
+drives the merge. This is the documented M3 over-merge failure mode (-0.63
+BCubed): one weak link in a long chain can pull unrelated records together.
+
+``CorrelationClusterer`` implements the classic *pivot algorithm* for
+correlation clustering (Ailon, Charikar & Newman, "Aggregating Inconsistent
+Information: Ranking and Clustering", JACM 2008, building on Bansal, Blum &
+Chawla's correlation-clustering formulation): a node only joins a cluster if
+it has a DIRECT edge >= threshold to that cluster's pivot. Chains without a
+direct edge to the pivot don't force a merge -- structurally resistant to the
+classic "chaining" failure, while a genuinely well-connected group (e.g. a
+clique where every pair was directly compared and matched) still merges fully,
+same as the base Clusterer.
+"""
+
+from collections.abc import Iterator
+from typing import ClassVar
+
+from langres.core.clusterer import Clusterer
+from langres.core.models import PairwiseJudgement
+from langres.core.registry import register
+
+
+@register("correlation_clusterer")
+class CorrelationClusterer(Clusterer):
+    """Merge-resistant Clusterer: the pivot algorithm for correlation clustering.
+
+    Drop-in alternative to the base :class:`~langres.core.clusterer.Clusterer`
+    (same ``threshold`` constructor, same ``config``/``from_config``,
+    inherits ``evaluate()``/``inspect_clusters()`` unchanged -- only
+    :meth:`cluster` differs). NOT the default: benchmark before switching (see
+    ``examples/w1_blocking_algebra_output.md``).
+
+    Algorithm, per call to :meth:`cluster`:
+
+    1. Build an undirected weighted graph from judgements with
+       ``score >= threshold`` (max score kept for a duplicate pair; self-pairs
+       ignored) -- same edge set the base Clusterer would use.
+    2. Process nodes in a deterministic order: highest max-incident-edge-score
+       first, ties broken by node id (so results are reproducible and biased
+       toward the most-confident evidence first).
+    3. For each unprocessed node (in that order), form a cluster from the node
+       plus every one of its DIRECT neighbours that is still unprocessed.
+       Remove those nodes from further consideration and continue.
+
+    A node with only an indirect (multi-hop) path to a cluster is never pulled
+    in -- unlike connected components, which merges anything reachable by any
+    chain of qualifying edges.
+    """
+
+    type_name: ClassVar[str] = "correlation_clusterer"
+
+    def cluster(
+        self,
+        judgements: Iterator[PairwiseJudgement] | list[PairwiseJudgement],
+    ) -> list[set[str]]:
+        """Form entity clusters via the pivot algorithm for correlation clustering.
+
+        Args:
+            judgements: Iterator or list of PairwiseJudgement objects.
+
+        Returns:
+            List of clusters (sets of entity ids). Like the base Clusterer,
+            entities with no qualifying edge are simply absent (no singleton
+            clusters).
+        """
+        adjacency = self._build_adjacency(judgements)
+
+        remaining = set(adjacency)
+        clusters: list[set[str]] = []
+        for node in sorted(adjacency, key=lambda n: self._pivot_priority(n, adjacency)):
+            if node not in remaining:
+                continue
+            cluster = {node} | (set(adjacency[node]) & remaining)
+            remaining -= cluster
+            clusters.append(cluster)
+        return clusters
+
+    def _build_adjacency(
+        self,
+        judgements: Iterator[PairwiseJudgement] | list[PairwiseJudgement],
+    ) -> dict[str, dict[str, float]]:
+        """Build a symmetric adjacency map from judgements meeting the threshold."""
+        edges: dict[frozenset[str], float] = {}
+        for judgement in judgements:
+            if judgement.left_id == judgement.right_id:
+                continue
+            if judgement.score < self.threshold:
+                continue
+            key = frozenset((judgement.left_id, judgement.right_id))
+            if key not in edges or judgement.score > edges[key]:
+                edges[key] = judgement.score
+
+        adjacency: dict[str, dict[str, float]] = {}
+        for key, score in edges.items():
+            left, right = tuple(key)
+            adjacency.setdefault(left, {})[right] = score
+            adjacency.setdefault(right, {})[left] = score
+        return adjacency
+
+    def _pivot_priority(
+        self, node: str, adjacency: dict[str, dict[str, float]]
+    ) -> tuple[float, str]:
+        """Sort key: highest-confidence edge first, ties broken by node id."""
+        best_score = max(adjacency[node].values())
+        return (-best_score, node)

--- a/src/langres/core/registry.py
+++ b/src/langres/core/registry.py
@@ -36,8 +36,18 @@ _SCHEMA_REGISTRY: dict[str, type[BaseModel]] = {}
 # the type. Keep in sync with any module kept off the eager-import path — e.g.
 # ``dspy_judge``, which would otherwise import ``dspy`` (and open its disk cache)
 # on plain ``import langres.core``.
+#
+# ``key_blocker``/``composite_blocker``/``correlation_clusterer`` are ALSO
+# eager-imported today (``core/__init__.py``, mirroring ``AllPairsBlocker``/
+# ``VectorBlocker``/``LLMJudge``), so this entry is currently redundant for
+# them -- it exists so a saved artifact referencing these types keeps resolving
+# once those eager imports are trimmed (planned packaging-dx work), the same
+# safety net ``select_judge``/``dspy_judge`` already rely on.
 _LAZY_COMPONENT_MODULES: dict[str, str] = {
+    "composite_blocker": "langres.core.blockers.composite",
+    "correlation_clusterer": "langres.core.clusterers.correlation",
     "dspy_judge": "langres.core.modules.dspy_judge",
+    "key_blocker": "langres.core.blockers.key",
     "select_judge": "langres.core.modules.select_judge",
 }
 

--- a/src/langres/core/resolver.py
+++ b/src/langres/core/resolver.py
@@ -43,6 +43,7 @@ from pydantic import BaseModel
 
 import langres
 from langres.core.blocker import Blocker
+from langres.core.blockers.composite import CompositeBlocker
 from langres.core.blockers.vector import VectorBlocker
 from langres.core.clusterer import Clusterer
 from langres.core.comparator import Comparator
@@ -155,6 +156,24 @@ def _build_embedding_blocker(schema: type[BaseModel]) -> VectorBlocker[Any]:
     return VectorBlocker(
         vector_index=index, schema=schema, text_field_extractor=extract, k_neighbors=10
     )
+
+
+def _iter_vector_blockers(blocker: object) -> Iterator[VectorBlocker[Any]]:
+    """Yield every ``VectorBlocker`` reachable from ``blocker``.
+
+    A plain ``VectorBlocker`` yields itself. A ``CompositeBlocker`` (the
+    blocking-algebra union/intersection/difference of child blockers) recurses
+    into ``children`` at arbitrary depth, so a composite wrapping another
+    composite still surfaces every nested ``VectorBlocker`` -- e.g. the
+    recall-first pattern ``CompositeBlocker([KeyBlocker(...), VectorBlocker(...)],
+    op="union")``. Index-free blockers (``AllPairsBlocker``, ``KeyBlocker``,
+    ``GLinkerAdapter``) contribute nothing.
+    """
+    if isinstance(blocker, VectorBlocker):
+        yield blocker
+    elif isinstance(blocker, CompositeBlocker):
+        for child in blocker.children:
+            yield from _iter_vector_blockers(child)
 
 
 def _component_config_dict(obj: object) -> dict[str, object]:
@@ -482,29 +501,30 @@ class Resolver:
         return self.clusterer.cluster(self._judgements(records))
 
     def _ensure_index_built(self, records: list[Any]) -> None:
-        """Build/populate a ``VectorBlocker``'s index from ``records``.
+        """Build/populate every reachable ``VectorBlocker``'s index from ``records``.
 
-        Embeds the records' text field and creates the index in place when it is
-        not yet built. For a blocker with no index (AllPairs, GLinker), this is a
-        no-op. When the index *is* already built (e.g. a freshly loaded FAISS
-        index, or a Resolver reused on the same records), the would-be corpus is
-        compared to the index's stored ``_corpus_texts``: identical -> reuse
-        (never re-embed, so restore + same-records round-trips are cheap);
-        different -> rebuild (so reusing the Resolver on a new record list scores
+        Embeds the records' text field and creates the index in place for each
+        index-backed blocker discovered via :func:`_iter_vector_blockers` --
+        whether ``self.blocker`` is a ``VectorBlocker`` directly, or one is
+        nested (at any depth) inside a ``CompositeBlocker``. A blocker with no
+        index (AllPairs, GLinker, KeyBlocker) contributes nothing. When an
+        index *is* already built (e.g. a freshly loaded FAISS index, or a
+        Resolver reused on the same records), the would-be corpus is compared
+        to the index's stored ``_corpus_texts``: identical -> reuse (never
+        re-embed, so restore + same-records round-trips are cheap); different
+        -> rebuild (so reusing the Resolver on a new record list scores
         against the right corpus rather than a stale one).
         """
-        if not isinstance(self.blocker, VectorBlocker):
-            return  # AllPairs, GLinker, and other index-free blockers.
+        for vector_blocker in _iter_vector_blockers(self.blocker):
+            entities = [vector_blocker.schema_factory(record) for record in records]
+            texts = [vector_blocker.text_field_extractor(entity) for entity in entities]
 
-        entities = [self.blocker.schema_factory(record) for record in records]
-        texts = [self.blocker.text_field_extractor(entity) for entity in entities]
+            index = vector_blocker.vector_index
+            if vector_blocker._index_is_built() and getattr(index, "_corpus_texts", None) == texts:
+                continue  # Same corpus already indexed -> reuse, never re-embed.
 
-        index = self.blocker.vector_index
-        if self.blocker._index_is_built() and getattr(index, "_corpus_texts", None) == texts:
-            return  # Same corpus already indexed -> reuse, never re-embed.
-
-        logger.info("Embedding %d records to build the blocker's vector index…", len(texts))
-        index.create_index(texts)
+            logger.info("Embedding %d records to build the blocker's vector index…", len(texts))
+            index.create_index(texts)
 
     # ------------------------------------------------------------------
     # Linking / streaming (M5)

--- a/tests/core/blockers/test_composite_blocker.py
+++ b/tests/core/blockers/test_composite_blocker.py
@@ -9,6 +9,8 @@ Schema-agnostic: exercised with both ``CompanySchema`` and a local
 ``ProductSchema``.
 """
 
+from typing import Any
+
 import pytest
 from pydantic import BaseModel
 
@@ -17,7 +19,7 @@ from langres.core.blockers.all_pairs import AllPairsBlocker
 from langres.core.blockers.composite import CompositeBlocker
 from langres.core.blockers.key import KeyBlocker
 from langres.core.groups import ERCandidateGroup
-from langres.core.models import CompanySchema
+from langres.core.models import CompanySchema, ERCandidate
 from langres.core.registry import get_component
 from tests.conftest import pairs_from_candidates, pairs_from_groups
 
@@ -115,6 +117,27 @@ def test_composite_blocker_union_dedups_pair_found_by_multiple_children() -> Non
     # (also produced by key_blocker).
     assert len(candidates) == 6
     assert len(pairs_from_candidates(candidates)) == 6
+
+
+def test_composite_blocker_dedups_a_single_child_emitting_the_same_pair_twice() -> None:
+    """Defensive dedup: a child that itself yields one pair twice still counts once."""
+
+    class _DuplicateEmittingBlocker(Blocker[CompanySchema]):
+        def stream(self, data):  # type: ignore[no-untyped-def]
+            left = CompanySchema(id="a", name="Acme")
+            right = CompanySchema(id="b", name="Acme Corp")
+            yield ERCandidate(left=left, right=right, blocker_name="dup")
+            yield ERCandidate(left=left, right=right, blocker_name="dup")
+
+        def inspect_candidates(self, candidates, entities, sample_size=10):  # type: ignore[no-untyped-def]
+            raise NotImplementedError
+
+    composite = CompositeBlocker(
+        children=[_DuplicateEmittingBlocker(), _all_pairs_blocker()], op="union"
+    )
+    candidates = list(composite.stream(COMPANY_DATA))
+
+    assert len({(c.left.id, c.right.id) for c in candidates}) == len(candidates)
 
 
 def test_composite_blocker_union_is_recall_maximizing() -> None:
@@ -218,7 +241,7 @@ def test_composite_blocker_empty_data() -> None:
     for op in ("union", "intersection", "difference"):
         composite = CompositeBlocker(
             children=[_key_blocker(), _all_pairs_blocker()],
-            op=op,  # type: ignore[arg-type]
+            op=op,
         )
         assert list(composite.stream([])) == []
 
@@ -226,7 +249,7 @@ def test_composite_blocker_empty_data() -> None:
 def test_composite_blocker_is_schema_agnostic_with_product_schema() -> None:
     """The same CompositeBlocker class works with a completely different schema."""
 
-    def product_factory(record: dict) -> ProductSchema:
+    def product_factory(record: dict[str, Any]) -> ProductSchema:
         return ProductSchema(
             id=record["id"], title=record["title"], manufacturer=record.get("manufacturer")
         )
@@ -273,7 +296,7 @@ def test_composite_blocker_registered_under_type_name() -> None:
 def test_composite_blocker_config_round_trips_simple_children() -> None:
     """config/from_config round-trip for children with plain (non-state) config."""
     original = CompositeBlocker(children=[_key_blocker(), _all_pairs_blocker()], op="intersection")
-    rebuilt = CompositeBlocker.from_config(original.config)
+    rebuilt: CompositeBlocker[CompanySchema] = CompositeBlocker.from_config(original.config)
 
     assert list(rebuilt.stream(COMPANY_DATA)) == list(original.stream(COMPANY_DATA))
     assert rebuilt.op == "intersection"
@@ -302,6 +325,62 @@ def test_composite_blocker_config_raises_for_child_without_type_name() -> None:
 
     with pytest.raises(ValueError, match="type_name"):
         _ = composite.config
+
+
+# ---------------------------------------------------------------------------
+# inspect_candidates
+# ---------------------------------------------------------------------------
+
+
+def test_composite_blocker_inspect_candidates_union_basic_shape() -> None:
+    """inspect_candidates reports totals, distribution, examples, recommendations."""
+    composite = CompositeBlocker(children=[_key_blocker(), _all_pairs_blocker()], op="union")
+    entities = [
+        CompanySchema(id=r["id"], name=r["name"], address=r.get("address")) for r in COMPANY_DATA
+    ]
+    candidates = list(composite.stream(COMPANY_DATA))
+
+    report = composite.inspect_candidates(candidates, entities, sample_size=3)
+
+    assert report.total_candidates == len(candidates)
+    assert len(report.examples) == 3
+    assert "union" in report.recommendations[0]
+
+
+def test_composite_blocker_inspect_candidates_intersection_recommendation() -> None:
+    """Non-union ops get a precision/recall trade-off warning."""
+    composite = CompositeBlocker(children=[_key_blocker(), _all_pairs_blocker()], op="intersection")
+    entities = [
+        CompanySchema(id=r["id"], name=r["name"], address=r.get("address")) for r in COMPANY_DATA
+    ]
+    candidates = list(composite.stream(COMPANY_DATA))
+
+    report = composite.inspect_candidates(candidates, entities)
+
+    assert "Pair-Completeness" in report.recommendations[0]
+
+
+def test_composite_blocker_inspect_candidates_falls_back_to_repr_without_name_field() -> None:
+    """A schema with no 'name' attribute falls back to str(entity) for example text."""
+
+    def product_factory(record: dict[str, Any]) -> ProductSchema:
+        return ProductSchema(
+            id=record["id"], title=record["title"], manufacturer=record.get("manufacturer")
+        )
+
+    data = [
+        {"id": "p1", "title": "iPhone 15", "manufacturer": "Apple"},
+        {"id": "p2", "title": "iPhone 15 Pro", "manufacturer": "Apple"},
+    ]
+    key_blocker = KeyBlocker(schema_factory=product_factory, key_field="manufacturer")
+    all_pairs = AllPairsBlocker(schema_factory=product_factory)
+    composite = CompositeBlocker(children=[key_blocker, all_pairs], op="union")
+    entities = [product_factory(r) for r in data]
+    candidates = list(composite.stream(data))
+
+    report = composite.inspect_candidates(candidates, entities)
+
+    assert report.examples[0]["left_text"] == str(entities[0])
 
 
 # ---------------------------------------------------------------------------

--- a/tests/core/blockers/test_composite_blocker.py
+++ b/tests/core/blockers/test_composite_blocker.py
@@ -1,0 +1,331 @@
+"""Tests for CompositeBlocker (W1.3): union/intersection/difference algebra.
+
+CompositeBlocker composes 2+ child Blockers' candidate pair-sets via a set
+operation (recall-first ``"union"`` default, plus ``"intersection"`` and
+``"difference"``), deduping by the canonical undirected pair key
+(``frozenset({left.id, right.id})``) with first-seen semantics, and carries
+per-pair provenance (which child(ren) produced it) on ``blocker_name``.
+Schema-agnostic: exercised with both ``CompanySchema`` and a local
+``ProductSchema``.
+"""
+
+import pytest
+from pydantic import BaseModel
+
+from langres.core.blocker import Blocker
+from langres.core.blockers.all_pairs import AllPairsBlocker
+from langres.core.blockers.composite import CompositeBlocker
+from langres.core.blockers.key import KeyBlocker
+from langres.core.groups import ERCandidateGroup
+from langres.core.models import CompanySchema
+from langres.core.registry import get_component
+from tests.conftest import pairs_from_candidates, pairs_from_groups
+
+
+class ProductSchema(BaseModel):
+    """Second schema for schema-agnostic verification."""
+
+    id: str
+    title: str
+    manufacturer: str | None = None
+
+
+COMPANY_DATA = [
+    {"id": "a", "name": "Acme", "address": "Zurich"},
+    {"id": "b", "name": "Acme Corp", "address": "Zurich"},
+    {"id": "c", "name": "Beta Inc", "address": "Geneva"},
+    {"id": "d", "name": "Beta", "address": "Bern"},
+]
+
+
+def _key_blocker() -> KeyBlocker[CompanySchema]:
+    """Blocks a/b (share 'zurich') only."""
+    return KeyBlocker(schema=CompanySchema, key_field="address")
+
+
+def _all_pairs_blocker() -> AllPairsBlocker[CompanySchema]:
+    """Blocks every pair (superset of anything else)."""
+    return AllPairsBlocker(schema=CompanySchema)
+
+
+class _NameFirstLetterBlocker(KeyBlocker[CompanySchema]):
+    """A second, disjoint-ish KeyBlocker for intersection/difference tests."""
+
+    def __init__(self) -> None:
+        super().__init__(
+            schema=CompanySchema,
+            key_fn=lambda c: c.name[0] if c.name else None,
+        )
+
+
+# ---------------------------------------------------------------------------
+# Constructor validation
+# ---------------------------------------------------------------------------
+
+
+def test_composite_blocker_requires_at_least_two_children() -> None:
+    """A composite of 0 or 1 children is not a meaningful algebra expression."""
+    with pytest.raises(ValueError, match="at least 2"):
+        CompositeBlocker(children=[])
+
+    with pytest.raises(ValueError, match="at least 2"):
+        CompositeBlocker(children=[_key_blocker()])
+
+
+def test_composite_blocker_rejects_unknown_op() -> None:
+    """Only union/intersection/difference are valid ops."""
+    with pytest.raises(ValueError, match="union.*intersection.*difference|op"):
+        CompositeBlocker(
+            children=[_key_blocker(), _all_pairs_blocker()],
+            op="xor",  # type: ignore[arg-type]
+        )
+
+
+def test_composite_blocker_defaults_to_union() -> None:
+    """The recall-maximizing default composition is union."""
+    composite = CompositeBlocker(children=[_key_blocker(), _all_pairs_blocker()])
+    assert composite.op == "union"
+
+
+# ---------------------------------------------------------------------------
+# Union
+# ---------------------------------------------------------------------------
+
+
+def test_composite_blocker_union_is_pair_set_union() -> None:
+    """Union yields every pair produced by ANY child, deduped."""
+    composite = CompositeBlocker(children=[_key_blocker(), _NameFirstLetterBlocker()], op="union")
+    candidates = list(composite.stream(COMPANY_DATA))
+
+    # key_blocker (by address): {a,b} only.
+    # name-first-letter blocker: "A"->{a,b}, "B"->{c,d}.
+    # Union: {a,b} (both children agree) + {c,d} (only the letter blocker).
+    assert pairs_from_candidates(candidates) == {
+        frozenset({"a", "b"}),
+        frozenset({"c", "d"}),
+    }
+
+
+def test_composite_blocker_union_dedups_pair_found_by_multiple_children() -> None:
+    """A pair produced by 2+ children appears exactly once in the union."""
+    composite = CompositeBlocker(children=[_key_blocker(), _all_pairs_blocker()], op="union")
+    candidates = list(composite.stream(COMPANY_DATA))
+
+    # AllPairs alone would give C(4,2)=6; union must not double-count {a,b}
+    # (also produced by key_blocker).
+    assert len(candidates) == 6
+    assert len(pairs_from_candidates(candidates)) == 6
+
+
+def test_composite_blocker_union_is_recall_maximizing() -> None:
+    """Union's candidate count is >= the max of any single child's count."""
+    key_only = list(_key_blocker().stream(COMPANY_DATA))
+    letter_only = list(_NameFirstLetterBlocker().stream(COMPANY_DATA))
+    composite = CompositeBlocker(children=[_key_blocker(), _NameFirstLetterBlocker()], op="union")
+    union_candidates = list(composite.stream(COMPANY_DATA))
+
+    assert len(union_candidates) >= max(len(key_only), len(letter_only))
+    # And it's a strict pairs-superset of each child.
+    assert pairs_from_candidates(key_only) <= pairs_from_candidates(union_candidates)
+    assert pairs_from_candidates(letter_only) <= pairs_from_candidates(union_candidates)
+
+
+def test_composite_blocker_union_blocker_name_lists_contributing_children() -> None:
+    """blocker_name records which child(ren) produced each pair (provenance)."""
+    composite = CompositeBlocker(children=[_key_blocker(), _NameFirstLetterBlocker()], op="union")
+    candidates = list(composite.stream(COMPANY_DATA))
+    by_pair = {frozenset({c.left.id, c.right.id}): c.blocker_name for c in candidates}
+
+    # {a,b} is produced by BOTH children -> both names present.
+    ab_name = by_pair[frozenset({"a", "b"})]
+    assert "key_blocker" in ab_name
+    assert "composite_union" in ab_name
+
+    # {c,d} is produced ONLY by the letter blocker.
+    cd_name = by_pair[frozenset({"c", "d"})]
+    assert "key_blocker" in cd_name  # both are KeyBlocker subclasses -> same type_name
+    assert "composite_union" in cd_name
+
+
+# ---------------------------------------------------------------------------
+# Intersection
+# ---------------------------------------------------------------------------
+
+
+def test_composite_blocker_intersection_keeps_only_shared_pairs() -> None:
+    """Intersection yields only pairs present in EVERY child."""
+    composite = CompositeBlocker(children=[_key_blocker(), _all_pairs_blocker()], op="intersection")
+    candidates = list(composite.stream(COMPANY_DATA))
+
+    # key_blocker only ever produces {a,b}; AllPairs is a superset -> intersection = {a,b}.
+    assert pairs_from_candidates(candidates) == {frozenset({"a", "b"})}
+
+
+def test_composite_blocker_intersection_empty_when_no_overlap() -> None:
+    """Intersection of children whose pair-sets don't overlap yields no pairs."""
+
+    class _CityBlocker(KeyBlocker[CompanySchema]):
+        def __init__(self) -> None:
+            super().__init__(schema=CompanySchema, key_field="address")
+
+    # Same city, different first letter -> the city blocker pairs them, the
+    # letter blocker doesn't -> intersection is empty.
+    disjoint_data = [
+        {"id": "1", "name": "Xavier", "address": "Bern"},
+        {"id": "2", "name": "Yara", "address": "Bern"},
+    ]
+    composite = CompositeBlocker(
+        children=[_CityBlocker(), _NameFirstLetterBlocker()], op="intersection"
+    )
+    candidates = list(composite.stream(disjoint_data))
+
+    assert candidates == []
+
+
+# ---------------------------------------------------------------------------
+# Difference
+# ---------------------------------------------------------------------------
+
+
+def test_composite_blocker_difference_keeps_first_minus_rest() -> None:
+    """Difference yields pairs in the first child not present in any other child."""
+    composite = CompositeBlocker(children=[_all_pairs_blocker(), _key_blocker()], op="difference")
+    candidates = list(composite.stream(COMPANY_DATA))
+
+    # AllPairs (6 pairs) minus key_blocker's {a,b} -> the other 5.
+    assert pairs_from_candidates(candidates) == pairs_from_candidates(
+        list(_all_pairs_blocker().stream(COMPANY_DATA))
+    ) - {frozenset({"a", "b"})}
+    assert len(candidates) == 5
+
+
+def test_composite_blocker_difference_blocker_name_shows_subtrahend() -> None:
+    """Difference provenance names the surviving (first) child only."""
+    composite = CompositeBlocker(children=[_all_pairs_blocker(), _key_blocker()], op="difference")
+    candidates = list(composite.stream(COMPANY_DATA))
+
+    assert all("composite_difference" in c.blocker_name for c in candidates)
+    assert all("all_pairs_blocker" in c.blocker_name for c in candidates)
+
+
+# ---------------------------------------------------------------------------
+# Dedup / first-seen semantics, empty/edge cases, schema-agnosticism
+# ---------------------------------------------------------------------------
+
+
+def test_composite_blocker_empty_data() -> None:
+    """Empty input -> no candidates, for every op."""
+    for op in ("union", "intersection", "difference"):
+        composite = CompositeBlocker(
+            children=[_key_blocker(), _all_pairs_blocker()],
+            op=op,  # type: ignore[arg-type]
+        )
+        assert list(composite.stream([])) == []
+
+
+def test_composite_blocker_is_schema_agnostic_with_product_schema() -> None:
+    """The same CompositeBlocker class works with a completely different schema."""
+
+    def product_factory(record: dict) -> ProductSchema:
+        return ProductSchema(
+            id=record["id"], title=record["title"], manufacturer=record.get("manufacturer")
+        )
+
+    data = [
+        {"id": "p1", "title": "iPhone 15", "manufacturer": "Apple"},
+        {"id": "p2", "title": "iPhone 15 Pro", "manufacturer": "Apple"},
+        {"id": "p3", "title": "Galaxy S24", "manufacturer": "Samsung"},
+    ]
+    key_blocker = KeyBlocker(schema_factory=product_factory, key_field="manufacturer")
+    all_pairs = AllPairsBlocker(schema_factory=product_factory)
+    composite = CompositeBlocker(children=[key_blocker, all_pairs], op="union")
+
+    candidates = list(composite.stream(data))
+
+    assert isinstance(candidates[0].left, ProductSchema)
+    assert pairs_from_candidates(candidates) == {
+        frozenset({"p1", "p2"}),
+        frozenset({"p1", "p3"}),
+        frozenset({"p2", "p3"}),
+    }
+
+
+def test_composite_blocker_nested_composite_children() -> None:
+    """A CompositeBlocker can itself be a child of another CompositeBlocker."""
+    inner = CompositeBlocker(children=[_key_blocker(), _NameFirstLetterBlocker()], op="union")
+    outer = CompositeBlocker(children=[inner, _all_pairs_blocker()], op="intersection")
+
+    candidates = list(outer.stream(COMPANY_DATA))
+    # inner union = {a,b},{c,d}; AllPairs is a superset -> intersection = inner's pairs.
+    assert pairs_from_candidates(candidates) == {frozenset({"a", "b"}), frozenset({"c", "d"})}
+
+
+# ---------------------------------------------------------------------------
+# Registry / config-registry serialization plumbing
+# ---------------------------------------------------------------------------
+
+
+def test_composite_blocker_registered_under_type_name() -> None:
+    """CompositeBlocker is registered under 'composite_blocker'."""
+    assert get_component("composite_blocker") is CompositeBlocker
+
+
+def test_composite_blocker_config_round_trips_simple_children() -> None:
+    """config/from_config round-trip for children with plain (non-state) config."""
+    original = CompositeBlocker(children=[_key_blocker(), _all_pairs_blocker()], op="intersection")
+    rebuilt = CompositeBlocker.from_config(original.config)
+
+    assert list(rebuilt.stream(COMPANY_DATA)) == list(original.stream(COMPANY_DATA))
+    assert rebuilt.op == "intersection"
+
+
+def test_composite_blocker_config_raises_for_non_serializable_child() -> None:
+    """A child built from an opaque callable propagates its own config error."""
+    non_serializable_child = KeyBlocker(schema=CompanySchema, key_fn=lambda c: c.name)
+    composite = CompositeBlocker(children=[non_serializable_child, _all_pairs_blocker()])
+
+    with pytest.raises(ValueError, match="key_fn"):
+        _ = composite.config
+
+
+def test_composite_blocker_config_raises_for_child_without_type_name() -> None:
+    """A child with no registry type_name cannot be serialized."""
+
+    class _UnregisteredBlocker(Blocker[CompanySchema]):
+        def stream(self, data):  # type: ignore[no-untyped-def]
+            return iter(())
+
+        def inspect_candidates(self, candidates, entities, sample_size=10):  # type: ignore[no-untyped-def]
+            raise NotImplementedError
+
+    composite = CompositeBlocker(children=[_UnregisteredBlocker(), _all_pairs_blocker()])
+
+    with pytest.raises(ValueError, match="type_name"):
+        _ = composite.config
+
+
+# ---------------------------------------------------------------------------
+# stream_groups(): inherited default (W1.0 exactly-once contract)
+# ---------------------------------------------------------------------------
+
+
+def test_composite_blocker_stream_groups_is_a_concrete_iterator() -> None:
+    """CompositeBlocker gets a working stream_groups() from the Blocker base default."""
+    composite = CompositeBlocker(children=[_key_blocker(), _all_pairs_blocker()], op="union")
+    groups = list(composite.stream_groups(COMPANY_DATA))
+    assert len(groups) > 0
+    assert isinstance(groups[0], ERCandidateGroup)
+
+
+@pytest.mark.parametrize("op", ["union", "intersection", "difference"])
+def test_composite_blocker_stream_groups_pairs_equivalence_property(op: str) -> None:
+    """Property (CEO #14): pairs from stream_groups() == pairs from stream(), for every op."""
+    composite = CompositeBlocker(
+        children=[_key_blocker(), _NameFirstLetterBlocker()],
+        op=op,  # type: ignore[arg-type]
+    )
+
+    stream_pairs = pairs_from_candidates(composite.stream(COMPANY_DATA))
+    group_pairs = pairs_from_groups(composite.stream_groups(COMPANY_DATA))
+
+    assert group_pairs == stream_pairs

--- a/tests/core/blockers/test_key_blocker.py
+++ b/tests/core/blockers/test_key_blocker.py
@@ -29,15 +29,15 @@ class ProductSchema(BaseModel):
 
 
 COMPANY_DATA = [
-    {"id": "a", "name": "Acme", "city": "Zurich"},
-    {"id": "b", "name": "Acme Corp", "city": "  ZURICH  "},
-    {"id": "c", "name": "Beta", "city": "Geneva"},
-    {"id": "d", "name": "Gamma", "city": None},
+    {"id": "a", "name": "Acme", "address": "Zurich"},
+    {"id": "b", "name": "Acme Corp", "address": "  ZURICH  "},
+    {"id": "c", "name": "Beta", "address": "Geneva"},
+    {"id": "d", "name": "Gamma", "address": None},
 ]
 
 
 def _company_factory(record: dict) -> CompanySchema:
-    return CompanySchema(id=record["id"], name=record["name"], address=record.get("city"))
+    return CompanySchema(id=record["id"], name=record["name"], address=record.get("address"))
 
 
 # ---------------------------------------------------------------------------
@@ -53,7 +53,7 @@ def test_key_blocker_pairs_only_within_matching_key() -> None:
     pairs = pairs_from_candidates(candidates)
 
     # "a"/"b" share the "zurich" key (after normalization); "c" is alone in
-    # "geneva"; "d" has no key (city=None) and is excluded entirely.
+    # "geneva"; "d" has no key (address=None) and is excluded entirely.
     assert pairs == {frozenset({"a", "b"})}
 
 
@@ -108,9 +108,9 @@ def test_key_blocker_single_record() -> None:
 def test_key_blocker_bucket_larger_than_two() -> None:
     """A 3-record bucket yields C(3,2) = 3 pairs."""
     data = [
-        {"id": "1", "name": "A", "city": "Bern"},
-        {"id": "2", "name": "B", "city": "Bern"},
-        {"id": "3", "name": "C", "city": "Bern"},
+        {"id": "1", "name": "A", "address": "Bern"},
+        {"id": "2", "name": "B", "address": "Bern"},
+        {"id": "3", "name": "C", "address": "Bern"},
     ]
     blocker = KeyBlocker(schema=CompanySchema, key_field="address")
     candidates = list(blocker.stream(data))
@@ -256,12 +256,33 @@ def test_key_blocker_inspect_candidates_basic_shape() -> None:
     assert report.recommendations
 
 
+def test_key_blocker_inspect_candidates_falls_back_to_repr_without_name_field() -> None:
+    """A schema with no 'name' attribute falls back to str(entity) for example text."""
+
+    def product_factory(record: dict) -> ProductSchema:
+        return ProductSchema(
+            id=record["id"], title=record["title"], manufacturer=record.get("manufacturer")
+        )
+
+    data = [
+        {"id": "p1", "title": "iPhone 15", "manufacturer": "Apple"},
+        {"id": "p2", "title": "iPhone 15 Pro", "manufacturer": "Apple"},
+    ]
+    blocker = KeyBlocker(schema_factory=product_factory, key_field="manufacturer")
+    entities = [product_factory(r) for r in data]
+    candidates = list(blocker.stream(data))
+
+    report = blocker.inspect_candidates(candidates, entities)
+
+    assert report.examples[0]["left_text"] == str(entities[0])
+
+
 def test_key_blocker_inspect_candidates_handles_zero_candidates() -> None:
     """No candidates (e.g. all keys unique) still produces a valid report."""
     blocker = KeyBlocker(schema=CompanySchema, key_field="address")
     data = [
-        {"id": "1", "name": "A", "city": "Bern"},
-        {"id": "2", "name": "B", "city": "Chur"},
+        {"id": "1", "name": "A", "address": "Bern"},
+        {"id": "2", "name": "B", "address": "Chur"},
     ]
     entities = [_company_factory(r) for r in data]
     candidates = list(blocker.stream(data))
@@ -290,10 +311,10 @@ def test_key_blocker_stream_groups_is_a_concrete_iterator() -> None:
 def test_key_blocker_stream_groups_pairs_equivalence_property() -> None:
     """Property (CEO #14): pairs from stream_groups() == pairs from stream()."""
     data = [
-        {"id": "1", "name": "A", "city": "Bern"},
-        {"id": "2", "name": "B", "city": "Bern"},
-        {"id": "3", "name": "C", "city": "Bern"},
-        {"id": "4", "name": "D", "city": "Chur"},
+        {"id": "1", "name": "A", "address": "Bern"},
+        {"id": "2", "name": "B", "address": "Bern"},
+        {"id": "3", "name": "C", "address": "Bern"},
+        {"id": "4", "name": "D", "address": "Chur"},
     ]
     blocker = KeyBlocker(schema=CompanySchema, key_field="address")
 
@@ -304,6 +325,8 @@ def test_key_blocker_stream_groups_pairs_equivalence_property() -> None:
     assert len(stream_pairs) == 3  # C(3,2) within the "bern" bucket
 
 
-def _typecheck_stream_return(blocker: KeyBlocker[CompanySchema]) -> Iterator[ERCandidate[CompanySchema]]:
+def _typecheck_stream_return(
+    blocker: KeyBlocker[CompanySchema],
+) -> Iterator[ERCandidate[CompanySchema]]:
     """mypy-only helper: confirms KeyBlocker.stream's declared return type."""
     return blocker.stream([])

--- a/tests/core/blockers/test_key_blocker.py
+++ b/tests/core/blockers/test_key_blocker.py
@@ -1,0 +1,309 @@
+"""Tests for KeyBlocker (W1.3): exact/normalized-key blocking.
+
+KeyBlocker buckets records by a configurable key (declarative ``key_field=``
+or a full ``key_fn=`` callable, mirroring the ``schema=``/``schema_factory=``
+mutual-exclusion pattern already used by ``AllPairsBlocker``/``VectorBlocker``)
+and emits all pairs within each bucket. Schema-agnostic: exercised with both
+``CompanySchema`` and a local ``ProductSchema``.
+"""
+
+from collections.abc import Iterator
+
+import pytest
+from pydantic import BaseModel
+
+from langres.core.blocker import Blocker
+from langres.core.blockers.key import KeyBlocker
+from langres.core.groups import ERCandidateGroup
+from langres.core.models import CompanySchema, ERCandidate
+from langres.core.registry import get_component
+from tests.conftest import pairs_from_candidates, pairs_from_groups
+
+
+class ProductSchema(BaseModel):
+    """Second schema for schema-agnostic verification."""
+
+    id: str
+    title: str
+    manufacturer: str | None = None
+
+
+COMPANY_DATA = [
+    {"id": "a", "name": "Acme", "city": "Zurich"},
+    {"id": "b", "name": "Acme Corp", "city": "  ZURICH  "},
+    {"id": "c", "name": "Beta", "city": "Geneva"},
+    {"id": "d", "name": "Gamma", "city": None},
+]
+
+
+def _company_factory(record: dict) -> CompanySchema:
+    return CompanySchema(id=record["id"], name=record["name"], address=record.get("city"))
+
+
+# ---------------------------------------------------------------------------
+# Basic bucketing behavior
+# ---------------------------------------------------------------------------
+
+
+def test_key_blocker_pairs_only_within_matching_key() -> None:
+    """Only records sharing a (normalized) key produce a candidate pair."""
+    blocker = KeyBlocker(schema=CompanySchema, key_field="address")
+
+    candidates = list(blocker.stream(COMPANY_DATA))
+    pairs = pairs_from_candidates(candidates)
+
+    # "a"/"b" share the "zurich" key (after normalization); "c" is alone in
+    # "geneva"; "d" has no key (city=None) and is excluded entirely.
+    assert pairs == {frozenset({"a", "b"})}
+
+
+def test_key_blocker_normalizes_case_and_whitespace_by_default() -> None:
+    """normalize=True (default) lowercases + strips before bucketing."""
+    blocker = KeyBlocker(schema=CompanySchema, key_field="address")
+    candidates = list(blocker.stream(COMPANY_DATA))
+
+    assert len(candidates) == 1
+    assert {candidates[0].left.id, candidates[0].right.id} == {"a", "b"}
+
+
+def test_key_blocker_normalize_false_is_exact_match() -> None:
+    """normalize=False requires byte-exact key equality."""
+    blocker = KeyBlocker(schema=CompanySchema, key_field="address", normalize=False)
+    candidates = list(blocker.stream(COMPANY_DATA))
+
+    # "Zurich" != "  ZURICH  " verbatim -> no pair.
+    assert candidates == []
+
+
+def test_key_blocker_excludes_records_with_none_key() -> None:
+    """A record whose key extraction is None never appears in any pair."""
+    blocker = KeyBlocker(schema=CompanySchema, key_field="address")
+    candidates = list(blocker.stream(COMPANY_DATA))
+
+    for cand in candidates:
+        assert cand.left.id != "d"
+        assert cand.right.id != "d"
+
+
+def test_key_blocker_blocker_name() -> None:
+    """Candidates carry blocker_name == 'key_blocker'."""
+    blocker = KeyBlocker(schema=CompanySchema, key_field="address")
+    candidates = list(blocker.stream(COMPANY_DATA))
+
+    assert all(c.blocker_name == "key_blocker" for c in candidates)
+
+
+def test_key_blocker_empty_data() -> None:
+    """Empty input -> no candidates."""
+    blocker = KeyBlocker(schema=CompanySchema, key_field="address")
+    assert list(blocker.stream([])) == []
+
+
+def test_key_blocker_single_record() -> None:
+    """A single record never pairs with itself."""
+    blocker = KeyBlocker(schema=CompanySchema, key_field="address")
+    assert list(blocker.stream([COMPANY_DATA[0]])) == []
+
+
+def test_key_blocker_bucket_larger_than_two() -> None:
+    """A 3-record bucket yields C(3,2) = 3 pairs."""
+    data = [
+        {"id": "1", "name": "A", "city": "Bern"},
+        {"id": "2", "name": "B", "city": "Bern"},
+        {"id": "3", "name": "C", "city": "Bern"},
+    ]
+    blocker = KeyBlocker(schema=CompanySchema, key_field="address")
+    candidates = list(blocker.stream(data))
+
+    assert len(candidates) == 3
+    assert pairs_from_candidates(candidates) == {
+        frozenset({"1", "2"}),
+        frozenset({"1", "3"}),
+        frozenset({"2", "3"}),
+    }
+
+
+# ---------------------------------------------------------------------------
+# key_fn (callable) construction path + schema-agnosticism
+# ---------------------------------------------------------------------------
+
+
+def test_key_blocker_key_fn_callable_path() -> None:
+    """key_fn= gives full control over key extraction, e.g. first-letter blocking."""
+
+    def first_letter(entity: CompanySchema) -> str | None:
+        return entity.name[0] if entity.name else None
+
+    data = [
+        {"id": "1", "name": "Acme"},
+        {"id": "2", "name": "Apex"},
+        {"id": "3", "name": "Beta"},
+    ]
+    blocker = KeyBlocker(schema_factory=_company_factory, key_fn=first_letter)
+    candidates = list(blocker.stream(data))
+
+    assert pairs_from_candidates(candidates) == {frozenset({"1", "2"})}
+
+
+def test_key_blocker_is_schema_agnostic_with_product_schema() -> None:
+    """The same KeyBlocker class works with a completely different schema."""
+
+    def product_factory(record: dict) -> ProductSchema:
+        return ProductSchema(
+            id=record["id"], title=record["title"], manufacturer=record.get("manufacturer")
+        )
+
+    data = [
+        {"id": "p1", "title": "iPhone 15", "manufacturer": "Apple"},
+        {"id": "p2", "title": "iPhone 15 Pro", "manufacturer": "apple"},
+        {"id": "p3", "title": "Galaxy S24", "manufacturer": "Samsung"},
+    ]
+    blocker = KeyBlocker(schema_factory=product_factory, key_field="manufacturer")
+    candidates = list(blocker.stream(data))
+
+    assert len(candidates) == 1
+    assert isinstance(candidates[0].left, ProductSchema)
+    assert {candidates[0].left.id, candidates[0].right.id} == {"p1", "p2"}
+
+
+# ---------------------------------------------------------------------------
+# Constructor validation (mutual exclusion, mirroring AllPairsBlocker)
+# ---------------------------------------------------------------------------
+
+
+def test_key_blocker_requires_exactly_one_schema_arg() -> None:
+    """Both schema and schema_factory (or neither) is an error."""
+    with pytest.raises(ValueError, match="schema"):
+        KeyBlocker(key_field="address")  # neither schema nor schema_factory
+
+    with pytest.raises(ValueError, match="schema"):
+        KeyBlocker(
+            schema=CompanySchema,
+            schema_factory=_company_factory,
+            key_field="address",
+        )
+
+
+def test_key_blocker_requires_exactly_one_key_arg() -> None:
+    """Both key_field and key_fn (or neither) is an error."""
+    with pytest.raises(ValueError, match="key_field.*key_fn|key_fn.*key_field"):
+        KeyBlocker(schema=CompanySchema)  # neither key_field nor key_fn
+
+    with pytest.raises(ValueError, match="key_field.*key_fn|key_fn.*key_field"):
+        KeyBlocker(schema=CompanySchema, key_field="address", key_fn=lambda e: e.name)
+
+
+# ---------------------------------------------------------------------------
+# Registry / config-registry serialization plumbing
+# ---------------------------------------------------------------------------
+
+
+def test_key_blocker_registered_under_type_name() -> None:
+    """KeyBlocker is registered under 'key_blocker'."""
+    assert get_component("key_blocker") is KeyBlocker
+
+
+def test_key_blocker_config_shape() -> None:
+    """config exposes schema_type_name + key_field + normalize."""
+    blocker = KeyBlocker(schema=CompanySchema, key_field="address", normalize=False)
+
+    assert blocker.config == {
+        "schema_type_name": "CompanySchema",
+        "key_field": "address",
+        "normalize": False,
+    }
+
+
+def test_key_blocker_from_config_round_trips() -> None:
+    """from_config rebuilds a functionally-equivalent KeyBlocker."""
+    original = KeyBlocker(schema=CompanySchema, key_field="address")
+    rebuilt = KeyBlocker.from_config(original.config)
+
+    assert list(rebuilt.stream(COMPANY_DATA)) == list(original.stream(COMPANY_DATA))
+
+
+def test_key_blocker_config_raises_for_schema_factory() -> None:
+    """A schema_factory-built KeyBlocker cannot serialize its entity normalization."""
+    blocker = KeyBlocker(schema_factory=_company_factory, key_field="address")
+
+    with pytest.raises(ValueError, match="schema_factory"):
+        _ = blocker.config
+
+
+def test_key_blocker_config_raises_for_key_fn() -> None:
+    """A key_fn-built KeyBlocker cannot serialize its key extraction."""
+    blocker = KeyBlocker(schema=CompanySchema, key_fn=lambda e: e.name)
+
+    with pytest.raises(ValueError, match="key_fn"):
+        _ = blocker.config
+
+
+# ---------------------------------------------------------------------------
+# inspect_candidates
+# ---------------------------------------------------------------------------
+
+
+def test_key_blocker_inspect_candidates_basic_shape() -> None:
+    """inspect_candidates reports totals, distribution, examples, recommendations."""
+    blocker = KeyBlocker(schema=CompanySchema, key_field="address")
+    entities = [_company_factory(r) for r in COMPANY_DATA]
+    candidates = list(blocker.stream(COMPANY_DATA))
+
+    report = blocker.inspect_candidates(candidates, entities, sample_size=5)
+
+    assert report.total_candidates == 1
+    assert report.examples[0]["left_id"] in {"a", "b"}
+    assert report.recommendations
+
+
+def test_key_blocker_inspect_candidates_handles_zero_candidates() -> None:
+    """No candidates (e.g. all keys unique) still produces a valid report."""
+    blocker = KeyBlocker(schema=CompanySchema, key_field="address")
+    data = [
+        {"id": "1", "name": "A", "city": "Bern"},
+        {"id": "2", "name": "B", "city": "Chur"},
+    ]
+    entities = [_company_factory(r) for r in data]
+    candidates = list(blocker.stream(data))
+
+    report = blocker.inspect_candidates(candidates, entities)
+
+    assert report.total_candidates == 0
+    assert report.recommendations
+
+
+# ---------------------------------------------------------------------------
+# stream_groups(): inherited default (W1.0 exactly-once contract)
+# ---------------------------------------------------------------------------
+
+
+def test_key_blocker_stream_groups_is_a_concrete_iterator() -> None:
+    """KeyBlocker gets a working stream_groups() from the Blocker base default."""
+    blocker = KeyBlocker(schema=CompanySchema, key_field="address")
+    assert isinstance(blocker, Blocker)
+
+    groups = list(blocker.stream_groups(COMPANY_DATA))
+    assert len(groups) == 1
+    assert isinstance(groups[0], ERCandidateGroup)
+
+
+def test_key_blocker_stream_groups_pairs_equivalence_property() -> None:
+    """Property (CEO #14): pairs from stream_groups() == pairs from stream()."""
+    data = [
+        {"id": "1", "name": "A", "city": "Bern"},
+        {"id": "2", "name": "B", "city": "Bern"},
+        {"id": "3", "name": "C", "city": "Bern"},
+        {"id": "4", "name": "D", "city": "Chur"},
+    ]
+    blocker = KeyBlocker(schema=CompanySchema, key_field="address")
+
+    stream_pairs = pairs_from_candidates(blocker.stream(data))
+    group_pairs = pairs_from_groups(blocker.stream_groups(data))
+
+    assert group_pairs == stream_pairs
+    assert len(stream_pairs) == 3  # C(3,2) within the "bern" bucket
+
+
+def _typecheck_stream_return(blocker: KeyBlocker[CompanySchema]) -> Iterator[ERCandidate[CompanySchema]]:
+    """mypy-only helper: confirms KeyBlocker.stream's declared return type."""
+    return blocker.stream([])

--- a/tests/core/clusterers/__init__.py
+++ b/tests/core/clusterers/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for langres clusterer implementations."""

--- a/tests/core/clusterers/test_correlation_clusterer.py
+++ b/tests/core/clusterers/test_correlation_clusterer.py
@@ -121,6 +121,14 @@ def test_correlation_clusterer_keeps_max_score_for_duplicate_pair_judgements() -
     assert clusterer.cluster(judgements) == [{"A", "B"}]
 
 
+def test_correlation_clusterer_a_later_weaker_duplicate_does_not_downgrade_the_edge() -> None:
+    """A weaker (but still >= threshold) duplicate seen AFTER the strong one is a no-op."""
+    judgements = [_j("A", "B", 0.9), _j("A", "B", 0.6)]
+    clusterer = CorrelationClusterer(threshold=0.5)
+
+    assert clusterer.cluster(judgements) == [{"A", "B"}]
+
+
 def test_correlation_clusterer_ignores_self_pairs() -> None:
     """A left_id == right_id judgement contributes no edge."""
     judgements = [_j("A", "A", 0.99)]

--- a/tests/core/clusterers/test_correlation_clusterer.py
+++ b/tests/core/clusterers/test_correlation_clusterer.py
@@ -1,0 +1,204 @@
+"""Tests for CorrelationClusterer (C6, W1.3): merge-resistant clustering.
+
+The default ``Clusterer`` builds a graph from edges >= threshold and takes
+connected components -- FULL transitive closure, so a chain of edges (A-B,
+B-C) with no direct A-C edge merges A, B, and C into one cluster even though
+A and C were never directly compared. This is the documented M3 over-merge
+failure mode (-0.63 BCubed).
+
+``CorrelationClusterer`` implements the classic *pivot algorithm* for
+correlation clustering (Ailon, Charikar & Newman, "Aggregating Inconsistent
+Information: Ranking and Clustering", JACM 2008): process nodes in a
+deterministic, highest-confidence-first order; each pivot's cluster is itself
+plus only its DIRECT neighbours >= threshold. A node with no direct edge to a
+cluster's pivot is never pulled in by transitivity alone -- this is what makes
+it merge-resistant relative to the base ``Clusterer``.
+"""
+
+import pytest
+
+from langres.core.clusterer import Clusterer
+from langres.core.clusterers.correlation import CorrelationClusterer
+from langres.core.models import PairwiseJudgement
+from langres.core.registry import get_component
+
+
+def _j(left: str, right: str, score: float) -> PairwiseJudgement:
+    return PairwiseJudgement(
+        left_id=left,
+        right_id=right,
+        score=score,
+        score_type="heuristic",
+        decision_step="test",
+        provenance={},
+    )
+
+
+# ---------------------------------------------------------------------------
+# The headline merge-resistance property
+# ---------------------------------------------------------------------------
+
+
+def test_correlation_clusterer_resists_chain_over_merge() -> None:
+    """A-B and B-C edges, NO direct A-C edge -> A and C do NOT end up together.
+
+    The base (transitive-closure) Clusterer merges all three into one cluster
+    on this exact input -- this is the documented over-merge failure mode C6
+    fixes.
+    """
+    judgements = [_j("A", "B", 0.9), _j("B", "C", 0.9)]
+
+    base_clusters = Clusterer(threshold=0.8).cluster(judgements)
+    assert base_clusters == [{"A", "B", "C"}]  # transitive closure over-merges
+
+    clusterer = CorrelationClusterer(threshold=0.8)
+    clusters = clusterer.cluster(judgements)
+
+    assert clusters == [{"A", "B"}, {"C"}]
+
+
+def test_correlation_clusterer_still_merges_a_fully_connected_triangle() -> None:
+    """A direct triangle (every pair connected) merges fully, same as the base."""
+    judgements = [_j("A", "B", 0.9), _j("B", "C", 0.9), _j("A", "C", 0.9)]
+
+    clusterer = CorrelationClusterer(threshold=0.8)
+    clusters = clusterer.cluster(judgements)
+
+    assert clusters == [{"A", "B", "C"}]
+
+
+def test_correlation_clusterer_longer_chain_stays_broken_up() -> None:
+    """A 4-node chain (A-B, B-C, C-D) fragments rather than one giant cluster."""
+    judgements = [_j("A", "B", 0.9), _j("B", "C", 0.9), _j("C", "D", 0.9)]
+
+    base_clusters = Clusterer(threshold=0.8).cluster(judgements)
+    assert base_clusters == [{"A", "B", "C", "D"}]
+
+    clusters = CorrelationClusterer(threshold=0.8).cluster(judgements)
+    total_clustered = sum(len(c) for c in clusters)
+
+    assert total_clustered == 4  # every node accounted for
+    assert len(clusters) >= 2  # NOT collapsed into one giant cluster
+
+
+# ---------------------------------------------------------------------------
+# Threshold semantics (mirrors base Clusterer)
+# ---------------------------------------------------------------------------
+
+
+def test_correlation_clusterer_threshold_is_inclusive() -> None:
+    """score == threshold counts as a match (mirrors base Clusterer's >=)."""
+    judgements = [_j("A", "B", 0.5)]
+    clusterer = CorrelationClusterer(threshold=0.5)
+
+    assert clusterer.cluster(judgements) == [{"A", "B"}]
+
+
+def test_correlation_clusterer_below_threshold_excluded() -> None:
+    """Edges below threshold produce no cluster (nodes simply absent)."""
+    judgements = [_j("A", "B", 0.4)]
+    clusterer = CorrelationClusterer(threshold=0.5)
+
+    assert clusterer.cluster(judgements) == []
+
+
+def test_correlation_clusterer_rejects_invalid_threshold() -> None:
+    """Threshold validation mirrors the base Clusterer."""
+    with pytest.raises(ValueError, match="threshold"):
+        CorrelationClusterer(threshold=1.5)
+
+
+# ---------------------------------------------------------------------------
+# Duplicate judgements, self-pairs, determinism
+# ---------------------------------------------------------------------------
+
+
+def test_correlation_clusterer_keeps_max_score_for_duplicate_pair_judgements() -> None:
+    """If the same pair is judged twice, the stronger edge wins (no double counting)."""
+    judgements = [_j("A", "B", 0.3), _j("A", "B", 0.9)]
+    clusterer = CorrelationClusterer(threshold=0.8)
+
+    assert clusterer.cluster(judgements) == [{"A", "B"}]
+
+
+def test_correlation_clusterer_ignores_self_pairs() -> None:
+    """A left_id == right_id judgement contributes no edge."""
+    judgements = [_j("A", "A", 0.99)]
+    clusterer = CorrelationClusterer(threshold=0.5)
+
+    assert clusterer.cluster(judgements) == []
+
+
+def test_correlation_clusterer_empty_input() -> None:
+    """No judgements -> no clusters."""
+    assert CorrelationClusterer(threshold=0.5).cluster([]) == []
+
+
+def test_correlation_clusterer_is_deterministic_across_runs() -> None:
+    """Repeated calls on the same judgements produce the identical result."""
+    judgements = [
+        _j("A", "B", 0.9),
+        _j("B", "C", 0.85),
+        _j("D", "E", 0.95),
+        _j("E", "F", 0.7),
+    ]
+    clusterer = CorrelationClusterer(threshold=0.6)
+
+    first = clusterer.cluster(judgements)
+    second = clusterer.cluster(list(reversed(judgements)))
+
+    assert first == second
+
+
+def test_correlation_clusterer_accepts_an_iterator() -> None:
+    """cluster() accepts an iterator, not just a list (matches base Clusterer)."""
+    judgements = iter([_j("A", "B", 0.9)])
+    clusterer = CorrelationClusterer(threshold=0.5)
+
+    assert clusterer.cluster(judgements) == [{"A", "B"}]
+
+
+# ---------------------------------------------------------------------------
+# Inherits Clusterer's generic evaluate()/inspect_clusters() (no override)
+# ---------------------------------------------------------------------------
+
+
+def test_correlation_clusterer_is_a_clusterer_subclass() -> None:
+    """CorrelationClusterer IS-A Clusterer -- drop-in for Resolver's clusterer slot."""
+    clusterer = CorrelationClusterer(threshold=0.7)
+    assert isinstance(clusterer, Clusterer)
+
+
+def test_correlation_clusterer_evaluate_works_via_inheritance() -> None:
+    """evaluate() (BCubed/pairwise) is inherited unchanged and works on our output."""
+    judgements = [_j("A", "B", 0.9)]
+    clusterer = CorrelationClusterer(threshold=0.8)
+    predicted = clusterer.cluster(judgements)
+
+    metrics = clusterer.evaluate(predicted, gold_clusters=[{"A", "B"}])
+
+    assert metrics["bcubed"]["f1"] == 1.0
+
+
+# ---------------------------------------------------------------------------
+# Registry / config-registry serialization plumbing
+# ---------------------------------------------------------------------------
+
+
+def test_correlation_clusterer_registered_under_type_name() -> None:
+    """CorrelationClusterer is registered under 'correlation_clusterer'."""
+    assert get_component("correlation_clusterer") is CorrelationClusterer
+
+
+def test_correlation_clusterer_config_shape() -> None:
+    """config exposes the threshold only (inherited from Clusterer)."""
+    clusterer = CorrelationClusterer(threshold=0.65)
+    assert clusterer.config == {"threshold": 0.65}
+
+
+def test_correlation_clusterer_from_config_round_trips() -> None:
+    """from_config rebuilds a CorrelationClusterer (not a base Clusterer)."""
+    rebuilt = CorrelationClusterer.from_config({"threshold": 0.42})
+
+    assert isinstance(rebuilt, CorrelationClusterer)
+    assert rebuilt.threshold == 0.42

--- a/tests/core/test_w1_3_registry_wiring.py
+++ b/tests/core/test_w1_3_registry_wiring.py
@@ -20,6 +20,7 @@ by that side effect.
 
 import subprocess
 import sys
+from pathlib import Path
 
 import pytest
 
@@ -44,4 +45,101 @@ def test_new_w1_3_components_register_via_langres_core_alone() -> None:
     )
 
     assert result.returncode == 0, result.stderr
+    assert "OK" in result.stdout
+
+
+def test_lazy_component_modules_includes_new_w1_3_components() -> None:
+    """key_blocker/composite_blocker/correlation_clusterer resolve via the lazy
+    registry path (``registry._LAZY_COMPONENT_MODULES``), not only via
+    ``core/__init__.py``'s current eager imports (review finding, P2).
+
+    Today's ``core/__init__.py`` happens to eager-import all three, so
+    ``get_component`` already resolves them regardless of this dict. But
+    ``_LAZY_COMPONENT_MODULES`` is the load-bearing mechanism once those eager
+    imports go away (planned in W0.4, packaging-dx) -- mirroring the existing
+    ``dspy_judge``/``select_judge`` entries, which are the only reason those two
+    survive a leaner import surface. Without an entry here, a saved artifact
+    referencing ``"key_blocker"``/``"composite_blocker"``/``"correlation_clusterer"``
+    would raise ``UnknownComponentType`` on ``Resolver.load`` post-W0.4.
+    """
+    from langres.core.registry import _LAZY_COMPONENT_MODULES
+
+    assert _LAZY_COMPONENT_MODULES["key_blocker"] == "langres.core.blockers.key"
+    assert _LAZY_COMPONENT_MODULES["composite_blocker"] == "langres.core.blockers.composite"
+    assert (
+        _LAZY_COMPONENT_MODULES["correlation_clusterer"] == "langres.core.clusterers.correlation"
+    )
+
+
+@pytest.mark.slow
+def test_resolver_fresh_process_roundtrip_with_composite_key_vector_blocker(
+    tmp_path: Path,
+) -> None:
+    """Fresh-process save/load/resolve for a CompositeBlocker(KeyBlocker, VectorBlocker).
+
+    Closes two things at once:
+
+    - Portability (P2): the subprocess imports ONLY ``from langres.core import
+      Resolver`` (never the blocker submodules directly) then ``Resolver.load``s
+      an artifact whose blocker slot is ``"composite_blocker"`` wrapping a
+      ``"key_blocker"`` and a ``"vector_blocker"`` child -- it must not raise
+      ``UnknownComponentType``.
+    - The nested-index sidecar sub-claim from the P1 finding: the reloaded
+      Resolver's nested VectorBlocker starts with an unbuilt (freshly
+      deserialized-config, no sidecar restore for a composite child) index, and
+      ``resolve()`` must still succeed by building it transparently via
+      ``Resolver._ensure_index_built``'s recursive traversal -- not just at the
+      top level.
+    """
+    from langres.core import (
+        Clusterer,
+        Comparator,
+        CompositeBlocker,
+        FAISSIndex,
+        FakeEmbedder,
+        KeyBlocker,
+        Resolver,
+        VectorBlocker,
+        WeightedAverageJudge,
+    )
+    from langres.core.models import CompanySchema
+    from tests.fixtures.companies import COMPANY_RECORDS
+
+    index = FAISSIndex(embedder=FakeEmbedder(embedding_dim=32), metric="cosine")
+    vector_blocker: VectorBlocker[CompanySchema] = VectorBlocker(
+        vector_index=index, schema=CompanySchema, text_field="name", k_neighbors=5
+    )
+    key_blocker: KeyBlocker[CompanySchema] = KeyBlocker(schema=CompanySchema, key_field="address")
+    composite: CompositeBlocker[CompanySchema] = CompositeBlocker(
+        children=[key_blocker, vector_blocker], op="union"
+    )
+    comparator = Comparator.from_schema(CompanySchema)
+    resolver = Resolver(
+        blocker=composite,
+        comparator=comparator,
+        module=WeightedAverageJudge(feature_specs=comparator.feature_specs),
+        clusterer=Clusterer(threshold=0.7),
+    )
+    resolver.resolve(COMPANY_RECORDS)  # builds the nested index before saving
+    resolver.save(tmp_path)
+
+    script = (
+        "from langres.core import Resolver\n"
+        "from tests.fixtures.companies import COMPANY_RECORDS\n"
+        f"reloaded = Resolver.load({str(tmp_path)!r})\n"
+        "clusters = reloaded.resolve(COMPANY_RECORDS)\n"
+        "assert isinstance(clusters, list)\n"
+        "print('OK')\n"
+    )
+    result = subprocess.run(
+        [sys.executable, "-c", script],
+        capture_output=True,
+        text=True,
+        timeout=60,
+    )
+
+    assert result.returncode == 0, (
+        f"fresh-process composite-blocker roundtrip failed.\n"
+        f"STDOUT:\n{result.stdout}\nSTDERR:\n{result.stderr}"
+    )
     assert "OK" in result.stdout

--- a/tests/core/test_w1_3_registry_wiring.py
+++ b/tests/core/test_w1_3_registry_wiring.py
@@ -66,9 +66,7 @@ def test_lazy_component_modules_includes_new_w1_3_components() -> None:
 
     assert _LAZY_COMPONENT_MODULES["key_blocker"] == "langres.core.blockers.key"
     assert _LAZY_COMPONENT_MODULES["composite_blocker"] == "langres.core.blockers.composite"
-    assert (
-        _LAZY_COMPONENT_MODULES["correlation_clusterer"] == "langres.core.clusterers.correlation"
-    )
+    assert _LAZY_COMPONENT_MODULES["correlation_clusterer"] == "langres.core.clusterers.correlation"
 
 
 @pytest.mark.slow

--- a/tests/core/test_w1_3_registry_wiring.py
+++ b/tests/core/test_w1_3_registry_wiring.py
@@ -1,0 +1,47 @@
+"""Regression: KeyBlocker/CompositeBlocker/CorrelationClusterer register on
+plain ``import langres.core`` (W1.3).
+
+``@register(...)`` only fires when a component's OWNING MODULE is imported
+(see ``langres.core.registry``'s module docstring). Every registrable
+component must therefore be eager-imported by either ``core/blockers/
+__init__.py`` + ``core/__init__.py`` (or ``core/clusterers/__init__.py`` +
+``core/__init__.py`` for clusterer variants) -- mirroring the existing
+``AllPairsBlocker``/``VectorBlocker``/``LLMJudge`` pattern -- or listed in
+``registry._LAZY_COMPONENT_MODULES``. Without that wiring, a fresh process
+that does ``from langres.core import Resolver`` and then ``Resolver.load()``
+on an artifact referencing ``"key_blocker"``/``"composite_blocker"``/
+``"correlation_clusterer"`` raises ``UnknownComponentType`` -- even though
+each test module for these three classes imports them directly at module
+scope, which trivially (and misleadingly) registers them as a side effect
+before any test body runs. This test spawns a genuinely fresh subprocess that
+does NOT import any of the three submodules directly, so it can't be fooled
+by that side effect.
+"""
+
+import subprocess
+import sys
+
+import pytest
+
+
+@pytest.mark.slow
+def test_new_w1_3_components_register_via_langres_core_alone() -> None:
+    """A fresh process resolves key_blocker/composite_blocker/correlation_clusterer
+    via ``from langres.core import get_component`` alone -- no submodule imports.
+    """
+    result = subprocess.run(
+        [
+            sys.executable,
+            "-c",
+            "from langres.core import get_component\n"
+            "for name in ('key_blocker', 'composite_blocker', 'correlation_clusterer'):\n"
+            "    get_component(name)\n"
+            "print('OK')\n",
+        ],
+        capture_output=True,
+        text=True,
+        timeout=60,
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert "OK" in result.stdout

--- a/tests/test_resolver_roundtrip.py
+++ b/tests/test_resolver_roundtrip.py
@@ -412,7 +412,8 @@ def _composite_vector_resolver(op: str = "union") -> "object":
         key_field="address",
     )
     composite: CompositeBlocker[CompanySchema] = CompositeBlocker(
-        children=[key_blocker, vector_blocker], op=op  # type: ignore[arg-type]
+        children=[key_blocker, vector_blocker],
+        op=op,  # type: ignore[arg-type]
     )
     comparator = Comparator.from_schema(CompanySchema, weights=NAME_DOMINANT_WEIGHTS)
     return Resolver(
@@ -468,12 +469,8 @@ def test_resolver_builds_vector_index_nested_two_levels_deep_in_composite_blocke
         text_field="name",
         k_neighbors=5,
     )
-    key_blocker_a: KeyBlocker[CompanySchema] = KeyBlocker(
-        schema=CompanySchema, key_field="address"
-    )
-    key_blocker_b: KeyBlocker[CompanySchema] = KeyBlocker(
-        schema=CompanySchema, key_field="phone"
-    )
+    key_blocker_a: KeyBlocker[CompanySchema] = KeyBlocker(schema=CompanySchema, key_field="address")
+    key_blocker_b: KeyBlocker[CompanySchema] = KeyBlocker(schema=CompanySchema, key_field="phone")
     inner = CompositeBlocker(children=[key_blocker_a, vector_blocker], op="union")
     outer = CompositeBlocker(children=[inner, key_blocker_b], op="union")
 

--- a/tests/test_resolver_roundtrip.py
+++ b/tests/test_resolver_roundtrip.py
@@ -381,6 +381,115 @@ def test_resolver_rebuilds_vector_index_on_new_corpus() -> None:
     assert resolver.blocker.vector_index._corpus_texts == expected_texts_b  # type: ignore[attr-defined]
 
 
+def _composite_vector_resolver(op: str = "union") -> "object":
+    """Build a Resolver whose top-level blocker is a CompositeBlocker wrapping a
+    KeyBlocker and a VectorBlocker (FakeEmbedder, fast). Mirrors the flagship
+    "recall-first key + vector union" pattern documented in the blocking-algebra
+    example and TECHNICAL_OVERVIEW.
+    """
+    from langres.core import (
+        Clusterer,
+        Comparator,
+        CompositeBlocker,
+        FAISSIndex,
+        FakeEmbedder,
+        KeyBlocker,
+        Resolver,
+        VectorBlocker,
+        WeightedAverageJudge,
+    )
+    from langres.core.models import CompanySchema
+
+    index = FAISSIndex(embedder=FakeEmbedder(embedding_dim=32), metric="cosine")
+    vector_blocker: VectorBlocker[CompanySchema] = VectorBlocker(
+        vector_index=index,
+        schema=CompanySchema,
+        text_field="name",
+        k_neighbors=5,
+    )
+    key_blocker: KeyBlocker[CompanySchema] = KeyBlocker(
+        schema=CompanySchema,
+        key_field="address",
+    )
+    composite: CompositeBlocker[CompanySchema] = CompositeBlocker(
+        children=[key_blocker, vector_blocker], op=op  # type: ignore[arg-type]
+    )
+    comparator = Comparator.from_schema(CompanySchema, weights=NAME_DOMINANT_WEIGHTS)
+    return Resolver(
+        blocker=composite,
+        comparator=comparator,
+        module=WeightedAverageJudge(feature_specs=comparator.feature_specs),
+        clusterer=Clusterer(threshold=0.7),
+    )
+
+
+@pytest.mark.parametrize("op", ["union", "intersection", "difference"])
+def test_resolver_builds_nested_vector_index_inside_composite_blocker(op: str) -> None:
+    """resolve() must build a VectorBlocker's index even when it is nested inside
+    a CompositeBlocker used as the top-level Resolver.blocker.
+
+    Regression for a reviewer-caught bug: ``_ensure_index_built`` only checked
+    ``isinstance(self.blocker, VectorBlocker)`` at the top level, so a composed
+    ``CompositeBlocker(children=[KeyBlocker(...), VectorBlocker(...)])`` crashed
+    with ``RuntimeError: Index not built...`` on first ``resolve()`` -- breaking
+    this PR's own flagship documented pattern. Covers all three composite ops,
+    since the fix must not depend on which algebra op is selected.
+    """
+    resolver = _composite_vector_resolver(op=op)
+    nested_vector_blocker = resolver.blocker.children[1]  # type: ignore[attr-defined]
+    assert not nested_vector_blocker._index_is_built()
+    clusters = resolver.resolve(COMPANY_RECORDS)
+    assert nested_vector_blocker._index_is_built()
+    assert isinstance(clusters, list)
+
+
+def test_resolver_builds_vector_index_nested_two_levels_deep_in_composite_blockers() -> None:
+    """The index-build traversal recurses through nested CompositeBlockers, not
+    just one level -- a CompositeBlocker may itself wrap another CompositeBlocker
+    (e.g. union of two intersections).
+    """
+    from langres.core import (
+        Clusterer,
+        Comparator,
+        CompositeBlocker,
+        FAISSIndex,
+        FakeEmbedder,
+        KeyBlocker,
+        Resolver,
+        VectorBlocker,
+        WeightedAverageJudge,
+    )
+    from langres.core.models import CompanySchema
+
+    index = FAISSIndex(embedder=FakeEmbedder(embedding_dim=32), metric="cosine")
+    vector_blocker: VectorBlocker[CompanySchema] = VectorBlocker(
+        vector_index=index,
+        schema=CompanySchema,
+        text_field="name",
+        k_neighbors=5,
+    )
+    key_blocker_a: KeyBlocker[CompanySchema] = KeyBlocker(
+        schema=CompanySchema, key_field="address"
+    )
+    key_blocker_b: KeyBlocker[CompanySchema] = KeyBlocker(
+        schema=CompanySchema, key_field="phone"
+    )
+    inner = CompositeBlocker(children=[key_blocker_a, vector_blocker], op="union")
+    outer = CompositeBlocker(children=[inner, key_blocker_b], op="union")
+
+    comparator = Comparator.from_schema(CompanySchema, weights=NAME_DOMINANT_WEIGHTS)
+    resolver = Resolver(
+        blocker=outer,
+        comparator=comparator,
+        module=WeightedAverageJudge(feature_specs=comparator.feature_specs),
+        clusterer=Clusterer(threshold=0.7),
+    )
+
+    assert not vector_blocker._index_is_built()
+    resolver.resolve(COMPANY_RECORDS)
+    assert vector_blocker._index_is_built()
+
+
 def test_resolver_roundtrip_with_faiss_state(tmp_path: Path) -> None:
     """An index-backed Resolver persists + restores its FAISS state (sidecar)."""
     from langres.core import Resolver


### PR DESCRIPTION
## What / Why

Implements W1.3 of the M4.5/M5 plan on top of the merged W1.0 contracts (`ERCandidateGroup`/`GroupwiseModule`, `Blocker.stream_groups()`).

1. **`KeyBlocker`** (`src/langres/core/blockers/key.py`) — buckets records by a configurable key (`key_field=`, declarative/serializable, or `key_fn=`, callable) with `.strip().lower()` normalization by default. Mirrors `AllPairsBlocker`'s `schema=`/`schema_factory=` mutual-exclusion pattern. Registered as `"key_blocker"`.
2. **`CompositeBlocker`** (`src/langres/core/blockers/composite.py`) — set algebra (`union`/`intersection`/`difference`) over 2+ child blockers. Dedups by canonical undirected pair key with first-seen semantics; `blocker_name` carries real per-pair provenance (`composite_union(key_blocker+vector_blocker)`, naming exactly which child(ren) produced that pair). `union` is the recall-maximizing default. Relies on the inherited `Blocker.stream_groups()` default (documented why: no natural per-anchor structure for intersection/difference across heterogeneous children) — verified lossless via a parametrized pairs-equivalence property test across all three ops. Registered as `"composite_blocker"`.
3. **`CorrelationClusterer`** (C6, `src/langres/core/clusterers/correlation.py`) — a `Clusterer` subclass implementing the pivot algorithm for correlation clustering (Ailon, Charikar & Newman, JACM 2008): highest-confidence-edge-first pivot selection, cluster = pivot + only its *direct* neighbours ≥ threshold. Fixes the base `Clusterer`'s transitive-closure over-merge (a chain A-B, B-C with no direct A-C edge no longer force-merges all three — verified in a synthetic unit test showing `{A,B,C}` (base) vs `{A,B},{C}` (C6) on identical input). Registered as `"correlation_clusterer"`; inherits `config`/`from_config`/`evaluate`/`inspect_clusters` unchanged, only `cluster()` differs — drop-in for the `Resolver.clusterer` slot. **Not the default** (see benchmark below).

New `src/langres/core/clusterers/` package mirrors the existing `blocker.py` (base) + `blockers/` (variants) split for the base `clusterer.py` + variants.

## Benchmark (Fodors-Zagat + Amazon-Google, $0, full script + narrative: `examples/w1_blocking_algebra.py` / `examples/w1_blocking_algebra_output.md`)

### Composite blocking: Pair-Completeness (PC) / Reduction-Ratio (RR)

| dataset | blocker | n_candidates | PC | RR |
| --- | --- | --- | --- | --- |
| fodors_zagat | VectorBlocker only (k=5, pinned) | 1,381 | 0.9911 | 0.9922 |
| fodors_zagat | **KeyBlocker(city) UNION VectorBlocker** | 10,901 | **1.0000** | 0.9382 |
| amazon_google | VectorBlocker only (k=50, pinned) | 60,502 | 0.8388 | 0.9862 |
| amazon_google | KeyBlocker(manufacturer) UNION VectorBlocker | 61,439 | 0.8388 | 0.9860 |

FZ: composite blocking closes the documented single-pair gap (the `f640`/`z325` identical-`embed_text` edge case `VectorBlocker`'s self-skip structurally misses) — PC 0.9911 → 1.0000. AG: **no PC lift** — `manufacturer` is missing on 62.5% of AG records, so the key mostly excludes itself from contributing; an honest negative result for this specific key choice (field-selectivity problem, not a blocker-correctness problem), documented rather than hidden.

### Clusterer comparison: base `Clusterer` vs `CorrelationClusterer` (C6)

Same blocking + judge (`WeightedAverageJudge`, threshold 0.80, reused from `examples/m3_zero_spend_race_output.md`) for both — only the clusterer differs.

| dataset | clusterer | bc_P | bc_R | bc_F1 |
| --- | --- | --- | --- | --- |
| fodors_zagat | Clusterer (default) | 0.9888 | 0.9583 | 0.9733 |
| fodors_zagat | CorrelationClusterer (C6) | 0.9911 | 0.9572 | 0.9739 |
| amazon_google | Clusterer (default) | 0.6746 | 0.7978 | 0.7311 |
| amazon_google | **CorrelationClusterer (C6)** | **0.7461** | 0.7818 | **0.7635** |

FZ: a wash (+0.0006 BCubed F1 — small, saturated, mostly 2-record clusters, little chaining structure to over-merge). AG: **C6 clearly wins** (+0.0324 BCubed F1, +0.0715 precision at -0.016 recall) — exactly the over-merge signature the base `Clusterer`'s transitive closure produces on the harder, chattier dataset (the milder version of M3's documented -0.63 BCubed regression).

### Default-flip decision: **NOT flipped**

Per the exit criterion, C6 must *clearly win* to flip the default. It wins clearly on AG but is a wash on FZ — one hard-dataset win + one no-op isn't broad enough evidence to change a global default that also affects easy/well-behaved data. `CorrelationClusterer` ships as a registered, opt-in `Clusterer` variant, recommended for harder/messier ER problems.

## Coverage / mypy / test status

- `uv run ruff check src tests` — clean
- `uv run ruff format --check src tests` — clean
- `uv run mypy src` — clean (strict, 69 files)
- `uv run pytest -m "not slow and not integration" --cov=src/langres` — **1459 passed**, 98.24% total coverage (95% gate); all three new modules (`key.py`, `composite.py`, `clusterers/correlation.py`) are **100% covered**
- All $0 — no LLM calls anywhere in this branch's tests or benchmark

## Deviations from the task brief

- None structural. One scope note: RR is computed against the cross-source product denominator (matching the existing pinned-`k` PC methodology in `er_benchmarks.py`/`amazon_google.py`) rather than full `C(n,2)`, so the composite-blocking numbers are directly comparable to the codebase's own documented baselines (`DEFAULT_BLOCKING_K`, `ACHIEVED_PC_AT_DEFAULT_K`).
- `docs/TECHNICAL_OVERVIEW.md` gained a new §9 documenting all three components (mirrors the existing §8 W1.0 pattern); `CHANGELOG.md`/`ROADMAP.md` are left untouched — the plan explicitly assigns those to W3.2 ("docs: ROADMAP (M4.5/M5 evidence), CHANGELOG... updated with outcomes"), and W0.1/W0.3/W1.0 didn't touch them either.

## Test plan

- [x] `uv run ruff check src tests && uv run ruff format --check src tests && uv run mypy src` all green
- [x] `uv run pytest -m "not slow and not integration" --cov=src/langres` green, 98.24% total, 100% on new modules
- [x] `uv run python examples/w1_blocking_algebra.py` run fresh, output matches `examples/w1_blocking_algebra_output.md`
- [x] All commits atomic (test-then-implementation per component), pushed, working tree clean

https://claude.ai/code/session_0115MvWbHaCKT1A39PKDWqey