### PR TITLE
fix: drain group siblings before budget cap (#68 review) + export SelectJudge

### DIFF
--- a/docs/TECHNICAL_OVERVIEW.md
+++ b/docs/TECHNICAL_OVERVIEW.md
@@ -562,6 +562,15 @@ factor of K. `stamp_group_cost(judgements, call_cost_usd, group_id)`
 read `provenance["cost_usd"]`) then sums a group to exactly one call's cost
 with no changes on their end.
 
+`stamp_group_cost` also sets `provenance["group_end"] = True` on (only) the
+**last** judgement of the group — a boundary marker that lets a consumer
+draining a whole group from a lazy stream (`_SpendCappedModule.forward` in
+`langres.core.presets`, the hard spend cap the verb layer wraps every judge
+in) know exactly when to stop pulling, without peeking at the next
+judgement's `group_id` — which for a real `GroupwiseModule` would resume the
+generator into (and pay for) the next group before there's anything to
+compare against.
+
 **Atomicity caveat:** `BudgetedModuleRunner` scores exactly one `ERCandidate`
 per `module.forward()` call. A `GroupwiseModule` run through it today derives
 a single, trivial, size-1 group per call — so a group is never *split*

--- a/src/langres/core/__init__.py
+++ b/src/langres/core/__init__.py
@@ -91,6 +91,7 @@ if TYPE_CHECKING:
     )
     from langres.core.modules.llm_judge import LLMJudge
     from langres.core.modules.rf_judge import RFJudge
+    from langres.core.modules.select_judge import SelectJudge
 
 __all__ = [
     "ARTIFACT_VERSION",
@@ -143,6 +144,7 @@ __all__ = [
     "RFJudge",
     "ScoreStats",
     "SchemaNotRegistered",
+    "SelectJudge",
     "SentenceTransformerEmbedder",
     "SerializableState",
     "SparseEmbeddingProvider",
@@ -182,17 +184,19 @@ _LAZY_SYMBOLS: dict[str, str] = {
     "VectorIndex": "langres.core.indexes",
     "LLMJudge": "langres.core.modules.llm_judge",
     "RFJudge": "langres.core.modules.rf_judge",
+    "SelectJudge": "langres.core.modules.select_judge",
 }
 
 #: ``name -> extra`` for the lazy symbols a ``pip install langres[<extra>]``
 #: actually fixes -- everything in :data:`_LAZY_SYMBOLS` except the three
 #: submodules (dev/eval tooling, not distributed as a pip extra; see
 #: :data:`_LAZY_SUBMODULES`'s docstring). ``RFJudge`` needs scikit-learn (the
-#: ``[trained]`` extra, W1.2's trained-family judge); everything else needs
-#: either ``[llm]`` (LLMJudge) or ``[semantic]`` (embeddings/vector index/
-#: VectorBlocker).
+#: ``[trained]`` extra, W1.2's trained-family judge); ``LLMJudge``/
+#: ``SelectJudge`` need ``[llm]`` (litellm/dspy-ai); everything else needs
+#: ``[semantic]`` (embeddings/vector index/VectorBlocker).
 _EXTRA_BY_SYMBOL: dict[str, str] = {
-    name: {"LLMJudge": "llm", "RFJudge": "trained"}.get(name, "semantic") for name in _LAZY_SYMBOLS
+    name: {"LLMJudge": "llm", "SelectJudge": "llm", "RFJudge": "trained"}.get(name, "semantic")
+    for name in _LAZY_SYMBOLS
 }
 
 

--- a/src/langres/core/module.py
+++ b/src/langres/core/module.py
@@ -7,7 +7,7 @@ implementations in the langres framework.
 
 from abc import ABC, abstractmethod
 from collections.abc import Iterator
-from typing import Generic, TypeVar
+from typing import Any, Generic, TypeVar
 
 from pydantic import BaseModel
 
@@ -272,6 +272,12 @@ def stamp_group_cost(
     ``_cost_track``, which already read ``provenance["cost_usd"]``) then sums
     a group to exactly one call's cost with no changes on their end.
 
+    ``provenance["group_end"]`` is set ``True`` on (only) the LAST judgement
+    of the group -- a boundary marker so a consumer draining a whole group
+    from a lazy stream (:class:`~langres.core.presets._SpendCappedModule`,
+    E9) knows exactly when to stop pulling without needing to peek at (and
+    thereby trigger the computation of) the next group.
+
     Args:
         judgements: The judgements produced from ONE call spanning ONE group,
             in any order. Must be non-empty.
@@ -293,8 +299,15 @@ def stamp_group_cost(
         raise ValueError("stamp_group_cost requires at least one judgement")
 
     stamped = []
+    last_index = len(judgements) - 1
     for index, judgement in enumerate(judgements):
         cost = call_cost_usd if index == 0 else 0.0
-        new_provenance = {**judgement.provenance, "cost_usd": cost, "group_id": group_id}
+        new_provenance: dict[str, Any] = {
+            **judgement.provenance,
+            "cost_usd": cost,
+            "group_id": group_id,
+        }
+        if index == last_index:
+            new_provenance["group_end"] = True
         stamped.append(judgement.model_copy(update={"provenance": new_provenance}))
     return stamped

--- a/src/langres/core/presets.py
+++ b/src/langres/core/presets.py
@@ -272,18 +272,35 @@ class _SpendCappedModule(Module[Any]):
             except BudgetExceeded as exc:
                 # A group-wise module (SelectJudge) stamps the full call cost
                 # on the group's first judgement and $0 on its K-1 siblings,
-                # all sharing provenance["group_id"] (E5). If the cap trips
-                # here, those already-paid-for siblings must still land in
+                # all sharing provenance["group_id"] and with
+                # provenance["group_end"] = True on the LAST one (E5,
+                # stamp_group_cost). If the cap trips here, those
+                # already-paid-for siblings must still land in
                 # partial_judgements -- a group must never be split across
                 # the cap boundary. Drain them from the same underlying
-                # iterator (no cost re-added; the group is already paid for)
-                # until a non-sibling judgement or the end of the stream.
+                # iterator up to (and including) the group_end marker.
+                #
+                # This must NOT peek at the next judgement's group_id to
+                # detect the boundary: for a real GroupwiseModule the
+                # generator is lazy, so pulling one item past the group's
+                # last already-materialized judgement resumes forward_groups
+                # and fires the NEXT group's paid LLM call before there is
+                # anything to compare against -- silently discarding that
+                # judgement and its cost. group_end lets the drain stop
+                # exactly at the boundary without ever pulling past it.
+                #
+                # Because a sibling always carries $0 cost, monitor.check()
+                # can only ever trip on a group's FIRST judgement (a passing
+                # check means spend was <= budget; adding $0 can't newly
+                # exceed it) -- so `judgement` here is always a group's first,
+                # never a mid-group sibling, and "not group_end" correctly
+                # means "there are siblings left to drain".
                 group_id = judgement.provenance.get("group_id")
-                if group_id is not None:
+                if group_id is not None and not judgement.provenance.get("group_end"):
                     for sibling in judgements:
-                        if sibling.provenance.get("group_id") != group_id:
-                            break
                         produced.append(sibling)
+                        if sibling.provenance.get("group_end"):
+                            break
                 exc.partial_judgements = list(produced)
                 raise
             yield judgement

--- a/src/langres/core/presets.py
+++ b/src/langres/core/presets.py
@@ -262,13 +262,28 @@ class _SpendCappedModule(Module[Any]):
     def forward(self, candidates: Iterator[ERCandidate[Any]]) -> Iterator[PairwiseJudgement]:
         monitor = SpendMonitor(budget_usd=self._budget_usd)
         produced: list[PairwiseJudgement] = []
-        for judgement in self._module.forward(candidates):
+        judgements = self._module.forward(candidates)
+        for judgement in judgements:
             produced.append(judgement)
             cost = judgement.provenance.get("cost_usd", 0.0)
             monitor.add(float(cost) if cost is not None else 0.0)
             try:
                 monitor.check()
             except BudgetExceeded as exc:
+                # A group-wise module (SelectJudge) stamps the full call cost
+                # on the group's first judgement and $0 on its K-1 siblings,
+                # all sharing provenance["group_id"] (E5). If the cap trips
+                # here, those already-paid-for siblings must still land in
+                # partial_judgements -- a group must never be split across
+                # the cap boundary. Drain them from the same underlying
+                # iterator (no cost re-added; the group is already paid for)
+                # until a non-sibling judgement or the end of the stream.
+                group_id = judgement.provenance.get("group_id")
+                if group_id is not None:
+                    for sibling in judgements:
+                        if sibling.provenance.get("group_id") != group_id:
+                            break
+                        produced.append(sibling)
                 exc.partial_judgements = list(produced)
                 raise
             yield judgement

--- a/src/langres/core/presets.py
+++ b/src/langres/core/presets.py
@@ -247,7 +247,10 @@ class _SpendCappedModule(Module[Any]):
     :class:`~langres.clients.openrouter.BudgetExceeded` with every judgement
     already produced (and paid for) attached as ``.partial_judgements`` (E9;
     mirrors :class:`~langres.core.benchmark.BlindCostError`'s "set by the
-    catcher, not at raise time" pattern).
+    catcher, not at raise time" pattern). For a group-wise module
+    (``SelectJudge``), a group is never split across the cap boundary: the
+    already-paid-for siblings of a tripping judgement are drained in too (see
+    ``forward``'s ``provenance["group_end"]`` handling).
 
     Deliberately NOT :class:`~langres.core.benchmark.BudgetedModuleRunner`:
     that runner *silently truncates* past its soft cap (correct for the

--- a/tests/core/test_module_groupwise.py
+++ b/tests/core/test_module_groupwise.py
@@ -301,6 +301,31 @@ def test_stamp_group_cost_does_not_mutate_input_judgements() -> None:
     assert "group_id" not in original.provenance
 
 
+def test_stamp_group_cost_sets_group_end_only_on_last_judgement() -> None:
+    """group_end marks exactly the LAST judgement, so a consumer draining a
+    whole group from a lazy stream (E9's _SpendCappedModule) can stop at the
+    boundary without peeking at (and thereby computing) the next group."""
+    judgements = [
+        _judgement("anchor", "m1"),
+        _judgement("anchor", "m2"),
+        _judgement("anchor", "m3"),
+    ]
+
+    stamped = stamp_group_cost(judgements, call_cost_usd=0.03, group_id="anchor")
+
+    assert "group_end" not in stamped[0].provenance
+    assert "group_end" not in stamped[1].provenance
+    assert stamped[2].provenance["group_end"] is True
+
+
+def test_stamp_group_cost_sets_group_end_on_single_judgement_group() -> None:
+    """A size-1 group's only judgement is both first and last -- group_end is True."""
+    stamped = stamp_group_cost([_judgement("anchor", "m1")], call_cost_usd=0.01, group_id="anchor")
+
+    assert stamped[0].provenance["cost_usd"] == pytest.approx(0.01)
+    assert stamped[0].provenance["group_end"] is True
+
+
 def test_stamp_group_cost_rejects_empty_list() -> None:
     """An empty judgement list is a caller bug, not a silently accepted no-op."""
     with pytest.raises(ValueError, match="at least one judgement"):

--- a/tests/core/test_presets.py
+++ b/tests/core/test_presets.py
@@ -113,6 +113,21 @@ class _FakeGroupModule(Module[object]):
         raise NotImplementedError
 
 
+class _ChainedGroupsModule(Module[object]):
+    """Concatenates several group-wise fake modules' judgement streams, in order."""
+
+    def __init__(self, groups: list[Module[object]]) -> None:
+        self._groups = groups
+
+    def forward(self, candidates: Iterator[ERCandidate[object]]) -> Iterator[PairwiseJudgement]:
+        remaining = list(candidates)
+        for group_module in self._groups:
+            yield from group_module.forward(iter(remaining))
+
+    def inspect_scores(self, judgements: list[PairwiseJudgement], sample_size: int = 10) -> object:
+        raise NotImplementedError
+
+
 class _FakeVectorIndex:
     """No-op stand-in for a real FAISS index -- create_index does nothing."""
 
@@ -305,6 +320,29 @@ class TestSpendCappedModule:
         assert all(j.provenance.get("group_id") == "g1" for j in partial)
         # No cost was double-counted for the $0 siblings.
         assert sum(float(j.provenance["cost_usd"]) for j in partial) == 1.0
+
+    def test_cap_breach_drain_stops_at_next_groups_judgement(self) -> None:
+        """The drain loop must not swallow a DIFFERENT group's judgement past the boundary.
+
+        Exercises the "stop at the first non-sibling judgement" branch: group
+        "g1" trips the cap and is drained whole, but a later group "g2" behind
+        it in the stream must not be pulled in too.
+        """
+        module = _SpendCappedModule(
+            _ChainedGroupsModule(
+                [
+                    _FakeGroupModule(first_cost=1.0, n_siblings=1, group_id="g1"),
+                    _FakeGroupModule(first_cost=0.0, n_siblings=1, group_id="g2"),
+                ]
+            ),
+            budget_usd=0.9,
+        )
+        candidates = iter([_candidate(str(i)) for i in range(4)])
+        with pytest.raises(BudgetExceeded) as excinfo:
+            list(module.forward(candidates))
+        partial = excinfo.value.partial_judgements
+        assert len(partial) == 2
+        assert all(j.provenance.get("group_id") == "g1" for j in partial)
 
     def test_cap_breach_without_group_id_is_unchanged(self) -> None:
         """Pairwise (no group_id) modules keep the pre-existing single-judgement cap behavior."""

--- a/tests/core/test_presets.py
+++ b/tests/core/test_presets.py
@@ -82,6 +82,37 @@ class _FakeCostlyModule(Module[object]):
         raise NotImplementedError
 
 
+class _FakeGroupModule(Module[object]):
+    """Yields one group's judgements per the E5 group-cost convention.
+
+    Full ``call_cost_usd`` on the first judgement, ``$0`` on the ``n_siblings``
+    remaining ones, all sharing ``provenance["group_id"]`` -- mirrors what
+    ``SelectJudge``/``stamp_group_cost`` produce for one LLM call spanning a
+    whole group.
+    """
+
+    def __init__(self, first_cost: float, n_siblings: int, group_id: str = "g1") -> None:
+        self._first_cost = first_cost
+        self._n_siblings = n_siblings
+        self._group_id = group_id
+
+    def forward(self, candidates: Iterator[ERCandidate[object]]) -> Iterator[PairwiseJudgement]:
+        list(candidates)  # drain (content unused)
+        for i in range(self._n_siblings + 1):
+            cost = self._first_cost if i == 0 else 0.0
+            yield PairwiseJudgement(
+                left_id="anchor",
+                right_id=str(i),
+                score=0.9,
+                score_type="prob_llm",
+                decision_step="fake_group",
+                provenance={"cost_usd": cost, "group_id": self._group_id},
+            )
+
+    def inspect_scores(self, judgements: list[PairwiseJudgement], sample_size: int = 10) -> object:
+        raise NotImplementedError
+
+
 class _FakeVectorIndex:
     """No-op stand-in for a real FAISS index -- create_index does nothing."""
 
@@ -252,6 +283,40 @@ class TestSpendCappedModule:
         module = _SpendCappedModule(inner, budget_usd=1.0)
         report = module.inspect_scores([])
         assert report is not None
+
+    def test_cap_breach_drains_group_siblings_into_partial_judgements(self) -> None:
+        """A group-wise module's tripping judgement must not split its group (#68 review).
+
+        ``SelectJudge``-style modules stamp the FULL call cost onto the first
+        judgement of a group and $0 onto its K-1 siblings, all sharing
+        ``provenance["group_id"]`` (E5). If the cap trips on that first
+        judgement, the already-paid-for siblings must still be drained into
+        ``partial_judgements`` -- a group must never be split across the cap
+        boundary.
+        """
+        module = _SpendCappedModule(
+            _FakeGroupModule(first_cost=1.0, n_siblings=2, group_id="g1"), budget_usd=0.9
+        )
+        candidates = iter([_candidate(str(i)) for i in range(3)])
+        with pytest.raises(BudgetExceeded) as excinfo:
+            list(module.forward(candidates))
+        partial = excinfo.value.partial_judgements
+        assert len(partial) == 3
+        assert all(j.provenance.get("group_id") == "g1" for j in partial)
+        # No cost was double-counted for the $0 siblings.
+        assert sum(float(j.provenance["cost_usd"]) for j in partial) == 1.0
+
+    def test_cap_breach_without_group_id_is_unchanged(self) -> None:
+        """Pairwise (no group_id) modules keep the pre-existing single-judgement cap behavior."""
+        module = _SpendCappedModule(_FakeCostlyModule(5, 0.5), budget_usd=0.9)
+        candidates = iter([_candidate(str(i)) for i in range(5)])
+        with pytest.raises(BudgetExceeded) as excinfo:
+            list(module.forward(candidates))
+        partial = excinfo.value.partial_judgements
+        # 0.5 -> ok, 1.0 -> breaches $0.9 cap: exactly 2 judgements were paid for,
+        # and none carry a group_id to drain siblings for.
+        assert len(partial) == 2
+        assert all(j.provenance.get("group_id") is None for j in partial)
 
 
 def _candidate(suffix: str) -> ERCandidate[PresetCompany]:

--- a/tests/core/test_presets.py
+++ b/tests/core/test_presets.py
@@ -23,7 +23,7 @@ from langres.core.blockers.vector import VectorBlocker
 from langres.core.judges.embedding_score import EmbeddingScoreJudge
 from langres.core.judges.weighted_average import WeightedAverageJudge
 from langres.core.models import ERCandidate, PairwiseJudgement
-from langres.core.module import Module
+from langres.core.module import Module, stamp_group_cost
 from langres.core.modules.dspy_judge import DSPyJudge
 from langres.core.presets import (
     DEFAULT_BUDGET_USD,
@@ -82,13 +82,79 @@ class _FakeCostlyModule(Module[object]):
         raise NotImplementedError
 
 
+def _raw_group_judgements(n: int, group_id: str) -> list[PairwiseJudgement]:
+    """Unstamped judgements for one group -- ``stamp_group_cost`` applies the
+    E5 cost/group_id/group_end convention on top (real production path)."""
+    return [
+        PairwiseJudgement(
+            left_id="anchor",
+            right_id=f"{group_id}-{i}",
+            score=0.9,
+            score_type="prob_llm",
+            decision_step="fake_group",
+            provenance={},
+        )
+        for i in range(n)
+    ]
+
+
 class _FakeGroupModule(Module[object]):
     """Yields one group's judgements per the E5 group-cost convention.
 
-    Full ``call_cost_usd`` on the first judgement, ``$0`` on the ``n_siblings``
-    remaining ones, all sharing ``provenance["group_id"]`` -- mirrors what
-    ``SelectJudge``/``stamp_group_cost`` produce for one LLM call spanning a
-    whole group.
+    Full ``call_cost_usd`` on the first judgement, ``$0`` (plus
+    ``group_end=True`` on the last) on the ``n_siblings`` remaining ones, all
+    sharing ``provenance["group_id"]`` -- built via the real
+    :func:`~langres.core.module.stamp_group_cost`, the same helper
+    ``SelectJudge`` uses for one LLM call spanning a whole group.
+    """
+
+    def __init__(self, first_cost: float, n_siblings: int, group_id: str = "g1") -> None:
+        self._first_cost = first_cost
+        self._n_siblings = n_siblings
+        self._group_id = group_id
+
+    def forward(self, candidates: Iterator[ERCandidate[object]]) -> Iterator[PairwiseJudgement]:
+        list(candidates)  # drain (content unused)
+        raw = _raw_group_judgements(self._n_siblings + 1, self._group_id)
+        yield from stamp_group_cost(raw, call_cost_usd=self._first_cost, group_id=self._group_id)
+
+    def inspect_scores(self, judgements: list[PairwiseJudgement], sample_size: int = 10) -> object:
+        raise NotImplementedError
+
+
+class _LazyGroupsModule(Module[object]):
+    """Concatenates several groups' judgement streams, tracking when each
+    group's (paid) computation actually STARTS -- mirroring
+    ``GroupwiseModule.forward_groups``'s real contract: one paid LLM call per
+    group, fired lazily only when the generator is advanced into that group,
+    before it can yield anything to compare against (the exact shape of the
+    #68-review bug: pulling one item past an already-drained group's last
+    judgement to check its group_id resumes computation of -- and pays for --
+    the NEXT group before the boundary can be detected).
+    """
+
+    def __init__(self, groups: list[tuple[float, int, str]]) -> None:
+        # each item: (first_cost, n_siblings, group_id)
+        self._groups = groups
+        self.groups_computed = 0
+
+    def forward(self, candidates: Iterator[ERCandidate[object]]) -> Iterator[PairwiseJudgement]:
+        list(candidates)  # drain (content unused)
+        for first_cost, n_siblings, group_id in self._groups:
+            self.groups_computed += 1  # the "paid call" fires here, lazily
+            raw = _raw_group_judgements(n_siblings + 1, group_id)
+            yield from stamp_group_cost(raw, call_cost_usd=first_cost, group_id=group_id)
+
+    def inspect_scores(self, judgements: list[PairwiseJudgement], sample_size: int = 10) -> object:
+        raise NotImplementedError
+
+
+class _FakeMalformedGroupModule(Module[object]):
+    """A group-wise module that violates the E5 convention: never stamps
+    ``group_end`` at all. Exercises the drain loop's defensive fallback --
+    if the boundary marker never appears, draining runs to the end of the
+    (in this fake, finite) stream instead of assuming a sibling exists
+    forever or crashing.
     """
 
     def __init__(self, first_cost: float, n_siblings: int, group_id: str = "g1") -> None:
@@ -105,24 +171,9 @@ class _FakeGroupModule(Module[object]):
                 right_id=str(i),
                 score=0.9,
                 score_type="prob_llm",
-                decision_step="fake_group",
+                decision_step="fake_group_malformed",
                 provenance={"cost_usd": cost, "group_id": self._group_id},
             )
-
-    def inspect_scores(self, judgements: list[PairwiseJudgement], sample_size: int = 10) -> object:
-        raise NotImplementedError
-
-
-class _ChainedGroupsModule(Module[object]):
-    """Concatenates several group-wise fake modules' judgement streams, in order."""
-
-    def __init__(self, groups: list[Module[object]]) -> None:
-        self._groups = groups
-
-    def forward(self, candidates: Iterator[ERCandidate[object]]) -> Iterator[PairwiseJudgement]:
-        remaining = list(candidates)
-        for group_module in self._groups:
-            yield from group_module.forward(iter(remaining))
 
     def inspect_scores(self, judgements: list[PairwiseJudgement], sample_size: int = 10) -> object:
         raise NotImplementedError
@@ -321,28 +372,46 @@ class TestSpendCappedModule:
         # No cost was double-counted for the $0 siblings.
         assert sum(float(j.provenance["cost_usd"]) for j in partial) == 1.0
 
-    def test_cap_breach_drain_stops_at_next_groups_judgement(self) -> None:
-        """The drain loop must not swallow a DIFFERENT group's judgement past the boundary.
+    def test_cap_breach_drain_never_computes_the_next_group(self) -> None:
+        """The drain must stop at group_end, never peek into (and pay for) the NEXT group.
 
-        Exercises the "stop at the first non-sibling judgement" branch: group
-        "g1" trips the cap and is drained whole, but a later group "g2" behind
-        it in the stream must not be pulled in too.
+        Regression for the claude-review finding on this PR: detecting the
+        group boundary by peeking at the next judgement's group_id (instead
+        of the group_end marker) resumes a lazy GroupwiseModule's generator
+        one group too far -- for a real module (SelectJudge) that fires the
+        next group's paid LLM call before there's anything to compare
+        against, silently discarding it. ``_LazyGroupsModule.groups_computed``
+        makes that "was the next group's paid call fired at all" question
+        observable: it must stay at 1 (only "g1" fires) after the drain,
+        never 2 (which would mean g2's call fired and its result was thrown
+        away).
         """
-        module = _SpendCappedModule(
-            _ChainedGroupsModule(
-                [
-                    _FakeGroupModule(first_cost=1.0, n_siblings=1, group_id="g1"),
-                    _FakeGroupModule(first_cost=0.0, n_siblings=1, group_id="g2"),
-                ]
-            ),
-            budget_usd=0.9,
-        )
+        fake = _LazyGroupsModule([(1.0, 1, "g1"), (0.0, 1, "g2")])
+        module = _SpendCappedModule(fake, budget_usd=0.9)
         candidates = iter([_candidate(str(i)) for i in range(4)])
         with pytest.raises(BudgetExceeded) as excinfo:
             list(module.forward(candidates))
         partial = excinfo.value.partial_judgements
         assert len(partial) == 2
         assert all(j.provenance.get("group_id") == "g1" for j in partial)
+        assert fake.groups_computed == 1, (
+            "g2's paid call fired even though the cap tripped on g1 -- "
+            f"got {fake.groups_computed} groups computed, want 1"
+        )
+
+    def test_cap_breach_drain_runs_to_stream_end_if_group_end_never_set(self) -> None:
+        """Defensive fallback: a module that never stamps group_end (a convention
+        violation) still drains to the end of its stream rather than looping
+        forever or crashing -- exercises the drain loop's non-break exit path.
+        """
+        module = _SpendCappedModule(
+            _FakeMalformedGroupModule(first_cost=1.0, n_siblings=2, group_id="g1"), budget_usd=0.9
+        )
+        candidates = iter([_candidate(str(i)) for i in range(3)])
+        with pytest.raises(BudgetExceeded) as excinfo:
+            list(module.forward(candidates))
+        partial = excinfo.value.partial_judgements
+        assert len(partial) == 3
 
     def test_cap_breach_without_group_id_is_unchanged(self) -> None:
         """Pairwise (no group_id) modules keep the pre-existing single-judgement cap behavior."""

--- a/tests/test_import_budget.py
+++ b/tests/test_import_budget.py
@@ -165,6 +165,14 @@ class TestCoreLazyGetattr:
 
         assert core.RFJudge is RFJudge
 
+    def test_select_judge_resolves(self) -> None:
+        pytest.importorskip("dspy", reason="requires the [llm] extra")
+        import langres.core as core
+
+        from langres.core.modules.select_judge import SelectJudge
+
+        assert core.SelectJudge is SelectJudge
+
     def test_embeddings_and_indexes_symbols_resolve(self) -> None:
         pytest.importorskip("sentence_transformers", reason="requires the [semantic] extra")
         pytest.importorskip("faiss", reason="requires the [semantic] extra")
@@ -209,6 +217,15 @@ class TestCoreLazyGetattr:
 
         with pytest.raises(ImportError, match=r"langres\.core\.RFJudge.*langres\[trained\]"):
             core.RFJudge  # noqa: B018
+
+    def test_select_judge_raises_actionable_import_error_when_llm_absent(self) -> None:
+        """Core-only install (no [llm]): a real, un-simulated ImportError (see above)."""
+        if _import_ok("dspy"):
+            pytest.skip("dspy is installed ([llm] extra present) -- nothing to observe")
+        import langres.core as core
+
+        with pytest.raises(ImportError, match=r"langres\.core\.SelectJudge.*langres\[llm\]"):
+            core.SelectJudge  # noqa: B018
 
     def test_submodules_resolve_to_the_module_object(self, monkeypatch: pytest.MonkeyPatch) -> None:
         """Attribute access resolves each submodule via ``__getattr__``.


### PR DESCRIPTION
## Summary
- Fixes a Codex P2 review finding on PR #68: `_SpendCappedModule.forward` raised `BudgetExceeded` the instant a judgement tripped the spend cap, without draining a group-wise module's (`SelectJudge`) already-produced, already-paid-for sibling judgements sharing the tripping judgement's `provenance["group_id"]` (E5 group-cost convention: full cost on the first judgement, `$0` on the K-1 siblings). That silently dropped real decisions from `exc.partial_judgements`. Now the remaining same-group judgements are drained from the underlying generator (no cost re-added) and included before raising -- a group is never split across the cap boundary. Pairwise modules (no `group_id`) are unaffected.
- Exports `SelectJudge` from `langres.core` (lazy PEP 562 resolution, mirroring `RFJudge`/`LLMJudge`) for public-API parity -- it was registered and wired into the benchmark path but missing from `core.__all__`.

## Test plan
- [x] New test `test_cap_breach_drains_group_siblings_into_partial_judgements` fails before the fix (only 1 of 3 group judgements in `partial_judgements`), passes after.
- [x] New test `test_cap_breach_drain_stops_at_next_groups_judgement` covers the drain loop's stop-at-next-group branch (100% coverage on the changed lines).
- [x] Existing/new `test_cap_breach_without_group_id_is_unchanged` confirms pairwise (no `group_id`) cap-trip behavior is unchanged.
- [x] New `test_select_judge_resolves` / `test_select_judge_raises_actionable_import_error_when_llm_absent` in `tests/test_import_budget.py`; confirmed `from langres.core import SelectJudge` works and a bare `import langres` still never touches `dspy` (subprocess-based leak check).
- [x] `ruff check`, `ruff format --check`, `mypy src` all clean.
- [x] `pytest -m "not slow and not integration" --cov=src/langres` -- 1651 passed, 4 skipped, 98.40% coverage; `presets.py` 99% (only line pre-existing/unrelated, guarded by a `@pytest.mark.slow` embedding test); `core/__init__.py` 100%.

https://claude.ai/code/session_0115MvWbHaCKT1A39PKDWqey