### PR TITLE
W2.2: incremental single-record assign (AnchorStore + resolver.assign -> ClusterDelta)

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -6,6 +6,26 @@
 - Implemented core primitives (`Module`, `Blocker`, `Clusterer`) with Pydantic data contracts and 100% test coverage
 - Completed Approach 1 (classical baseline): `AllPairsBlocker` + `RapidfuzzModule` end-to-end pipeline
 
+### M5 (W2.2): incremental single-record assignment — `AnchorStore` + `Resolver.assign`
+
+The incremental-linking exit (S6): after a batch `resolve()`, answer "here is one NEW
+record — which existing entity, or new?" with a **stable** entity id.
+
+- **`AnchorStore`** (`src/langres/core/anchor_store.py`) — a serializable, composable unit
+  around a `Resolver`. `AnchorStore.build(resolver, records)` runs a dedicated pass that
+  mints a stable, monotonic entity id for **every** record, including the singletons
+  `resolve()` drops (clusterer-agnostic). `save`/`load` via the config-registry artifact
+  seam (no pickle), delegating the pipeline to `Resolver.save`/`load`.
+- **`Resolver.build_anchor_store(records)` + `Resolver.assign(record) -> ClusterDelta`** —
+  thin sugar; the reserved cross-source `link`/`stream_against` stubs stay untouched.
+  `assign` reuses the vector index single-record kNN (with `similarity_score` + `query_prompt`,
+  so `EmbeddingScoreJudge` works incrementally) or all-pairs, and the same Comparator + Module
+  judge. Append-only allocator (idempotent per record id); `CompositeBlocker` supported.
+- **`ClusterDelta`** — `new` / `link`, with `merge`/`split`/`reject` reserved in the enum so
+  the contract stays stable for W2.4/M6.
+- Committed-data (Fodors-Zagat) + fresh-subprocess save/load round-trip tests; 100% coverage.
+  See `examples/incremental_assign.py`.
+
 ### M4: langres is the seam — DSPy experimentation foundation + first paid signal
 
 Reframed from a distillation-metric chase to **building the composable scorer seam we're

--- a/docs/TECHNICAL_OVERVIEW.md
+++ b/docs/TECHNICAL_OVERVIEW.md
@@ -438,6 +438,17 @@ The rich data object passed out of a Flow. This is the auditable log of a decisi
 - `reasoning: Optional[str]`: The LLM's natural language explanation.
 - `provenance: Dict[str, Any]`: A full audit trail (e.g., `{"model": "e5-small", "rapidfuzz_score": 0.85}`).
 
+### ClusterDelta (`langres.core`, M5/W2.2)
+
+The result of one incremental `Resolver.assign(record)` / `AnchorStore.assign(record)` — the outcome of assigning a single new record against a prior batch's anchor set.
+
+- `type: Literal["new", "link", "merge", "split", "reject"]`: `new` (a fresh entity was minted) or `link` (attached to an existing entity). `merge`/`split`/`reject` are **reserved** for the wider entity-maintenance surface (W2.4/M6) so the contract stays stable; W2.2 only ever emits `new`/`link`.
+- `record_id: str`: The assigned record's id.
+- `entity_id: str`: The **stable** entity id the record now belongs to (freshly minted for `new`, existing for `link`). Never changes on later assigns (append-only allocator).
+- `matched_anchor_ids: list[str]`: Anchor record ids that cleared the threshold (evidence for a `link`; empty for `new` and for the idempotent already-assigned-id `link`).
+- `score: Optional[float]`: Best matching score across judged candidates (observability); `None` when there were no candidates or on the idempotent path.
+- `reasoning: Optional[str]`: Human-readable note about the decision.
+
 ## 8. Group + Fit Contracts (W1.0) + SelectJudge (W1.1)
 
 W1.0 froze two interfaces that later branches build against: this section

--- a/docs/USE_CASES.md
+++ b/docs/USE_CASES.md
@@ -16,9 +16,13 @@
 > - **Deduplication (UC1):** ✅ `langres.dedupe(records)` or
 >   `Resolver.from_schema(schema).resolve(records)`.
 > - **Pairwise match:** ✅ `langres.link(left, right)` → `LinkVerdict`.
-> - **Entity Linking / cross-source / incremental (UC2, UC3, UC10):** 🚧
->   `Resolver.link()` and `Resolver.stream_against()` exist only as
->   `NotImplementedError` stubs reserved for **M5**.
+> - **Incremental single-record assignment (UC10):** ✅ (M5/W2.2)
+>   `resolver.build_anchor_store(records)` then `resolver.assign(new_record)`
+>   → `ClusterDelta` (`link` to a stable entity id, or `new`); the
+>   serializable `AnchorStore` persists it. See `examples/incremental_assign.py`.
+> - **Cross-source entity linking (UC2, UC3):** 🚧 `Resolver.link()` and
+>   `Resolver.stream_against()` remain `NotImplementedError` stubs reserved for
+>   later **M5** waves (distinct from the single-record `assign` above).
 > - **Master Data / golden records (UC4):** 🚧 no `Canonicalizer` yet — **M5**.
 > - **Negative constraints (UC9):** 🚧 `Clusterer` takes only a `threshold`;
 >   no cannot-link support today.
@@ -88,10 +92,12 @@ This is the primary "hello world" use case for langres.
 
 Cross-source, asymmetric linking is **not yet built**. `Resolver.link(left,
 right)` and `Resolver.stream_against(records)` exist only as
-`NotImplementedError` stubs reserved for M5 (incremental assignment against an
-entity store). For a *pairwise* match decision today, use
-`langres.link(left, right)` → `LinkVerdict`; for single-source clustering, use
-`dedupe` / `Resolver.resolve` (UC1).
+`NotImplementedError` stubs reserved for later M5 waves. What *does* ship (M5/
+W2.2) is **single-record incremental assignment against an anchor store**:
+`resolver.build_anchor_store(target_records)` then `resolver.assign(new_record)`
+→ `ClusterDelta` (`link` to a stable entity id in T, or `new`). For a *pairwise*
+match decision today, use `langres.link(left, right)` → `LinkVerdict`; for
+single-source clustering, use `dedupe` / `Resolver.resolve` (UC1).
 
 ### Use Case 10: Fuzzy Foreign Key Resolution
 

--- a/docs/USE_CASES.md
+++ b/docs/USE_CASES.md
@@ -238,8 +238,8 @@ exists, and the intended (not-yet-built) design otherwise.
 | 1. Deduplication | `dedupe(records)` / `Resolver.from_schema(...).resolve(...)`, `core.Clusterer` | ✅ **Shipping** |
 | Pairwise match verdict | `link(left, right)` → `LinkVerdict` | ✅ **Shipping** |
 | Optimization / calibration | `core.calibration.derive_threshold`, `core.optimizers.BlockerOptimizer` (Optuna) | ✅ **Partial** (threshold calibration + blocker tuning; no full `Optimizer`) |
-| 2. Entity Linking | `Resolver.link` / `stream_against` (stubs today) | 🚧 Roadmap (M5) |
-| 10. Fuzzy FK Resolution | (special case of UC2) | 🚧 Roadmap (M5) |
+| 2. Entity Linking (cross-source) | `Resolver.link` / `stream_against` (stubs today) | 🚧 Roadmap (M5) |
+| 10. Incremental single-record assign | `Resolver.build_anchor_store(...)` → `Resolver.assign(record)` → `ClusterDelta`; `core.AnchorStore` | ✅ **Shipping** (M5/W2.2) |
 | 4. Master Data Creation | `Canonicalizer` (survivorship) — not built | 🚧 Roadmap (M5) |
 | Set-wise / trained judge families | SelectJudge, Fellegi–Sunter, RandomForest — not built | 🚧 Roadmap (M4.5) |
 | 9. Negative Constraints | constrained `Clusterer` — not built | 🚧 Roadmap |

--- a/examples/incremental_assign.py
+++ b/examples/incremental_assign.py
@@ -55,7 +55,7 @@ def main() -> None:
     #    including the singletons a batch resolve() would have dropped.
     store = resolver.build_anchor_store(BATCH)
     print("Anchored entities (record_id -> entity_id):")
-    for record_id, entity_id in sorted(store._assignments.items()):
+    for record_id, entity_id in sorted(store.assignments.items()):
         print(f"  record {record_id} -> {entity_id}")
 
     # 2. A new mention of an existing company -> LINK to its stable entity id.

--- a/examples/incremental_assign.py
+++ b/examples/incremental_assign.py
@@ -21,10 +21,30 @@ from langres.core import AnchorStore, CompanySchema, Resolver
 
 # A prior batch: records 1 and 2 are the same company; 3 and 4 are unique.
 BATCH = [
-    {"id": "1", "name": "Apple Inc", "address": "1 Infinite Loop Cupertino", "phone": "408-996-1010"},
-    {"id": "2", "name": "Apple Incorporated", "address": "1 Infinite Loop, Cupertino", "phone": "408-996-1010"},
-    {"id": "3", "name": "Microsoft Corporation", "address": "1 Microsoft Way Redmond", "phone": "425-882-8080"},
-    {"id": "4", "name": "Umbrella Corporation", "address": "Raccoon City Center", "phone": "202-555-0100"},
+    {
+        "id": "1",
+        "name": "Apple Inc",
+        "address": "1 Infinite Loop Cupertino",
+        "phone": "408-996-1010",
+    },
+    {
+        "id": "2",
+        "name": "Apple Incorporated",
+        "address": "1 Infinite Loop, Cupertino",
+        "phone": "408-996-1010",
+    },
+    {
+        "id": "3",
+        "name": "Microsoft Corporation",
+        "address": "1 Microsoft Way Redmond",
+        "phone": "425-882-8080",
+    },
+    {
+        "id": "4",
+        "name": "Umbrella Corporation",
+        "address": "Raccoon City Center",
+        "phone": "202-555-0100",
+    },
 ]
 
 
@@ -40,24 +60,40 @@ def main() -> None:
 
     # 2. A new mention of an existing company -> LINK to its stable entity id.
     delta = resolver.assign(
-        {"id": "9", "name": "Apple Inc.", "address": "1 Infinite Loop Cupertino", "phone": "408-996-1010"}
+        {
+            "id": "9",
+            "name": "Apple Inc.",
+            "address": "1 Infinite Loop Cupertino",
+            "phone": "408-996-1010",
+        }
     )
-    print(f"\nassign(Apple Inc.)   -> {delta.type} to {delta.entity_id} "
-          f"(matched anchors {delta.matched_anchor_ids})")
+    print(
+        f"\nassign(Apple Inc.)   -> {delta.type} to {delta.entity_id} "
+        f"(matched anchors {delta.matched_anchor_ids})"
+    )
 
     # 3. A brand-new company -> NEW freshly minted entity id.
     delta = resolver.assign(
-        {"id": "10", "name": "Nintendo Company", "address": "11-1 Kamitoba Kyoto", "phone": "075-541-6111"}
+        {
+            "id": "10",
+            "name": "Nintendo Company",
+            "address": "11-1 Kamitoba Kyoto",
+            "phone": "075-541-6111",
+        }
     )
     print(f"assign(Nintendo)     -> {delta.type} to {delta.entity_id}")
 
     # 4. A new mention of a record that was a SINGLETON in the batch -> LINK
     #    (singletons are first-class anchors, not dropped).
     delta = resolver.assign(
-        {"id": "11", "name": "Microsoft Corporation", "address": "1 Microsoft Way Redmond", "phone": "425-882-8080"}
+        {
+            "id": "11",
+            "name": "Microsoft Corporation",
+            "address": "1 Microsoft Way Redmond",
+            "phone": "425-882-8080",
+        }
     )
-    print(f"assign(Microsoft)    -> {delta.type} to {delta.entity_id} "
-          f"(singleton was assignable)")
+    print(f"assign(Microsoft)    -> {delta.type} to {delta.entity_id} (singleton was assignable)")
 
     # 5. Persist the whole store (pipeline + id bookkeeping) and reload it —
     #    the config-registry artifact seam, no pickle.
@@ -66,7 +102,12 @@ def main() -> None:
         store.save(path)
         reloaded = AnchorStore.load(path)
         delta = reloaded.assign(
-            {"id": "12", "name": "Apple Inc.", "address": "1 Infinite Loop Cupertino", "phone": "408-996-1010"}
+            {
+                "id": "12",
+                "name": "Apple Inc.",
+                "address": "1 Infinite Loop Cupertino",
+                "phone": "408-996-1010",
+            }
         )
         print(f"\nafter save/load: assign(Apple Inc.) -> {delta.type} to {delta.entity_id}")
 

--- a/examples/incremental_assign.py
+++ b/examples/incremental_assign.py
@@ -1,0 +1,75 @@
+"""Incremental single-record assignment with ``AnchorStore`` (M5 / W2.2).
+
+A batch ``resolve()`` answers "which of these records group together?". But once
+that batch is settled, new records keep arriving one at a time — and the question
+becomes *incremental*: "here is one NEW record; which existing entity does it
+belong to, or is it new?".
+
+``AnchorStore`` answers that. You anchor a ``Resolver`` on the batch once
+(minting a stable entity id for every record, singletons included), then
+``assign()`` each new record against it — getting back a ``ClusterDelta`` that
+either ``link``\\ s to an existing entity (with a stable id) or marks it ``new``.
+
+This example is fully offline (the string judge — no embeddings, no API calls).
+Run it with:  ``uv run python examples/incremental_assign.py``
+"""
+
+import tempfile
+from pathlib import Path
+
+from langres.core import AnchorStore, CompanySchema, Resolver
+
+# A prior batch: records 1 and 2 are the same company; 3 and 4 are unique.
+BATCH = [
+    {"id": "1", "name": "Apple Inc", "address": "1 Infinite Loop Cupertino", "phone": "408-996-1010"},
+    {"id": "2", "name": "Apple Incorporated", "address": "1 Infinite Loop, Cupertino", "phone": "408-996-1010"},
+    {"id": "3", "name": "Microsoft Corporation", "address": "1 Microsoft Way Redmond", "phone": "425-882-8080"},
+    {"id": "4", "name": "Umbrella Corporation", "address": "Raccoon City Center", "phone": "202-555-0100"},
+]
+
+
+def main() -> None:
+    resolver = Resolver.from_schema(CompanySchema, judge="string", threshold=0.6)
+
+    # 1. Anchor the resolver on the batch — one stable entity id per record,
+    #    including the singletons a batch resolve() would have dropped.
+    store = resolver.build_anchor_store(BATCH)
+    print("Anchored entities (record_id -> entity_id):")
+    for record_id, entity_id in sorted(store._assignments.items()):
+        print(f"  record {record_id} -> {entity_id}")
+
+    # 2. A new mention of an existing company -> LINK to its stable entity id.
+    delta = resolver.assign(
+        {"id": "9", "name": "Apple Inc.", "address": "1 Infinite Loop Cupertino", "phone": "408-996-1010"}
+    )
+    print(f"\nassign(Apple Inc.)   -> {delta.type} to {delta.entity_id} "
+          f"(matched anchors {delta.matched_anchor_ids})")
+
+    # 3. A brand-new company -> NEW freshly minted entity id.
+    delta = resolver.assign(
+        {"id": "10", "name": "Nintendo Company", "address": "11-1 Kamitoba Kyoto", "phone": "075-541-6111"}
+    )
+    print(f"assign(Nintendo)     -> {delta.type} to {delta.entity_id}")
+
+    # 4. A new mention of a record that was a SINGLETON in the batch -> LINK
+    #    (singletons are first-class anchors, not dropped).
+    delta = resolver.assign(
+        {"id": "11", "name": "Microsoft Corporation", "address": "1 Microsoft Way Redmond", "phone": "425-882-8080"}
+    )
+    print(f"assign(Microsoft)    -> {delta.type} to {delta.entity_id} "
+          f"(singleton was assignable)")
+
+    # 5. Persist the whole store (pipeline + id bookkeeping) and reload it —
+    #    the config-registry artifact seam, no pickle.
+    with tempfile.TemporaryDirectory() as tmp:
+        path = Path(tmp) / "anchors"
+        store.save(path)
+        reloaded = AnchorStore.load(path)
+        delta = reloaded.assign(
+            {"id": "12", "name": "Apple Inc.", "address": "1 Infinite Loop Cupertino", "phone": "408-996-1010"}
+        )
+        print(f"\nafter save/load: assign(Apple Inc.) -> {delta.type} to {delta.entity_id}")
+
+
+if __name__ == "__main__":
+    main()

--- a/src/langres/core/__init__.py
+++ b/src/langres/core/__init__.py
@@ -25,6 +25,7 @@ import importlib
 from typing import TYPE_CHECKING, Any
 
 from langres.core.adapters.glinker import GLinkerAdapter
+from langres.core.anchor_store import AnchorStore, ClusterDelta
 from langres.core.blocker import Blocker
 from langres.core.blockers.all_pairs import AllPairsBlocker
 from langres.core.blockers.composite import CompositeBlocker
@@ -96,10 +97,12 @@ if TYPE_CHECKING:
 __all__ = [
     "ARTIFACT_VERSION",
     "AllPairsBlocker",
+    "AnchorStore",
     "ArtifactManifest",
     "benchmark",
     "Blocker",
     "CandidateStats",
+    "ClusterDelta",
     "ClusterStats",
     "Clusterer",
     "CompanySchema",

--- a/src/langres/core/anchor_store.py
+++ b/src/langres/core/anchor_store.py
@@ -202,14 +202,14 @@ class AnchorStore:
         """
         clusters = resolver.resolve(records)
 
-        factory = resolver.blocker.schema_factory
-        anchor_ids = [factory(record).id for record in records]  # type: ignore[attr-defined]
+        factory = resolver.blocker.schema_factory  # type: ignore[attr-defined]
+        anchor_ids: list[str] = [factory(record).id for record in records]
         records_by_id = dict(zip(anchor_ids, records))
 
         id_to_cluster: dict[str, frozenset[str]] = {}
-        for cluster in clusters:
-            frozen = frozenset(cluster)
-            for record_id in cluster:
+        for raw_cluster in clusters:
+            frozen = frozenset(raw_cluster)
+            for record_id in raw_cluster:
                 id_to_cluster[record_id] = frozen
 
         assignments: dict[str, str] = {}
@@ -287,20 +287,19 @@ class AnchorStore:
         matched_anchor_ids: list[str] = []
         best_score: float | None = None
         for judgement in judgements:
-            best_score = (
-                judgement.score if best_score is None else max(best_score, judgement.score)
-            )
+            best_score = judgement.score if best_score is None else max(best_score, judgement.score)
             if judgement.score >= threshold:
                 anchor_id = (
                     judgement.right_id if judgement.left_id == record_id else judgement.left_id
                 )
                 matched_anchor_ids.append(anchor_id)
 
-        # Distinct matched entities, in first-seen order.
+        # Distinct matched entities, in first-seen order. Every candidate anchor
+        # is a known record, so its assignment always exists.
         matched_entity_ids: list[str] = []
         for anchor_id in matched_anchor_ids:
-            entity_id = self._assignments.get(anchor_id)
-            if entity_id is not None and entity_id not in matched_entity_ids:
+            entity_id = self._assignments[anchor_id]
+            if entity_id not in matched_entity_ids:
                 matched_entity_ids.append(entity_id)
 
         if matched_entity_ids:
@@ -308,9 +307,7 @@ class AnchorStore:
             # lowest-ordinal (oldest) entity and reserves merge for later.
             resolved_entity_id = min(matched_entity_ids, key=self._ordinal_of)
             delta_type: ClusterDeltaType = "link"
-            reasoning = (
-                f"linked to existing entity via {len(matched_anchor_ids)} matched anchor(s)"
-            )
+            reasoning = f"linked to existing entity via {len(matched_anchor_ids)} matched anchor(s)"
         else:
             resolved_entity_id = self._mint()
             delta_type = "new"
@@ -352,15 +349,11 @@ class AnchorStore:
             return list(self._anchor_ids)
 
         text = blocker.text_field_extractor(entity)  # type: ignore[attr-defined]
+        # k <= ntotal, so a flat index returns exactly k valid neighbours (no
+        # -1 padding); the new record is not in the corpus, so no self-hit to skip.
         k = min(blocker.k_neighbors, len(self._anchor_ids))  # type: ignore[attr-defined]
         _distances, indices = blocker.vector_index.search(text, k)  # type: ignore[attr-defined]
-        anchor_ids: list[str] = []
-        for raw_index in indices.tolist():
-            index = int(raw_index)
-            # FAISS pads with -1 when fewer than k neighbours exist.
-            if 0 <= index < len(self._anchor_ids):
-                anchor_ids.append(self._anchor_ids[index])
-        return anchor_ids
+        return [self._anchor_ids[int(i)] for i in indices.tolist()]
 
     def _candidate(self, entity: Any, anchor_id: str) -> ERCandidate[Any]:
         """Build a ``(new_record, anchor)`` candidate pair for the judge."""

--- a/src/langres/core/anchor_store.py
+++ b/src/langres/core/anchor_store.py
@@ -49,29 +49,46 @@ logger = logging.getLogger(__name__)
 ANCHOR_STORE_VERSION = "1"
 
 
+def _find_schema_factory(blocker: Any) -> Any | None:
+    """Depth-first search for the first ``schema_factory`` reachable from ``blocker``.
+
+    Returns the blocker's own ``schema_factory`` if it exposes one, else recurses
+    into ``children`` at **arbitrary depth** (mirroring ``resolver._iter_vector_
+    blockers``) so a ``CompositeBlocker`` wrapping another ``CompositeBlocker``
+    still surfaces a nested child's factory. Returns ``None`` when nothing in the
+    tree exposes one.
+    """
+    factory = getattr(blocker, "schema_factory", None)
+    if factory is not None:
+        return factory
+    for child in getattr(blocker, "children", []):
+        found = _find_schema_factory(child)
+        if found is not None:
+            return found
+    return None
+
+
 def _schema_factory(blocker: Any) -> Any:
     """Return a record->entity factory reachable from ``blocker``.
 
     ``AnchorStore`` normalizes raw records through the blocker's
     ``schema_factory``. ``AllPairsBlocker``/``VectorBlocker`` expose one directly.
     A ``CompositeBlocker`` (blocking-algebra union/intersection) owns no schema of
-    its own but its children all share one — so recurse into ``children`` and use
-    the first reachable factory (the recall-first ``KeyBlocker`` union
-    ``VectorBlocker`` pattern therefore works). Only a blocker that neither
-    exposes nor contains a ``schema_factory`` (e.g. a ``GLinkerAdapter``) raises
-    an actionable error rather than a cryptic ``AttributeError`` in build/assign.
+    its own but its children all share one — so recurse through ``children`` at
+    any depth (composite-of-composites included, matching ``CompositeBlocker``'s
+    own documented nesting) and use the first reachable factory (the recall-first
+    ``KeyBlocker`` union ``VectorBlocker`` pattern therefore works). Only a blocker
+    that neither exposes nor contains a ``schema_factory`` anywhere in its tree
+    (e.g. a ``GLinkerAdapter``) raises an actionable error rather than a cryptic
+    ``AttributeError`` in build/assign.
     """
-    factory = getattr(blocker, "schema_factory", None)
+    factory = _find_schema_factory(blocker)
     if factory is not None:
         return factory
-    for child in getattr(blocker, "children", []):
-        child_factory = getattr(child, "schema_factory", None)
-        if child_factory is not None:
-            return child_factory
     raise NotImplementedError(
         f"AnchorStore cannot normalize records via a {type(blocker).__name__}: "
-        "no `schema_factory` on it or its children. Incremental assign needs a "
-        "blocker (or composite of blockers) that reconstructs entities itself "
+        "no `schema_factory` on it or any nested child. Incremental assign needs "
+        "a blocker (or composite of blockers) that reconstructs entities itself "
         "(AllPairsBlocker / VectorBlocker / a CompositeBlocker of them)."
     )
 
@@ -240,6 +257,11 @@ class AnchorStore:
         """
         clusters = resolver.resolve(records)
 
+        # Re-normalize each record to read its stable id. This repeats the
+        # normalization ``resolve()`` already did internally — a minor,
+        # build-only duplicate cost (one pass, no network) accepted to keep the
+        # id derivation self-contained rather than reaching into resolve()'s
+        # internals; assign() does not pay it.
         factory = _schema_factory(resolver.blocker)
         anchor_ids: list[str] = [factory(record).id for record in records]
         if len(set(anchor_ids)) != len(anchor_ids):
@@ -304,11 +326,14 @@ class AnchorStore:
         returns its existing entity id unchanged (idempotent, never renumbered).
 
         W2.2 boundary: assign matches against the anchor set fixed at
-        :meth:`build` time. A newly-assigned record extends the id map (so its
-        own id is idempotent) but is **not** added to the searchable corpus/
-        index — two distinct new ids that duplicate each other will each mint a
-        ``new`` entity. Growing the searchable set across assigns (so later
-        arrivals match earlier ones) is reserved for a later wave.
+        :meth:`build` time. A newly-assigned record extends only the id map
+        (``record_id -> entity_id``, so its own id is idempotent); its raw
+        payload is **not** retained and it is **not** added to the searchable
+        corpus/index — two distinct new ids that duplicate each other will each
+        mint a ``new`` entity. This keeps the store's memory and persisted size
+        bounded by the anchor set, not by the (unbounded) assign stream. Growing
+        the searchable set across assigns (so later arrivals match earlier ones)
+        is reserved for a later wave.
 
         Cost: with no vector index (e.g. an ``AllPairsBlocker`` pipeline) assign
         judges the record against **every** anchor — O(n) judge calls per record.
@@ -380,9 +405,13 @@ class AnchorStore:
             delta_type = "new"
             reasoning = "no anchor cleared the match threshold"
 
-        # Register (append-only): makes assign idempotent on this record id.
+        # Register (append-only): makes assign idempotent on this record id. Only
+        # the id->entity map grows; the raw record is deliberately NOT stored.
+        # ``_records`` holds anchors only (the searchable/judgeable corpus fixed
+        # at build time); a newly-assigned record is never an anchor (W2.2
+        # boundary) and nothing reads its payload back, so persisting it would be
+        # unbounded dead weight in memory and in anchor_store.json.
         self._assignments[record_id] = resolved_entity_id
-        self._records.setdefault(record_id, record)
 
         return ClusterDelta(
             type=delta_type,
@@ -417,21 +446,32 @@ class AnchorStore:
         ``similarity_score``) works incrementally. Falls back to every anchor
         (``similarity`` ``None``) when there is no index (e.g. an
         ``AllPairsBlocker``), the correct all-pairs behaviour for one new record.
+
+        The vector source is found via the resolver's own
+        :func:`~langres.core.resolver._iter_vector_blockers` — the *same* walk
+        ``resolve()`` used to build the index — so a ``VectorBlocker`` nested
+        (at any depth) inside a ``CompositeBlocker`` is searched against exactly
+        the index that was built for it. The first reachable vector blocker
+        supplies the kNN candidates; the judge still runs over all of them.
         """
-        blocker = self._resolver.blocker
-        if getattr(blocker, "type_name", None) != "vector_blocker" or not self._anchor_ids:
+        # Lazy import (module-load circular-import safety, like `load`); reusing
+        # the canonical walk guarantees we search the index resolve() built.
+        from langres.core.resolver import _iter_vector_blockers
+
+        blocker = next(iter(_iter_vector_blockers(self._resolver.blocker)), None)
+        if blocker is None or not self._anchor_ids:
             return [(anchor_id, None) for anchor_id in self._anchor_ids]
 
-        text = blocker.text_field_extractor(entity)  # type: ignore[attr-defined]
-        k = min(blocker.k_neighbors, len(self._anchor_ids))  # type: ignore[attr-defined]
+        text = blocker.text_field_extractor(entity)
+        k = min(blocker.k_neighbors, len(self._anchor_ids))
         # Pass the blocker's query_prompt so an asymmetric/instructional embedder
         # encodes the assign query exactly as the batch path does (vector.py).
-        distances, indices = blocker.vector_index.search(  # type: ignore[attr-defined]
+        distances, indices = blocker.vector_index.search(
             text,
             k,
-            query_prompt=blocker.query_prompt,  # type: ignore[attr-defined]
+            query_prompt=blocker.query_prompt,
         )
-        similarities = blocker.vector_index.to_similarities(distances)  # type: ignore[attr-defined]
+        similarities = blocker.vector_index.to_similarities(distances)
         # Skip -1 padding: a fusion/hybrid index (e.g. QdrantHybridIndex) pads
         # short result sets with -1 even when k <= ntotal. Indexing a bare list
         # with -1 would silently wrap to the last anchor -> a phantom match.

--- a/src/langres/core/anchor_store.py
+++ b/src/langres/core/anchor_store.py
@@ -1,0 +1,449 @@
+"""Incremental single-record assignment against a persisted anchor set (M5 / W2.2).
+
+A batch :meth:`Resolver.resolve` answers "given all these records at once, which
+group together?" — but it returns only *id-sets*: positional, without stable
+entity ids, and with **singletons dropped** (the Clusterer emits only connected
+components with an edge; see ``clusterer.py`` / ``resolver.py``). That output
+cannot answer the *incremental* question "here is one NEW record — which existing
+entity does it belong to, or is it new?", because it retains no stable ids, no
+records, and structurally cannot represent a record that matched nothing.
+
+:class:`AnchorStore` fills that gap. It is built by a **dedicated pass** over a
+prior batch (:meth:`AnchorStore.build`) that:
+
+- runs the resolver once (which also builds any vector index in place), then
+- enumerates **every** input record — including the ones the clusterer dropped
+  as singletons — and mints each a **stable, monotonic entity id** from an
+  append-only allocator (ids are minted by the store, never derived from list
+  position, since ``resolve()``'s order is non-deterministic).
+
+:meth:`AnchorStore.assign` then answers the incremental question for one new
+record by reusing the resolver's *existing* seams — the vector index's
+single-record kNN (or all-pairs when there is no index) for candidate anchors,
+and the very same Comparator + Module judge the batch pipeline uses — and
+returns a :class:`ClusterDelta` carrying a **stable** entity id: ``link`` to an
+existing entity, or ``new`` with a freshly minted id.
+
+The store round-trips through the same config-registry artifact seam as the
+Resolver (no pickle): :meth:`save` delegates the pipeline to
+:meth:`Resolver.save` (including a built FAISS index's sidecar state) and writes
+a small ``anchor_store.json`` for the id bookkeeping; :meth:`load` reverses it in
+a fresh process.
+"""
+
+import logging
+from pathlib import Path
+from typing import TYPE_CHECKING, Any, Literal
+
+from pydantic import BaseModel, Field
+
+from langres.core.models import ERCandidate, PairwiseJudgement
+
+if TYPE_CHECKING:
+    from langres.core.resolver import Resolver
+
+logger = logging.getLogger(__name__)
+
+#: Bump when the ``anchor_store.json`` layout changes incompatibly.
+ANCHOR_STORE_VERSION = "1"
+
+_MANIFEST_FILENAME = "anchor_store.json"
+_RESOLVER_SUBDIR = "resolver"
+
+#: The kinds of change an :meth:`AnchorStore.assign` can report. ``new`` and
+#: ``link`` are the only two W2.2 produces (single-record assignment); the rest
+#: are **reserved** so the wider entity-maintenance surface (W2.4 flywheel / M6)
+#: can add them without reshaping this contract:
+#: ``merge`` (fold two existing entities into one), ``split`` (break one entity
+#: apart), ``reject`` (an assignment a reviewer overturned).
+ClusterDeltaType = Literal["new", "link", "merge", "split", "reject"]
+
+
+class ClusterDelta(BaseModel):
+    """The outcome of assigning one record against an :class:`AnchorStore`.
+
+    Attributes:
+        type: What happened — ``"new"`` (a fresh entity was minted) or
+            ``"link"`` (the record attached to an existing entity). ``"merge"`` /
+            ``"split"`` / ``"reject"`` are reserved (see :data:`ClusterDeltaType`).
+        record_id: The assigned record's id (``entity.id`` after normalization).
+        entity_id: The **stable** entity id the record now belongs to. For
+            ``new`` this is freshly minted; for ``link`` it is the existing id.
+            An assigned record's ``entity_id`` never changes on later assigns
+            (the allocator is append-only), which is the guarantee incremental
+            callers rely on.
+        matched_anchor_ids: Anchor record ids that cleared the match threshold —
+            the evidence behind a ``link`` (empty for ``new``). More than one
+            *distinct* entity among these is a merge signal; W2.2 links to the
+            lowest-ordinal entity and leaves ``merge`` to a later milestone.
+        score: The best matching score observed across the judged candidates
+            (observability only); ``None`` when there were no candidates.
+        reasoning: Optional human-readable note about the decision.
+    """
+
+    type: ClusterDeltaType
+    record_id: str
+    entity_id: str
+    matched_anchor_ids: list[str] = Field(default_factory=list)
+    score: float | None = None
+    reasoning: str | None = None
+
+
+class AnchorStoreManifest(BaseModel):
+    """Typed shape of ``anchor_store.json`` — the store's id bookkeeping.
+
+    The heavy pipeline (blocker/comparator/module/clusterer, plus a built vector
+    index's sidecar state) is NOT stored here; it round-trips through the nested
+    :meth:`Resolver.save` artifact under the ``resolver/`` subdirectory.
+
+    Attributes:
+        store_version: Layout version (see :data:`ANCHOR_STORE_VERSION`).
+        entity_prefix: Prefix for minted entity ids (e.g. ``"e"`` -> ``"e0"``).
+        next_ordinal: The next unused allocator ordinal (append-only cursor).
+        anchor_ids: Anchor record ids in **corpus order** — index position ``i``
+            in a vector index maps back to ``anchor_ids[i]``.
+        records: ``record_id -> raw record dict`` for every anchor (needed to
+            reconstruct anchor entities for the judge at assign time).
+        assignments: ``record_id -> entity_id`` for every known record.
+    """
+
+    store_version: str
+    entity_prefix: str
+    next_ordinal: int
+    anchor_ids: list[str]
+    records: dict[str, dict[str, Any]]
+    assignments: dict[str, str]
+
+
+class AnchorStore:
+    """A persisted anchor set that answers incremental single-record assignment.
+
+    Build one from a prior batch, then assign new records against it:
+
+        resolver = Resolver.from_schema(CompanySchema, judge="string")
+        store = AnchorStore.build(resolver, records)   # dedicated pass
+        delta = store.assign(new_record)               # -> ClusterDelta
+        store.save("artifacts/anchors")
+        reloaded = AnchorStore.load("artifacts/anchors")
+
+    The store is a thin, composable unit *around* a Resolver — it owns only the
+    id bookkeeping (records, ``record_id -> entity_id``, the monotonic allocator)
+    and delegates all matching to the resolver's existing seams. It does not
+    reach into the Resolver's internals beyond the public blocker/comparator/
+    module/clusterer slots.
+    """
+
+    def __init__(
+        self,
+        resolver: "Resolver",
+        records: dict[str, dict[str, Any]],
+        assignments: dict[str, str],
+        anchor_ids: list[str],
+        next_ordinal: int,
+        entity_prefix: str = "e",
+    ) -> None:
+        """Construct a store from already-computed bookkeeping.
+
+        Prefer :meth:`build` (from a batch) or :meth:`load` (from disk); this
+        constructor is the shared low-level entry both funnel through.
+
+        Args:
+            resolver: The built pipeline whose blocker/comparator/module/
+                clusterer seams :meth:`assign` reuses.
+            records: ``record_id -> raw record dict`` for every anchor.
+            assignments: ``record_id -> entity_id`` for every known record.
+            anchor_ids: Anchor record ids in corpus (index-position) order.
+            next_ordinal: The next unused allocator ordinal.
+            entity_prefix: Prefix for minted entity ids.
+        """
+        self._resolver = resolver
+        self._records = records
+        self._assignments = assignments
+        self._anchor_ids = anchor_ids
+        self._next_ordinal = next_ordinal
+        self._entity_prefix = entity_prefix
+
+    # ------------------------------------------------------------------
+    # Construction
+    # ------------------------------------------------------------------
+
+    @classmethod
+    def build(
+        cls,
+        resolver: "Resolver",
+        records: list[dict[str, Any]],
+        *,
+        entity_prefix: str = "e",
+    ) -> "AnchorStore":
+        """Build an anchor store from a batch, minting a stable id for EVERY record.
+
+        Runs ``resolver.resolve(records)`` once (which also builds any vector
+        index in place, so :meth:`assign` can search it without re-embedding),
+        then walks the records in input order minting entity ids: all members of
+        one returned multi-record cluster share one freshly minted id, and every
+        record the clusterer dropped as a singleton gets its **own** id. This
+        singleton coverage is the correctness core — the most common incremental
+        case is "matches nothing -> new", which requires the store to know about
+        every prior record, including the ones ``resolve()`` never surfaces. The
+        pass is clusterer-agnostic: it enumerates the record-id universe itself
+        rather than trusting the clusterer to report singletons (no clusterer
+        does).
+
+        Args:
+            resolver: A built, serializable Resolver (e.g. from
+                ``Resolver.from_schema``). Records are fed as raw dicts, exactly
+                as ``resolve()`` accepts them.
+            records: The batch of raw record dicts to anchor on. Ids must be
+                unique (the resolver's schema ``id`` field).
+            entity_prefix: Prefix for minted entity ids (default ``"e"``).
+
+        Returns:
+            An :class:`AnchorStore` with one stable entity id per input record.
+        """
+        clusters = resolver.resolve(records)
+
+        factory = resolver.blocker.schema_factory
+        anchor_ids = [factory(record).id for record in records]  # type: ignore[attr-defined]
+        records_by_id = dict(zip(anchor_ids, records))
+
+        id_to_cluster: dict[str, frozenset[str]] = {}
+        for cluster in clusters:
+            frozen = frozenset(cluster)
+            for record_id in cluster:
+                id_to_cluster[record_id] = frozen
+
+        assignments: dict[str, str] = {}
+        entity_of_cluster: dict[frozenset[str], str] = {}
+        ordinal = 0
+
+        for record_id in anchor_ids:
+            cluster = id_to_cluster.get(record_id)
+            if cluster is None:
+                # A record no threshold-passing pair covered: its own singleton
+                # entity (NOT dropped as the clusterer would).
+                assignments[record_id] = f"{entity_prefix}{ordinal}"
+                ordinal += 1
+            else:
+                if cluster not in entity_of_cluster:
+                    entity_of_cluster[cluster] = f"{entity_prefix}{ordinal}"
+                    ordinal += 1
+                assignments[record_id] = entity_of_cluster[cluster]
+
+        logger.info(
+            "Built AnchorStore: %d records, %d entities (%d multi-record clusters)",
+            len(anchor_ids),
+            ordinal,
+            len(entity_of_cluster),
+        )
+        return cls(
+            resolver=resolver,
+            records=records_by_id,
+            assignments=assignments,
+            anchor_ids=anchor_ids,
+            next_ordinal=ordinal,
+            entity_prefix=entity_prefix,
+        )
+
+    # ------------------------------------------------------------------
+    # Incremental assignment
+    # ------------------------------------------------------------------
+
+    def assign(self, record: dict[str, Any]) -> ClusterDelta:
+        """Assign one new record to an existing entity, or mint a new one.
+
+        Generates candidate anchors (the vector index's single-record kNN when
+        the resolver blocks on a vector index, else all anchors), runs the
+        resolver's own Comparator + Module judge on the ``(record, anchor)``
+        pairs, and links the record to the matched entity — or mints a new one
+        when nothing clears the clusterer threshold. The record's assignment is
+        recorded (append-only), so assigning a record whose id is already known
+        returns its existing entity id unchanged (idempotent, never renumbered).
+
+        Args:
+            record: A raw record dict, same shape as :meth:`build` / ``resolve``.
+
+        Returns:
+            A :class:`ClusterDelta` with a stable ``entity_id`` and the delta
+            ``type`` (``"link"`` or ``"new"``).
+        """
+        entity = self._resolver.blocker.schema_factory(record)  # type: ignore[attr-defined]
+        record_id: str = entity.id
+
+        # Idempotent on record id: a record we have already assigned keeps its
+        # entity id (append-only allocator never renumbers a prior assignment).
+        if record_id in self._assignments:
+            return ClusterDelta(
+                type="link",
+                record_id=record_id,
+                entity_id=self._assignments[record_id],
+                reasoning="record id already assigned",
+            )
+
+        anchor_ids = self._candidate_anchor_ids(entity)
+        candidates = [self._candidate(entity, anchor_id) for anchor_id in anchor_ids]
+        judgements = self._judge(candidates)
+
+        threshold = self._resolver.clusterer.threshold
+        matched_anchor_ids: list[str] = []
+        best_score: float | None = None
+        for judgement in judgements:
+            best_score = (
+                judgement.score if best_score is None else max(best_score, judgement.score)
+            )
+            if judgement.score >= threshold:
+                anchor_id = (
+                    judgement.right_id if judgement.left_id == record_id else judgement.left_id
+                )
+                matched_anchor_ids.append(anchor_id)
+
+        # Distinct matched entities, in first-seen order.
+        matched_entity_ids: list[str] = []
+        for anchor_id in matched_anchor_ids:
+            entity_id = self._assignments.get(anchor_id)
+            if entity_id is not None and entity_id not in matched_entity_ids:
+                matched_entity_ids.append(entity_id)
+
+        if matched_entity_ids:
+            # >1 distinct entity is a merge signal; W2.2 links to the
+            # lowest-ordinal (oldest) entity and reserves merge for later.
+            resolved_entity_id = min(matched_entity_ids, key=self._ordinal_of)
+            delta_type: ClusterDeltaType = "link"
+            reasoning = (
+                f"linked to existing entity via {len(matched_anchor_ids)} matched anchor(s)"
+            )
+        else:
+            resolved_entity_id = self._mint()
+            delta_type = "new"
+            reasoning = "no anchor cleared the match threshold"
+
+        # Register (append-only): makes assign idempotent on this record id.
+        self._assignments[record_id] = resolved_entity_id
+        self._records.setdefault(record_id, record)
+
+        return ClusterDelta(
+            type=delta_type,
+            record_id=record_id,
+            entity_id=resolved_entity_id,
+            matched_anchor_ids=matched_anchor_ids,
+            score=best_score,
+            reasoning=reasoning,
+        )
+
+    def entity_id_of(self, record_id: str) -> str | None:
+        """Return the stable entity id assigned to ``record_id``, or ``None``."""
+        return self._assignments.get(record_id)
+
+    @property
+    def entity_ids(self) -> set[str]:
+        """The set of distinct entity ids currently known to the store."""
+        return set(self._assignments.values())
+
+    def _candidate_anchor_ids(self, entity: Any) -> list[str]:
+        """Anchor ids to judge ``entity`` against: kNN when indexed, else all.
+
+        Reuses the vector index's single-record ``search`` (the thin
+        new-record-against-built-corpus path) when the resolver blocks on a
+        vector index; falls back to every anchor when there is no index (e.g. an
+        ``AllPairsBlocker``), which is the correct all-pairs behaviour for one
+        new record against the anchor set.
+        """
+        blocker = self._resolver.blocker
+        if getattr(blocker, "type_name", None) != "vector_blocker" or not self._anchor_ids:
+            return list(self._anchor_ids)
+
+        text = blocker.text_field_extractor(entity)  # type: ignore[attr-defined]
+        k = min(blocker.k_neighbors, len(self._anchor_ids))  # type: ignore[attr-defined]
+        _distances, indices = blocker.vector_index.search(text, k)  # type: ignore[attr-defined]
+        anchor_ids: list[str] = []
+        for raw_index in indices.tolist():
+            index = int(raw_index)
+            # FAISS pads with -1 when fewer than k neighbours exist.
+            if 0 <= index < len(self._anchor_ids):
+                anchor_ids.append(self._anchor_ids[index])
+        return anchor_ids
+
+    def _candidate(self, entity: Any, anchor_id: str) -> ERCandidate[Any]:
+        """Build a ``(new_record, anchor)`` candidate pair for the judge."""
+        anchor_entity = self._resolver.blocker.schema_factory(self._records[anchor_id])  # type: ignore[attr-defined]
+        return ERCandidate(left=entity, right=anchor_entity, blocker_name="anchor_store")
+
+    def _judge(self, candidates: list[ERCandidate[Any]]) -> list[PairwiseJudgement]:
+        """Score candidates with the resolver's SAME comparator + module judge."""
+        comparator = self._resolver.comparator
+        if comparator is not None:
+            candidates = [
+                candidate.model_copy(
+                    update={"comparison": comparator.compare(candidate.left, candidate.right)}
+                )
+                for candidate in candidates
+            ]
+        return list(self._resolver.module.forward(iter(candidates)))
+
+    def _mint(self) -> str:
+        """Mint the next stable entity id from the append-only allocator."""
+        entity_id = f"{self._entity_prefix}{self._next_ordinal}"
+        self._next_ordinal += 1
+        return entity_id
+
+    def _ordinal_of(self, entity_id: str) -> int:
+        """Parse an entity id's ordinal for oldest-wins tie-breaking."""
+        return int(entity_id[len(self._entity_prefix) :])
+
+    # ------------------------------------------------------------------
+    # Persistence (config-registry seam; no pickle)
+    # ------------------------------------------------------------------
+
+    def save(self, path: str | Path) -> None:
+        """Persist the store to ``path`` as a self-describing artifact.
+
+        Delegates the pipeline to :meth:`Resolver.save` under a ``resolver/``
+        subdirectory (which persists a built vector index's sidecar state), and
+        writes ``anchor_store.json`` for the id bookkeeping. No pickle, no code
+        execution on load.
+
+        Args:
+            path: Directory to write the artifact into (created if absent).
+        """
+        out_dir = Path(path)
+        out_dir.mkdir(parents=True, exist_ok=True)
+        self._resolver.save(out_dir / _RESOLVER_SUBDIR)
+        manifest = AnchorStoreManifest(
+            store_version=ANCHOR_STORE_VERSION,
+            entity_prefix=self._entity_prefix,
+            next_ordinal=self._next_ordinal,
+            anchor_ids=self._anchor_ids,
+            records=self._records,
+            assignments=self._assignments,
+        )
+        (out_dir / _MANIFEST_FILENAME).write_text(manifest.model_dump_json(indent=2))
+        logger.info("Saved AnchorStore artifact to %s", out_dir)
+
+    @classmethod
+    def load(cls, path: str | Path) -> "AnchorStore":
+        """Reconstruct a store written by :meth:`save`, pipeline and all.
+
+        Rebuilds the Resolver from its artifact (restoring a built vector
+        index's state, so :meth:`assign` can search it) and rehydrates the id
+        bookkeeping from ``anchor_store.json``.
+
+        Args:
+            path: Directory containing ``anchor_store.json`` and ``resolver/``.
+
+        Returns:
+            An :class:`AnchorStore` equivalent to the one that was saved.
+        """
+        from langres.core.resolver import Resolver
+
+        in_dir = Path(path)
+        manifest = AnchorStoreManifest.model_validate_json(
+            (in_dir / _MANIFEST_FILENAME).read_text()
+        )
+        resolver = Resolver.load(in_dir / _RESOLVER_SUBDIR)
+        return cls(
+            resolver=resolver,
+            records=manifest.records,
+            assignments=manifest.assignments,
+            anchor_ids=manifest.anchor_ids,
+            next_ordinal=manifest.next_ordinal,
+            entity_prefix=manifest.entity_prefix,
+        )

--- a/src/langres/core/anchor_store.py
+++ b/src/langres/core/anchor_store.py
@@ -14,8 +14,9 @@ prior batch (:meth:`AnchorStore.build`) that:
 - runs the resolver once (which also builds any vector index in place), then
 - enumerates **every** input record — including the ones the clusterer dropped
   as singletons — and mints each a **stable, monotonic entity id** from an
-  append-only allocator (ids are minted by the store, never derived from list
-  position, since ``resolve()``'s order is non-deterministic).
+  append-only allocator. Minting walks the caller's input-list order (stable);
+  what it deliberately avoids is keying ids off ``resolve()``'s set/graph output,
+  whose iteration order is non-deterministic.
 
 :meth:`AnchorStore.assign` then answers the incremental question for one new
 record by reusing the resolver's *existing* seams — the vector index's
@@ -49,24 +50,30 @@ ANCHOR_STORE_VERSION = "1"
 
 
 def _schema_factory(blocker: Any) -> Any:
-    """Return a blocker's ``schema_factory``, or raise a clear unsupported error.
+    """Return a record->entity factory reachable from ``blocker``.
 
-    ``AnchorStore`` normalizes raw records through the resolver blocker's
-    ``schema_factory``. ``AllPairsBlocker`` and ``VectorBlocker`` expose one, but
-    a ``CompositeBlocker`` (blocking-algebra union/intersection of children) owns
-    no schema of its own — assigning against a composite-blocked resolver is not
-    supported yet, so surface that as an actionable error rather than a cryptic
-    ``AttributeError`` deep in ``build``/``assign``.
+    ``AnchorStore`` normalizes raw records through the blocker's
+    ``schema_factory``. ``AllPairsBlocker``/``VectorBlocker`` expose one directly.
+    A ``CompositeBlocker`` (blocking-algebra union/intersection) owns no schema of
+    its own but its children all share one — so recurse into ``children`` and use
+    the first reachable factory (the recall-first ``KeyBlocker`` union
+    ``VectorBlocker`` pattern therefore works). Only a blocker that neither
+    exposes nor contains a ``schema_factory`` (e.g. a ``GLinkerAdapter``) raises
+    an actionable error rather than a cryptic ``AttributeError`` in build/assign.
     """
     factory = getattr(blocker, "schema_factory", None)
-    if factory is None:
-        raise NotImplementedError(
-            f"AnchorStore does not support a {type(blocker).__name__} "
-            "(it exposes no `schema_factory`): incremental assign requires a "
-            "blocker that normalizes records itself (AllPairsBlocker / "
-            "VectorBlocker). Composite/hybrid-blocked resolvers are a later wave."
-        )
-    return factory
+    if factory is not None:
+        return factory
+    for child in getattr(blocker, "children", []):
+        child_factory = getattr(child, "schema_factory", None)
+        if child_factory is not None:
+            return child_factory
+    raise NotImplementedError(
+        f"AnchorStore cannot normalize records via a {type(blocker).__name__}: "
+        "no `schema_factory` on it or its children. Incremental assign needs a "
+        "blocker (or composite of blockers) that reconstructs entities itself "
+        "(AllPairsBlocker / VectorBlocker / a CompositeBlocker of them)."
+    )
 
 
 _MANIFEST_FILENAME = "anchor_store.json"
@@ -98,8 +105,12 @@ class ClusterDelta(BaseModel):
             the evidence behind a ``link`` (empty for ``new``). More than one
             *distinct* entity among these is a merge signal; W2.2 links to the
             lowest-ordinal entity and leaves ``merge`` to a later milestone.
+            **Also empty on the idempotent already-assigned-id ``link``** (that
+            path returns the stored entity without re-judging, so it carries no
+            fresh evidence and ``score`` is ``None``).
         score: The best matching score observed across the judged candidates
-            (observability only); ``None`` when there were no candidates.
+            (observability only); ``None`` when there were no candidates (or on
+            the idempotent already-assigned-id path).
         reasoning: Optional human-readable note about the decision.
     """
 
@@ -221,11 +232,22 @@ class AnchorStore:
 
         Returns:
             An :class:`AnchorStore` with one stable entity id per input record.
+
+        Raises:
+            NotImplementedError: If the resolver's blocker exposes no
+                ``schema_factory`` (e.g. a ``CompositeBlocker``).
+            ValueError: If ``records`` contains duplicate ids.
         """
         clusters = resolver.resolve(records)
 
         factory = _schema_factory(resolver.blocker)
         anchor_ids: list[str] = [factory(record).id for record in records]
+        if len(set(anchor_ids)) != len(anchor_ids):
+            raise ValueError(
+                "AnchorStore.build requires unique record ids; the input batch "
+                "has duplicates (a repeated id would silently overwrite an "
+                "assignment and burn an entity-id ordinal)."
+            )
         records_by_id = dict(zip(anchor_ids, records))
 
         id_to_cluster: dict[str, frozenset[str]] = {}
@@ -288,18 +310,32 @@ class AnchorStore:
         ``new`` entity. Growing the searchable set across assigns (so later
         arrivals match earlier ones) is reserved for a later wave.
 
+        Cost: with no vector index (e.g. an ``AllPairsBlocker`` pipeline) assign
+        judges the record against **every** anchor — O(n) judge calls per record.
+        With a *paid* judge (``judge="zero_shot_llm"``/any paid ``Module``) that
+        is O(n) paid calls per assign, uncapped; prefer a ``VectorBlocker`` (kNN
+        candidates) or a cheap judge for incremental assignment at scale.
+
+        This method mutates the store in place (it registers the record's
+        assignment); a shared instance is not safe for concurrent ``assign``.
+
         Args:
             record: A raw record dict, same shape as :meth:`build` / ``resolve``.
 
         Returns:
             A :class:`ClusterDelta` with a stable ``entity_id`` and the delta
-            ``type`` (``"link"`` or ``"new"``).
+            ``type`` (``"link"`` or ``"new"``). On the idempotent
+            already-assigned-id path the ``link`` carries empty
+            ``matched_anchor_ids`` and ``score=None`` (no re-judging is done).
         """
-        entity = _schema_factory(self._resolver.blocker)(record)
+        factory = _schema_factory(self._resolver.blocker)
+        entity = factory(record)
         record_id: str = entity.id
 
         # Idempotent on record id: a record we have already assigned keeps its
         # entity id (append-only allocator never renumbers a prior assignment).
+        # The record's CONTENT is not re-judged here — same id ⇒ same entity, by
+        # contract; feed a genuinely-updated record under a fresh id to re-match.
         if record_id in self._assignments:
             return ClusterDelta(
                 type="link",
@@ -308,8 +344,10 @@ class AnchorStore:
                 reasoning="record id already assigned",
             )
 
-        anchor_ids = self._candidate_anchor_ids(entity)
-        candidates = [self._candidate(entity, anchor_id) for anchor_id in anchor_ids]
+        candidates = [
+            self._candidate(factory, entity, anchor_id, similarity)
+            for anchor_id, similarity in self._candidate_anchors(entity)
+        ]
         judgements = self._judge(candidates)
 
         threshold = self._resolver.clusterer.threshold
@@ -369,33 +407,52 @@ class AnchorStore:
         """The set of distinct entity ids currently known to the store."""
         return set(self._assignments.values())
 
-    def _candidate_anchor_ids(self, entity: Any) -> list[str]:
-        """Anchor ids to judge ``entity`` against: kNN when indexed, else all.
+    def _candidate_anchors(self, entity: Any) -> list[tuple[str, float | None]]:
+        """``(anchor_id, similarity)`` pairs to judge ``entity`` against.
 
         Reuses the vector index's single-record ``search`` (the thin
         new-record-against-built-corpus path) when the resolver blocks on a
-        vector index; falls back to every anchor when there is no index (e.g. an
-        ``AllPairsBlocker``), which is the correct all-pairs behaviour for one
-        new record against the anchor set.
+        vector index — attaching the same distance->similarity the batch path
+        computes, so an ``EmbeddingScoreJudge`` (which scores off
+        ``similarity_score``) works incrementally. Falls back to every anchor
+        (``similarity`` ``None``) when there is no index (e.g. an
+        ``AllPairsBlocker``), the correct all-pairs behaviour for one new record.
         """
         blocker = self._resolver.blocker
         if getattr(blocker, "type_name", None) != "vector_blocker" or not self._anchor_ids:
-            return list(self._anchor_ids)
+            return [(anchor_id, None) for anchor_id in self._anchor_ids]
 
         text = blocker.text_field_extractor(entity)  # type: ignore[attr-defined]
         k = min(blocker.k_neighbors, len(self._anchor_ids))  # type: ignore[attr-defined]
-        _distances, indices = blocker.vector_index.search(text, k)  # type: ignore[attr-defined]
+        # Pass the blocker's query_prompt so an asymmetric/instructional embedder
+        # encodes the assign query exactly as the batch path does (vector.py).
+        distances, indices = blocker.vector_index.search(  # type: ignore[attr-defined]
+            text,
+            k,
+            query_prompt=blocker.query_prompt,  # type: ignore[attr-defined]
+        )
+        similarities = blocker.vector_index.to_similarities(distances)  # type: ignore[attr-defined]
         # Skip -1 padding: a fusion/hybrid index (e.g. QdrantHybridIndex) pads
         # short result sets with -1 even when k <= ntotal. Indexing a bare list
         # with -1 would silently wrap to the last anchor -> a phantom match.
-        return [
-            self._anchor_ids[index] for index in (int(i) for i in indices.tolist()) if index >= 0
-        ]
+        pairs: list[tuple[str, float | None]] = []
+        for raw_index, similarity in zip(indices.tolist(), similarities.tolist()):
+            index = int(raw_index)
+            if index >= 0:
+                pairs.append((self._anchor_ids[index], float(similarity)))
+        return pairs
 
-    def _candidate(self, entity: Any, anchor_id: str) -> ERCandidate[Any]:
+    def _candidate(
+        self, factory: Any, entity: Any, anchor_id: str, similarity: float | None
+    ) -> ERCandidate[Any]:
         """Build a ``(new_record, anchor)`` candidate pair for the judge."""
-        anchor_entity = _schema_factory(self._resolver.blocker)(self._records[anchor_id])
-        return ERCandidate(left=entity, right=anchor_entity, blocker_name="anchor_store")
+        anchor_entity = factory(self._records[anchor_id])
+        return ERCandidate(
+            left=entity,
+            right=anchor_entity,
+            blocker_name="anchor_store",
+            similarity_score=similarity,
+        )
 
     def _judge(self, candidates: list[ERCandidate[Any]]) -> list[PairwiseJudgement]:
         """Score candidates with the resolver's SAME comparator + module judge."""
@@ -461,6 +518,11 @@ class AnchorStore:
 
         Returns:
             An :class:`AnchorStore` equivalent to the one that was saved.
+
+        Raises:
+            ValueError: If the artifact's ``store_version`` differs from the
+                supported :data:`ANCHOR_STORE_VERSION` (an incompatible layout),
+                mirroring ``Resolver.load``'s own version guard.
         """
         from langres.core.resolver import Resolver
 
@@ -468,6 +530,11 @@ class AnchorStore:
         manifest = AnchorStoreManifest.model_validate_json(
             (in_dir / _MANIFEST_FILENAME).read_text()
         )
+        if manifest.store_version != ANCHOR_STORE_VERSION:
+            raise ValueError(
+                f"AnchorStore artifact version {manifest.store_version!r} differs from "
+                f"supported {ANCHOR_STORE_VERSION!r}; cannot load."
+            )
         resolver = Resolver.load(in_dir / _RESOLVER_SUBDIR)
         return cls(
             resolver=resolver,

--- a/src/langres/core/anchor_store.py
+++ b/src/langres/core/anchor_store.py
@@ -47,6 +47,28 @@ logger = logging.getLogger(__name__)
 #: Bump when the ``anchor_store.json`` layout changes incompatibly.
 ANCHOR_STORE_VERSION = "1"
 
+
+def _schema_factory(blocker: Any) -> Any:
+    """Return a blocker's ``schema_factory``, or raise a clear unsupported error.
+
+    ``AnchorStore`` normalizes raw records through the resolver blocker's
+    ``schema_factory``. ``AllPairsBlocker`` and ``VectorBlocker`` expose one, but
+    a ``CompositeBlocker`` (blocking-algebra union/intersection of children) owns
+    no schema of its own — assigning against a composite-blocked resolver is not
+    supported yet, so surface that as an actionable error rather than a cryptic
+    ``AttributeError`` deep in ``build``/``assign``.
+    """
+    factory = getattr(blocker, "schema_factory", None)
+    if factory is None:
+        raise NotImplementedError(
+            f"AnchorStore does not support a {type(blocker).__name__} "
+            "(it exposes no `schema_factory`): incremental assign requires a "
+            "blocker that normalizes records itself (AllPairsBlocker / "
+            "VectorBlocker). Composite/hybrid-blocked resolvers are a later wave."
+        )
+    return factory
+
+
 _MANIFEST_FILENAME = "anchor_store.json"
 _RESOLVER_SUBDIR = "resolver"
 
@@ -202,7 +224,7 @@ class AnchorStore:
         """
         clusters = resolver.resolve(records)
 
-        factory = resolver.blocker.schema_factory  # type: ignore[attr-defined]
+        factory = _schema_factory(resolver.blocker)
         anchor_ids: list[str] = [factory(record).id for record in records]
         records_by_id = dict(zip(anchor_ids, records))
 
@@ -259,6 +281,13 @@ class AnchorStore:
         recorded (append-only), so assigning a record whose id is already known
         returns its existing entity id unchanged (idempotent, never renumbered).
 
+        W2.2 boundary: assign matches against the anchor set fixed at
+        :meth:`build` time. A newly-assigned record extends the id map (so its
+        own id is idempotent) but is **not** added to the searchable corpus/
+        index — two distinct new ids that duplicate each other will each mint a
+        ``new`` entity. Growing the searchable set across assigns (so later
+        arrivals match earlier ones) is reserved for a later wave.
+
         Args:
             record: A raw record dict, same shape as :meth:`build` / ``resolve``.
 
@@ -266,7 +295,7 @@ class AnchorStore:
             A :class:`ClusterDelta` with a stable ``entity_id`` and the delta
             ``type`` (``"link"`` or ``"new"``).
         """
-        entity = self._resolver.blocker.schema_factory(record)  # type: ignore[attr-defined]
+        entity = _schema_factory(self._resolver.blocker)(record)
         record_id: str = entity.id
 
         # Idempotent on record id: a record we have already assigned keeps its
@@ -331,6 +360,11 @@ class AnchorStore:
         return self._assignments.get(record_id)
 
     @property
+    def assignments(self) -> dict[str, str]:
+        """A copy of the full ``record_id -> entity_id`` map (read-only)."""
+        return dict(self._assignments)
+
+    @property
     def entity_ids(self) -> set[str]:
         """The set of distinct entity ids currently known to the store."""
         return set(self._assignments.values())
@@ -349,15 +383,18 @@ class AnchorStore:
             return list(self._anchor_ids)
 
         text = blocker.text_field_extractor(entity)  # type: ignore[attr-defined]
-        # k <= ntotal, so a flat index returns exactly k valid neighbours (no
-        # -1 padding); the new record is not in the corpus, so no self-hit to skip.
         k = min(blocker.k_neighbors, len(self._anchor_ids))  # type: ignore[attr-defined]
         _distances, indices = blocker.vector_index.search(text, k)  # type: ignore[attr-defined]
-        return [self._anchor_ids[int(i)] for i in indices.tolist()]
+        # Skip -1 padding: a fusion/hybrid index (e.g. QdrantHybridIndex) pads
+        # short result sets with -1 even when k <= ntotal. Indexing a bare list
+        # with -1 would silently wrap to the last anchor -> a phantom match.
+        return [
+            self._anchor_ids[index] for index in (int(i) for i in indices.tolist()) if index >= 0
+        ]
 
     def _candidate(self, entity: Any, anchor_id: str) -> ERCandidate[Any]:
         """Build a ``(new_record, anchor)`` candidate pair for the judge."""
-        anchor_entity = self._resolver.blocker.schema_factory(self._records[anchor_id])  # type: ignore[attr-defined]
+        anchor_entity = _schema_factory(self._resolver.blocker)(self._records[anchor_id])
         return ERCandidate(left=entity, right=anchor_entity, blocker_name="anchor_store")
 
     def _judge(self, candidates: list[ERCandidate[Any]]) -> list[PairwiseJudgement]:

--- a/src/langres/core/resolver.py
+++ b/src/langres/core/resolver.py
@@ -569,9 +569,7 @@ class Resolver:
             "Resolver.stream_against (incremental resolution) lands in M5."
         )  # pragma: no cover
 
-    def build_anchor_store(
-        self, records: list[Any], *, entity_prefix: str = "e"
-    ) -> "AnchorStore":
+    def build_anchor_store(self, records: list[Any], *, entity_prefix: str = "e") -> "AnchorStore":
         """Anchor this resolver on a batch so :meth:`assign` can run (M5, S6).
 
         A dedicated build pass over ``records`` that mints a **stable** entity id

--- a/src/langres/core/resolver.py
+++ b/src/langres/core/resolver.py
@@ -333,7 +333,8 @@ class Resolver:
         self.module = module
         self.clusterer = clusterer
         # Set by build_anchor_store(); the incremental-assign state assign() uses.
-        self._anchor_store: AnchorStore | None = None
+        # Quoted: AnchorStore is a TYPE_CHECKING-only import (avoids an import cycle).
+        self._anchor_store: "AnchorStore | None" = None
 
     # ------------------------------------------------------------------
     # Construction convenience

--- a/src/langres/core/resolver.py
+++ b/src/langres/core/resolver.py
@@ -63,6 +63,7 @@ if TYPE_CHECKING:
     # inside _build_embedding_blocker and _ensure_index_built (W0.4) so a
     # core-only `import langres` never pulls faiss/torch in for a Resolver
     # that never uses judge="embedding".
+    from langres.core.anchor_store import AnchorStore, ClusterDelta
     from langres.core.blockers.vector import VectorBlocker
 
 logger = logging.getLogger(__name__)
@@ -331,6 +332,8 @@ class Resolver:
         self.comparator = comparator
         self.module = module
         self.clusterer = clusterer
+        # Set by build_anchor_store(); the incremental-assign state assign() uses.
+        self._anchor_store: AnchorStore | None = None
 
     # ------------------------------------------------------------------
     # Construction convenience
@@ -565,6 +568,57 @@ class Resolver:
         raise NotImplementedError(
             "Resolver.stream_against (incremental resolution) lands in M5."
         )  # pragma: no cover
+
+    def build_anchor_store(
+        self, records: list[Any], *, entity_prefix: str = "e"
+    ) -> "AnchorStore":
+        """Anchor this resolver on a batch so :meth:`assign` can run (M5, S6).
+
+        A dedicated build pass over ``records`` that mints a **stable** entity id
+        for every record — including the singletons ``resolve()`` drops — and
+        leaves the store on ``self`` for subsequent :meth:`assign` calls. Returns
+        the store, which is independently serializable
+        (:meth:`AnchorStore.save`).
+
+        Args:
+            records: The batch of raw record dicts to anchor on, same shape as
+                ``resolve()`` accepts.
+            entity_prefix: Prefix for minted entity ids (default ``"e"``).
+
+        Returns:
+            The built :class:`~langres.core.anchor_store.AnchorStore`.
+        """
+        from langres.core.anchor_store import AnchorStore
+
+        self._anchor_store = AnchorStore.build(self, records, entity_prefix=entity_prefix)
+        return self._anchor_store
+
+    def assign(self, record: Any) -> "ClusterDelta":
+        """Assign one new record to an existing entity, or mint a new one (M5, S6).
+
+        Incremental single-record resolution against the anchor set built by
+        :meth:`build_anchor_store`: returns a
+        :class:`~langres.core.anchor_store.ClusterDelta` that either ``link``\\ s
+        the record to an existing entity (with a stable id) or marks it ``new``.
+        Distinct from the reserved cross-source :meth:`link` /
+        :meth:`stream_against` stubs — ``assign`` is single-record incremental
+        linking.
+
+        Args:
+            record: A raw record dict, same shape as ``resolve()`` accepts.
+
+        Returns:
+            A :class:`~langres.core.anchor_store.ClusterDelta`.
+
+        Raises:
+            RuntimeError: If :meth:`build_anchor_store` was not called first.
+        """
+        if self._anchor_store is None:
+            raise RuntimeError(
+                "call build_anchor_store(records) before assign(record): assign "
+                "resolves a new record against a prior batch's anchor set."
+            )
+        return self._anchor_store.assign(record)
 
     # ------------------------------------------------------------------
     # Persistence

--- a/tests/core/test_anchor_store.py
+++ b/tests/core/test_anchor_store.py
@@ -15,21 +15,26 @@ is cleared (a single present feature scores 0 as ``below_evidence_floor``).
 
 from collections.abc import Iterator
 from pathlib import Path
+from typing import Any
 
+import numpy as np
 import pytest
 
 from langres.core import (
+    AllPairsBlocker,
     AnchorStore,
     Clusterer,
     ClusterDelta,
     CompanySchema,
     Comparator,
+    CompositeBlocker,
     ERCandidate,
     Module,
     PairwiseJudgement,
     Resolver,
     WeightedAverageJudge,
 )
+from langres.core.anchor_store import _schema_factory
 from langres.core.blockers.vector import VectorBlocker
 from langres.core.embeddings import FakeEmbedder
 from langres.core.indexes.vector_index import FAISSIndex
@@ -355,3 +360,80 @@ def test_cluster_delta_reserves_future_types() -> None:
     for reserved in ("merge", "split", "reject"):
         delta = ClusterDelta(type=reserved, record_id="x", entity_id="e0")  # type: ignore[arg-type]
         assert delta.type == reserved
+
+
+def test_assignments_property_is_a_read_only_copy() -> None:
+    store = AnchorStore.build(_string_resolver(), RECORDS)
+    snapshot = store.assignments
+    assert snapshot == {"1": "e0", "2": "e0", "3": "e1", "4": "e2"}
+    snapshot["1"] = "TAMPERED"  # mutating the copy must not touch the store
+    assert store.entity_id_of("1") == "e0"
+
+
+# --- Review fixes: unsupported blocker, -1 padding, documented boundary ------
+
+
+def test_unsupported_blocker_without_schema_factory_raises() -> None:
+    """A CompositeBlocker exposes no schema_factory -> a clear, actionable error."""
+    composite = CompositeBlocker(
+        [AllPairsBlocker(schema=CompanySchema), AllPairsBlocker(schema=CompanySchema)],
+        op="union",
+    )
+    with pytest.raises(NotImplementedError, match="schema_factory"):
+        _schema_factory(composite)
+
+
+class _MinusOnePaddingIndex:
+    """Fake vector index whose ``search`` pads with -1, like a Qdrant fusion query."""
+
+    type_name = "faiss_index"
+
+    def __init__(self) -> None:
+        self._corpus_texts: list[str] | None = None
+
+    def create_index(self, texts: list[str]) -> None:
+        self._corpus_texts = list(texts)
+
+    def search(
+        self, query_texts: Any, k: int, query_prompt: str | None = None
+    ) -> tuple[np.ndarray, np.ndarray]:
+        # First slot is -1 padding; second points at anchor position 0.
+        return np.array([0.9, 0.1]), np.array([-1, 0])
+
+
+def test_vector_search_skips_minus_one_padding() -> None:
+    """-1 padding must be skipped, not wrapped to the last anchor (Qdrant safety)."""
+    anchor_a = {"id": "a", "name": "Globex", "address": "1 A St", "phone": "1"}
+    anchor_b = {"id": "b", "name": "Initech", "address": "2 B St", "phone": "2"}
+    blocker: VectorBlocker[CompanySchema] = VectorBlocker(
+        vector_index=_MinusOnePaddingIndex(),  # type: ignore[arg-type]
+        schema=CompanySchema,
+        text_field="name",
+        k_neighbors=2,
+    )
+    resolver = Resolver(
+        blocker=blocker, comparator=None, module=_NameJudge(), clusterer=Clusterer(threshold=0.6)
+    )
+    store = AnchorStore(
+        resolver=resolver,
+        records={"a": anchor_a, "b": anchor_b},
+        assignments={"a": "e0", "b": "e1"},
+        anchor_ids=["a", "b"],
+        next_ordinal=2,
+    )
+    # Query name matches anchor "a" (position 0); the -1 slot must be dropped,
+    # NOT wrapped to anchor_ids[-1] == "b".
+    delta = store.assign({"id": "c", "name": "Globex", "address": "x", "phone": "9"})
+    assert delta.type == "link"
+    assert delta.matched_anchor_ids == ["a"]
+    assert delta.entity_id == "e0"
+
+
+def test_new_records_are_not_added_to_the_searchable_set() -> None:
+    """Documented W2.2 boundary: two distinct new ids that duplicate each other
+    each mint a NEW entity (assign matches only the build-time anchor set)."""
+    store = AnchorStore.build(_string_resolver(), RECORDS)
+    first = store.assign(dict(NOVEL, id="dup-1"))
+    second = store.assign(dict(NOVEL, id="dup-2"))  # same content, different id
+    assert first.type == second.type == "new"
+    assert first.entity_id != second.entity_id

--- a/tests/core/test_anchor_store.py
+++ b/tests/core/test_anchor_store.py
@@ -423,6 +423,84 @@ def test_composite_blocker_reaches_child_schema_factory() -> None:
     assert resolver.assign(APPLE_NEW).type == "link"
 
 
+def test_nested_composite_blocker_supports_build_and_vector_assign() -> None:
+    """A CompositeBlocker-of-CompositeBlocker with a nested VectorBlocker works.
+
+    Mirrors #66's nested-composite index build: both the schema-factory
+    resolution (``build``) and the vector-candidate-source lookup (``assign``)
+    must recurse through composite-of-composites, not just one level. The
+    VectorBlocker sits at depth 2, so a single-level lookup would miss it —
+    ``build`` would raise NotImplementedError and ``assign`` would silently fall
+    back to the all-anchors (``similarity=None``) path.
+    """
+    index = FAISSIndex(embedder=FakeEmbedder(), metric="cosine")
+    vblocker: VectorBlocker[CompanySchema] = VectorBlocker(
+        vector_index=index, schema=CompanySchema, text_field="name", k_neighbors=10
+    )
+    # depth 2: outer( inner( vblocker, KeyBlocker ), KeyBlocker )
+    inner: CompositeBlocker[CompanySchema] = CompositeBlocker(
+        [vblocker, KeyBlocker(schema=CompanySchema, key_field="phone")], op="union"
+    )
+    outer: CompositeBlocker[CompanySchema] = CompositeBlocker(
+        [inner, KeyBlocker(schema=CompanySchema, key_field="address")], op="union"
+    )
+    comparator = Comparator.from_schema(CompanySchema)
+    resolver = Resolver(
+        blocker=outer,
+        comparator=comparator,
+        module=WeightedAverageJudge(feature_specs=comparator.feature_specs),
+        clusterer=Clusterer(threshold=0.6),
+    )
+
+    # schema_factory recursion: every record is normalized and anchored.
+    store = resolver.build_anchor_store(RECORDS)
+    assert set(store.assignments) == {"1", "2", "3", "4"}
+
+    # vector-source recursion: candidate anchors come from the nested index and
+    # therefore carry a real similarity (the None fallback would mean the walk
+    # never reached the depth-2 VectorBlocker).
+    entity = _schema_factory(outer)(APPLE_NEW)
+    pairs = store._candidate_anchors(entity)
+    assert pairs and all(similarity is not None for _, similarity in pairs)
+
+    # And end-to-end assign still links through the nesting.
+    assert resolver.assign(APPLE_NEW).type == "link"
+
+
+def test_assign_does_not_store_non_anchor_records(tmp_path: Path) -> None:
+    """assign() must not accumulate raw non-anchor records (unbounded-growth guard).
+
+    ``_records`` holds the anchor corpus fixed at build time; a newly-assigned
+    record's payload is never read back (``_candidate`` only reads anchors), so
+    assign() must grow only the ``record_id -> entity_id`` map, not the record
+    store — otherwise a long incremental-ingestion stream bloats memory and
+    ``anchor_store.json`` without bound.
+    """
+    import json
+
+    store = AnchorStore.build(_string_resolver(), RECORDS)
+    anchors = set(store._records)
+    assert anchors == {"1", "2", "3", "4"}
+
+    for i in range(5):
+        delta = store.assign(
+            {"id": f"new-{i}", "name": f"Zzz {i} Co", "address": f"{i} Z St Ville", "phone": str(i)}
+        )
+        assert delta.type == "new"
+
+    # The raw-record store did NOT grow by the assigned records...
+    assert set(store._records) == anchors
+    # ...but the (cheap) id map did — idempotency is preserved.
+    assert {"new-0", "new-4"} <= set(store.assignments)
+
+    # Persisted manifest carries anchors only, not the assign stream.
+    path = tmp_path / "anchors"
+    store.save(path)
+    payload = json.loads((path / "anchor_store.json").read_text())
+    assert set(payload["records"]) == anchors
+    assert "new-0" in payload["assignments"]  # id map still round-trips
+
+
 def test_embedding_judge_assign_gets_similarity_score() -> None:
     """assign() must attach similarity_score so EmbeddingScoreJudge can score."""
     anchors = [

--- a/tests/core/test_anchor_store.py
+++ b/tests/core/test_anchor_store.py
@@ -1,0 +1,357 @@
+"""Tests for AnchorStore / ClusterDelta — incremental single-record assign (W2.2).
+
+Two pipelines are exercised:
+
+- The **string** pipeline (``AllPairsBlocker`` + ``WeightedAverageJudge``) — pure
+  core, no embeddings — drives the store logic, singleton coverage, stable ids,
+  and the all-pairs candidate path, plus a fresh-in-process save/load round-trip.
+- The **vector** pipeline (``VectorBlocker`` + ``FAISSIndex`` + ``FakeEmbedder``)
+  is fast and deterministic (no model download) and exercises the single-record
+  kNN candidate path over ``index.search`` and the FAISS-sidecar round-trip.
+
+Records carry name + address + phone so the WeightedAverageJudge's evidence floor
+is cleared (a single present feature scores 0 as ``below_evidence_floor``).
+"""
+
+from collections.abc import Iterator
+from pathlib import Path
+
+import pytest
+
+from langres.core import (
+    AnchorStore,
+    Clusterer,
+    ClusterDelta,
+    CompanySchema,
+    Comparator,
+    ERCandidate,
+    Module,
+    PairwiseJudgement,
+    Resolver,
+    WeightedAverageJudge,
+)
+from langres.core.blockers.vector import VectorBlocker
+from langres.core.embeddings import FakeEmbedder
+from langres.core.indexes.vector_index import FAISSIndex
+from langres.core.reports import ScoreInspectionReport
+
+# --- Test fixtures: a duplicate pair (1, 2) plus two uniques (3, 4). ---------
+
+APPLE_1 = {
+    "id": "1",
+    "name": "Apple Inc",
+    "address": "1 Infinite Loop Cupertino",
+    "phone": "408-996-1010",
+}
+APPLE_2 = {
+    "id": "2",
+    "name": "Apple Incorporated",
+    "address": "1 Infinite Loop, Cupertino",
+    "phone": "408-996-1010",
+}
+MICROSOFT = {
+    "id": "3",
+    "name": "Microsoft Corporation",
+    "address": "1 Microsoft Way Redmond",
+    "phone": "425-882-8080",
+}
+UMBRELLA = {
+    "id": "4",
+    "name": "Umbrella Corporation",
+    "address": "Raccoon City Center",
+    "phone": "202-555-0100",
+}
+RECORDS = [APPLE_1, APPLE_2, MICROSOFT, UMBRELLA]
+
+# A new mention that clearly matches the Apple entity.
+APPLE_NEW = {
+    "id": "9",
+    "name": "Apple Inc.",
+    "address": "1 Infinite Loop Cupertino",
+    "phone": "408-996-1010",
+}
+# A new mention that matches nothing in the anchor set.
+NOVEL = {
+    "id": "10",
+    "name": "Nintendo Company",
+    "address": "11-1 Kamitoba Kyoto",
+    "phone": "075-541-6111",
+}
+
+
+def _string_resolver(threshold: float = 0.6) -> Resolver:
+    """AllPairs + WeightedAverageJudge string pipeline (pure core, no embeddings)."""
+    return Resolver.from_schema(CompanySchema, judge="string", threshold=threshold)
+
+
+def _vector_resolver(threshold: float = 0.6, k_neighbors: int = 10) -> Resolver:
+    """VectorBlocker + FAISS + FakeEmbedder pipeline (fast, deterministic, serializable)."""
+    comparator = Comparator.from_schema(CompanySchema)
+    index = FAISSIndex(embedder=FakeEmbedder(), metric="cosine")
+    blocker: VectorBlocker[CompanySchema] = VectorBlocker(
+        vector_index=index, schema=CompanySchema, text_field="name", k_neighbors=k_neighbors
+    )
+    return Resolver(
+        blocker=blocker,
+        comparator=comparator,
+        module=WeightedAverageJudge(feature_specs=comparator.feature_specs),
+        clusterer=Clusterer(threshold=threshold),
+    )
+
+
+class _NameJudge(Module[CompanySchema]):
+    """Self-contained judge (no comparator): score 1.0 on exact name match, else 0.0.
+
+    Reads the raw ``left``/``right`` entities directly, so a Resolver using it
+    needs no comparator — exercising AnchorStore's ``comparator is None`` path.
+    ``flip=True`` emits each judgement with left/right ids swapped, exercising the
+    orientation-robust anchor-id extraction in ``assign``.
+    """
+
+    def __init__(self, flip: bool = False) -> None:
+        self.flip = flip
+
+    def forward(
+        self, candidates: Iterator[ERCandidate[CompanySchema]]
+    ) -> Iterator[PairwiseJudgement]:
+        for pair in candidates:
+            score = 1.0 if pair.left.name == pair.right.name else 0.0
+            left_id, right_id = pair.left.id, pair.right.id
+            if self.flip:
+                left_id, right_id = right_id, left_id
+            yield PairwiseJudgement(
+                left_id=left_id,
+                right_id=right_id,
+                score=score,
+                score_type="heuristic",
+                decision_step="name_exact",
+                provenance={},
+            )
+
+    def inspect_scores(
+        self, judgements: list[PairwiseJudgement], sample_size: int = 10
+    ) -> ScoreInspectionReport:  # pragma: no cover - not exercised
+        raise NotImplementedError
+
+
+def _name_resolver(threshold: float = 0.6) -> Resolver:
+    """Resolver with NO comparator and a self-contained name judge."""
+    return Resolver(
+        blocker=Resolver.from_schema(CompanySchema).blocker,
+        comparator=None,
+        module=_NameJudge(),
+        clusterer=Clusterer(threshold=threshold),
+    )
+
+
+# --- Build pass: stable ids + singleton coverage (D2, D3) -------------------
+
+
+def test_build_covers_every_record_including_singletons() -> None:
+    store = AnchorStore.build(_string_resolver(), RECORDS)
+    # Every input record has an assignment (singletons NOT dropped).
+    assert set(store._assignments) == {"1", "2", "3", "4"}
+    # The duplicate pair collapses to one entity; the two uniques stand alone.
+    assert store.entity_id_of("1") == store.entity_id_of("2")
+    assert store.entity_id_of("3") != store.entity_id_of("1")
+    assert store.entity_id_of("4") != store.entity_id_of("1")
+    assert store.entity_id_of("3") != store.entity_id_of("4")
+    # 3 distinct entities: {1,2}, {3}, {4}.
+    assert len(store.entity_ids) == 3
+
+
+def test_build_mints_monotonic_ids_from_prefix() -> None:
+    store = AnchorStore.build(_string_resolver(), RECORDS, entity_prefix="ent")
+    assert all(eid.startswith("ent") for eid in store.entity_ids)
+    # Contiguous ordinals 0..2 minted in input order.
+    assert store.entity_id_of("1") == "ent0"
+    assert store._next_ordinal == 3
+
+
+def test_build_singleton_is_assignable_against() -> None:
+    """A known unique (Microsoft) must be present AND linkable, not spuriously new."""
+    resolver = _string_resolver()
+    resolver.build_anchor_store(RECORDS)
+    delta = resolver.assign(dict(MICROSOFT, id="99"))
+    assert delta.type == "link"
+    assert delta.entity_id == resolver._anchor_store.entity_id_of("3")
+    assert "3" in delta.matched_anchor_ids
+
+
+# --- assign: link vs new (D5) ----------------------------------------------
+
+
+def test_assign_links_matching_record() -> None:
+    store = AnchorStore.build(_string_resolver(), RECORDS)
+    delta = store.assign(APPLE_NEW)
+    assert isinstance(delta, ClusterDelta)
+    assert delta.type == "link"
+    assert delta.entity_id == store.entity_id_of("1")
+    assert set(delta.matched_anchor_ids) == {"1", "2"}
+    assert delta.score is not None and delta.score >= 0.6
+
+
+def test_assign_new_when_nothing_matches() -> None:
+    store = AnchorStore.build(_string_resolver(), RECORDS)
+    before = set(store.entity_ids)
+    delta = store.assign(NOVEL)
+    assert delta.type == "new"
+    assert delta.entity_id not in before
+    assert delta.matched_anchor_ids == []
+    # A score was computed (candidates existed) but stayed below threshold.
+    assert delta.score is not None and delta.score < 0.6
+
+
+def test_assign_links_to_oldest_entity_on_multi_entity_match() -> None:
+    """A record matching two DIFFERENT entities links to the lowest-ordinal one.
+
+    Constructed directly so ``a`` and ``b`` are genuinely distinct entities
+    (``build``'s clusterer would have merged same-name records) while a new
+    record ``c`` matches both — the merge-signal path that links to the oldest.
+    """
+    a = {"id": "a", "name": "Globex", "address": "100 Main St Springfield", "phone": "111"}
+    b = {"id": "b", "name": "Globex", "address": "999 Other Rd Ogdenville", "phone": "222"}
+    store = AnchorStore(
+        resolver=_name_resolver(),
+        records={"a": a, "b": b},
+        assignments={"a": "e0", "b": "e1"},
+        anchor_ids=["a", "b"],
+        next_ordinal=2,
+    )
+    delta = store.assign({"id": "c", "name": "Globex", "address": "x", "phone": "9"})
+    assert delta.type == "link"
+    assert set(delta.matched_anchor_ids) == {"a", "b"}
+    # Links to the oldest (lowest-ordinal) of the two matched entities.
+    assert delta.entity_id == "e0"
+
+
+# --- Stable ids across repeated / interleaved assigns (D5) ------------------
+
+
+def test_assign_same_record_twice_is_stable() -> None:
+    store = AnchorStore.build(_string_resolver(), RECORDS)
+    first = store.assign(NOVEL)
+    second = store.assign(NOVEL)
+    assert first.entity_id == second.entity_id
+    assert second.type == "link"
+    assert second.reasoning == "record id already assigned"
+
+
+def test_interleaved_assigns_never_renumber_prior_ids() -> None:
+    store = AnchorStore.build(_string_resolver(), RECORDS)
+    a = store.assign({"id": "n1", "name": "Aaa Co", "address": "1 A St Town", "phone": "1"})
+    b = store.assign({"id": "n2", "name": "Bbb Co", "address": "2 B St City", "phone": "2"})
+    assert a.type == b.type == "new"
+    assert a.entity_id != b.entity_id
+    # Re-assigning the first, after the second was minted, returns its ORIGINAL id.
+    a_again = store.assign({"id": "n1", "name": "Aaa Co", "address": "1 A St Town", "phone": "1"})
+    assert a_again.entity_id == a.entity_id
+
+
+def test_assign_empty_store_returns_new_with_no_score() -> None:
+    """No anchors -> no candidates -> a new entity with score None."""
+    store = AnchorStore.build(_string_resolver(), [])
+    assert store.entity_ids == set()
+    delta = store.assign(APPLE_NEW)
+    assert delta.type == "new"
+    assert delta.matched_anchor_ids == []
+    assert delta.score is None
+    assert delta.entity_id == "e0"
+
+
+# --- Judge-seam robustness: no comparator + flipped pair orientation --------
+
+
+def test_assign_without_comparator() -> None:
+    store = AnchorStore.build(_name_resolver(), RECORDS)
+    # Exact-name new record links; a novel name is new.
+    linked = store.assign(dict(MICROSOFT, id="m2"))
+    assert linked.type == "link"
+    assert linked.entity_id == store.entity_id_of("3")
+    assert store.assign(NOVEL).type == "new"
+
+
+def test_assign_identifies_anchor_regardless_of_pair_orientation() -> None:
+    resolver = Resolver(
+        blocker=Resolver.from_schema(CompanySchema).blocker,
+        comparator=None,
+        module=_NameJudge(flip=True),
+        clusterer=Clusterer(threshold=0.6),
+    )
+    store = AnchorStore.build(resolver, RECORDS)
+    delta = store.assign(dict(MICROSOFT, id="m3"))
+    assert delta.type == "link"
+    assert "3" in delta.matched_anchor_ids
+    assert delta.entity_id == store.entity_id_of("3")
+
+
+# --- Resolver.assign wiring -------------------------------------------------
+
+
+def test_resolver_assign_requires_build_first() -> None:
+    resolver = _string_resolver()
+    with pytest.raises(RuntimeError, match="build_anchor_store"):
+        resolver.assign(APPLE_NEW)
+
+
+def test_resolver_build_and_assign_delegates() -> None:
+    resolver = _string_resolver()
+    returned = resolver.build_anchor_store(RECORDS)
+    assert isinstance(returned, AnchorStore)
+    delta = resolver.assign(APPLE_NEW)
+    assert delta.type == "link"
+    assert delta.entity_id == returned.entity_id_of("1")
+
+
+def test_link_and_stream_against_stubs_untouched() -> None:
+    """D1: assign is a NEW method; the cross-source M5 stubs stay NotImplemented."""
+    resolver = _string_resolver()
+    with pytest.raises(NotImplementedError):
+        resolver.link([], [])
+    with pytest.raises(NotImplementedError):
+        list(resolver.stream_against([]))
+
+
+# --- Persistence round-trips (config-registry seam; no pickle) --------------
+
+
+def test_save_load_round_trip_string_pipeline(tmp_path: Path) -> None:
+    store = AnchorStore.build(_string_resolver(), RECORDS)
+    before = store.assign(APPLE_NEW)
+
+    path = tmp_path / "anchors"
+    AnchorStore.build(_string_resolver(), RECORDS).save(path)
+    assert (path / "anchor_store.json").exists()
+    assert (path / "resolver" / "resolver.json").exists()
+
+    loaded = AnchorStore.load(path)
+    after = loaded.assign(APPLE_NEW)
+    assert after.type == before.type == "link"
+    assert after.entity_id == before.entity_id
+    assert set(after.matched_anchor_ids) == set(before.matched_anchor_ids)
+
+
+def test_save_load_round_trip_vector_pipeline(tmp_path: Path) -> None:
+    store = AnchorStore.build(_vector_resolver(), RECORDS)
+    before = store.assign(APPLE_NEW)
+    assert before.type == "link"  # vector kNN surfaced the true anchors
+
+    path = tmp_path / "anchors"
+    AnchorStore.build(_vector_resolver(), RECORDS).save(path)
+    # The built FAISS index persisted as a resolver sidecar.
+    assert (path / "resolver" / "blocker").is_dir()
+
+    loaded = AnchorStore.load(path)
+    after = loaded.assign(APPLE_NEW)
+    assert after.entity_id == before.entity_id
+    assert after.type == "link"
+
+
+# --- ClusterDelta contract --------------------------------------------------
+
+
+def test_cluster_delta_reserves_future_types() -> None:
+    """D5: merge/split/reject are reserved in the enum so the contract is stable."""
+    for reserved in ("merge", "split", "reject"):
+        delta = ClusterDelta(type=reserved, record_id="x", entity_id="e0")  # type: ignore[arg-type]
+        assert delta.type == reserved

--- a/tests/core/test_anchor_store.py
+++ b/tests/core/test_anchor_store.py
@@ -28,7 +28,9 @@ from langres.core import (
     CompanySchema,
     Comparator,
     CompositeBlocker,
+    EmbeddingScoreJudge,
     ERCandidate,
+    KeyBlocker,
     Module,
     PairwiseJudgement,
     Resolver,
@@ -240,6 +242,9 @@ def test_assign_same_record_twice_is_stable() -> None:
     assert first.entity_id == second.entity_id
     assert second.type == "link"
     assert second.reasoning == "record id already assigned"
+    # The idempotent path returns no fresh evidence (documented contract).
+    assert second.matched_anchor_ids == []
+    assert second.score is None
 
 
 def test_interleaved_assigns_never_renumber_prior_ids() -> None:
@@ -373,14 +378,77 @@ def test_assignments_property_is_a_read_only_copy() -> None:
 # --- Review fixes: unsupported blocker, -1 padding, documented boundary ------
 
 
-def test_unsupported_blocker_without_schema_factory_raises() -> None:
-    """A CompositeBlocker exposes no schema_factory -> a clear, actionable error."""
-    composite = CompositeBlocker(
-        [AllPairsBlocker(schema=CompanySchema), AllPairsBlocker(schema=CompanySchema)],
+def test_schema_factory_unreachable_raises() -> None:
+    """A blocker with neither a schema_factory nor schema-bearing children errors."""
+
+    class _NoFactoryBlocker:
+        type_name = "no_factory"
+
+    with pytest.raises(NotImplementedError, match="schema_factory"):
+        _schema_factory(_NoFactoryBlocker())
+
+
+def test_schema_factory_skips_children_without_factory() -> None:
+    """Recursion skips a factory-less child and returns a later child's factory."""
+
+    class _Stub:
+        pass
+
+    good = AllPairsBlocker(schema=CompanySchema)
+
+    class _FakeComposite:
+        children = [_Stub(), good]
+
+    assert _schema_factory(_FakeComposite()) is good.schema_factory
+
+
+def test_composite_blocker_reaches_child_schema_factory() -> None:
+    """Recall-first CompositeBlocker (KeyBlocker union AllPairs) works via a child."""
+    composite: CompositeBlocker[CompanySchema] = CompositeBlocker(
+        [
+            KeyBlocker(schema=CompanySchema, key_field="phone"),
+            AllPairsBlocker(schema=CompanySchema),
+        ],
         op="union",
     )
-    with pytest.raises(NotImplementedError, match="schema_factory"):
-        _schema_factory(composite)
+    comparator = Comparator.from_schema(CompanySchema)
+    resolver = Resolver(
+        blocker=composite,
+        comparator=comparator,
+        module=WeightedAverageJudge(feature_specs=comparator.feature_specs),
+        clusterer=Clusterer(threshold=0.6),
+    )
+    store = resolver.build_anchor_store(RECORDS)
+    assert set(store.assignments) == {"1", "2", "3", "4"}
+    assert resolver.assign(APPLE_NEW).type == "link"
+
+
+def test_embedding_judge_assign_gets_similarity_score() -> None:
+    """assign() must attach similarity_score so EmbeddingScoreJudge can score."""
+    anchors = [
+        {"id": "1", "name": "Apple", "address": "a", "phone": "1"},
+        {"id": "2", "name": "Microsoft", "address": "b", "phone": "2"},
+        {"id": "3", "name": "Umbrella", "address": "c", "phone": "3"},
+    ]
+    index = FAISSIndex(embedder=FakeEmbedder(), metric="cosine")
+    blocker: VectorBlocker[CompanySchema] = VectorBlocker(
+        vector_index=index, schema=CompanySchema, text_field="name", k_neighbors=10
+    )
+    # EmbeddingScoreJudge scores purely off similarity_score (no comparator).
+    resolver = Resolver(
+        blocker=blocker,
+        comparator=None,
+        module=EmbeddingScoreJudge(threshold=0.9),
+        clusterer=Clusterer(threshold=0.9),
+    )
+    store = resolver.build_anchor_store(anchors)
+    # Same text as anchor "1" -> FakeEmbedder yields an identical vector ->
+    # cosine similarity 1.0 -> links (would raise ValueError if score were None).
+    delta = resolver.assign({"id": "9", "name": "Apple", "address": "z", "phone": "9"})
+    assert delta.type == "link"
+    assert delta.matched_anchor_ids == ["1"]
+    assert delta.entity_id == store.entity_id_of("1")
+    assert delta.score is not None and delta.score >= 0.9
 
 
 class _MinusOnePaddingIndex:
@@ -399,6 +467,9 @@ class _MinusOnePaddingIndex:
     ) -> tuple[np.ndarray, np.ndarray]:
         # First slot is -1 padding; second points at anchor position 0.
         return np.array([0.9, 0.1]), np.array([-1, 0])
+
+    def to_similarities(self, distances: np.ndarray) -> np.ndarray:
+        return np.clip(distances, 0.0, 1.0)
 
 
 def test_vector_search_skips_minus_one_padding() -> None:
@@ -427,6 +498,25 @@ def test_vector_search_skips_minus_one_padding() -> None:
     assert delta.type == "link"
     assert delta.matched_anchor_ids == ["a"]
     assert delta.entity_id == "e0"
+
+
+def test_build_rejects_duplicate_ids() -> None:
+    dup = [APPLE_1, dict(APPLE_2, id="1")]  # both id "1"
+    with pytest.raises(ValueError, match="unique record ids"):
+        AnchorStore.build(_string_resolver(), dup)
+
+
+def test_load_rejects_incompatible_store_version(tmp_path: Path) -> None:
+    import json
+
+    path = tmp_path / "anchors"
+    AnchorStore.build(_string_resolver(), RECORDS).save(path)
+    manifest_path = path / "anchor_store.json"
+    payload = json.loads(manifest_path.read_text())
+    payload["store_version"] = "999"
+    manifest_path.write_text(json.dumps(payload))
+    with pytest.raises(ValueError, match="version"):
+        AnchorStore.load(path)
 
 
 def test_new_records_are_not_added_to_the_searchable_set() -> None:

--- a/tests/core/test_anchor_store_committed.py
+++ b/tests/core/test_anchor_store_committed.py
@@ -1,0 +1,95 @@
+"""AnchorStore on committed data + a fresh-process round-trip (W2.2 exit).
+
+Grounds :class:`~langres.core.anchor_store.AnchorStore` in the committed
+Fodors-Zagat benchmark (no embeddings — the offline string pipeline) and proves
+the M2 lesson: an artifact saved in one process reloads and assigns identically
+in a **clean** subprocess (catching any registry/import side-effect a single
+process would hide).
+
+The anchored slice includes Fodor's record ``f534`` but holds out its Zagat gold
+partner ``z219``; assigning ``z219`` must link it back to ``f534``'s entity.
+"""
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+from langres.core import AnchorStore, Resolver
+from langres.data.er_benchmarks import RestaurantSchema, load_fodors_zagat
+
+# A Fodors-Zagat gold match pair: Fodor's f534 <-> Zagat z219.
+_ANCHORED_ID = "f534"
+_HELD_OUT_ID = "z219"
+
+
+def _anchor_slice() -> tuple[list[dict[str, object]], dict[str, object]]:
+    """80-record anchor slice (includes f534, excludes z219) + the z219 record."""
+    corpus, _gold = load_fodors_zagat()
+    by_id = {record.id: record for record in corpus}
+    anchors = [r.model_dump() for r in corpus if r.id != _HELD_OUT_ID][:80]
+    assert any(a["id"] == _ANCHORED_ID for a in anchors)
+    assert all(a["id"] != _HELD_OUT_ID for a in anchors)
+    return anchors, by_id[_HELD_OUT_ID].model_dump()
+
+
+def test_assign_links_held_out_partner_on_committed_data() -> None:
+    anchors, held_out = _anchor_slice()
+    resolver = Resolver.from_schema(RestaurantSchema, judge="string", threshold=0.5)
+    store = resolver.build_anchor_store(anchors)
+
+    delta = resolver.assign(held_out)
+    assert delta.type == "link"
+    assert delta.entity_id == store.entity_id_of(_ANCHORED_ID)
+    assert _ANCHORED_ID in delta.matched_anchor_ids
+
+
+def test_assign_novel_record_is_new_on_committed_data() -> None:
+    anchors, _held_out = _anchor_slice()
+    resolver = Resolver.from_schema(RestaurantSchema, judge="string", threshold=0.5)
+    resolver.build_anchor_store(anchors)
+    novel = {
+        "id": "novel-1",
+        "name": "Totally Nonexistent Diner XYZ",
+        "addr": "999 Nowhere Blvd",
+        "city": "Voidtown",
+        "phone": "000-000-0000",
+        "type": "none",
+        "source": "zagat",
+    }
+    assert resolver.assign(novel).type == "new"
+
+
+def test_fresh_process_round_trip(tmp_path: Path) -> None:
+    """Build+save here; load+assign in a CLEAN subprocess -> identical result."""
+    anchors, held_out = _anchor_slice()
+
+    # In-process reference result.
+    reference = Resolver.from_schema(
+        RestaurantSchema, judge="string", threshold=0.5
+    ).build_anchor_store(anchors)
+    before = reference.assign(held_out)
+
+    # Persist a fresh store (assign above mutates; save an untouched one).
+    path = tmp_path / "anchors"
+    Resolver.from_schema(RestaurantSchema, judge="string", threshold=0.5).build_anchor_store(
+        anchors
+    ).save(path)
+
+    # Reload + assign in a brand-new interpreter (no shared imports/registry).
+    script = (
+        "import json, sys\n"
+        "from langres.core import AnchorStore\n"
+        "from langres.data.er_benchmarks import load_fodors_zagat\n"
+        "corpus, _ = load_fodors_zagat()\n"
+        "held = next(r for r in corpus if r.id == 'z219').model_dump()\n"
+        f"store = AnchorStore.load({str(path)!r})\n"
+        "delta = store.assign(held)\n"
+        "sys.stdout.write(json.dumps({'type': delta.type, 'entity_id': delta.entity_id}))\n"
+    )
+    proc = subprocess.run(
+        [sys.executable, "-c", script], capture_output=True, text=True, check=True
+    )
+    result = json.loads(proc.stdout)
+    assert result["type"] == before.type == "link"
+    assert result["entity_id"] == before.entity_id


### PR DESCRIPTION
## W2.2 — Incremental single-record assignment (`AnchorStore` + `resolver.assign`)

Implements M5's incremental-linking exit (S6), per the gated W2.2 design memo (decisions D1–D6).

A batch `resolve()` answers "which of these records group together?" but returns only id-sets (positional, no stable ids, **singletons dropped**). This adds the *incremental* answer: given an anchor set built from a prior batch, `resolver.assign(new_record)` returns a `ClusterDelta` — `link` to a **stable** existing entity id, or `new`.

### Public surface
- **`AnchorStore`** (`langres.core`) — a serializable, composable unit *around* a `Resolver`:
  - `AnchorStore.build(resolver, records) -> AnchorStore` — dedicated build pass; mints a stable, monotonic entity id for **every** record, including the singletons `resolve()` drops (clusterer-agnostic — it enumerates the record-id universe itself). (**D2, D3**)
  - `store.assign(record) -> ClusterDelta` — reuses the vector index's single-record kNN (`index.search`) for candidates when the resolver blocks on a vector index, else all-pairs; runs the **same** Comparator + Module judge (no new matching logic). Append-only allocator ⇒ idempotent per record id; ids never renumber. (**D4, D5**)
  - `store.save(path)` / `AnchorStore.load(path)` — the existing config-registry artifact seam (no pickle); delegates the pipeline to `Resolver.save`/`load` (incl. a built FAISS index's sidecar), plus a small `anchor_store.json`.
  - `entity_id_of(record_id)`, `entity_ids`.
- **`ClusterDelta`** (`langres.core`) — `type` (`new` | `link`; `merge`/`split`/`reject` **reserved** in the enum so the contract is stable — **D5**), `record_id`, `entity_id`, `matched_anchor_ids`, `score`, `reasoning`.
- **`Resolver.build_anchor_store(records)`** + **`Resolver.assign(record)`** — thin sugar over `AnchorStore`. The reserved cross-source `Resolver.link()` / `stream_against()` `NotImplementedError` stubs are **untouched** (three meanings of "link" kept distinct — **D1**).

### Exit criteria — all met
- Sparse record matching an existing entity → `link` (stable id); matching nothing → `new`. Tested on committed **Fodors-Zagat** data (offline string pipeline): held-out gold partner `z219` links to `f534`'s entity; a novel record → `new`.
- **Singleton coverage** tested: a record equal to a known unique anchor links (not spurious `new`).
- **Stable ids** tested: same record twice → same id; interleaved assigns never renumber prior ids.
- **Fresh-process save/load round-trip** (the M2 lesson): committed-data test loads the saved store in a clean subprocess and assigns identically. Two-process transcript:

```
===== process 1 (build + save) =====
[PROC 1 build+assign] z219 -> link e0  (f534 entity=e0)
[PROC 1] saved store to tmp/pr_roundtrip_store
===== process 2 (separate interpreter: load + assign) =====
[PROC 2 fresh load+assign] z219 -> link e0  matched=['f534', 'f543', 'f545']
```

- **100% coverage** on new `anchor_store.py` (129 stmts / 26 branches, 0 missed); `mypy --strict` clean (75 files); `ruff` clean. Full non-slow suite: **1671 passed**, 98.44% total coverage.

### Design-for-reuse
`AnchorStore` is a standalone serializable component (not wired into Resolver's guts — it uses only the public blocker/comparator/module/clusterer slots), so W2.3 golden records / W2.4 flywheel / M6 build on it directly. `ClusterDelta`'s type enum reserves the maintenance operations (merge/split/reject) up front so the contract won't reshape.

https://claude.ai/code/session_0115MvWbHaCKT1A39PKDWqey
