### PR TITLE
docs(w3): three DX guides — CSV tutorial, $0 DummyLM testing, adding a method

### DIFF
--- a/README.md
+++ b/README.md
@@ -209,9 +209,12 @@ are tracked in [TODOS.md](TODOS.md).
 
 - [Roadmap](docs/ROADMAP.md) — the composable-seam vision and milestones M0–M6
 - [POC Plan](docs/POC.md) — current stage, scope, success criteria
+- [Your own CSV in 15 minutes](docs/TUTORIAL_YOUR_OWN_CSV.md) — messy CSV → clusters, offline at $0, with threshold calibration and save/load
 - [Technical Overview](docs/TECHNICAL_OVERVIEW.md) — API reference and data contracts
 - [Resolver DX](docs/DX_RESOLVER.md) — the declarative `from_schema` + `save`/`load` path
 - [Experiments](docs/EXPERIMENTS.md) — experimentation DX, `derive_threshold`, the budget seam
+- [Testing at $0](docs/TESTING_AT_ZERO_COST.md) — DummyLM as the seam to test an ER pipeline without spending
+- [Adding a method](docs/ADDING_A_METHOD.md) — how to contribute a new ER method behind the seam (SelectJudge worked example)
 - [Use Cases](docs/USE_CASES.md) — use-case taxonomy and roadmap
 - [Dependencies](docs/DEPENDENCIES.md) — supply-chain policy and dependency management
 - [Examples](examples/) — runnable scripts

--- a/docs/ADDING_A_METHOD.md
+++ b/docs/ADDING_A_METHOD.md
@@ -232,10 +232,15 @@ cls = get_component("select_judge")       # lazily imports + registers
 assert cls.type_name == "select_judge"    # rebuildable by name, no pickle
 ```
 
-`tests/core/modules/test_dspy_judge.py` does the stronger version: it saves a
-`Resolver` (with the judge in the module slot) and reloads it in a **subprocess**,
-asserting the manifest carries `type_name` and **no `lm`** in the config. Mirror
-that for your judge.
+`tests/core/modules/test_dspy_judge.py` does the stronger version as **two**
+companion tests — mirror both for your judge:
+
+- `test_resolver_with_dspy_judge_saves_and_loads` — **in-process**: saves a
+  `Resolver` (judge in the module slot) and asserts the **manifest shape** —
+  `module_spec["type_name"] == "dspy_judge"` and **no `lm`** in the config.
+- `test_resolver_load_dspy_judge_in_fresh_process` (`@pytest.mark.slow`) — proves
+  the reload itself succeeds in a **fresh subprocess** (`Resolver.load` via
+  `langres.core` alone), i.e. that lazy registration fires on demand.
 
 ---
 

--- a/docs/ADDING_A_METHOD.md
+++ b/docs/ADDING_A_METHOD.md
@@ -1,0 +1,273 @@
+# Adding a matching method behind the seam
+
+langres' thesis is that a matching method — string similarity, embeddings, an
+LLM judge — is implemented **once** as a judge (a `Module`) and stays
+usable, swappable, and tunable by everyone through one seam. This guide walks the
+**current in-repo path** for contributing a new method, using the real
+**`SelectJudge`** (the ComEM-style set-wise judge, W1.1) as the worked example.
+
+> **No public plugin API yet.** There is deliberately **no** external/plugin
+> registration entry point today. A new *name-selectable* method must be wired
+> into the in-repo dispatch sites below. A single public method-registration API
+> that collapses them is **deferred to [issue #55](https://github.com/raisesquad/langres/issues/55)**
+> (see `TODOS.md`). This document is the contract *as it stands* — what a
+> contributor editing the repo does now.
+>
+> **You may not need any of this.** A judge you only ever pass as a `Module`
+> instance — `dedupe(records, judge=MySelectJudge(...))` — needs **zero**
+> registry wiring. The steps below are only for making a method selectable *by
+> name* (`"select_judge"`) across the benchmark harness and the two build paths.
+
+---
+
+## 1. Write the judge (a `Module`)
+
+A judge is a `Module[SchemaT]` whose `forward` yields one `PairwiseJudgement` per
+candidate pair. Everything downstream — the `Clusterer`, the metrics harness, the
+`JudgementLog` — consumes that flat pairwise stream, so **whatever shape your
+scoring logic has, the output contract is pairwise**.
+
+`SelectJudge` scores a whole *group* at once, so it subclasses
+`GroupwiseModule` (`src/langres/core/module.py`) rather than `Module` directly.
+`GroupwiseModule` **IS-A** `Module`: its concrete `forward` derives
+`ERCandidateGroup`s from the pairwise stream and dispatches to your
+`forward_groups`, then flattens the result back to pairwise. **Set-wise in,
+pairwise out** — the group structure never leaks past the class boundary, so the
+Resolver spine needs no changes. You implement only `forward_groups` and
+`inspect_scores`.
+
+### Riding the `ComparisonVector` seam
+
+An `ERCandidate` carries an optional `comparison: ComparisonVector`
+(`src/langres/core/models.py`). This is the two-phase pipeline seam:
+
+- **Comparison-aware judges** (e.g. `WeightedAverageJudge`, `RFJudge`,
+  `FellegiSunterJudge`) consume a per-feature `ComparisonVector` that a
+  `Comparator` stage attaches upstream, and raise if it's `None`. Wire these with
+  a `Comparator` (step 3 returns one alongside the module builder).
+- **Self-contained judges** (e.g. `LLMJudge`, `DSPyJudge`, `SelectJudge`) read
+  the raw `left`/`right` entities directly and **ignore** `comparison` — so it
+  stays `None` for them, and they need no `Comparator`.
+
+`SelectJudge` is self-contained: it renders each entity to JSON and asks the LLM
+to select the matching id. So its method-registry entry (step 3) returns
+`(builder, None)` — no comparator.
+
+---
+
+## 2. Emit the right `PairwiseJudgement` — `score_type` and the group-call cost
+
+Every judgement declares a **`score_type`** literal so a downstream reader knows
+what scale the `score` is on (thresholds are not comparable across scales). The
+allowed values live on `PairwiseJudgement` in `src/langres/core/models.py`:
+
+| `score_type` | Meaning | Emitting judge |
+|---|---|---|
+| `heuristic` | string-similarity score | `WeightedAverageJudge`, `RapidfuzzModule` |
+| `sim_cos` | cosine similarity | `EmbeddingScoreJudge` |
+| `prob_llm` | per-pair LLM probability | `DSPyJudge`, `LLMJudge` |
+| `prob_group_llm` | **set-wise** LLM decision decomposed to a pair | `SelectJudge` |
+| `calibrated_prob` | calibrated probability | cascade / calibrated modules |
+| `prob_fs` / `prob_rf` | Fellegi-Sunter / random-forest probability | `FellegiSunterJudge`, `RFJudge` |
+
+`SelectJudge` emits `score_type="prob_group_llm"` — a distinct literal precisely
+because its score comes from a *group* decision (1.0 for the single selected id,
+0.0 for the rest), not an independent per-pair judgement. **If your method scores
+on a genuinely new scale, add a literal here** (and keep the table above in sync).
+
+### The group-call cost convention
+
+A set-wise judge makes **one** LLM call for K pairs. Pricing each of the K
+resulting judgements at the full call cost would overcount spend K-fold. The
+convention (`stamp_group_cost` in `src/langres/core/module.py`) avoids that:
+
+- the **full `cost_usd`** is stamped on the **first** judgement of the group;
+- every **sibling** carries **`$0`**;
+- **`provenance["group_id"]`** is set on **all** of them (traceable back to the
+  one call);
+- **`provenance["group_end"] = True`** marks the **last** judgement — a boundary
+  marker so a consumer draining a lazy group stream (the verbs' spend cap,
+  `_SpendCappedModule`) knows where to stop without peeking past it and
+  triggering the next paid call.
+
+`SelectJudge.forward_groups` prices the call from token usage
+(`tokens / 1000 * price_per_1k_tokens`) and calls `stamp_group_cost(...)`. The
+existing cost aggregators (`benchmark._cost_track`) already read
+`provenance["cost_usd"]`, so a group sums to exactly one call's cost with no
+changes on their end. (`SelectJudge` also degrades gracefully: a malformed,
+out-of-group, or over-selecting LLM answer maps the *whole group* to `$0`-scored
+"no match" judgements carrying `provenance["select_error"]` rather than raising
+mid-stream — CEO #12. The call is still billed, so the same cost convention
+applies.)
+
+---
+
+## 3. Wire it into the dispatch sites (make it selectable by name)
+
+There is **no single registration seam** yet, so a new *public, name-selectable*
+judge must be wired into **up to three** dispatch sites, or it will be rejected by
+whichever path doesn't know it. `SelectJudge` needs only the first (it's a
+benchmark/experiment method, not a verbs/`from_schema` default):
+
+1. **`methods.py:_make_module_builder`** — the benchmark / method-registry path.
+   **Required for any name-selectable method.**
+2. **`core/resolver.py:_build_module_for_judge`** — what
+   `Resolver.from_schema(judge=...)` dispatches on. *Only if you want it as a
+   `from_schema` judge name.*
+3. **`core/presets.py:build_judge`** — what the verbs (`link`/`dedupe`, incl.
+   `"auto"`) dispatch on. *Only if you want it as a verb judge name.*
+
+These three are duplicated deliberately to keep the layering one-directional
+(`verbs -> presets -> Resolver`); see `.claude/rules/component-design.md`.
+
+### The `_make_module_builder` branch
+
+`make_resolver_factory` builds a `threshold -> Resolver` factory the benchmark
+harness consumes; `_make_module_builder` maps a **method name** to a
+`(module_builder, comparator)` pair. Adding a method is **one branch**:
+
+```python
+# src/langres/methods.py, inside _make_module_builder(...)
+if method == "select_judge":
+    # Lazy import: dspy must stay out of sys.modules unless this method is
+    # actually chosen (import langres.methods must not import dspy).
+    from langres.core.modules.select_judge import SelectJudge
+
+    select_price_per_1k = _dspy_price_per_1k(llm_model)
+
+    def build_select_judge() -> Module[Any]:
+        judge: SelectJudge[Any] = SelectJudge(lm=llm_client, model=llm_model)
+        judge.price_per_1k_tokens = select_price_per_1k  # honest-cost seam
+        return judge
+
+    return build_select_judge, None   # None -> self-contained, no Comparator
+```
+
+Then declare its **membership** in the method tuples at the top of `methods.py`
+so the harness races it:
+
+```python
+LLM_METHODS: tuple[str, ...] = ("llm_judge", "cascade", "dspy_judge", "select_judge")
+ALL_METHODS: tuple[str, ...] = ZERO_SPEND_METHODS + LLM_METHODS
+```
+
+Membership placement encodes a real contract:
+
+- **`ZERO_SPEND_METHODS`** — deterministic, no API call (`rapidfuzz`,
+  `weighted_average`, `embedding_cosine`).
+- **`LLM_METHODS`** — takes an *injected client*. Note the client *shape*
+  differs: `llm_judge` wants a LiteLLM client (`client.completion(...)`),
+  `cascade` an OpenAI-shaped one, and `dspy_judge`/`select_judge` a **DSPy LM**
+  (`dspy.LM` / `DummyLM`). Document which your method expects.
+- **Neither tuple** — a method the builder recognizes but that needs an explicit
+  `fit` step (`fellegi_sunter`, `random_forest`); the `run_methods` race can't
+  build+fit it per grid threshold, so it's driven via `Resolver.fit(...)`
+  instead. Wire it into the builder but leave it out of the race tuples.
+
+The `price_per_1k_tokens` assignment is the **honest-cost seam**: `SelectJudge`
+prices each call as `tokens/1000 * price_per_1k_tokens`, defaulting to `$0`. A
+real paid run must pin the price from the OpenRouter table
+(`_dspy_price_per_1k(llm_model)`), or cost would report `$0` and the live
+budget-stop would never fire.
+
+---
+
+## 4. Serialization — the config-registry contract (no pickle)
+
+A judge that goes into a `Resolver` slot must be **serializable without pickle**.
+The Resolver's `save`/`load` writes a human-readable `resolver.json` manifest and
+rebuilds every slot from the component registry **by `type_name`** — no code
+execution, no pickle. To participate, a judge provides four things (all visible on
+`SelectJudge` in `src/langres/core/modules/select_judge.py`):
+
+```python
+from langres.core.registry import register
+
+@register("select_judge")                       # (1) registry key
+class SelectJudge(GroupwiseModule[SchemaT]):
+    type_name: ClassVar[str] = "select_judge"    # (2) mirrored as a class attr
+
+    @property
+    def config(self) -> dict[str, object]:        # (3) PURE, JSON-able config
+        return {                                  #     never the LM or secrets
+            "model": self.model,
+            "temperature": self.temperature,
+            "entity_noun": self.entity_noun,
+        }
+
+    @classmethod
+    def from_config(cls, config: dict[str, object]) -> "SelectJudge[SchemaT]":
+        return cls(                               # (4) rebuild from config alone
+            lm=None,                              #     (LM rebuilt lazily)
+            model=str(config["model"]),
+            temperature=float(config["temperature"]),
+            entity_noun=str(config["entity_noun"]),
+        )
+```
+
+Rules the contract enforces:
+
+- **`config` is pure and JSON-serializable** — construction parameters only,
+  **never** the injected LM, an API key, or any live object. `from_config` alone
+  must rebuild an equivalent (uncompiled) judge, and it builds its LM lazily on
+  first use.
+- **`@register` may be lazy.** `SelectJudge` is registered via
+  `registry._LAZY_COMPONENT_MODULES` so `import langres.core` doesn't import dspy
+  (importing dspy opens a disk cache). `get_component("select_judge")` imports and
+  registers it on demand.
+- **Out-of-band state, if any, is a separate concern.** A judge with tuned state
+  (e.g. `DSPyJudge`'s compiled program) implements `save_state`/`load_state` and
+  the Resolver writes a per-slot sidecar. `SelectJudge` has **none** —
+  `from_config` fully rebuilds it, like any stateless judge.
+
+### A fresh-process round-trip is REQUIRED
+
+In-process `save`/`load` is not enough — the whole point of no-pickle
+serialization is that a **different process** can reload the artifact. Prove it:
+
+```python
+# In a FRESH interpreter (no prior import of your judge's module):
+from langres.core.registry import get_component
+cls = get_component("select_judge")       # lazily imports + registers
+assert cls.type_name == "select_judge"    # rebuildable by name, no pickle
+```
+
+`tests/core/modules/test_dspy_judge.py` does the stronger version: it saves a
+`Resolver` (with the judge in the module slot) and reloads it in a **subprocess**,
+asserting the manifest carries `type_name` and **no `lm`** in the config. Mirror
+that for your judge.
+
+---
+
+## 5. Test expectations
+
+- **100% coverage** (a POC requirement). Cover the happy path, every
+  `score_type` branch, and every error branch (for `SelectJudge`: parse failure,
+  unknown-id, over-selection — each maps a whole group to `select_error` without
+  raising).
+- **LLM paths run on `DummyLM` — $0, offline, deterministic.** Never make a real
+  call in a test. Build the judge with `lm=DummyLM([...canned answers...])`; the
+  answer dict is keyed by the DSPy signature's output field names (for
+  `SelectJudge`: `{"reasoning": ..., "selected_ids": '["b"]'}`). See
+  [`docs/TESTING_AT_ZERO_COST.md`](TESTING_AT_ZERO_COST.md) and
+  `tests/core/modules/test_select_judge.py` (DummyLM-driven throughout).
+- **Verify the cost convention.** Assert the full cost lands on the first
+  judgement, `$0` on siblings, and that a group sums to exactly one call's cost
+  (`test_forward_groups_group_cost_sums_to_exactly_one_calls_cost`).
+- **Guard against live spend.** Run `uv run pytest -m "not integration"` — never a
+  bare `pytest`, which can execute paid integration tests.
+
+---
+
+## Checklist
+
+- [ ] Judge is a `Module` (or `GroupwiseModule`) yielding `PairwiseJudgement`s.
+- [ ] Correct `score_type` (add a literal to `models.py` if genuinely new).
+- [ ] Set-wise judges apply the group-call cost convention (`stamp_group_cost`).
+- [ ] Honest-cost seam wired (`price_per_1k_tokens` pinned for paid runs).
+- [ ] Selectable by name? Branch in `_make_module_builder` **+** the right method
+      tuple — and, if it's also a `from_schema`/verb judge, the other two
+      dispatch sites.
+- [ ] `@register` + `type_name` + pure `config` + `from_config` (no pickle).
+- [ ] Fresh-process (subprocess) reload proven in a test.
+- [ ] 100% coverage; all LLM paths on DummyLM at $0.

--- a/docs/TESTING_AT_ZERO_COST.md
+++ b/docs/TESTING_AT_ZERO_COST.md
@@ -62,7 +62,8 @@ answer is fixed. The judge still runs the *real* `DSPyJudge.forward` code
 (rendering, parsing, scoring, provenance); only the model call is faked, so you
 are testing your pipeline wiring, not a mock of it.
 
-The same injection works for `link` and for a `Resolver`:
+The same injection works for `link` and for a `Resolver` (both blocks below reuse
+the `answer` dict and `Company` schema from the test above):
 
 ```python
 from langres import link

--- a/docs/TESTING_AT_ZERO_COST.md
+++ b/docs/TESTING_AT_ZERO_COST.md
@@ -1,0 +1,141 @@
+# Testing an ER pipeline at $0 (DummyLM)
+
+An LLM judge costs money and needs a network. Neither belongs in a unit test or
+CI run. langres' verbs (`link` / `dedupe`) and its `Resolver` all accept a
+**`Module` instance** in the `judge=` slot — the escape hatch that lets you swap
+the real LLM for a **`DummyLM`**-backed judge that replays canned answers
+offline, deterministically, and for **$0**.
+
+This is the same seam the project's own test suite runs on (see
+[`tests/test_verbs.py`](../tests/test_verbs.py) and
+[`tests/core/modules/test_dspy_judge.py`](../tests/core/modules/test_dspy_judge.py)).
+
+> **Why this matters — the spend footgun.** `import langres` eagerly imports
+> litellm, whose `load_dotenv()` side effect can silently load an
+> `OPENROUTER_API_KEY` from a `.env`. A test that reaches a *real* LLM judge then
+> spends **real money** — even in CI. Injecting a DummyLM judge means the paid
+> code path is never entered: no key is read for scoring, no request leaves the
+> process. Verify a suite is offline with `uv run pytest -m "not integration"`
+> (never a bare `pytest`, which can run live integration tests).
+
+---
+
+## The pattern
+
+`DummyLM` (from `dspy.utils.dummies`) is a DSPy language model that returns
+**canned answers** instead of calling a provider. You build a real judge
+(`DSPyJudge` for pairwise, `SelectJudge` for set-wise) around it and pass the
+judge as `judge=`:
+
+```python
+from dspy.utils.dummies import DummyLM
+from pydantic import BaseModel
+
+from langres import dedupe
+from langres.core.modules.dspy_judge import DSPyJudge
+
+
+class Company(BaseModel):
+    id: str
+    name: str
+
+
+def test_dedupe_merges_matching_records() -> None:
+    # DSPyJudge's signature has three output fields; a DummyLM answer is a dict
+    # keyed by those field names. DummyLM replays this same answer for every
+    # call -> fully deterministic.
+    answer = {"reasoning": "same company", "match": "True", "match_probability": "0.95"}
+    judge = DSPyJudge(lm=DummyLM([answer] * 20), entity_noun="company")
+
+    records = [
+        {"id": "a", "name": "Acme Corp"},
+        {"id": "b", "name": "Acme Corporation"},
+    ]
+    result = dedupe(records, schema=Company, judge=judge, threshold=0.5)
+
+    assert result == [{"a", "b"}]        # the pair merged into one cluster
+    assert result.judge_used == "custom"  # an injected Module reports as "custom"
+```
+
+No key, no network, no spend — and the assertion is exact because DummyLM's
+answer is fixed. The judge still runs the *real* `DSPyJudge.forward` code
+(rendering, parsing, scoring, provenance); only the model call is faked, so you
+are testing your pipeline wiring, not a mock of it.
+
+The same injection works for `link` and for a `Resolver`:
+
+```python
+from langres import link
+
+verdict = link(
+    {"id": "a", "name": "Acme"},
+    {"id": "b", "name": "Acme Inc"},
+    schema=Company,
+    judge=DSPyJudge(lm=DummyLM([answer] * 20), entity_noun="company"),
+    threshold=0.5,
+)
+assert verdict.match is True
+assert verdict.score == 0.95          # the parsed match_probability
+assert verdict.score_type == "prob_llm"
+```
+
+```python
+from langres.core import AllPairsBlocker, Clusterer, Resolver
+
+resolver = Resolver(
+    blocker=AllPairsBlocker(schema=Company),
+    comparator=None,
+    module=DSPyJudge(lm=DummyLM([answer] * 20), entity_noun="company"),
+    clusterer=Clusterer(threshold=0.5),
+)
+assert resolver.resolve(records) == [{"a", "b"}]
+```
+
+---
+
+## Set-wise judges (SelectJudge) at $0
+
+A `GroupwiseModule` like `SelectJudge` makes **one** LLM call per candidate
+*group* ("which of these K candidates matches the anchor?"). DummyLM tests it the
+same way — the canned answer carries the signature's `selected_ids` field:
+
+```python
+from dspy.utils.dummies import DummyLM
+from langres.core.groups import ERCandidateGroup
+from langres.core.modules.select_judge import SelectJudge
+
+judge = SelectJudge(
+    lm=DummyLM([{"reasoning": "b matches", "selected_ids": '["b"]'}]),
+    entity_noun="company",
+)
+group = ERCandidateGroup(
+    anchor=Company(id="a", name="Acme"),
+    members=[Company(id="b", name="Acme Corp"), Company(id="c", name="Other")],
+    group_id="a",
+)
+judgements = list(judge.forward_groups(iter([group])))
+
+scores = {j.right_id: j.score for j in judgements}
+assert scores == {"b": 1.0, "c": 0.0}                 # only "b" was selected
+assert judgements[0].score_type == "prob_group_llm"
+assert judgements[0].provenance["cost_usd"] == 0.0    # DummyLM = $0
+```
+
+---
+
+## Key facts
+
+- **`judge=<Module>` is the seam.** Any `Module` instance passed to `link` /
+  `dedupe` is used verbatim and reported as `judge_used="custom"`; passed to a
+  `Resolver`, it just fills the `module` slot.
+- **DummyLM is deterministic.** It replays its canned answers, so assertions are
+  exact — no flakiness, no seeds.
+- **Cost is honest and zero.** Under DummyLM, token counts are 0, so the
+  `provenance["cost_usd"]` a judge stamps is `$0`; the built-in spend cap on the
+  verbs never trips.
+- **DSPy is an extra.** `DSPyJudge` / `SelectJudge` / `DummyLM` live behind the
+  `[llm]` extra: `uv sync --extra llm` (or `--all-extras`). The string /
+  embedding judges need no LLM at all — for those, `judge="string"` is already a
+  $0 offline path with nothing to inject.
+- **Guard the suite.** Run `uv run pytest -m "not integration"` to keep live,
+  paid integration tests out. A bare `pytest` can spend.

--- a/docs/TUTORIAL_YOUR_OWN_CSV.md
+++ b/docs/TUTORIAL_YOUR_OWN_CSV.md
@@ -2,14 +2,20 @@
 
 You have a messy CSV of records — customers, companies, products — and some rows
 are the same real-world thing spelled differently. This tutorial takes you from
-that file to **entity clusters**, entirely offline and at **$0** (no API key, no
-network, no model download), then shows how to calibrate the match threshold from
-a handful of labels and persist the pipeline for reuse.
+that file to **entity clusters** at **$0** (no API key, no LLM, no spend), then
+shows how to calibrate the match threshold from a handful of labels and persist
+the pipeline for reuse.
 
-Everything here runs on langres' **core** install (`uv sync`) — the
-string-similarity judge needs only Pydantic, rapidfuzz, networkx, and numpy. The
-one step that pulls an extra is threshold calibration (`derive_threshold` needs
-scikit-learn, the `[trained]` extra); it is optional.
+> **What "runs on core" depends on your file size.** `dedupe` picks its blocker
+> by row count. At **≤ 100 rows** it uses an all-pairs blocker and needs only the
+> **core** install (`uv sync`: Pydantic, rapidfuzz, networkx, numpy) — fully
+> offline, no network, no model download. **Above 100 rows** it auto-switches to
+> an embedding blocker (MiniLM + FAISS) to scale O(N·k) instead of O(N²); that
+> path needs the **`[semantic]`** extra and does a **one-time MiniLM model
+> download** on first run. Either way it stays **$0** — no API key, no LLM call.
+> The examples below use a 5-row file, so they run on core alone. (Threshold
+> calibration in step 4 adds one more optional extra, `[trained]` for
+> scikit-learn.)
 
 This is the middle rung of the docs ladder:
 
@@ -54,13 +60,11 @@ artifact that references it cannot be reloaded in a fresh process (the class was
 minted at runtime and isn't importable by name). For anything you intend to
 `save`/`load`, declare a real schema.
 
-A langres schema is any Pydantic model with a **string `id`** field. Add a
-`@computed_field embed_text` property to control the text used for
-similarity/blocking (it joins the fields that actually identify the entity and
-skips missing ones so absent fields don't inject empty tokens):
+A langres schema is any Pydantic model with a **string `id`** field. Declare the
+fields you want to match on — the string judge compares them field-by-field:
 
 ```python
-from pydantic import BaseModel, computed_field
+from pydantic import BaseModel
 from langres.core.registry import register_schema
 
 @register_schema("Contact")          # register by name -> durable save/load
@@ -69,11 +73,6 @@ class Contact(BaseModel):
     name: str
     city: str | None = None
     email: str | None = None
-
-    @computed_field  # type: ignore[prop-decorator]
-    @property
-    def embed_text(self) -> str:
-        return " ".join(p for p in [self.name, self.city] if p)
 ```
 
 `@register_schema("Contact")` records the class in langres' component registry
@@ -82,13 +81,28 @@ that has imported the module — the config-registry contract, no pickle. (Omit 
 and in-process use still works; only cross-process `load` of an artifact needs
 the name.)
 
+> **What gets matched, and where `embed_text` fits.** The string judge scores on
+> the schema's declared `str | None` fields (`name`, `city`, `email` here) via
+> rapidfuzz — one similarity per field, weighted and combined; `id` is excluded.
+> When the embedding blocker is active (> 100 rows, or `judge="embedding"`),
+> `dedupe`/`Resolver.from_schema` derive the *blocking* text from those same
+> declared string fields automatically. A schema-level
+> `@computed_field embed_text` is a separate, **advanced** convention: it only
+> takes effect when you hand-build a `VectorBlocker(schema=..., text_field="embed_text")`
+> yourself (the declarative path the benchmark loaders use) — the verbs and
+> `from_schema` do **not** read it. You don't need it for this tutorial; just
+> declare the fields that identify the entity.
+
 ---
 
-## 3. Dedupe — offline by default
+## 3. Dedupe — no key, no spend
 
-`dedupe` groups the batch into clusters. Pin `judge="string"` to stay fully
-offline and free; the default `judge="auto"` would pick an LLM judge *if* an API
-key is set (and fall back to this same string judge, with one notice, if not):
+`dedupe` groups the batch into clusters. Pin `judge="string"` to stay **$0** with
+no LLM and no API key; the default `judge="auto"` would pick an LLM judge *if* an
+API key is set (and fall back to this same string judge, with one notice, if
+not). (For this 5-row file the string judge is also fully offline; on a file over
+100 rows the blocker step downloads MiniLM once, per the note at the top — still
+$0.)
 
 ```python
 from langres import dedupe

--- a/docs/TUTORIAL_YOUR_OWN_CSV.md
+++ b/docs/TUTORIAL_YOUR_OWN_CSV.md
@@ -1,0 +1,203 @@
+# Your own CSV in 15 minutes
+
+You have a messy CSV of records — customers, companies, products — and some rows
+are the same real-world thing spelled differently. This tutorial takes you from
+that file to **entity clusters**, entirely offline and at **$0** (no API key, no
+network, no model download), then shows how to calibrate the match threshold from
+a handful of labels and persist the pipeline for reuse.
+
+Everything here runs on langres' **core** install (`uv sync`) — the
+string-similarity judge needs only Pydantic, rapidfuzz, networkx, and numpy. The
+one step that pulls an extra is threshold calibration (`derive_threshold` needs
+scikit-learn, the `[trained]` extra); it is optional.
+
+This is the middle rung of the docs ladder:
+
+- **Below:** [`examples/quickstart_verbs.py`](../examples/quickstart_verbs.py) —
+  dedupe a list of dicts in ~10 lines.
+- **Here:** a real CSV, a typed schema, a calibrated threshold, save/load.
+- **Above:** [`docs/EXPERIMENTS.md`](EXPERIMENTS.md) — racing judges, paid LLM
+  judges, the budget seam.
+
+---
+
+## 1. From CSV to records
+
+langres verbs (`dedupe` / `link`) take **plain dicts**. pandas turns a CSV into
+exactly that with `df.to_dict("records")`:
+
+```python
+import pandas as pd
+
+# dtype=str keeps ids and zip codes as strings (no "1" -> 1 surprises).
+df = pd.read_csv("contacts.csv", dtype=str)
+records = df.to_dict("records")
+# records[0] -> {"id": "1", "name": "Acme Corporation", "city": "New York", ...}
+```
+
+Two conventions the verbs rely on:
+
+- **A unique `id` per record.** If every row has an `"id"` key, langres uses it;
+  if none do, it assigns positional ids. A *mix* raises (it can't tell which
+  source is authoritative). A duplicate `id` in a `dedupe` batch also raises.
+- **Flat, scalar fields.** Inferred schemas coerce each value to `str | None`
+  (and turn `NaN`/`None` into `None`, never the string `"nan"`). A nested
+  `list`/`dict` value raises with guidance — pass an explicit schema for those.
+
+---
+
+## 2. Author a Pydantic schema
+
+You *can* skip this — `dedupe(records)` will infer an ephemeral all-`str | None`
+schema from the record keys. But an inferred schema is **not durable**: a saved
+artifact that references it cannot be reloaded in a fresh process (the class was
+minted at runtime and isn't importable by name). For anything you intend to
+`save`/`load`, declare a real schema.
+
+A langres schema is any Pydantic model with a **string `id`** field. Add a
+`@computed_field embed_text` property to control the text used for
+similarity/blocking (it joins the fields that actually identify the entity and
+skips missing ones so absent fields don't inject empty tokens):
+
+```python
+from pydantic import BaseModel, computed_field
+from langres.core.registry import register_schema
+
+@register_schema("Contact")          # register by name -> durable save/load
+class Contact(BaseModel):
+    id: str
+    name: str
+    city: str | None = None
+    email: str | None = None
+
+    @computed_field  # type: ignore[prop-decorator]
+    @property
+    def embed_text(self) -> str:
+        return " ".join(p for p in [self.name, self.city] if p)
+```
+
+`@register_schema("Contact")` records the class in langres' component registry
+under a stable name, so a saved pipeline referencing it reloads in any process
+that has imported the module — the config-registry contract, no pickle. (Omit it
+and in-process use still works; only cross-process `load` of an artifact needs
+the name.)
+
+---
+
+## 3. Dedupe — offline by default
+
+`dedupe` groups the batch into clusters. Pin `judge="string"` to stay fully
+offline and free; the default `judge="auto"` would pick an LLM judge *if* an API
+key is set (and fall back to this same string judge, with one notice, if not):
+
+```python
+from langres import dedupe
+
+result = dedupe(records, schema=Contact, judge="string", threshold=0.6)
+
+for cluster in result:
+    print(sorted(cluster))
+# [['1', '2'], ['3', '4']]      # "Acme Corporation"/"Acme Corp", etc.
+
+print(result.judge_used, result.score_type)
+# string heuristic
+```
+
+The result is a plain `list[set[str]]` of id-clusters, and it is
+**self-describing**: `result.judge_used`, `result.score_type`, and
+`result.fallback_reason` tell you exactly what ran. **Singletons are dropped** —
+a record that matches nothing does not appear in the output.
+
+> **Entity linking instead of dedupe?** Use `link(left, right, schema=Contact,
+> judge="string")` to score one pair; it returns a `LinkVerdict` that is truthy
+> iff it's a match (`if link(a, b): ...`) and carries `.score`, `.reasoning`,
+> and the full `.judgement`.
+
+### On the threshold
+
+`threshold=0.6` is a **magic constant** — a guess. Different judges score on
+different scales (`"heuristic"` for string, `"sim_cos"` for embeddings,
+`"prob_llm"` for an LLM), so a number that's right for one is meaningless for
+another. `threshold=None` (the default) resolves to a sane per-judge default, but
+the honest move is to derive it from data.
+
+---
+
+## 4. Calibrate the threshold from a few labels
+
+Once you can label even a handful of pairs as match / non-match, stop guessing.
+Score those pairs with `link`, then hand the scores and labels to
+`derive_threshold`, which picks the cut that best separates them (Youden's J on
+the ROC curve by default):
+
+```python
+from langres.core.calibration import derive_threshold
+
+labeled = [
+    (records[0], records[1], True),    # Acme Corporation / Acme Corp  -> match
+    (records[2], records[3], True),    # Totally Different Co / Company -> match
+    (records[0], records[4], False),   # Acme / Unrelated Bakery        -> no
+    (records[1], records[4], False),
+]
+
+scores, labels = [], []
+for left, right, is_match in labeled:
+    verdict = link(left, right, schema=Contact, judge="string")
+    scores.append(verdict.score)
+    labels.append(is_match)
+
+threshold = derive_threshold(scores, labels)   # -> ~0.907, from the data
+clusters = dedupe(records, schema=Contact, judge="string", threshold=threshold)
+```
+
+`derive_threshold` needs the `[trained]` extra (scikit-learn):
+`uv sync --extra trained`. It needs **both** a positive and a negative label
+under the default `"youden"` method (it raises on a single class); pass
+`method="percentile", percentile=...` for a label-agnostic cut.
+
+> **Where do labels come from at scale?** langres has a whole *flywheel* for
+> this: opt into `dedupe(..., log="judgements.jsonl")` to record every judge
+> call, collect human corrections, and harvest them into labeled pairs with
+> `langres.core.harvest` — which feeds this exact `derive_threshold`. See
+> [`examples/flywheel_threshold_harvest.py`](../examples/flywheel_threshold_harvest.py)
+> and [`docs/EXPERIMENTS.md`](EXPERIMENTS.md).
+
+---
+
+## 5. Save and load the pipeline
+
+The verbs rebuild their pipeline per call. To freeze a configured pipeline —
+schema, blocker, judge, calibrated threshold — into a reusable artifact, drop to
+the `Resolver` (the declarative mid-layer the verbs sit on) and use
+`save`/`load`:
+
+```python
+from langres import Resolver
+
+resolver = Resolver.from_schema(Contact, judge="string", threshold=threshold)
+clusters = resolver.resolve(records)          # same clusters as dedupe()
+
+resolver.save("artifacts/contacts_v1")        # writes resolver.json (+ sidecars)
+reloaded = Resolver.load("artifacts/contacts_v1")
+assert reloaded.resolve(records) == clusters
+```
+
+`save` writes a **human-readable `resolver.json` manifest** plus per-component
+sidecar state; `load` rebuilds every slot from the component registry by its
+`type_name` — **no pickle, no code execution**. This is why step 2's
+`@register_schema("Contact")` matters: `load` looks the schema up by that name.
+Load the artifact in a fresh process and it reconstructs identically (import the
+module that defines `Contact` first so the registration runs).
+
+---
+
+## Where to go next
+
+- **Spend a little on an LLM judge.** Set `OPENROUTER_API_KEY` and drop the
+  `judge=` kwarg: `dedupe(records, schema=Contact)` picks an LLM judge under a
+  default **$1 spend cap** (`budget_usd=`). See [`docs/EXPERIMENTS.md`](EXPERIMENTS.md).
+- **Test your pipeline in CI without spending.** See
+  [`docs/TESTING_AT_ZERO_COST.md`](TESTING_AT_ZERO_COST.md) — inject a DummyLM-backed
+  judge for deterministic, offline, $0 assertions.
+- **Contribute a new matching method.** See
+  [`docs/ADDING_A_METHOD.md`](ADDING_A_METHOD.md).

--- a/docs/TUTORIAL_YOUR_OWN_CSV.md
+++ b/docs/TUTORIAL_YOUR_OWN_CSV.md
@@ -109,8 +109,7 @@ from langres import dedupe
 
 result = dedupe(records, schema=Contact, judge="string", threshold=0.6)
 
-for cluster in result:
-    print(sorted(cluster))
+print([sorted(c) for c in result])
 # [['1', '2'], ['3', '4']]      # "Acme Corporation"/"Acme Corp", etc.
 
 print(result.judge_used, result.score_type)


### PR DESCRIPTION
Three new DX docs (all new files; **no `src/**` changes**), each snippet verified against the real current API on this base (head 6a10412).

## Deliverables

- **`docs/TUTORIAL_YOUR_OWN_CSV.md`** — "your own CSV in 15 minutes." Messy CSV → clusters, fully offline at **$0**: `pandas df.to_dict("records")`, a Pydantic schema with `@computed_field embed_text` + `@register_schema` for durable save/load, `dedupe(..., judge="string")`, threshold calibration via `derive_threshold`, and the `Resolver.save`/`load` lifecycle.
- **`docs/TESTING_AT_ZERO_COST.md`** — `judge=<DummyLM-backed Module>` as the user-facing seam to test `link`/`dedupe`/`Resolver` without spend. Deterministic, offline, $0 assertions for pairwise (`DSPyJudge`) and set-wise (`SelectJudge`) judges; calls out the eager-litellm spend footgun and the `pytest -m "not integration"` guard.
- **`docs/ADDING_A_METHOD.md`** — the current in-repo method-contribution path, worked on **SelectJudge**: the `_make_module_builder` seam + method-tuple membership, the `ComparisonVector` seam (self-contained vs comparison-aware), `score_type` literals incl. `prob_group_llm`, the group-call cost convention (full `cost_usd` on the first group judgement, $0 siblings, `group_id` + `group_end`), the config-registry no-pickle serialization contract (`type_name`/`config`/`from_config`) with a **required fresh-process round-trip**, and test expectations (100% coverage, DummyLM for LLM paths). States clearly that a public/plugin registration API is **deferred to #55**.
- **`README.md`** — links all three from the Documentation index.

## Verification (how snippets were checked)
- Read the real signatures first: `verbs.py`, `core/presets.py`, `Resolver.from_schema`/`save`/`load`, `core/modules/select_judge.py`, `core/methods.py`, `core/calibration.py`, `core/harvest.py`, `core/module.py` (`GroupwiseModule`/`stamp_group_cost`), `core/models.py` (`score_type`), and the DummyLM patterns in `tests/`.
- Ran the **CSV tutorial path end-to-end at $0** (judge="string" throughout, no LLM call): CSV→records→`dedupe`→`derive_threshold` (≈0.907)→calibrated `dedupe`→`Resolver.save`/`load` round-trip — all clusters match.
- Ran the **DummyLM/SelectJudge paths at $0**: `dedupe(judge=<DummyLM DSPyJudge>)` (`judge_used="custom"`), `SelectJudge.forward_groups` (`prob_group_llm`, cost on first judgement, `group_id`/`group_end`), config round-trip, and fresh-process `get_component("select_judge")`.
- `uv run pytest -m "not integration"` on the doc-relevant modules (`test_verbs`, `test_select_judge`, `test_dspy_judge`, `test_calibration`): **136 passed**. The lone embedding failure was environmental (missing `[semantic]` extra) and passes with `--extra semantic`; this docs-only change touches no `src/`/`tests/`.

## Intended CHANGELOG line (not edited here per task scope)
`docs(W3): DX docs — TUTORIAL_YOUR_OWN_CSV (messy CSV → clusters at $0), TESTING_AT_ZERO_COST (DummyLM seam), ADDING_A_METHOD (in-repo method-contribution path, SelectJudge worked example; public plugin API deferred to #55).`

https://claude.ai/code/session_0115MvWbHaCKT1A39PKDWqey