### PR TITLE
feat(benchmark): external slice tags + honest fixed-threshold sliced aggregation (Wave D / eval-readiness P2)

### DIFF
--- a/src/langres/core/benchmark.py
+++ b/src/langres/core/benchmark.py
@@ -28,6 +28,7 @@ contract across methods is a complete resolver.
 import logging
 import math
 import time
+from collections import defaultdict
 from collections.abc import Callable, Sequence
 from typing import TYPE_CHECKING, Any, Protocol, TypeVar, runtime_checkable
 
@@ -713,6 +714,12 @@ class JudgePairEval(BaseModel):
         best_threshold: The grid threshold maximizing pair-level F1.
         truncated: ``True`` when fewer pairs were judged than supplied (a budget
             cap fired or calls were skipped) — the cell is partial.
+        slices: Optional per-slice pair tracks, each graded at the SAME fixed
+            ``best_threshold`` as ``pair`` (never a per-slice argmax). Populated
+            only when :func:`evaluate_judge_on_candidates` is given a ``slice_fn``;
+            ``None`` otherwise. This is the honest seen -> unseen view: one global
+            cut, reported across data slices, so a degradation cannot be tuned
+            away.
     """
 
     pair: PairTrack
@@ -722,6 +729,55 @@ class JudgePairEval(BaseModel):
     n_judged: int
     best_threshold: float
     truncated: bool
+    slices: dict[str, PairTrack] | None = None
+
+
+def _grade_slices(
+    judgements: list[PairwiseJudgement],
+    gold_in_scope: set[frozenset[str]],
+    slice_fn: Callable[[frozenset[str]], str | None],
+    threshold: float,
+) -> dict[str, PairTrack]:
+    """Grade each data slice at ONE fixed ``threshold`` (never a per-slice argmax).
+
+    The load-bearing honesty rule of the sliced eval: the global best-F1
+    ``threshold`` is chosen once over *all* judged pairs, then every slice is
+    graded at that SAME cut via :func:`~langres.core.metrics.classify_pairs`. A
+    per-slice argmax would re-tune the threshold within each slice and so hide the
+    seen -> unseen degradation this report exists to expose.
+
+    Judged pairs are grouped by ``slice_fn`` of their order-independent pair key,
+    and ``gold_in_scope`` by the same tagger; a pair tagged ``None`` is excluded
+    from every slice. The judged-tag and gold-tag sets are *unioned* so a slice
+    holding gold pairs but no judged pair (e.g. a budget runner dropped its
+    candidates, or the judge skipped them) still reports recall — ``0.0`` with no
+    divide-by-zero — rather than silently vanishing.
+
+    Args:
+        judgements: The judgements actually produced by the judge.
+        gold_in_scope: Gold pairs realizable from the candidate set (already
+            intersected with the candidate pairs by the caller).
+        slice_fn: Maps a pair key to a slice tag, or ``None`` to drop the pair.
+        threshold: The single fixed cut every slice is graded at.
+
+    Returns:
+        ``tag -> PairTrack`` (``pr_curve=None`` — a single fixed cut has no curve).
+    """
+    judged_by_tag: dict[str, list[PairwiseJudgement]] = defaultdict(list)
+    for judgement in judgements:
+        tag = slice_fn(frozenset((judgement.left_id, judgement.right_id)))
+        if tag is not None:
+            judged_by_tag[tag].append(judgement)
+    gold_by_tag: dict[str, set[frozenset[str]]] = defaultdict(set)
+    for pair_key in gold_in_scope:
+        tag = slice_fn(pair_key)
+        if tag is not None:
+            gold_by_tag[tag].add(pair_key)
+    slices: dict[str, PairTrack] = {}
+    for tag in set(judged_by_tag) | set(gold_by_tag):
+        metrics = classify_pairs(judged_by_tag.get(tag, []), gold_by_tag.get(tag, set()), threshold)
+        slices[tag] = PairTrack(precision=metrics.precision, recall=metrics.recall, f1=metrics.f1)
+    return slices
 
 
 def evaluate_judge_on_candidates(
@@ -730,6 +786,7 @@ def evaluate_judge_on_candidates(
     gold_pairs: set[frozenset[str]],
     grid: Sequence[float],
     *,
+    slice_fn: Callable[[frozenset[str]], str | None] | None = None,
     runner: "BudgetedModuleRunner | None" = None,
     price_per_token_or_pair: float = 0.0,
     cost_track_fn: Callable[[list[PairwiseJudgement]], CostTrack] = _cost_track,
@@ -748,6 +805,12 @@ def evaluate_judge_on_candidates(
         candidates: The fixed candidate pairs to judge (each an ``ERCandidate``).
         gold_pairs: True match pairs as order-independent ``frozenset`` pairs.
         grid: Score thresholds to sweep for the pair-level PR curve.
+        slice_fn: Optional tagger mapping a pair key (``frozenset({left_id,
+            right_id})``) to a slice tag, or ``None`` to exclude the pair. When
+            given, the judged pairs and the in-scope gold are grouped by tag and
+            each slice is graded at the ONE global ``best_threshold`` (never a
+            per-slice argmax), populating ``JudgePairEval.slices``. When ``None``
+            (default), ``slices`` stays ``None`` and the result is unchanged.
         runner: Optional budget runner. When given, the judge runs through it (its
             ``module`` must be ``module``) so spend is hard-capped; the run may
             therefore judge fewer pairs than supplied. When ``None``, the judge is
@@ -784,6 +847,13 @@ def evaluate_judge_on_candidates(
     best = max(curve, key=lambda m: m.f1)
     pair = PairTrack(precision=best.precision, recall=best.recall, f1=best.f1, pr_curve=curve)
 
+    # Sliced view (honest): grade every slice at the SAME global best.threshold.
+    slices = (
+        _grade_slices(judgements, gold_in_scope, slice_fn, best.threshold)
+        if slice_fn is not None
+        else None
+    )
+
     n_judged = len(judgements)
     latency = LatencyTrack(seconds_per_pair=elapsed / n_judged if n_judged > 0 else 0.0)
     result = JudgePairEval(
@@ -794,6 +864,7 @@ def evaluate_judge_on_candidates(
         n_judged=n_judged,
         best_threshold=best.threshold,
         truncated=n_judged < len(candidates),
+        slices=slices,
     )
     return result, judgements
 

--- a/tests/core/test_benchmark.py
+++ b/tests/core/test_benchmark.py
@@ -38,6 +38,7 @@ from langres.core.blockers.vector import VectorBlocker
 from langres.core.clusterer import Clusterer
 from langres.core.groups import ERCandidateGroup
 from langres.core.indexes.vector_index import FakeVectorIndex
+from langres.core.metrics import classify_pairs
 from langres.core.models import CompanySchema, ERCandidate, PairwiseJudgement
 from langres.core.module import GroupwiseModule, Module
 from langres.core.reports import ScoreInspectionReport
@@ -476,14 +477,21 @@ class _ScoreModule(Module[CompanySchema]):
     written to ``provenance['cost_usd']`` so the cost track is exercised too.
     """
 
-    def __init__(self, scores: dict[str, float], *, cost: float = 0.0) -> None:
+    def __init__(
+        self, scores: dict[str, float], *, cost: float = 0.0, skip: frozenset[str] = frozenset()
+    ) -> None:
         self._scores = scores
         self._cost = cost
+        self._skip = skip
 
     def forward(
         self, candidates: Iterator[ERCandidate[CompanySchema]]
     ) -> Iterator[PairwiseJudgement]:
         for cand in candidates:
+            # ``skip`` yields NO judgement for those left ids, modelling a judge
+            # that produced no verdict for a candidate (the gold-only slice case).
+            if cand.left.id in self._skip:
+                continue
             yield PairwiseJudgement(
                 left_id=cand.left.id,
                 right_id=cand.right.id,
@@ -593,6 +601,121 @@ def test_evaluate_judge_on_candidates_ignores_gold_outside_candidates() -> None:
     # Only p0 is in scope; it is caught and n0 excluded -> perfect, ghost ignored.
     assert result.pair.recall == pytest.approx(1.0)
     assert result.pair.f1 == pytest.approx(1.0)
+
+
+# ---------------------------------------------------------------------------
+# evaluate_judge_on_candidates — honest fixed-threshold sliced aggregation
+# ---------------------------------------------------------------------------
+
+
+def _slice_candidates(
+    scores: dict[str, float], positives: set[str]
+) -> tuple[list[ERCandidate[CompanySchema]], set[frozenset[str]]]:
+    """Candidates keyed by left id (right id is ``r_<lid>``); gold = ``positives``."""
+    cands = [
+        ERCandidate(
+            left=CompanySchema(id=lid, name=lid),
+            right=CompanySchema(id=f"r_{lid}", name=lid),
+            blocker_name="test",
+        )
+        for lid in scores
+    ]
+    gold = {frozenset({lid, f"r_{lid}"}) for lid in positives}
+    return cands, gold
+
+
+def _tag_by_base_prefix(pair_key: frozenset[str]) -> str:
+    """Tag a ``{lid, r_<lid>}`` pair by the first char of its non-``r_`` id."""
+    base = next(i for i in pair_key if not i.startswith("r_"))
+    return base[0]
+
+
+def test_evaluate_judge_no_slice_fn_leaves_slices_none() -> None:
+    # Default (no slice_fn): slices stays None and the rest of the result is intact.
+    scores = {"p0": 0.9, "n0": 0.2}
+    cands, gold = _labeled_candidates(scores)
+    result, _ = benchmark_module.evaluate_judge_on_candidates(
+        _ScoreModule(scores), cands, gold, grid=(0.5,)
+    )
+    assert result.slices is None
+    assert result.pair.f1 == pytest.approx(1.0)
+
+
+def test_evaluate_judge_grades_slices_at_fixed_threshold_not_per_slice_argmax() -> None:
+    # Two slices A and B. The GLOBAL best-F1 threshold is 0.3 (ties break to the
+    # first grid entry). At that FIXED cut slice A scores F1=0.667 — but slice A's
+    # OWN argmax threshold (0.6, isolating its one true match) would score F1=1.0.
+    # An honest sliced eval must report 0.667 (the fixed cut), never the 1.0 an
+    # argmax would fake — that is exactly how a seen->unseen drop gets hidden.
+    scores = {"A_p": 0.9, "A_n": 0.5, "B_p": 0.4, "B_n": 0.35}
+    cands, gold = _slice_candidates(scores, positives={"A_p", "B_p"})
+    result, judgements = benchmark_module.evaluate_judge_on_candidates(
+        _ScoreModule(scores), cands, gold, grid=(0.3, 0.6), slice_fn=_tag_by_base_prefix
+    )
+
+    assert result.best_threshold == 0.3
+    assert result.slices is not None
+    assert set(result.slices) == {"A", "B"}
+
+    # Every slice is graded at the ONE global threshold: reconstruct via
+    # classify_pairs at result.best_threshold and it must match exactly.
+    for tag, track in result.slices.items():
+        tag_judged = [j for j in judgements if j.left_id.startswith(tag)]
+        tag_gold = {pk for pk in gold if _tag_by_base_prefix(pk) == tag}
+        expected = classify_pairs(tag_judged, tag_gold, result.best_threshold)
+        assert track.precision == pytest.approx(expected.precision)
+        assert track.recall == pytest.approx(expected.recall)
+        assert track.f1 == pytest.approx(expected.f1)
+        assert track.pr_curve is None  # a single fixed cut has no per-slice curve
+
+    # Proof it is NOT a per-slice argmax: slice A's own best threshold (0.6) beats
+    # its fixed-cut grade, so an argmax would have reported the higher number.
+    a_judged = [j for j in judgements if j.left_id.startswith("A")]
+    a_gold = {pk for pk in gold if _tag_by_base_prefix(pk) == "A"}
+    a_argmax_f1 = classify_pairs(a_judged, a_gold, 0.6).f1
+    assert a_argmax_f1 == pytest.approx(1.0)
+    assert a_argmax_f1 > result.slices["A"].f1
+
+
+def test_evaluate_judge_slice_fn_none_tag_excludes_pairs_from_every_slice() -> None:
+    # slice_fn returns None for X-prefixed pairs -> they land in no slice, even
+    # though X0 is a (high-scoring) gold pair that would form its own slice.
+    scores = {"A0": 0.9, "B0": 0.8, "X0": 0.9}
+    cands, gold = _slice_candidates(scores, positives={"A0", "B0", "X0"})
+
+    def slice_fn(pair_key: frozenset[str]) -> str | None:
+        tag = _tag_by_base_prefix(pair_key)
+        return None if tag == "X" else tag
+
+    result, _ = benchmark_module.evaluate_judge_on_candidates(
+        _ScoreModule(scores), cands, gold, grid=(0.5,), slice_fn=slice_fn
+    )
+    assert result.slices is not None
+    assert set(result.slices) == {"A", "B"}
+    assert None not in result.slices
+
+
+def test_evaluate_judge_gold_only_slice_reports_zero_recall_no_divide_by_zero() -> None:
+    # The judge produces NO verdict for G0 (skip), but G0 is a gold candidate, so
+    # its slice "G" holds a gold pair with zero judged pairs. Unioning the tag sets
+    # keeps slice G reporting recall=0 (a real miss) instead of vanishing — and
+    # classify_pairs over an empty predicted set must not divide by zero.
+    scores = {"S0": 0.9, "S1": 0.2, "G0": 0.9}
+    cands, gold = _slice_candidates(scores, positives={"S0", "G0"})
+    result, judgements = benchmark_module.evaluate_judge_on_candidates(
+        _ScoreModule(scores, skip=frozenset({"G0"})),
+        cands,
+        gold,
+        grid=(0.5,),
+        slice_fn=_tag_by_base_prefix,
+    )
+    assert not any(j.left_id == "G0" for j in judgements)  # G0 truly unjudged
+    assert result.slices is not None
+    assert set(result.slices) == {"S", "G"}
+    assert result.slices["G"].recall == 0.0
+    assert result.slices["G"].precision == 0.0
+    assert result.slices["G"].f1 == 0.0
+    assert result.slices["S"].f1 == pytest.approx(1.0)  # S0 caught, S1 below cut
 
 
 # ---------------------------------------------------------------------------

--- a/tests/data/test_wdc_computers.py
+++ b/tests/data/test_wdc_computers.py
@@ -2,11 +2,30 @@
 
 Runs the shared loader contract (``tests/data/_loader_contract.py``) against the
 factory-built ``WdcComputersBenchmark`` and checks the Wave D ``wdc_slice_map``
-seen/unseen tagging. Both are fast (CSV parse + partition; no embeddings).
+seen/unseen tagging. The third test wires the slice map through
+``evaluate_judge_on_candidates`` end-to-end (a rapidfuzz judge over the WDC test
+pairs) to prove the honest fixed-threshold sliced eval on real data. All are fast
+(CSV parse + rapidfuzz over titles; no embeddings).
 """
 
-from langres.data.wdc_computers import WdcComputersBenchmark, wdc_slice_map
+import logging
+
+import pytest
+
+from langres.core.benchmark import evaluate_judge_on_candidates
+from langres.core.metrics import classify_pairs
+from langres.core.models import ERCandidate
+from langres.core.modules.rapidfuzz import RapidfuzzModule
+from langres.data.wdc_computers import (
+    WdcComputersBenchmark,
+    WdcComputersSchema,
+    load_wdc_computers,
+    load_wdc_computers_pair_splits,
+    wdc_slice_map,
+)
 from tests.data._loader_contract import assert_loader_contract
+
+logger = logging.getLogger(__name__)
 
 #: Pinned as evidence (see ``datasets/wdc_computers/ATTRIBUTION.md``): 2204 tableA
 #: + 2443 tableB records, and 1111 transitive-closure within-cluster gold pairs
@@ -37,3 +56,65 @@ def test_wdc_slice_map_tags_test_pairs_seen_and_unseen() -> None:
     present = set(tags.values())
     assert "seen" in present, "no fully-seen test pairs (Wave D needs both endpoints)"
     assert "unseen" in present, "no fully-unseen test pairs (Wave D needs both endpoints)"
+
+
+def test_wdc_sliced_judge_eval_grades_every_slice_at_one_fixed_threshold() -> None:
+    """End-to-end honest seen->unseen eval: one judge, one threshold, many slices.
+
+    Builds candidates from WDC's labelled TEST pairs, judges them with an offline
+    rapidfuzz module over ``title``, and evaluates with a ``slice_fn`` closed over
+    ``wdc_slice_map("test")``. The mechanism is the assertion: the single global
+    best-F1 threshold is chosen once, then every slice (seen / half_seen / unseen)
+    is graded at that SAME cut — reconstructed exactly via ``classify_pairs`` at
+    ``result.best_threshold``. The observed per-slice F1s are reported (not forced
+    into a fixed inequality: WDC is title-only and noisy).
+    """
+    corpus, _gold_clusters, _gold_pairs = load_wdc_computers()
+    by_id: dict[str, WdcComputersSchema] = {r.id: r for r in corpus}
+    test_pairs = load_wdc_computers_pair_splits()["test"]
+
+    candidates: list[ERCandidate[WdcComputersSchema]] = [
+        ERCandidate(left=by_id[left], right=by_id[right], blocker_name="wdc_test_pairs")
+        for (left, right, _label) in test_pairs
+    ]
+    gold_pairs = {frozenset({left, right}) for (left, right, label) in test_pairs if label == 1}
+
+    judge: RapidfuzzModule[WdcComputersSchema] = RapidfuzzModule(
+        field_extractors={"title": (lambda r: r.title, 1.0)},
+        algorithm="token_set_ratio",
+    )
+    slice_map = wdc_slice_map("test")
+
+    def slice_fn(pair_key: frozenset[str]) -> str | None:
+        return slice_map.get(pair_key)
+
+    grid = tuple(round(0.05 * i, 2) for i in range(21))  # 0.00 .. 1.00 step 0.05
+    result, judgements = evaluate_judge_on_candidates(
+        judge, candidates, gold_pairs, grid, slice_fn=slice_fn
+    )
+
+    assert result.slices is not None
+    assert set(result.slices) <= {"seen", "half_seen", "unseen"}
+    assert len(result.slices) >= 2, "expected at least two distinct slices"
+
+    # Mechanism: every slice is graded at the ONE global threshold. Reconstruct
+    # each slice's track via classify_pairs at result.best_threshold and require
+    # an exact match — a per-slice argmax would diverge here.
+    candidate_pairs = {frozenset({c.left.id, c.right.id}) for c in candidates}
+    gold_in_scope = gold_pairs & candidate_pairs
+    for tag, track in result.slices.items():
+        tag_judged = [
+            j for j in judgements if slice_map.get(frozenset({j.left_id, j.right_id})) == tag
+        ]
+        tag_gold = {pk for pk in gold_in_scope if slice_map.get(pk) == tag}
+        expected = classify_pairs(tag_judged, tag_gold, result.best_threshold)
+        assert track.precision == pytest.approx(expected.precision)
+        assert track.recall == pytest.approx(expected.recall)
+        assert track.f1 == pytest.approx(expected.f1)
+        assert track.pr_curve is None
+
+    # Report the observed seen/half_seen/unseen F1 at the fixed threshold. The
+    # slices are genuinely distinct (not one number copied across tags).
+    observed = {tag: round(t.f1, 4) for tag, t in result.slices.items()}
+    logger.info("WDC test sliced F1 @ fixed threshold %.2f: %s", result.best_threshold, observed)
+    assert result.slices["seen"] != result.slices["unseen"]


### PR DESCRIPTION
Adds honest per-slice judge reporting to the eval harness: grade the **same** judge at **one** global threshold across data slices (e.g. seen/unseen entities) to see where it degrades — the instrument the training-gated seen→unseen experiment needs. Part of `feat/eval-readiness` — merges into the integration branch, not `main`.

## What's here (only `src/langres/core/benchmark.py` + its tests)
- `evaluate_judge_on_candidates(..., slice_fn: Callable[[frozenset[str]], str | None] | None = None)` — keyword-only, opt-in.
- `JudgePairEval.slices: dict[str, PairTrack] | None = None`.
- `_grade_slices` helper: choose the **one** global best-F1 threshold as before, then grade **every slice at that same fixed cut** via `classify_pairs` (union of judged-tag + gold-tag sets so a gold-only slice still reports recall; `None` tags excluded).
- **No `ERCandidate` / `FixedSplitPairBenchmark` change** — slices stay external, the caller supplies `slice_fn` (e.g. closing over `wdc_computers.wdc_slice_map`).

## The load-bearing honesty rule
One global best-F1 threshold, chosen once; every slice graded at that **fixed** cut — never a per-slice argmax (which would fake away any drop). A dedicated test proves it: a slice whose own argmax F1 would be 1.0 (at t=0.6) is instead correctly graded 0.667 at the global threshold.

## Honest WDC demo result (un-gamed)
At the global best threshold 0.45, the rapidfuzz-over-title judge scores seen F1 **0.43**, half_seen **0.42**, unseen **0.53** — i.e. *no* seen→unseen drop. That's correct: rapidfuzz is a string matcher that never sees the train split, so "seen vs unseen" is noise to it. The drop only appears for a **trained** judge — which is what this instrument unlocks. The test asserts the mechanism (distinct slices reconstructed exactly at one shared threshold), not a forced inequality.

## Verification
mypy `--strict` clean · ruff clean · `core/benchmark.py` **100%** coverage (263 stmts / 46 branches, 0 missed — 95–100% core tier) · 44 tests pass (`tests/core/test_benchmark.py` + `tests/data/test_wdc_computers.py`, fast subset).