### PR TITLE
test(data): wire 4 datasets + OpenSanctions into registry + honest-constants regression tests (Wave C finalize)

### DIFF
--- a/src/langres/data/registry.py
+++ b/src/langres/data/registry.py
@@ -249,3 +249,68 @@ register(
         loader_symbol="TinyFixtureBenchmark",
     )
 )
+
+# ---------------------------------------------------------------------------
+# Wave C/D: the four DeepMatcher-style loaders (bibliographic + product) plus
+# the external-only OpenSanctions entry (loadable=False; never vendored because
+# CC-BY-NC is incompatible with langres's Apache-2.0 license). Its fetch_hint
+# points at the source data + the published matcher baselines.
+# ---------------------------------------------------------------------------
+
+register(
+    BenchmarkEntry(
+        name="dblp_acm",
+        task="linkage",
+        domain="bibliographic",
+        loadable=True,
+        module_path="langres.data.dblp_acm",
+        loader_symbol="DblpAcmBenchmark",
+    )
+)
+register(
+    BenchmarkEntry(
+        name="dblp_scholar",
+        task="linkage",
+        domain="bibliographic",
+        loadable=True,
+        module_path="langres.data.dblp_scholar",
+        loader_symbol="DblpScholarBenchmark",
+    )
+)
+register(
+    BenchmarkEntry(
+        name="walmart_amazon",
+        task="linkage",
+        domain="product",
+        loadable=True,
+        module_path="langres.data.walmart_amazon",
+        loader_symbol="WalmartAmazonBenchmark",
+    )
+)
+register(
+    BenchmarkEntry(
+        name="wdc_computers",
+        task="linkage",
+        domain="product",
+        loadable=True,
+        module_path="langres.data.wdc_computers",
+        loader_symbol="WdcComputersBenchmark",
+    )
+)
+register(
+    BenchmarkEntry(
+        name="opensanctions",
+        task="linkage",
+        domain="person/org",
+        loadable=False,
+        module_path="",
+        loader_symbol="",
+        fetch_hint=(
+            "OpenSanctions is CC-BY-NC 4.0 — incompatible with langres's Apache-2.0 "
+            "license, so it is never vendored. Fetch the entity-matching data from "
+            "https://www.opensanctions.org/docs/ and compare against the published "
+            "matcher baselines (rule-based F1 91.33, GPT-4o 98.95, "
+            "DeepSeek-R1-Distill-14B 98.23, Llama-3.1-8B 95.94)."
+        ),
+    )
+)

--- a/tests/data/test_dblp_acm.py
+++ b/tests/data/test_dblp_acm.py
@@ -8,7 +8,16 @@ blocking / Pair-Completeness measurement lives in the pinned constants (measured
 once, recorded in ``langres.data.dblp_acm``), not in this per-PR test.
 """
 
-from langres.data.dblp_acm import DblpAcmBenchmark
+import pytest
+
+from langres.data import _benchmark_utils as _bu
+from langres.data.dblp_acm import (
+    DBLP_ACM_ACHIEVED_PC,
+    DBLP_ACM_BLOCKING_K,
+    DblpAcmBenchmark,
+    DblpAcmSchema,
+    load_dblp_acm,
+)
 from tests.data._loader_contract import assert_loader_contract
 
 #: Vendored counts (see ``src/langres/data/datasets/dblp_acm/ATTRIBUTION.md``):
@@ -23,3 +32,23 @@ def test_dblp_acm_satisfies_the_loader_contract() -> None:
         expected_corpus_size=_N_CORPUS,
         expected_gold_pairs=_N_GOLD_PAIRS,
     )
+
+
+@pytest.mark.slow
+def test_sweep_blocking_k_pins_documented_pair_completeness() -> None:
+    """Re-measure blocking Pair-Completeness at the pinned k, guarding the constant.
+
+    Mirrors ``test_amazon_google.py``: runs the real embedding sweep at
+    ``DBLP_ACM_BLOCKING_K`` and asserts the live cross-source PC matches the
+    pinned ``DBLP_ACM_ACHIEVED_PC`` within tolerance. Slow (loads MiniLM +
+    embeds the corpus) → weekly ``test-full`` only, zero per-PR cost.
+    """
+    corpus, gold_clusters, _pairs = load_dblp_acm()
+    recalls = _bu.sweep_blocking_k(
+        corpus,
+        gold_clusters,
+        DblpAcmSchema,
+        text_field="embed_text",
+        ks=(DBLP_ACM_BLOCKING_K,),
+    )
+    assert recalls[DBLP_ACM_BLOCKING_K] == pytest.approx(DBLP_ACM_ACHIEVED_PC, abs=5e-3)

--- a/tests/data/test_dblp_scholar.py
+++ b/tests/data/test_dblp_scholar.py
@@ -13,7 +13,16 @@ benchmark is many-to-many, so ``Benchmark.load`` re-derives more pairs than the
 raw split positives). See ``datasets/dblp_scholar/ATTRIBUTION.md``.
 """
 
-from langres.data.dblp_scholar import DblpScholarBenchmark
+import pytest
+
+from langres.data import _benchmark_utils as _bu
+from langres.data.dblp_scholar import (
+    DBLP_SCHOLAR_ACHIEVED_PC,
+    DBLP_SCHOLAR_BLOCKING_K,
+    DblpScholarBenchmark,
+    DblpScholarSchema,
+    load_dblp_scholar,
+)
 from tests.data._loader_contract import assert_loader_contract
 
 _N_CORPUS = 66879
@@ -26,3 +35,29 @@ def test_dblp_scholar_satisfies_the_loader_contract() -> None:
         expected_corpus_size=_N_CORPUS,
         expected_gold_pairs=_N_GOLD_PAIRS,
     )
+
+
+@pytest.mark.slow
+def test_sweep_blocking_k_pins_documented_pair_completeness() -> None:
+    """Re-measure blocking Pair-Completeness at the pinned k, guarding the constant.
+
+    Mirrors ``test_amazon_google.py`` but asserts only the SINGLE pinned
+    ``DBLP_SCHOLAR_BLOCKING_K`` point — embedding the full 66879-record corpus is
+    expensive, so this sweeps one k rather than the full grid. The pinned PC is an
+    honest 0.3945 (capped near the ~0.3977 many-to-many artifact ceiling; the low
+    number is a metric-definition ceiling, not a blocking failure — see the loader
+    module). Slow → weekly ``test-full`` only.
+
+    macOS local run: prefix with ``OMP_NUM_THREADS=1 KMP_DUPLICATE_LIB_OK=1``
+    (or ``uv run --env-file .env pytest``) to avoid the libomp duplicate-runtime
+    abort documented in ``docs/FRICTION_LOG.md``.
+    """
+    corpus, gold_clusters, _pairs = load_dblp_scholar()
+    recalls = _bu.sweep_blocking_k(
+        corpus,
+        gold_clusters,
+        DblpScholarSchema,
+        text_field="embed_text",
+        ks=(DBLP_SCHOLAR_BLOCKING_K,),
+    )
+    assert recalls[DBLP_SCHOLAR_BLOCKING_K] == pytest.approx(DBLP_SCHOLAR_ACHIEVED_PC, abs=5e-3)

--- a/tests/data/test_registry.py
+++ b/tests/data/test_registry.py
@@ -17,8 +17,23 @@ from langres.data.registry import (
     register,
 )
 
-#: The four vendored benchmarks + the tiny fixture that this wave registers.
-_EXPECTED_NAMES = {"abt_buy", "amazon_google", "febrl_person", "fodors_zagat", "tiny_fixture"}
+#: Every benchmark that ships loadable in-repo data: the five originals (Wave B)
+#: plus the four DeepMatcher loaders wired in by Wave C/D.
+_LOADABLE_NAMES = {
+    "abt_buy",
+    "amazon_google",
+    "dblp_acm",
+    "dblp_scholar",
+    "febrl_person",
+    "fodors_zagat",
+    "tiny_fixture",
+    "walmart_amazon",
+    "wdc_computers",
+}
+#: External-only entries (loadable=False; fetched manually, never vendored).
+_EXTERNAL_NAMES = {"opensanctions"}
+#: The full manifest = loadable + external-only.
+_EXPECTED_NAMES = _LOADABLE_NAMES | _EXTERNAL_NAMES
 
 
 # --- list_benchmarks: metadata only ---------------------------------------------
@@ -27,8 +42,11 @@ _EXPECTED_NAMES = {"abt_buy", "amazon_google", "febrl_person", "fodors_zagat", "
 def test_list_benchmarks_returns_every_registered_entry() -> None:
     entries = list_benchmarks()
     assert {e.name for e in entries} == _EXPECTED_NAMES
-    # All five ship in-repo this wave.
-    assert all(e.loadable for e in entries)
+    # Loadable flags: every in-repo dataset is loadable; the external-only entry
+    # (OpenSanctions) is not.
+    by_name = {e.name: e for e in entries}
+    assert {n for n, e in by_name.items() if e.loadable} == _LOADABLE_NAMES
+    assert {n for n, e in by_name.items() if not e.loadable} == _EXTERNAL_NAMES
     # Name-sorted for determinism.
     assert [e.name for e in entries] == sorted(e.name for e in entries)
 
@@ -41,8 +59,14 @@ def test_benchmark_entries_carry_correct_metadata() -> None:
     assert by_name["amazon_google"].loader_symbol == "AmazonGoogleBenchmark"
     assert by_name["febrl_person"].domain == "person"
     assert by_name["fodors_zagat"].domain == "restaurant"
-    # No loadable entry carries a fetch hint (that's the external-only seam).
-    assert all(e.fetch_hint is None for e in list_benchmarks())
+    # The Wave C/D loaders carry their own task/domain metadata.
+    assert by_name["dblp_acm"].domain == "bibliographic"
+    assert by_name["dblp_scholar"].loader_symbol == "DblpScholarBenchmark"
+    assert by_name["walmart_amazon"].module_path == "langres.data.walmart_amazon"
+    assert by_name["wdc_computers"].domain == "product"
+    # No loadable entry carries a fetch hint; only the external-only seam does.
+    assert all(e.fetch_hint is None for e in list_benchmarks() if e.loadable)
+    assert by_name["opensanctions"].fetch_hint is not None
 
 
 # --- list_methods ---------------------------------------------------------------
@@ -72,6 +96,29 @@ def test_get_benchmark_instantiates_existing_class_entries() -> None:
     benchmark = get_benchmark("fodors_zagat")
     assert isinstance(benchmark, Benchmark)
     assert benchmark.name == "fodors_zagat"
+
+
+@pytest.mark.parametrize("name", ["dblp_acm", "dblp_scholar", "walmart_amazon", "wdc_computers"])
+def test_get_benchmark_resolves_the_new_wave_c_loaders(name: str) -> None:
+    """Each new loadable entry imports + instantiates to a ``Benchmark``.
+
+    Only imports the loader module and builds the (cheap) benchmark instance —
+    it deliberately does NOT call ``.load()`` (DBLP-Scholar is a 66879-record,
+    ~8MB corpus). The per-dataset contract tests already exercise ``.load()``.
+    """
+    benchmark = get_benchmark(name)
+    assert isinstance(benchmark, Benchmark)
+    assert benchmark.name == name
+    assert callable(benchmark.load)  # present, but intentionally not invoked here.
+
+
+def test_get_benchmark_opensanctions_is_external_only() -> None:
+    """The registered ``loadable=False`` OpenSanctions entry raises with its hint."""
+    with pytest.raises(ExternalBenchmarkError) as exc:
+        get_benchmark("opensanctions")
+    message = str(exc.value)
+    assert "external-only" in message
+    assert "opensanctions.org" in message  # the fetch hint is surfaced
 
 
 def test_unknown_name_raises_with_did_you_mean() -> None:

--- a/tests/data/test_walmart_amazon.py
+++ b/tests/data/test_walmart_amazon.py
@@ -7,7 +7,16 @@ counts, no embeddings); the honest blocking k-sweep is measured out-of-band via
 ``tmp/measure_walmart_amazon_blocking.py`` and pinned in the loader module.
 """
 
-from langres.data.walmart_amazon import WalmartAmazonBenchmark
+import pytest
+
+from langres.data import _benchmark_utils as _bu
+from langres.data.walmart_amazon import (
+    WALMART_AMAZON_ACHIEVED_PC,
+    WALMART_AMAZON_BLOCKING_K,
+    WalmartAmazonBenchmark,
+    WalmartAmazonSchema,
+    load_walmart_amazon,
+)
 from tests.data._loader_contract import assert_loader_contract
 
 #: Vendored corpus size (2554 Walmart + 22074 Amazon) — see ATTRIBUTION.md.
@@ -24,3 +33,24 @@ def test_walmart_amazon_satisfies_the_loader_contract() -> None:
         expected_corpus_size=_N_CORPUS,
         expected_gold_pairs=_N_GOLD_PAIRS,
     )
+
+
+@pytest.mark.slow
+def test_sweep_blocking_k_pins_documented_pair_completeness() -> None:
+    """Re-measure blocking Pair-Completeness at the pinned k, guarding the constant.
+
+    Mirrors ``test_amazon_google.py``: runs the real embedding sweep at
+    ``WALMART_AMAZON_BLOCKING_K`` and asserts the live cross-source PC matches the
+    pinned ``WALMART_AMAZON_ACHIEVED_PC`` (an honest sub-gate 0.8773) within
+    tolerance. Slow (loads MiniLM + embeds the 24628-record corpus) → weekly
+    ``test-full`` only, zero per-PR cost.
+    """
+    corpus, gold_clusters, _pairs = load_walmart_amazon()
+    recalls = _bu.sweep_blocking_k(
+        corpus,
+        gold_clusters,
+        WalmartAmazonSchema,
+        text_field="embed_text",
+        ks=(WALMART_AMAZON_BLOCKING_K,),
+    )
+    assert recalls[WALMART_AMAZON_BLOCKING_K] == pytest.approx(WALMART_AMAZON_ACHIEVED_PC, abs=5e-3)

--- a/tests/data/test_wdc_computers.py
+++ b/tests/data/test_wdc_computers.py
@@ -5,7 +5,17 @@ factory-built ``WdcComputersBenchmark`` and checks the Wave D ``wdc_slice_map``
 seen/unseen tagging. Both are fast (CSV parse + partition; no embeddings).
 """
 
-from langres.data.wdc_computers import WdcComputersBenchmark, wdc_slice_map
+import pytest
+
+from langres.data import _benchmark_utils as _bu
+from langres.data.wdc_computers import (
+    WDC_COMPUTERS_ACHIEVED_PC,
+    WDC_COMPUTERS_BLOCKING_K,
+    WdcComputersBenchmark,
+    WdcComputersSchema,
+    load_wdc_computers,
+    wdc_slice_map,
+)
 from tests.data._loader_contract import assert_loader_contract
 
 #: Pinned as evidence (see ``datasets/wdc_computers/ATTRIBUTION.md``): 2204 tableA
@@ -37,3 +47,24 @@ def test_wdc_slice_map_tags_test_pairs_seen_and_unseen() -> None:
     present = set(tags.values())
     assert "seen" in present, "no fully-seen test pairs (Wave D needs both endpoints)"
     assert "unseen" in present, "no fully-unseen test pairs (Wave D needs both endpoints)"
+
+
+@pytest.mark.slow
+def test_sweep_blocking_k_pins_documented_pair_completeness() -> None:
+    """Re-measure blocking Pair-Completeness at the pinned k, guarding the constant.
+
+    Mirrors ``test_amazon_google.py``: runs the real embedding sweep at
+    ``WDC_COMPUTERS_BLOCKING_K`` and asserts the live cross-source PC matches the
+    pinned ``WDC_COMPUTERS_ACHIEVED_PC`` (an honest sub-gate 0.7237 — title-only
+    text is hard) within tolerance. Slow (loads MiniLM + embeds the corpus) →
+    weekly ``test-full`` only, zero per-PR cost.
+    """
+    corpus, gold_clusters, _pairs = load_wdc_computers()
+    recalls = _bu.sweep_blocking_k(
+        corpus,
+        gold_clusters,
+        WdcComputersSchema,
+        text_field="embed_text",
+        ks=(WDC_COMPUTERS_BLOCKING_K,),
+    )
+    assert recalls[WDC_COMPUTERS_BLOCKING_K] == pytest.approx(WDC_COMPUTERS_ACHIEVED_PC, abs=5e-3)


### PR DESCRIPTION
Finalizes the Wave C loader portfolio: central registry wiring + a registry smoke test + the `@pytest.mark.slow` PC-regression tests the #92 review warranted. Part of `feat/eval-readiness` — merges into the integration branch, not `main`.

## What's here
- **`registry.py`** — 5 `register(BenchmarkEntry(...))` entries: the 4 new loadable loaders (dblp_acm, dblp_scholar, walmart_amazon, wdc_computers) + **opensanctions** (`loadable=False`, with the CC-BY-NC fetch hint + published matcher baselines). `list_benchmarks()` now surfaces 10 benchmarks (9 loadable + 1 external).
- **`tests/data/test_registry.py`** — asserts the new names + loadable flags, `get_benchmark("<x>")` returns each loadable Benchmark, and `get_benchmark("opensanctions")` raises `ExternalBenchmarkError` with the fetch hint. Import-light subprocess test stays green.
- **4 × `@pytest.mark.slow` PC-regression tests** (one per new loader) — re-run `sweep_blocking_k` and assert live PC ≈ the pinned `achieved_pc` within 5e-3 (mirrors amazon_google's pattern). Weekly `test-full` only → zero per-PR cost. dblp_acm (k=5→0.991) and wdc (k=50→0.724) verified live; walmart/scholar assert a single k=50 point (large corpora), scholar with the documented macOS libomp remedy.

## Verification
mypy `src` clean (89 files, CI parity) · ruff clean · `pytest tests/data/test_registry.py tests/test_import_budget.py -m "not slow and not integration"` = 37 passed / 4 skipped · slow tests collect. (Pre-existing mypy call-arg notes on `tests/` `<X>Benchmark()` instantiations are out of scope — CI mypy targets `src` only.)