### PR TITLE
feat(dx): evaluate() one-liner + registry-driven portfolio race + benchmark docs (Wave E / eval-readiness)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -67,6 +67,7 @@ langres/
 │   ├── methods.py      # method registry / _make_module_builder (benchmark path)
 │   ├── clients/        # OpenRouter client, SpendMonitor, pricing
 │   └── data/           # benchmark dataset loaders (FZ, Amazon-Google, ...)
+│       └── registry.py # name→benchmark manifest: list_benchmarks() / get_benchmark()
 ├── tests/              # Test suite
 ├── examples/           # Usage examples (quickstart_verbs.py is the offline quickstart)
 └── docs/               # Documentation
@@ -115,4 +116,5 @@ The `.agent/` folder contains external expert analyses of the langres project:
 - **`docs/USE_CASES.md`** — use-case taxonomy and roadmap (V1 / V1.1 / out-of-scope; streaming, temporal, collective resolution).
 - **`docs/DX_RESOLVER.md`** — before/after of the M0 `Resolver`: the manual lambda pipeline vs. the declarative `from_schema` + `save`/`load` path.
 - **`docs/EXPERIMENTS.md`** — experimentation DX getting-started: the `run_methods` full-pipeline race vs. `evaluate_judge_on_candidates` (judged-once) for compiled/paid judges; `derive_threshold` to kill magic constants; the `SpendMonitor` budget seam.
+- **`docs/BENCHMARKS.md`** — the benchmark portfolio (each dataset + why it's a target + caveats), the `data/registry` discoverability seam (`list_benchmarks` / `get_benchmark`, the `portfolio_race` example), and the `evaluate()` bring-your-own-data pair-scoring walkthrough.
 - **`docs/CHANGELOG.md`** — project progress; completed POC milestones.

--- a/docs/BENCHMARKS.md
+++ b/docs/BENCHMARKS.md
@@ -1,0 +1,146 @@
+# The benchmark portfolio (and scoring your own data)
+
+langres ships a **portfolio** of entity-resolution datasets behind one
+discoverable, serializable registry, plus a one-liner to score **your own**
+labeled pairs with the same honest pair-level metrics. This doc covers both:
+
+1. [Discover + race the portfolio](#1-discover-and-race-the-portfolio) — the
+   `data/registry` manifest and the `portfolio_race` example.
+2. [The datasets, and why each is a target](#2-the-datasets-and-why-each-is-a-target).
+3. [Score your own data](#3-score-your-own-data) — `evaluate(judge, candidates,
+   gold_pairs)`.
+
+---
+
+## 1. Discover and race the portfolio
+
+The datasets live behind a static, import-light manifest in
+`langres.data.registry` — a **name → benchmark** map you can list without
+importing any loader (so it is safe in a core-only install and never pulls the
+`[semantic]` stack into `sys.modules`):
+
+```python
+from langres.data.registry import list_benchmarks, get_benchmark
+
+for entry in list_benchmarks():           # metadata only, no dataset load
+    print(entry.name, entry.task, entry.domain, "loadable" if entry.loadable else "external")
+
+bench = get_benchmark("dblp_acm")         # imports ONLY the selected loader, lazily
+```
+
+`get_benchmark(name)` returns a ready benchmark conforming to
+`langres.core.benchmark.Benchmark` (and the `langres.methods.BlockingBenchmark`
+contract), so it drops straight into the race harness. A non-loadable entry
+(`opensanctions`, below) raises a clear external-only error instead of a broken
+load.
+
+**Race the whole portfolio** with the offline, zero-spend methods via
+[`examples/research/portfolio_race.py`](../examples/research/portfolio_race.py) —
+it iterates the registry so a newly-registered dataset appears automatically,
+with no edit to the script:
+
+```bash
+uv run python examples/research/portfolio_race.py           # full portfolio
+uv run python examples/research/portfolio_race.py --fast     # FZ + DBLP-ACM only
+uv run python examples/research/portfolio_race.py --fast --paid --budget 5   # + a capped LLM row
+```
+
+> **What the registry actually buys you — honestly.** `run_methods` already
+> collapsed the per-method racing boilerplate into one call; the registry adds the
+> missing half — **name → benchmark discoverability** and a serializable manifest
+> — replacing the scattered, hand-maintained `_BENCHMARKS = (FodorsZagatBenchmark(),
+> …)` tuples each race script used to carry. The `--paid` LLM row is graded
+> **judged-once** (via `evaluate_judge_on_candidates` under a `BudgetedModuleRunner`
+> + one `SpendMonitor`), never through `run_methods` — see the KISS warning in
+> [`docs/EXPERIMENTS.md`](EXPERIMENTS.md) about re-judging a paid judge per grid
+> threshold.
+
+---
+
+## 2. The datasets, and why each is a target
+
+Every entry is a **cross-source linkage** benchmark (find the pairs across two
+sources that refer to the same entity). All ship in-repo (`loadable=True`) except
+OpenSanctions.
+
+| Benchmark | Domain | Why it's in the portfolio |
+| --- | --- | --- |
+| `fodors_zagat` | restaurant | **Saturated regression guard.** Tiny, easy, blocking Pair-Completeness ≥ 0.99 — the "nothing should ever regress here" floor. |
+| `abt_buy` | product | **Product regression guard.** Short, noisy product titles; a standard DeepMatcher band to hold the line against. |
+| `amazon_google` | product | **Hard product guard.** Unsaturated — blocking PC ~0.84 caps recall, so it separates weak from strong scorers (used as the discrimination check). |
+| `dblp_acm` | bibliographic | **Clean, 1:1, gate-passing.** High-quality bibliographic records; blocking PC saturates early. The "does the honest pipeline pass a clean gate" check. |
+| `dblp_scholar` | bibliographic | **Many-to-many bibliographic.** Match graph has clusters > 2 records. **Caveat:** ~60% of gold pairs are *intra-source*, so the cross-source blocking PC reads ~0.39 — a many-to-many closure artifact, **not** a blocking failure (true cross-source recall is ~0.99). Read the loader header before concluding "blocking is bad". |
+| `walmart_amazon` | product | **Harder product.** Long, structured product records; blocking honestly *misses* — highest measured PC ~0.877 (gate not met), recorded in `WALMART_AMAZON_ACHIEVED_PC`. A dataset where the ceiling is a real, documented shortfall. |
+| `wdc_computers` | product | **Title-only, textually hard** — each record is one noisy free-text `title` blob (specs + brand + multilingual retailer fragments). Also exposes a derived **seen/unseen slice** (`wdc_slice_map`) to demonstrate the honest seen → unseen F1 drop at a fixed threshold. |
+| `febrl_person` | person | **Synthetic person set (FEBRL4).** A *second entity type* (not a product/bibliographic record) — the generality check that the pipeline isn't product-shaped. |
+| `opensanctions` | person/org | **External baseline only — not bundled.** CC-BY-NC 4.0 is incompatible with langres's Apache-2.0 license, so it is never vendored; `get_benchmark` raises `ExternalBenchmarkError` pointing at where to fetch it and the published matcher F1 baselines. |
+
+---
+
+## 3. Score your own data
+
+Have your own records plus some labeled `(id_a, id_b, match?)` pairs? Score any
+judge over them at honest pair-level Precision/Recall/F1 with the one-liner
+`evaluate(judge, candidates, gold_pairs)` (`langres.core.benchmark`). It grades
+the judge at the best-F1 threshold over a grid and returns a `JudgePairEval` — no
+blocking-recall ceiling, no clustering amplification, so the number is directly
+comparable to pairwise-F1 SOTA.
+
+The reusable bridge from raw `(id_a, id_b, label)` rows to scored candidates is
+`FixedSplitPairBenchmark.from_loaders` (`langres.data.fixed_split_pair_benchmark`):
+give it your schema and two loaders, and `build(split)` returns the
+`ERCandidate`s (each carrying a comparison vector) and the gold pair set.
+
+```python
+from pydantic import BaseModel
+
+from langres.core.benchmark import evaluate
+from langres.core.judges.weighted_average import WeightedAverageJudge
+from langres.data.fixed_split_pair_benchmark import FixedSplitPairBenchmark
+
+
+class Product(BaseModel):
+    id: str
+    title: str | None = None
+    brand: str | None = None
+
+
+# Your data: a corpus of records + labeled pairs (1 = match, 0 = non-match).
+records = [Product(id="a1", title="Canon EOS 80D"), Product(id="b1", title="canon eos 80d dslr"), ...]
+labeled_pairs = [("a1", "b1", 1), ("a1", "b2", 0), ...]
+
+bench = FixedSplitPairBenchmark.from_loaders(
+    name="my_products",
+    schema=Product,
+    corpus_loader=lambda: (records, None, None),   # only element 0 (the corpus) is used
+    pair_split_loader=lambda: {"test": labeled_pairs},
+)
+data = bench.build("test")                          # candidates (comparison attached) + gold
+
+# Any Module works as the judge; WeightedAverageJudge scores the attached
+# comparison vector using the auto-derived StringComparator's features.
+judge = WeightedAverageJudge(feature_specs=bench.feature_specs)
+
+result = evaluate(judge, data.candidates, data.gold)
+print(result.pair.precision, result.pair.recall, result.pair.f1, result.best_threshold)
+```
+
+Swap the judge for anything else — an `EmbeddingScoreJudge`, an `LLMJudge`, a
+fitted `RandomForestJudge` — and the call is identical. For a **paid or compiled**
+judge that needs a spend cap or the raw judgements back, call the fuller
+`evaluate_judge_on_candidates` directly (pass a `BudgetedModuleRunner` via
+`runner=`); `evaluate()` is the thin, common-case one-liner over it. To reflect a
+seen → unseen split, pass `slice_fn=` — every slice is graded at the one global
+best-F1 threshold (never a per-slice argmax).
+
+---
+
+## See also
+
+- [`docs/EXPERIMENTS.md`](EXPERIMENTS.md) — the two measurement surfaces
+  (`run_methods` vs. `evaluate_judge_on_candidates`), the DSPy loop, calibration,
+  and the `SpendMonitor` budget seam.
+- [`docs/TUTORIAL_YOUR_OWN_CSV.md`](TUTORIAL_YOUR_OWN_CSV.md) — the *clustering*
+  counterpart: a messy CSV → entity clusters via `dedupe`, at $0.
+- [`examples/research/portfolio_race.py`](../examples/research/portfolio_race.py)
+  — the registry-driven race this doc describes.

--- a/docs/EXPERIMENTS.md
+++ b/docs/EXPERIMENTS.md
@@ -61,6 +61,14 @@ print(result.pair.f1, result.pair.precision, result.pair.recall, result.best_thr
   experimentation surface** and the SOTA-comparable precision measurement. For a
   paid judge, pass a `BudgetedModuleRunner` via `runner=` to hard-cap spend.
 
+> **One-liner for the common case.** When you just want honest pair-level P/R/F1
+> for a judge over a fixed candidate set — no spend cap, no raw judgements back —
+> `evaluate(judge, candidates, gold_pairs)` (`langres.core.benchmark`) is the thin
+> wrapper over `evaluate_judge_on_candidates` that returns only the `JudgePairEval`
+> (default grid `DEFAULT_PAIR_GRID`; `slice_fn=` forwarded). See
+> [`docs/BENCHMARKS.md`](BENCHMARKS.md#3-score-your-own-data) for the
+> bring-your-own-data walkthrough.
+
 > **KISS warning — do NOT race a compiled/paid LLM judge through `run_methods`.**
 > `run_methods`/`run_method` call the resolver factory *per grid threshold* and
 > **rebuild the module uncompiled, then re-judge every time**. For a compiled DSPy
@@ -286,6 +294,11 @@ with `examples/data/flywheel/generate_fixtures.py`.
 
 ## See also
 
+- [`docs/BENCHMARKS.md`](BENCHMARKS.md) — the benchmark portfolio + registry
+  (`list_benchmarks` / `get_benchmark`), and the `evaluate()` bring-your-own-data
+  scoring walkthrough.
+- `examples/research/portfolio_race.py` — registry-driven race over every loadable
+  benchmark (offline by default; optional capped LLM row).
 - `examples/research/m4_experiment_loop.py` — the runnable zero-spend loop documented here.
 - `examples/research/m4_dspy_judge.py` — DSPyJudge compile + save/load round-trip.
 - `examples/research/m4_calibration.py` — honest held-out `derive_threshold` lift on AG.

--- a/examples/research/portfolio_race.py
+++ b/examples/research/portfolio_race.py
@@ -158,10 +158,13 @@ def race_paid_llm(
     For each benchmark the test split is blocked once into a fixed candidate set,
     then an ``LLMJudge`` is graded pairwise via
     :func:`~langres.core.benchmark.evaluate_judge_on_candidates` under a
-    :class:`~langres.core.benchmark.BudgetedModuleRunner` pre-flight cap sized by
-    the remaining budget. A single :class:`SpendMonitor` meters cumulative spend and
-    raises before the cap is crossed. Judged **once** (never via ``run_methods``) so
-    a paid judge is not re-charged per grid threshold.
+    :class:`~langres.core.benchmark.BudgetedModuleRunner` whose hard cap is the
+    budget *still remaining* (never a fresh floored allowance), so cumulative spend
+    across datasets cannot exceed ``budget_usd``. A single :class:`SpendMonitor`
+    meters that cumulative spend; once too little is left to fund even one
+    worst-case pair the loop stops early, keeping the rows already collected. Judged
+    **once** (never via ``run_methods``) so a paid judge is not re-charged per grid
+    threshold.
 
     Args:
         names: Loadable benchmark names to score.
@@ -180,9 +183,20 @@ def race_paid_llm(
     monitor = SpendMonitor(budget_usd=budget_usd)
     client = create_llm_client()
     worst_per_token = per_token_worst_price(model)
+    # Cost of one worst-case pair — the minimum budget needed to make progress on a
+    # dataset. Below this, minting a fresh runner would only overshoot the cumulative
+    # cap (SpendMonitor.check runs after each dataset, so it can't pre-empt spend).
+    min_progress_usd = WORST_CASE_TOKENS_PER_PAIR * worst_per_token
     rows: list[tuple[str, PairTrack, float]] = []
 
     for name in names:
+        if monitor.remaining < min_progress_usd:
+            print(
+                f"[stop] budget exhausted: ${monitor.remaining:.4f} left "
+                f"< ${min_progress_usd:.4f}/pair worst case; skipping remaining datasets."
+            )
+            break
+
         bench = cast(_RaceBenchmark, get_benchmark(name))
         corpus, gold_clusters, _ = bench.load()
         _, test_records, _, test_clusters = bench.split(corpus, gold_clusters, seed=SEED)
@@ -190,13 +204,18 @@ def race_paid_llm(
         resolver = make_resolver_factory("llm_judge", bench, llm_client=client, llm_model=model)(
             0.5
         )
-        candidates = list(resolver._candidates(test_records))
+        candidates = list(resolver._candidates([r.model_dump() for r in test_records]))
         gold_pairs = gold_pairs_from_clusters(test_clusters)
 
+        # Bound both budgets by what's actually left — never mint fresh budget. Hard
+        # cap = remaining (so cumulative spend can't exceed ``budget_usd``); soft cap
+        # = 90% of remaining for pre-flight headroom. The break above guarantees
+        # ``remaining >= min_progress_usd > 0``, so both are positive and soft <= hard
+        # (the runner's constructor invariants).
         runner = BudgetedModuleRunner(
             resolver.module,
-            budget_usd=max(0.02, monitor.remaining),
-            budget_soft_usd=max(0.01, monitor.remaining - 0.20),
+            budget_usd=monitor.remaining,
+            budget_soft_usd=monitor.remaining * 0.9,
             worst_case_units_per_pair=WORST_CASE_TOKENS_PER_PAIR,
         )
         print(f"[paid] {name}: judging {len(candidates)} candidates with {model} ...")

--- a/examples/research/portfolio_race.py
+++ b/examples/research/portfolio_race.py
@@ -1,0 +1,303 @@
+"""Portfolio race: discover the benchmark portfolio from the registry and race it.
+
+This is the registry-driven counterpart to the hand-written per-dataset race
+scripts (``m3_zero_spend_race.py``, ``w2_person_benchmark.py``): instead of a
+local, hard-coded ``_BENCHMARKS = (FodorsZagatBenchmark(), AmazonGoogleBenchmark(),
+...)`` tuple that every new dataset has to be manually threaded into, it iterates
+:func:`langres.data.registry.list_benchmarks` and races **whatever is registered**.
+
+What this actually buys you — honestly:
+
+- ``run_methods`` already killed the per-method racing boilerplate (build a
+  factory, ``run_method``, ``table.add`` — one call now). This example adds
+  nothing there; it *uses* that.
+- The registry adds the missing half: **name -> benchmark discoverability** (a new
+  dataset shows up here the moment it is ``register(...)``ed, with no edit to this
+  file) and the same **serializable manifest** the CLI / other tools read. That is
+  the real delta over a scattered local list — not a new racing capability.
+
+Two surfaces, mirroring ``docs/EXPERIMENTS.md``:
+
+- **Offline race (default).** The two zero-spend methods — ``rapidfuzz`` (string)
+  and ``embedding_cosine`` (embedding) — raced via ``run_methods(bench, ...,
+  budget=0.0)`` on every loadable benchmark, printed as one
+  :meth:`~langres.core.benchmark.BenchmarkTable.to_markdown` table. Non-loadable
+  entries (``opensanctions``: CC-BY-NC, never vendored) are skipped with a note.
+- **Paid LLM row (``--paid``, OFF by default).** A zero-shot ``LLMJudge`` graded
+  **judged-once** via :func:`~langres.core.benchmark.evaluate_judge_on_candidates`
+  under a :class:`~langres.core.benchmark.BudgetedModuleRunner` pre-flight cap, all
+  metered by one :class:`~langres.clients.openrouter.SpendMonitor`. Judged once —
+  never through ``run_methods`` — because ``run_methods`` re-judges per grid
+  threshold, which for a paid judge multiplies spend by the grid size (see the KISS
+  warning in ``docs/EXPERIMENTS.md``). Requires ``OPENROUTER_API_KEY`` and a priced
+  ``--model``; without either it prints why it skipped and does nothing.
+
+Run (offline, $0)::
+
+    uv run python examples/research/portfolio_race.py            # full portfolio
+    uv run python examples/research/portfolio_race.py --fast     # FZ + DBLP-ACM only
+
+Run (paid, capped)::
+
+    uv run python examples/research/portfolio_race.py --fast --paid --budget 5
+
+``print`` is allowed in examples (this is an operator tool).
+"""
+
+import os
+
+# Pin OpenMP / FAISS threading BEFORE importing anything that pulls torch/faiss
+# (the dataset loaders import the embedding stack at module load; macOS libomp
+# duplicate-load guard — mirrors examples/research/m3_zero_spend_race.py).
+os.environ.setdefault("OMP_NUM_THREADS", "1")
+os.environ.setdefault("KMP_DUPLICATE_LIB_OK", "TRUE")
+
+import argparse  # noqa: E402
+import logging  # noqa: E402
+from typing import Any, Protocol, cast  # noqa: E402
+
+from langres.core.benchmark import (  # noqa: E402
+    Benchmark,
+    BenchmarkTable,
+    DEFAULT_PAIR_GRID,
+    PairTrack,
+    gold_pairs_from_clusters,
+    run_methods,
+)
+from langres.data.registry import BenchmarkEntry, get_benchmark, list_benchmarks  # noqa: E402
+from langres.methods import BlockingBenchmark, make_resolver_factory  # noqa: E402
+
+logger = logging.getLogger("portfolio_race")
+
+#: The two offline, zero-spend scorers: string similarity + local embeddings.
+OFFLINE_METHODS: tuple[str, ...] = ("rapidfuzz", "embedding_cosine")
+#: The small, fast, in-repo subset for a quick smoke (``--fast``): a saturated
+#: restaurant set + a clean bibliographic one — both tiny, both offline.
+FAST_SUBSET: frozenset[str] = frozenset({"fodors_zagat", "dblp_acm"})
+SEED = 0
+
+#: Paid-row defaults (only used with ``--paid``). gpt-4o-mini is priced in
+#: PRICES_PER_1M; a $5 cap is a generous backstop for the small candidate bands.
+DEFAULT_LLM_MODEL = "openrouter/openai/gpt-4o-mini"
+DEFAULT_PAID_BUDGET_USD = 5.0
+#: Generous worst-case tokens/pair sizing the BudgetedModuleRunner pre-flight cap.
+WORST_CASE_TOKENS_PER_PAIR = 1200.0
+
+
+class _RaceBenchmark(Benchmark[Any], BlockingBenchmark, Protocol):
+    """A benchmark usable by BOTH the harness and the method registry.
+
+    ``run_methods`` needs the :class:`~langres.core.benchmark.Benchmark` contract
+    (``name`` / ``load`` / ``split`` / ``threshold_grid``); ``make_resolver_factory``
+    needs the :class:`~langres.methods.BlockingBenchmark` contract (``schema`` +
+    pinned blocking). Every registered loader satisfies this intersection, so a
+    ``get_benchmark(name)`` result is cast to it (mirrors m3_zero_spend_race's
+    ``_RaceBenchmark``).
+    """
+
+
+def select_benchmarks(*, fast: bool) -> list[str]:
+    """Registry-driven benchmark selection: every loadable entry (or the fast subset).
+
+    Iterates :func:`list_benchmarks` and returns the loadable names, printing a
+    one-line note for each skipped non-loadable (external-only) entry so the
+    portfolio's edges are visible rather than silent.
+
+    Args:
+        fast: If set, keep only :data:`FAST_SUBSET` (FZ + DBLP-ACM).
+
+    Returns:
+        Registered benchmark names to race, in registry (name-sorted) order.
+    """
+    names: list[str] = []
+    for entry in list_benchmarks():
+        if not entry.loadable:
+            print(f"[skip] {entry.name}: external-only, not bundled — {_fetch_note(entry)}")
+            continue
+        names.append(entry.name)
+    if fast:
+        names = [n for n in names if n in FAST_SUBSET]
+    return names
+
+
+def _fetch_note(entry: BenchmarkEntry) -> str:
+    """A short reason/where-to-get-it note for a non-loadable entry."""
+    hint = entry.fetch_hint or ""
+    # First sentence only; split on ". " (period-space) so "CC-BY-NC 4.0" survives.
+    return hint.split(". ")[0] if hint else "fetch manually"
+
+
+def race_offline(names: list[str]) -> BenchmarkTable:
+    """Race the offline methods on each named benchmark into one merged table.
+
+    For each name, ``get_benchmark(name)`` is raced through
+    :func:`~langres.core.benchmark.run_methods` with ``budget=0.0`` (a hard
+    assertion of genuine zero spend), and the per-dataset results are merged into a
+    single :class:`~langres.core.benchmark.BenchmarkTable`.
+
+    Args:
+        names: Loadable benchmark names (from :func:`select_benchmarks`).
+
+    Returns:
+        One table with ``len(names) * len(OFFLINE_METHODS)`` rows.
+    """
+    table = BenchmarkTable()
+    for name in names:
+        bench = cast(_RaceBenchmark, get_benchmark(name))
+        print(f"[race] {name}: {', '.join(OFFLINE_METHODS)} (offline, $0) ...")
+        sub = run_methods(bench, list(OFFLINE_METHODS), seed=SEED, budget=0.0)
+        table.results.extend(sub.results)
+    return table
+
+
+def race_paid_llm(
+    names: list[str], *, model: str, budget_usd: float
+) -> list[tuple[str, PairTrack, float]]:
+    """Grade a zero-shot LLM judge, judged once, on each benchmark under one budget.
+
+    For each benchmark the test split is blocked once into a fixed candidate set,
+    then an ``LLMJudge`` is graded pairwise via
+    :func:`~langres.core.benchmark.evaluate_judge_on_candidates` under a
+    :class:`~langres.core.benchmark.BudgetedModuleRunner` pre-flight cap sized by
+    the remaining budget. A single :class:`SpendMonitor` meters cumulative spend and
+    raises before the cap is crossed. Judged **once** (never via ``run_methods``) so
+    a paid judge is not re-charged per grid threshold.
+
+    Args:
+        names: Loadable benchmark names to score.
+        model: A ``PRICES_PER_1M``-priced OpenRouter model id.
+        budget_usd: Hard cumulative spend cap across all datasets.
+
+    Returns:
+        ``(name, pair_track, usd_spent)`` per benchmark (pair-level P/R/F1 at the
+        best-F1 threshold, and the honest spend for that dataset).
+    """
+    # Paid-only imports kept local so the offline default never pulls litellm.
+    from langres.clients import create_llm_client
+    from langres.clients.openrouter import SpendMonitor, per_token_worst_price
+    from langres.core.benchmark import BudgetedModuleRunner, evaluate_judge_on_candidates
+
+    monitor = SpendMonitor(budget_usd=budget_usd)
+    client = create_llm_client()
+    worst_per_token = per_token_worst_price(model)
+    rows: list[tuple[str, PairTrack, float]] = []
+
+    for name in names:
+        bench = cast(_RaceBenchmark, get_benchmark(name))
+        corpus, gold_clusters, _ = bench.load()
+        _, test_records, _, test_clusters = bench.split(corpus, gold_clusters, seed=SEED)
+
+        resolver = make_resolver_factory("llm_judge", bench, llm_client=client, llm_model=model)(
+            0.5
+        )
+        candidates = list(resolver._candidates(test_records))
+        gold_pairs = gold_pairs_from_clusters(test_clusters)
+
+        runner = BudgetedModuleRunner(
+            resolver.module,
+            budget_usd=max(0.02, monitor.remaining),
+            budget_soft_usd=max(0.01, monitor.remaining - 0.20),
+            worst_case_units_per_pair=WORST_CASE_TOKENS_PER_PAIR,
+        )
+        print(f"[paid] {name}: judging {len(candidates)} candidates with {model} ...")
+        result, judgements = evaluate_judge_on_candidates(
+            resolver.module,
+            candidates,
+            gold_pairs,
+            DEFAULT_PAIR_GRID,
+            runner=runner,
+            price_per_token_or_pair=worst_per_token,
+        )
+        monitor.add(result.cost.usd_total)
+        monitor.check()
+        rows.append((name, result.pair, result.cost.usd_total))
+    return rows
+
+
+def _paid_table(rows: list[tuple[str, PairTrack, float]]) -> str:
+    """Render the paid LLM pair-level rows as a small Markdown table."""
+    header = (
+        "| dataset | judge | pair_P | pair_R | pair_F1 | usd |\n"
+        "| --- | --- | --- | --- | --- | --- |"
+    )
+    body = [
+        f"| {name} | llm_judge | {pair.precision:.4f} | {pair.recall:.4f} "
+        f"| {pair.f1:.4f} | {usd:.4f} |"
+        for name, pair, usd in rows
+    ]
+    return "\n".join([header, *body])
+
+
+def _paid_guard_reason(model: str) -> str | None:
+    """Return why the paid row must be skipped, or ``None`` if it can run.
+
+    Checks (a) ``OPENROUTER_API_KEY`` is set and (b) ``model`` is priced (so its
+    spend cap is not blind) — the same two guards the paid smoke scripts enforce.
+    """
+    from dotenv import load_dotenv
+
+    from langres.clients.openrouter import PRICES_PER_1M
+
+    load_dotenv(".env")  # OPENROUTER_API_KEY lives in .env, not Settings.
+    if "OPENROUTER_API_KEY" not in os.environ:
+        return "OPENROUTER_API_KEY not set"
+    if model not in PRICES_PER_1M:
+        return f"model {model!r} is not priced in PRICES_PER_1M (cap would be blind)"
+    return None
+
+
+def main() -> int:
+    logging.basicConfig(level=logging.INFO, format="%(message)s")
+    logging.getLogger("LiteLLM").setLevel(logging.WARNING)
+
+    parser = argparse.ArgumentParser(
+        description="Registry-driven portfolio race: offline methods on every "
+        "loadable benchmark, plus an optional budget-capped LLM row."
+    )
+    parser.add_argument(
+        "--fast", action="store_true", help="Race only the fast subset (FZ + DBLP-ACM)."
+    )
+    parser.add_argument(
+        "--paid",
+        action="store_true",
+        help="Also grade a zero-shot LLMJudge (needs OPENROUTER_API_KEY; costs money).",
+    )
+    parser.add_argument(
+        "--model", default=DEFAULT_LLM_MODEL, help="Priced OpenRouter model for the --paid row."
+    )
+    parser.add_argument(
+        "--budget",
+        type=float,
+        default=DEFAULT_PAID_BUDGET_USD,
+        help="Hard spend cap (USD) for the --paid row.",
+    )
+    args = parser.parse_args()
+
+    print("=" * 78)
+    print(f"Portfolio race — {'fast subset' if args.fast else 'full portfolio'} (seed={SEED})")
+    print("=" * 78)
+
+    names = select_benchmarks(fast=args.fast)
+    if not names:
+        print("[fatal] no loadable benchmarks selected; nothing to race.")
+        return 1
+    print(f"[plan] racing {len(names)} benchmark(s): {', '.join(names)}\n")
+
+    table = race_offline(names)
+    print("\n## Offline methods — pipeline BCubed F1 + pair F1 (BenchmarkTable)\n")
+    print(table.to_markdown())
+
+    if args.paid:
+        reason = _paid_guard_reason(args.model)
+        if reason is not None:
+            print(f"\n[skip] --paid row: {reason}. Offline table above is complete.")
+        else:
+            print(f"\n## Paid zero-shot LLM judge — judged once, capped at ${args.budget:.2f}\n")
+            rows = race_paid_llm(names, model=args.model, budget_usd=args.budget)
+            print(_paid_table(rows))
+
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/langres/core/benchmark.py
+++ b/src/langres/core/benchmark.py
@@ -694,6 +694,15 @@ def run_methods(
 # ---------------------------------------------------------------------------
 
 
+#: Default score-threshold grid for :func:`evaluate` — the fine ``0.05..0.95``
+#: sweep (19 points) a pair-level argmax wants. ``core.benchmark`` is
+#: deliberately free of any ``langres.data`` import (the harness is
+#: dataset-agnostic), so this mirrors
+#: ``langres.data.fixed_split_pair_benchmark.DEFAULT_ARGMAX_GRID`` by value rather
+#: than importing it.
+DEFAULT_PAIR_GRID: tuple[float, ...] = tuple(round(i * 0.05, 2) for i in range(1, 20))
+
+
 class JudgePairEval(BaseModel):
     """Pair-level evaluation of one judge over a *given* candidate set.
 
@@ -867,6 +876,44 @@ def evaluate_judge_on_candidates(
         slices=slices,
     )
     return result, judgements
+
+
+def evaluate(
+    module: Module[Any],
+    candidates: Sequence[Any],
+    gold_pairs: set[frozenset[str]],
+    *,
+    grid: Sequence[float] = DEFAULT_PAIR_GRID,
+    slice_fn: Callable[[frozenset[str]], str | None] | None = None,
+) -> JudgePairEval:
+    """Score any judge over a fixed candidate set against gold — the BYO-data one-liner.
+
+    A thin wrapper over :func:`evaluate_judge_on_candidates` that drops the raw
+    judgements (and the paid-judge ``runner`` / cost knobs) so the common
+    bring-your-own-data case is a single call returning honest pair-level
+    Precision/Recall/F1 at the best-F1 grid threshold, plus the full PR curve. For
+    a paid or compiled judge that needs a spend cap, custom cost accounting, or the
+    raw judgements back, call :func:`evaluate_judge_on_candidates` directly.
+
+    Args:
+        module: The scorer to evaluate (any :class:`~langres.core.module.Module`).
+        candidates: The fixed candidate pairs to judge (each an ``ERCandidate``).
+        gold_pairs: True match pairs as order-independent ``frozenset`` pairs.
+        grid: Score thresholds to sweep for the pair-level PR curve (defaults to
+            :data:`DEFAULT_PAIR_GRID`, the fine ``0.05..0.95`` sweep).
+        slice_fn: Optional pair-key tagger forwarded verbatim to
+            :func:`evaluate_judge_on_candidates`; when given, the result's
+            ``slices`` are graded at the one global best-F1 threshold (the honest
+            seen -> unseen view). ``None`` (default) leaves ``slices`` unset.
+
+    Returns:
+        A :class:`JudgePairEval` — pair P/R/F1 at the best-F1 threshold, the PR
+        curve, cost, latency, and (when ``slice_fn`` is given) per-slice tracks.
+    """
+    result, _ = evaluate_judge_on_candidates(
+        module, candidates, gold_pairs, grid, slice_fn=slice_fn
+    )
+    return result
 
 
 # ---------------------------------------------------------------------------

--- a/tests/core/test_benchmark.py
+++ b/tests/core/test_benchmark.py
@@ -719,6 +719,51 @@ def test_evaluate_judge_gold_only_slice_reports_zero_recall_no_divide_by_zero() 
 
 
 # ---------------------------------------------------------------------------
+# evaluate() — the bring-your-own-data one-liner over evaluate_judge_on_candidates
+# ---------------------------------------------------------------------------
+
+
+def test_evaluate_returns_pair_eval_with_sane_metrics() -> None:
+    # Happy path: two true matches scored high, one non-match low -> at the tuned
+    # threshold the judge is perfect. evaluate() returns just the JudgePairEval.
+    scores = {"p0": 0.9, "p1": 0.8, "n0": 0.2}
+    cands, gold = _labeled_candidates(scores)
+    result = benchmark_module.evaluate(_ScoreModule(scores), cands, gold, grid=(0.5, 0.85))
+    assert isinstance(result, benchmark_module.JudgePairEval)
+    assert result.pair.precision == pytest.approx(1.0)
+    assert result.pair.recall == pytest.approx(1.0)
+    assert result.pair.f1 == pytest.approx(1.0)
+    assert result.best_threshold == 0.5
+    assert result.n_candidates == 3
+    assert result.slices is None  # no slice_fn passed
+
+
+def test_evaluate_passes_slice_fn_through() -> None:
+    # slice_fn is forwarded: the result carries per-slice tracks graded at the one
+    # global best-F1 threshold (evaluate() is a thin passthrough, so this just
+    # confirms the kwarg reaches evaluate_judge_on_candidates).
+    scores = {"A_p": 0.9, "A_n": 0.5, "B_p": 0.4, "B_n": 0.35}
+    cands, gold = _slice_candidates(scores, positives={"A_p", "B_p"})
+    result = benchmark_module.evaluate(
+        _ScoreModule(scores), cands, gold, grid=(0.3, 0.6), slice_fn=_tag_by_base_prefix
+    )
+    assert result.slices is not None
+    assert set(result.slices) == {"A", "B"}
+
+
+def test_evaluate_uses_default_pair_grid_when_grid_omitted() -> None:
+    # Omitting grid= sweeps DEFAULT_PAIR_GRID (the fine 0.05..0.95, 19 points), so
+    # the PR curve has one point per grid threshold and the tuned cut lands inside it.
+    scores = {"p0": 0.9, "p1": 0.85, "n0": 0.1}
+    cands, gold = _labeled_candidates(scores)
+    result = benchmark_module.evaluate(_ScoreModule(scores), cands, gold)
+    assert result.pair.pr_curve is not None
+    assert len(result.pair.pr_curve) == len(benchmark_module.DEFAULT_PAIR_GRID) == 19
+    assert result.best_threshold in benchmark_module.DEFAULT_PAIR_GRID
+    assert result.pair.f1 == pytest.approx(1.0)  # matches separable from the non-match
+
+
+# ---------------------------------------------------------------------------
 # complete_partition (re-homed to core)
 # ---------------------------------------------------------------------------
 

--- a/tests/examples/test_portfolio_race.py
+++ b/tests/examples/test_portfolio_race.py
@@ -1,0 +1,82 @@
+"""Smoke tests for the registry-driven portfolio race example.
+
+Two tiers, matching the example's behavior/smoke coverage:
+
+- **Fast, network- and embedding-free:** the genuinely new logic in this example
+  is the registry-driven *selection* (``select_benchmarks``) and the report
+  formatting. These assert loadable entries are raced, the external-only
+  ``opensanctions`` entry is skipped with a note, and ``--fast`` narrows to the
+  bundled subset — all from the static manifest, no dataset load.
+- **Slow, embedding-backed:** one true end-to-end ``race_offline`` over the tiny
+  12-record fixture, proving the offline surface yields populated, zero-spend
+  ``MethodResult``s and renders a table. Marked ``slow`` (it loads MiniLM), so it
+  runs in the weekly full suite, not per-PR.
+"""
+
+import pytest
+
+from examples.research.portfolio_race import (
+    FAST_SUBSET,
+    OFFLINE_METHODS,
+    _paid_table,
+    race_offline,
+    select_benchmarks,
+)
+from langres.core.benchmark import PairTrack
+
+
+def test_select_benchmarks_full_skips_external_only_with_a_note(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """The full selection returns loadable names and skips ``opensanctions`` (noted)."""
+    names = select_benchmarks(fast=False)
+
+    # Loadable entries are selected; the external-only one never is.
+    assert "opensanctions" not in names
+    assert "fodors_zagat" in names
+    assert "dblp_acm" in names
+    # A visible skip note names the external-only entry and its license reason.
+    out = capsys.readouterr().out
+    assert "[skip] opensanctions" in out
+    assert "CC-BY-NC" in out
+
+
+def test_select_benchmarks_fast_narrows_to_bundled_subset() -> None:
+    """``--fast`` keeps only the fast subset (a strict subset of the full list)."""
+    fast = select_benchmarks(fast=True)
+    full = select_benchmarks(fast=False)
+
+    assert set(fast) == set(FAST_SUBSET)
+    assert set(fast) < set(full)
+
+
+def test_paid_table_renders_one_row_per_dataset() -> None:
+    """The paid pair-level table renders a header plus one row per (name, track)."""
+    rows = [
+        ("dblp_acm", PairTrack(precision=0.9, recall=0.8, f1=0.85), 0.12),
+        ("fodors_zagat", PairTrack(precision=1.0, recall=0.7, f1=0.82), 0.05),
+    ]
+    table = _paid_table(rows)
+    lines = table.splitlines()
+    # Header row + separator row + one row per dataset.
+    assert len(lines) == 2 + len(rows)
+    assert "dblp_acm" in table
+    assert "0.8500" in table  # f1 formatted to 4 dp
+
+
+@pytest.mark.slow
+def test_race_offline_tiny_fixture_populates_zero_spend_results() -> None:
+    """End-to-end offline race over the 12-record fixture: full, $0 MethodResults."""
+    table = race_offline(["tiny_fixture"])
+
+    # One row per offline method on the single fixture.
+    assert len(table.results) == len(OFFLINE_METHODS)
+    assert {r.dataset for r in table.results} == {"tiny_fixture"}
+    for r in table.results:
+        assert 0.0 <= r.pair.f1 <= 1.0
+        assert r.pair.pr_curve is not None and len(r.pair.pr_curve) > 0
+        assert 0.0 <= r.pipeline.bcubed_f1 <= 1.0
+        assert r.cost.usd_total == 0.0  # offline: nothing charged
+
+    # to_markdown renders a header (+ separator) plus one row per result.
+    assert len(table.to_markdown().splitlines()) == 2 + len(table.results)


### PR DESCRIPTION
## Wave E — Developer-Experience layer (eval-readiness)

Makes "race any method / score your own data with honest metrics" a near-zero-boilerplate one-liner, and the benchmark portfolio discoverable + documented. Final wave of the eval-readiness effort (after A=RR/GMD metrics, B=registry+factory, C=4 loaders, D=slice aggregation).

### What's in it
- **`evaluate()` one-liner** (`core/benchmark.py`) — `evaluate(module, candidates, gold_pairs, *, grid=DEFAULT_PAIR_GRID, slice_fn=None) -> JudgePairEval`, a thin typed wrapper over `evaluate_judge_on_candidates` that drops the raw judgements + paid knobs. New `DEFAULT_PAIR_GRID` (19-pt 0.05–0.95 sweep). 3 core-tier unit tests (happy path, slice_fn passthrough, default grid).
- **`examples/research/portfolio_race.py`** — registry-driven race: iterates `list_benchmarks()`, skips non-loadable `opensanctions` with a note, races offline `rapidfuzz` + `embedding_cosine` via `run_methods(budget=0.0)` into one `BenchmarkTable`. `--fast` = FZ + DBLP-ACM. `--paid` LLM row is OFF by default (API-key + priced-model guarded), graded **judged-once** under a `BudgetedModuleRunner`+`SpendMonitor` (not through `run_methods`, which would multiply paid spend per threshold).
- **`docs/BENCHMARKS.md`** — registry discoverability + dataset catalog with honest caveats (DBLP-Scholar cross-source PC ~0.39 = many-to-many closure artifact; Walmart-Amazon 0.877 gate-not-met; WDC title-only + seen/unseen slice; OpenSanctions CC-BY-NC external-only) + a verified-runnable "score your own data" walkthrough. `EXPERIMENTS.md`/`CLAUDE.md` synced.

### Honest notes
- **`evaluate` is exported from `langres.core.benchmark`, not root `langres`** — `core.benchmark` transitively imports dev-only `ranx`, so a root `langres.evaluate` would `ImportError` on non-dev installs. Consistent with `run_methods`/`evaluate_judge_on_candidates`. Root `__init__` unchanged → import-budget test stays green.
- **`--paid` path not executed** (no paid LLM calls permitted this wave) — type/lint-verified only. Offline `--fast` ran end-to-end ($0, table below).

### Verification (agent-run)
- `uv run mypy src/` strict clean (89 files); ruff format+lint clean.
- `pytest tests/core/test_benchmark.py tests/test_import_budget.py -m "not slow and not integration"` → 65 passed, 4 skipped; import budget green.
- Example ran offline end-to-end over 2 datasets:

```
| method           | dataset      | threshold | bcubed_f1 | pair_f1 | usd_total |
| rapidfuzz        | dblp_acm     | 0.70      | 0.9131    | 0.8203  | 0.0000    |
| embedding_cosine | dblp_acm     | 0.80      | 0.2709    | 0.3328  | 0.0000    |
| rapidfuzz        | fodors_zagat | 0.80      | 0.9785    | 0.7059  | 0.0000    |
| embedding_cosine | fodors_zagat | 0.80      | 0.3316    | 0.1049  | 0.0000    |
```
