### PR TITLE
feat(tracking): experiment tracking & LLM observability (run-store + MLflow/W&B adapters + trace correlation)

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -4,7 +4,7 @@ on:
   push:
     branches: [main]
   pull_request:
-    branches: [main, feat/m4-foundation, feat/m5-foundation]
+    branches: [main, feat/m4-foundation, feat/m5-foundation, feat/tracking-observability]
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,8 @@ tmp/
 uv.lock
 .claude/*.bak
 wandb/
+mlflow.db
+mlruns/
 
 # macOS
 .DS_Store

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -53,6 +53,43 @@ Docs (`docs/GETTING_STARTED.md` + the doc-ladder rewire) are detailed under
 - Implemented core primitives (`Module`, `Blocker`, `Clusterer`) with Pydantic data contracts and 100% test coverage
 - Completed Approach 1 (classical baseline): `AllPairsBlocker` + `RapidfuzzModule` end-to-end pipeline
 
+### Experiment tracking & observability — run store, `ExperimentTracker`, LLM trace correlation
+
+The missing spine under langres's otherwise-**ephemeral** benchmark runs (rich results
+were printed, then lost — no run id, no config/data snapshot, no cross-run compare):
+content-addressed run identity, JSONL persistence, a pluggable tracker seam, and
+end-to-end trace correlation — **dependency-free** on the core path (`import langres`
+still pulls no `mlflow`/`wandb`).
+
+- **Run store + identity** (`langres.core.runs`, root-exported) — `RunContext` (the
+  recipe) + `RunRecord` (recipe + outcomes) with a content-addressed `recipe_id`
+  (`sha256` over config/data/seeds, *excluding* code/env provenance so a dirty tree or
+  `uv.lock` bump keeps the id) and an `attempt_id` PK; an `fcntl.flock`-guarded,
+  append-only JSONL `RunStore` (`read()` collapses `running`+terminal lines
+  last-wins-by-`attempt_id`); and `capture_run(context, *, store=None,
+  tracker=NoOpTracker())` — writes a `running` line at start and a terminal line on
+  exit, and sets the `current_run` contextvar. **`store=None` writes nothing.**
+- **`ExperimentTracker` Protocol + adapters** (`langres.core.trackers`) — an
+  Accelerate-style seam (`NoOpTracker` null default, `MultiTracker` fan-out to run
+  MLflow *and* W&B at once, `resolve_tracker` dispatch) with lazy **MLflow** and **W&B**
+  adapters behind the `[mlflow]` / `[wandb]` extras (a missing extra raises a helpful
+  `pip install 'langres[<backend>]'` `ImportError`). MLflow defaults to a local file
+  store out of the box; W&B supports keyless `offline`/`disabled` runs for CI/no-key use.
+- **LLM trace correlation** — `capture_run` sets `current_run`; `JudgementLog` records
+  the active `run_id`, and `LLMJudge` injects litellm `metadata` (`langres_attempt_id`
+  + pair ids + decision step) on **both** the sync (`forward`) and async
+  (`forward_async`) paths, so a Langfuse/OTel trace joins the `RunRecord` and
+  `JudgementLog`. Off a run (or a non-litellm client) the calls stay byte-identical
+  (no `metadata`).
+- **DSPy compile lineage** — `DSPyJudge.compile(...)` records the compilation as a
+  first-class optimization run via `capture_run` and stamps `_compile_run_id`, so a
+  later eval run threads it into `parent_run_id` (compile → eval lineage).
+- **`Settings`** — `RUN_STORE_PATH`, `MLFLOW_TRACKING_URI`, `MLFLOW_EXPERIMENT` (the
+  MLflow ones consumed by `MlflowTracker`; a zero-config default `store` from
+  `RUN_STORE_PATH` is deferred to the benchmark wrap — pass `store=` explicitly today).
+  Docs: `docs/EXPERIMENTS.md`; runnable zero-spend
+  `examples/research/experiment_tracking_demo.py`.
+
 ### Flywheel closed loop — `docs/GETTING_STARTED.md` + doc-ladder rewire
 
 The one entry doc for the closed flywheel (fail-fast `auto`, `select_for_review`

--- a/docs/EXPERIMENTS.md
+++ b/docs/EXPERIMENTS.md
@@ -241,6 +241,19 @@ agents can write one file safely. Pass `tracker=` (an `ExperimentTracker`) to *a
 mirror params/metrics into MLflow or W&B; omit it for the JSONL-only path.
 (`git_sha()` and `dataset_fingerprint()` live in `langres.core.runs`.)
 
+**How the tracking `Settings` take effect (today).** `Settings` reads
+`RUN_STORE_PATH`, `MLFLOW_TRACKING_URI`, and `MLFLOW_EXPERIMENT`, but they are
+*not* auto-applied by `capture_run`:
+
+- `RUN_STORE_PATH` is **not** wired as a default `store` yet — `capture_run`'s
+  `store` still defaults to `None` (writes nothing), so you pass it explicitly:
+  `capture_run(context, store=Settings().run_store_path)`. Threading it as the
+  zero-config default is deferred to the benchmark/harness wrap.
+- `MLFLOW_TRACKING_URI` / `MLFLOW_EXPERIMENT` are consumed by the **MLflow
+  tracker** (`resolve_tracker("mlflow")` / `MlflowTracker`), not by `capture_run`
+  — they take effect only when you pass that tracker. Likewise `WANDB_*` is read
+  by `WandbTracker`. With no tracker (`NoOpTracker`) none of these are read.
+
 **Idempotent replay — the agent move.** LLM runs are nondeterministic, so identity
 is *same recipe → same `recipe_id`*, **not** same metrics. An agent re-running a
 sweep skips a config it already paid for and checks its budget in two lines:

--- a/docs/EXPERIMENTS.md
+++ b/docs/EXPERIMENTS.md
@@ -188,6 +188,77 @@ it does not throttle the LM. For a hard pre-flight cap on the run itself, wrap t
 judge in a `BudgetedModuleRunner` and pass it to `evaluate_judge_on_candidates`. On
 the zero-spend `DummyLM` path both report **$0.00**.
 
+## Persisting & comparing runs (`capture_run` + `RunStore`)
+
+Every surface above scores a run, prints it, and forgets it — no run id, no
+config/data snapshot, no way to compare against last week's run. `capture_run`
+adds the missing spine: it wraps a run, gives it a content-addressed identity, and
+persists one JSONL line you can read back and diff across sessions. It is
+**dependency-free** (stdlib + pydantic) and writes nothing unless you pass a `store`.
+
+```python
+from langres import dedupe
+from langres.core import RunContext, RunStore, capture_run, compute_recipe_id
+
+context = RunContext(
+    experiment="string-judge-sweep",
+    resolver_config={"judge": "string", "threshold": 0.6},   # config snapshot (hashed)
+    dataset_name="toy-companies",
+    seeds={"split": 13},                                     # named seeds (hashed)
+)
+
+with capture_run(context, store=RunStore("runs/langres_runs.jsonl")) as run:
+    result = dedupe(records, judge="string", threshold=0.6)
+    run.log_metrics({"f1": 0.75}, metric_definition="pair_f1", headline_metric=0.75)
+    run.record_cost(0.0)               # = SpendMonitor.spent for a paid judge
+
+runs = RunStore("runs/langres_runs.jsonl").read()            # list[RunRecord]
+```
+
+**What a `RunRecord` captures** — one frozen line per attempt:
+
+- **Identity.** `recipe_id` = `sha256` over the *recipe fields* (`resolver_config`,
+  `dataset_name`, `dataset_fingerprint`, `llm_model`, `seeds`, …); `attempt_id` =
+  `f"{recipe_id}-{started_at}"` is the record PK.
+- **Config snapshot** — `resolver_config` (best-effort; `None` for a bespoke run
+  with no registered config) plus `llm_model` / `blocking_k` / `method` / `budget_usd`.
+- **Provenance, recorded but *not* hashed** — `git_sha` + `git_dirty`,
+  `lockfile_hash`, `langres_version`, `python_version`, `platform`. So a dirty tree
+  or a `uv.lock` bump does **not** mint a new `recipe_id`: it stays a dedup key over
+  the *logical* experiment (config + data + seeds), stable across code churn.
+- **Metrics** (`metrics` opaque dict + `metric_definition` + `headline_metric` +
+  `per_seed_metrics`), **cost** (`spend_usd`, `budget_exceeded`), **artifacts**, and
+  **status** (`running` / `completed` / `failed` / `budget_exceeded` — `running` is
+  written at *start*, so a crashed run leaves a visible lone line).
+
+**The API.** `capture_run(context, *, store=None, tracker=NoOpTracker())` computes
+the identity, writes the `running` line, yields a handle (`log_metrics` /
+`record_cost` / `log_artifact` / `set_status`), then finalizes the terminal record
+on exit. `store` accepts a path or a `RunStore`; **`store=None` writes nothing**.
+`RunStore.read()` collapses each attempt's `running`+terminal lines
+**last-wins-by-`attempt_id`** and takes an `fcntl.flock` per append, so several
+agents can write one file safely. Pass `tracker=` (an `ExperimentTracker`) to *also*
+mirror params/metrics into MLflow or W&B; omit it for the JSONL-only path.
+(`git_sha()` and `dataset_fingerprint()` live in `langres.core.runs`.)
+
+**Idempotent replay — the agent move.** LLM runs are nondeterministic, so identity
+is *same recipe → same `recipe_id`*, **not** same metrics. An agent re-running a
+sweep skips a config it already paid for and checks its budget in two lines:
+
+```python
+completed = [r for r in RunStore("runs/langres_runs.jsonl").read() if r.status == "completed"]
+already_ran = compute_recipe_id(context) in {r.recipe_id for r in completed}   # skip if True
+remaining = 5.0 - sum(r.spend_usd for r in completed)                          # budget left
+```
+
+`RunContext.parent_run_id` threads lineage — a sweep parents its per-seed children;
+a DSPy-compile run parents the eval runs that reuse its compiled program.
+
+Runnable, zero-spend end to end: **`examples/research/experiment_tracking_demo.py`**
+captures a two-threshold sweep, reads it back, and prints the two-run metric diff
+plus the agent two-liner. Run it:
+`uv run python examples/research/experiment_tracking_demo.py`.
+
 ## W3 paid smoke — SelectJudge vs pairwise, measured
 
 `examples/research/w3_paid_smoke.py` is the ≤$10, SpendMonitor-capped operator run
@@ -292,4 +363,6 @@ with `examples/data/flywheel/generate_fixtures.py`.
 - `examples/judgement_log_demo.py` — `JudgementLog` write-then-read round-trip.
 - `examples/flywheel_threshold_harvest.py` — harvest verdicts + corrections → a
   re-derived threshold, with before/after held-out gold F1.
+- `examples/research/experiment_tracking_demo.py` — persist runs with `capture_run`
+  + `RunStore`, diff two runs across sessions, and the agent idempotency/budget two-liner.
 - `examples/research/m3_race.py` / `examples/research/m3_zero_spend_race.py` — multi-method races.

--- a/docs/plans/20260708_tracking_observability_plan.md
+++ b/docs/plans/20260708_tracking_observability_plan.md
@@ -1,0 +1,269 @@
+# Experiment Tracking & LLM Observability — build plan (review-hardened)
+
+Date: 2026-07-08
+Integration branch: `feat/tracking-observability` (off `feat/eval-readiness`)
+Status: approved (David) + hardened by a 4-voice gstack autoplan review
+(Codex + rev-ceo + rev-eng + rev-dx, 2026-07-08).
+
+Companion research (committed, unmerged): `docs/research/20260708_experiment_tracking_observability_analysis.md`.
+
+## Context — why
+
+langres benchmark runs are **ephemeral**: `run_method`/`run_methods` produce rich
+Pydantic results (`MethodResult`, `CostTrack`, the `reports.py` family) that are
+`.model_dump()`'d or rendered to markdown, then lost — **no run id, no config
+snapshot, no dataset/split identity, no persistence, no cross-run comparison, no
+lineage.** Impossible to reproduce months later or compare across sessions —
+exactly what the team now needs, reproducing published ER research (Ditto/
+Jellyfish/AnyMatch, epic #85) as *clients of langres*, increasingly via agents.
+
+Five-workstream research + first-hand code verification concluded: **don't build a
+tracker — add a thin pluggable adapter that wraps langres's existing seams and
+reuses its existing Pydantic result models.** langres already has the hard parts
+(auto per-judge capture via `LoggingModule`, honest cost via `SpendMonitor` +
+pinned prices, rich serializable reports, a `"v":1` JSONL idiom). Missing: run
+identity + config/dataset/split capture + backend persistence + lineage.
+
+## Decisions (David, at the autoplan gate)
+
+- **D1 — scope: BOTH backends in cut 1.** Ship MLflow **and** W&B adapters (Streams
+  S3 + S4), not MLflow-only. The pluggable `ExperimentTracker` Protocol treats them
+  symmetrically (no privileged default), honoring "both backends, no single default."
+- **D2 — base off `feat/eval-readiness`, defer the `benchmark.py` wrap (Stream C).**
+  Verified ground truth (2026-07-08): `feat/eval-readiness` = `main` + 2 planning-doc
+  commits only; RR/GMD (#89), the registry (#90), and `slice_fn` are **not merged
+  into it** yet (they live on separate unmerged branches; Wave C loaders are the only
+  thing live, and they don't touch `benchmark.py`). So `benchmark.py` here is
+  byte-identical to main. The disjoint streams build cleanly now; the `benchmark.py`
+  wrap is **held until eval-readiness Wave D/E lands** (Wave D adds `slice_fn` to
+  `evaluate_judge_on_candidates` — the exact function we'd wrap), so we wrap the final
+  shape once, with no double-write.
+
+## What to track — the schema (centerpiece, review-corrected)
+
+Two frozen Pydantic models in a **dep-free** `core/runs.py`. LLM runs are
+nondeterministic, so "idempotent replay" = *same recipe → same `recipe_id`*
+(detect/skip/compare an already-paid config), **not** same metrics.
+
+### Identity split (rev-ceo/Codex + rev-eng HIGH-1)
+- **`recipe_id`** = `sha256(canonical_json(<recipe fields only>))[:16]`, where
+  `canonical_json` = `json.dumps(obj, sort_keys=True, separators=(",", ":"))`.
+  **Recipe fields (the hash domain) = inputs that determine the run:** `experiment`,
+  `resolver_config`, `llm_model`, `cascade_band`, `blocking_k`, `budget_usd`,
+  `method`, `dataset_name`, `dataset_fingerprint`, `split_id`, `split_seed`, `seeds`.
+  **Explicitly NOT hashed (provenance-only, recorded but excluded):** `git_sha`,
+  `git_dirty`, `lockfile_hash`, `langres_version`, `tracking_schema_version`, and
+  every timing field. Rationale: recipe_id is a *dedup key over the logical
+  experiment* (config+data+seeds), stable across code/dep churn, so a dirty tree or
+  a `uv.lock` bump does not mint a new id (fixes HIGH-1; resolves the lockfile debate
+  — record it, don't hash it). Code/env identity stays queryable for explaining a
+  metrics move, just not part of dedup identity.
+- **`attempt_id`** = record PK = `f"{recipe_id}-{started_at}"`. Each attempt is one
+  record; the `running` line and the terminal line share `attempt_id`, so the reader
+  does **last-wins-by-`attempt_id`**. Idempotency query = "is there a record with
+  `recipe_id == X` and `status == completed`?" → skip/compare.
+
+### `RunContext` — the recipe
+- *Identity:* `experiment`, `group?`, `parent_run_id?` (lineage: a DSPy-compile run
+  parents the eval runs using its program; a sweep parents its per-seed children),
+  `tags: dict[str,str]`.
+- *Code/env (provenance, NOT hashed):* `git_sha?`, `git_dirty`, `lockfile_hash?`
+  (sha256 of `uv.lock`), `langres_version`, `tracking_schema_version=1`,
+  `python_version?`, `platform?`, `reproduction_adapter_version?`.
+- *Config (hashed):* `resolver_config?` (full pipeline snapshot via the new
+  `Resolver.config_dict()` — **best-effort**, see S2/HIGH-2), `llm_model?`,
+  `cascade_band?`, `blocking_k?`, `budget_usd?`, `method?`.
+- *Data (hashed):* `dataset_name`, `dataset_fingerprint?` (sha256 over corpus+gold),
+  `split_id?`, `split_seed`.
+- *Seeds (hashed):* `seeds: dict[str,int]` — named union of every source (`"split"`
+  + each stochastic component's `random_state`/`seed` from its `ComponentSpec.config`).
+  (Store `split_seed` **once**, in `seeds["split"]`; drop the duplicate scalar field —
+  rev-eng HIGH-1 minor.)
+
+### `RunRecord` — `context` + outcomes, one JSONL line
+- `attempt_id` (PK), `recipe_id`, `context`, `v=1`.
+- *Timing (never hashed):* `started_at`, `finished_at?`, `duration_seconds?`.
+- *Metrics (reuse existing models as an opaque dict — HIGH-4):* `metrics?` (a
+  `MethodResult`/`JudgePairEval`/`HonestPairEval`/`BenchmarkTable` `.model_dump()`),
+  `metric_definition?` (`"pair_f1@best_threshold"` vs `"bcubed_f1"` vs
+  `"honest_fixed_split"` — self-labels so comparison can't silently mix definitions),
+  `per_seed_metrics?`, `headline_metric?`.
+- *Cost (langres-native):* `spend_usd` (= `SpendMonitor.spent` = Σ judgement
+  `cost_usd`), `budget_exceeded`.
+- *Artifacts:* `judgement_log_path?`, `trace_id?` (= `attempt_id`, threaded to
+  Langfuse), `artifacts: dict[str,str]` (resolver.save dir, report md,
+  `mlflow_run_url`, `wandb_run_url`, `langfuse_trace_url`).
+- *Status/failure:* `status: Literal["running","completed","failed","budget_exceeded"]`
+  (**`"running"` written at start** → a crashed/torn-down run leaves a visible gap),
+  `error_type?`, `error_message?` (truncated, no full traceback/PII).
+
+### Gap-closing helpers (all reuse existing internals; verified feasible)
+- `Resolver.config_dict() -> dict` (S2) — factor the `save()` loop
+  (`resolver.py:655-676`: `_component_spec` over `_slots()` → `ArtifactManifest`) into
+  a public method returning `.model_dump()` **without** writing to disk. `save()` then
+  = `config_dict()` + write + sidecars.
+- `compute_recipe_id(context) -> str` (public, in `__all__`) — the hash above.
+- `git_sha() -> tuple[str|None, bool]` — `git rev-parse HEAD` + `--porcelain` dirty;
+  short `timeout`, `check=False`, `cwd`=repo root, swallow `FileNotFoundError` →
+  `(None, False)`; one-time `logger.warning` when sha is None (rev-dx Mi2).
+- `dataset_fingerprint(corpus, gold) -> str` — sha256 over **already-loaded**
+  `(corpus, gold)` (thread them in; do NOT re-`load()` — rev-eng M-2); canonical order.
+- `_collect_seeds(split_seed, resolver_config) -> dict[str,int]` — split seed + scan
+  configs for `random_state`/`seed` keys; degrades to just the split seed if config is None.
+
+## Design — the layer
+
+```
+core/runs.py            NEW dep-free: RunContext, RunRecord, RunStore (JSONL
+                        append/read, last-wins-by-attempt_id, fcntl.flock per append),
+                        capture_run(), current_run contextvar, compute_recipe_id(),
+                        git_sha(), dataset_fingerprint(), _collect_seeds(), env helpers,
+                        resolve_store() (str|Path|RunStore -> RunStore)
+core/trackers/__init__.py  NEW dep-free: ExperimentTracker(Protocol), NoOpTracker,
+                        MultiTracker (exposes .trackers), resolve_tracker(); lazy
+                        __getattr__ -> Mlflow/Wandb adapters
+core/trackers/mlflow_tracker.py  NEW (S3): MlflowTracker — lazy `import mlflow`
+core/trackers/wandb_tracker.py   NEW (S4): WandbTracker — reuses clients/tracking.py
+core/resolver.py        (S2) + Resolver.config_dict()
+core/modules/llm_judge.py  (S5) + litellm metadata {langres_attempt_id,left_id,
+                        right_id,decision_step} — ONLY when current_run set AND on the
+                        litellm path (gate so a user-supplied client can't 400)
+core/modules/dspy_judge.py (S6) + named tracker/store/parent_run_id on compile()
+                        (bound before **kwargs); stamp judge._compile_run_id for lineage
+core/judgement_log.py   (S5) + nullable run_id (= current attempt_id) on the row
+core/__init__.py        (S1) + eager RunContext/RunRecord/RunStore/ExperimentTracker/
+                        MultiTracker/NoOpTracker/capture_run/compute_recipe_id/
+                        resolve_tracker/resolve_store; lazy MlflowTracker/WandbTracker
+clients/settings.py     (S1) + run_store_path / mlflow_tracking_uri / mlflow_experiment
+pyproject.toml          (S3) + [project.optional-dependencies] mlflow=[...], wandb=[...]
+                        (real extras — rev-dx H1); mlflow added to dev group (wandb
+                        already there). Attempt `uv lock`; if the index is unreachable
+                        offline, flag a lock-refresh follow-up — do NOT block adapter code
+tests/test_import_budget.py (S1) + "mlflow","wandb" in _HEAVY_MODULES; + subprocess
+                        assertions that ranx/mlflow/wandb NOT in sys.modules after
+                        `import langres` (HIGH-4 + LOW)
+examples/research/experiment_tracking_demo.py (S7) NEW — mirrors judgement_log_demo.py
+docs/EXPERIMENTS.md     (S7) + "Persisting & comparing runs" section
+```
+
+### `ExperimentTracker` Protocol (Accelerate `GeneralTracker` shape)
+`name`; `start_run(context, *, run_name=None)`; `log_params`; `log_metrics(..., step=None)`;
+`log_artifact`; `set_tags`; `finish(*, status)`; `run_url` property (deep link →
+`RunRecord.artifacts`); `native` property (escape hatch — renamed from `.tracker`,
+rev-dx Mi1). Backends flatten `context`→params themselves.
+- **`MultiTracker`** — fan-out to N children (compose, not merge); exposes `.trackers:
+  list` so a specific backend is reachable when running MLflow+W&B together (Mi1).
+- **`NoOpTracker`** — null default; zero overhead when unconfigured.
+- **`resolve_tracker(spec)`** — `None`→NoOp; `"mlflow"`/`"wandb"`→lazy adapter
+  (availability-gated `ImportError` naming the real extra: `pip install 'langres[mlflow]'`);
+  an instance→as-is (DI); a sequence→`MultiTracker`. Mirrors `resolve_judge`.
+- **`resolve_store(spec)`** — `None`→None (no persistence); `str|Path`→`RunStore(path)`;
+  a `RunStore`→as-is. Symmetric with the `log:` precedent on `link`/`dedupe` (rev-dx M1).
+
+### `capture_run(context, *, store=None, tracker=NoOpTracker())` — the one primitive
+Context manager: compute `recipe_id`+`attempt_id`; if `store` set, mkdir-parents and
+append `status="running"` (wrap write failures as `RunStoreError` with an actionable
+message — rev-dx M4); set `current_run` contextvar (use set/reset tokens so nested
+capture restores the parent on exit — rev-eng); `tracker.start_run`; yield a handle
+(`log_metrics`/`log_artifact`/`set_status`); on exit finalize the `RunRecord`
+(status/metrics/cost/timing/artifacts + `run_url`), append terminal line, `tracker.finish`.
+
+### Default persistence (rev-dx C1 — the headline fix)
+The plan's whole point is killing ephemerality, so **persistence is free**: the
+harness wrap (deferred Stream C) will default `store` to
+`Settings.run_store_path` (a conventional gitignored path, e.g. `runs/langres_runs.jsonl`;
+`JudgementLog` sets the mkdir-parents precedent at `judgement_log.py:84`). For cut 1
+(no harness wrap yet), `capture_run(store=None)` writes nothing — the invariant is
+"**`store=None` → no files**" (reconciles the old contradiction between "unconditional"
+and verification #9). Agents/users pass a store or path explicitly; the zero-config
+default lands with Stream C.
+
+## Execution — parallel worktree streams → `feat/tracking-observability`
+
+Single-owner-per-file (rule #5). Each stream = an isolated worktree + TDD agent,
+committing early (worktree-teardown rule), merged into the integration branch after a
+gstack `/review` + internal `langres-code-reviewer` pass.
+
+| Stream | Files owned | Depends on | Wave |
+|---|---|---|---|
+| **S1 Foundation** | `core/runs.py`, `core/trackers/__init__.py`, `core/__init__.py`, `clients/settings.py`, `tests/test_import_budget.py`, `tests/test_runs.py`, `tests/test_trackers.py` | — | 1 |
+| **S2 config_dict** | `core/resolver.py`, `tests/test_resolver_config_dict.py` | — | 1 |
+| **S3 MLflow** | `core/trackers/mlflow_tracker.py`, `pyproject.toml`, `tests/test_mlflow_tracker.py` | S1 | 2 |
+| **S4 W&B** | `core/trackers/wandb_tracker.py`, `tests/test_wandb_tracker.py` | S1 | 2 |
+| **S5 LLM correlation** | `core/modules/llm_judge.py`, `core/judgement_log.py`, tests | S1 | 2 |
+| **S6 DSPy compile** | `core/modules/dspy_judge.py`, tests | S1 | 2 |
+| **S7 Examples+docs** | `examples/research/experiment_tracking_demo.py`, `docs/EXPERIMENTS.md` | S1 | 2 |
+| **Stream C (DEFERRED)** | `core/benchmark.py` wrap + default store + run_methods example | eval Wave D/E merged | fast-follow |
+
+Wave 1 = S1, S2 (parallel roots). **S1 merges into the integration branch first**
+(it owns the exports every Wave-2 stream imports); then Wave 2 = S3, S4, S5, S6, S7
+branch off the updated integration branch, fully parallel. Wave 3 = integration
+verification.
+
+## Acceptance criteria (per stream — enforce by reviewer discipline; per-PR CI does NOT gate coverage)
+- **S1 invariants (the subtle-bug locus):** pure logic (RunContext/RunRecord/RunStore/
+  resolve_tracker/resolve_store/NoOp/Multi/compute_recipe_id) at **95–100%** cov.
+  `recipe_id` excludes `git_dirty`/`lockfile_hash`/code/env/timing. `import langres`
+  pulls **no** ranx/mlflow/wandb/litellm (subprocess assertion) and stays <2.0s.
+  `runs.py` result-model refs are `TYPE_CHECKING`-only (HIGH-4). RunStore append uses
+  `fcntl.flock` (cross-process safety, rev-eng M-1). `store=None` → no files.
+- **S2:** `config_dict()` == the dict `save()` would manifest, no disk write; round-trips
+  through the registry for the built-in judges. (Compiled-DSPy state is a known
+  limitation — document it; S5/S6 don't rely on it.)
+- **S3/S4:** adapter bodies are behavior/smoke with `# pragma: no cover` on un-mockable
+  external calls (rev-eng M-5); lazy `import mlflow`/`wandb` only inside the adapter;
+  `resolve_tracker("mlflow")` raises a helpful `ImportError` when the extra is absent.
+  S3 owns `pyproject.toml` (adds both `[mlflow]` and `[wandb]` extras + `mlflow` dev dep);
+  S4 adds only `wandb_tracker.py` (wandb is already a dependency).
+- **S5:** `completion()` gets `metadata=` **only when `current_run` is set** AND on the
+  litellm path (test the omitted-tracker path asserts NO `metadata` kwarg — locks the
+  byte-identical invariant); `JudgementLog` row carries the `attempt_id` for the exact
+  three-way join (record ↔ judgement ↔ trace).
+- **S6:** `compile()` binds `tracker`/`store`/`parent_run_id` before `**kwargs`; stamps
+  `judge._compile_run_id` so a later `capture_run` can read it into `parent_run_id`.
+- **S7:** demo mirrors `examples/judgement_log_demo.py`; shows `capture_run(..., store=)`
+  then `RunStore(path).read()` + a filter-by-experiment + 2-run metric diff (rev-dx M5),
+  plus a two-line agent idempotency+budget snippet (rev-dx M3); EXPERIMENTS.md section
+  wired into its "See also".
+
+## Verification — beyond testing (Wave 3)
+1. **Import budget** — `pytest tests/test_import_budget.py`; `mlflow`+`wandb` in
+   `_HEAVY_MODULES`; bare `import langres` pulls no mlflow/wandb/**ranx**, <2.0s, no env leak.
+2. **Inspect a RunRecord** — `capture_run` a zero-spend flow with `store=` + a
+   `MultiTracker(["mlflow","wandb"])`; read the JSONL; assert `attempt_id`, `recipe_id`,
+   `git_sha`/dirty, `resolver_config`, `seeds` union, `dataset_fingerprint`, `metrics`,
+   `metric_definition`, `spend_usd`, `status`, `"v":1`, and a `"running"` line preceding
+   the terminal line (crash-visibility).
+3. **Idempotent replay** — same recipe → `compute_recipe_id` equal; dirty tree flips
+   `git_dirty=True` while `recipe_id` stays equal (HIGH-1 regression guard); distinct
+   seeds → distinct `recipe_id` (no collision).
+4. **Dataset-mutation detection** — mutate one corpus row → `dataset_fingerprint` and
+   `recipe_id` change.
+5. **Best-effort snapshot** — an unregistered/bespoke judge (no `type_name`) → capture
+   yields `resolver_config=None`, **no crash** (HIGH-2).
+6. **MLflow + W&B UIs** — run appears with params (`git_sha`, `llm_model`, `blocking_k`,
+   `seeds.*`) and metrics; `run_url == RunRecord.artifacts[...]`.
+7. **Cost cross-check** — `spend_usd == SpendMonitor.spent == Σ JudgementLog cost_usd`.
+8. **Crash visibility (fault injection)** — kill mid-`capture_run` → a lone `running`
+   line survives and the reader reports it.
+9. **mypy strict + coverage** — `uv run mypy src/` clean; S1 pure logic 95–100%.
+
+## Risks
+- **litellm `langfuse_otel` metadata passthrough** — the one unverified seam, but
+  **off the critical path**: Phase-3 correlation's *primary* join is `attempt_id`
+  written into `JudgementLog` + `RunRecord` (JSONL, works regardless of Langfuse).
+  Verify the OTel span-attribute passthrough in S5; fallback = set span attrs via the
+  Langfuse SDK inside `forward`.
+- **Cross-process RunStore append** — `fcntl.flock` per append (S1) handles the
+  multi-agent case (rev-eng M-1).
+- **Building on unmerged `feat/eval-readiness`** — cut 1 is disjoint from eval code, so
+  it rebases cleanly; the PR-target / rebase-onto-main decision is taken at integration
+  time (surfaced to David then), once eval-readiness's own timeline is clear.
+
+## Deferred to fast-follow (after eval-readiness Wave D/E merges)
+- **Stream C** — wrap `run_method`/`run_methods`/`evaluate_judge_on_candidates` (final
+  post-`slice_fn` shape) in `capture_run`; default `store` on; `run_methods` opens a
+  **parent** sweep run and threads `parent_run_id`+`llm_model` to children; update the
+  demo to the `run_methods(store=)` one-liner.
+- Aim adapter; the agent-ready sugar (`has_run`/remaining-budget/failure API) — the
+  Phase-0 primitives already make these two-liners (rev-dx M3), so this is sugar only.

--- a/examples/research/experiment_tracking_demo.py
+++ b/examples/research/experiment_tracking_demo.py
@@ -1,0 +1,182 @@
+"""Persist & compare experiment runs -- the tracking layer, end to end.
+
+langres benchmark results are otherwise *ephemeral*: a run scores well, prints,
+and is gone -- no run id, no config/data snapshot, no way to compare against a
+run from last week. ``capture_run`` fixes that: it gives every run a
+content-addressed identity (``recipe_id``), snapshots the config + git sha +
+seeds + dataset fingerprint into one JSONL line, and reads back as a list of
+frozen ``RunRecord`` models you can diff across sessions.
+
+This demo is offline and free (like ``judgement_log_demo.py``): it runs the
+zero-spend ``"string"`` judge -- no API key, no extras -- at two thresholds,
+captures each run under ``capture_run(store=)``, then reads the store back to
+
+1. diff the two runs' metrics (the "compare across sessions" move); and
+2. show the agent two-liner: "already ran this recipe? / how much have I spent?"
+
+The demo uses ``capture_run`` directly. A later stream wraps the benchmark
+harness so ``run_methods(store=)`` captures runs for you; the primitive shown
+here is what that wrap is built on.
+
+Run it:
+    uv run python examples/research/experiment_tracking_demo.py
+    # macOS + numpy may need: KMP_DUPLICATE_LIB_OK=TRUE uv run python ...
+"""
+
+from pathlib import Path
+
+from langres import dedupe
+from langres.core import RunContext, RunStore, capture_run, compute_recipe_id
+from langres.core.runs import dataset_fingerprint, git_sha
+
+STORE_PATH = "tmp/tracking_demo/runs.jsonl"
+EXPERIMENT = "string-judge-threshold-sweep"
+BUDGET_USD = 5.0
+
+# Toy company records with three true duplicate groups (a*/b*/c*) plus one
+# string-similar distractor (x1) that a lenient threshold wrongly merges.
+records = [
+    {"id": "a1", "name": "Acme Corporation"},
+    {"id": "a2", "name": "Acme Corp"},
+    {"id": "b1", "name": "Globex Incorporated"},
+    {"id": "b2", "name": "Globex Inc"},
+    {"id": "c1", "name": "Initech"},
+    {"id": "c2", "name": "Initech LLC"},
+    {"id": "x1", "name": "Acme Consulting"},
+]
+gold_pairs = {frozenset({"a1", "a2"}), frozenset({"b1", "b2"}), frozenset({"c1", "c2"})}
+
+# One dataset fingerprint over the already-loaded corpus+gold: mutate any record
+# and this (and therefore recipe_id) changes -- data identity, not a filename.
+DATASET_FP = dataset_fingerprint(records, gold_pairs)
+
+
+def pair_prf(clusters: list[set[str]], gold: set[frozenset[str]]) -> dict[str, float]:
+    """Pairwise precision/recall/F1 of a clustering against gold match pairs."""
+    predicted: set[frozenset[str]] = set()
+    for cluster in clusters:
+        members = sorted(cluster)
+        for i, left in enumerate(members):
+            for right in members[i + 1 :]:
+                predicted.add(frozenset({left, right}))
+    true_positives = len(predicted & gold)
+    precision = true_positives / len(predicted) if predicted else 0.0
+    recall = true_positives / len(gold) if gold else 0.0
+    f1 = 2 * precision * recall / (precision + recall) if precision + recall else 0.0
+    return {"precision": precision, "recall": recall, "f1": f1}
+
+
+def sweep_context() -> RunContext:
+    """The parent sweep's recipe: an umbrella over the per-threshold children.
+
+    It has no single config, so ``resolver_config`` stays ``None`` -- the
+    best-effort snapshot path (a bespoke run with no registered config captures
+    cleanly, it does not crash).
+    """
+    sha, dirty = git_sha()
+    return RunContext(
+        experiment=EXPERIMENT,
+        git_sha=sha,
+        git_dirty=dirty,
+        method="threshold_sweep",
+        dataset_name="toy-companies",
+        dataset_fingerprint=DATASET_FP,
+        seeds={"split": 13},
+    )
+
+
+def config_context(threshold: float, *, parent_run_id: str | None = None) -> RunContext:
+    """The recipe for one threshold config: config + data + seeds + provenance.
+
+    ``resolver_config`` is a minimal hand-built snapshot here; the deferred
+    harness wrap fills it from ``Resolver.config_dict()``. ``parent_run_id`` is
+    identity-only (not hashed), so the same config under a different sweep keeps
+    the same ``recipe_id`` -- idempotency is parent-independent.
+    """
+    sha, dirty = git_sha()
+    return RunContext(
+        experiment=EXPERIMENT,
+        parent_run_id=parent_run_id,
+        git_sha=sha,
+        git_dirty=dirty,
+        resolver_config={"judge": "string", "threshold": threshold},
+        method="dedupe_string",
+        dataset_name="toy-companies",
+        dataset_fingerprint=DATASET_FP,
+        seeds={"split": 13},
+    )
+
+
+def main() -> None:
+    store = RunStore(STORE_PATH)
+    # Fresh file so this demo's output is deterministic. In a real workflow you
+    # would NOT reset -- successive sessions append and the idempotency guard
+    # (Part 3) skips recipes already completed.
+    Path(store.path).unlink(missing_ok=True)
+
+    # --- Part 1: capture a two-config threshold sweep -----------------------
+    # Lineage: the sweep is the PARENT run; each threshold config is a CHILD
+    # carrying parent_run_id = <sweep attempt_id>. The same shape models a
+    # DSPy-compile run parenting the eval runs that reuse its compiled program.
+    print(f"Capturing runs to {store.path}")
+    child_f1s: list[float] = []
+    with capture_run(sweep_context(), store=store) as sweep:
+        print(f"  sweep run {sweep.recipe_id} ({sweep.attempt_id})")
+        for threshold in (0.60, 0.70):
+            with capture_run(
+                config_context(threshold, parent_run_id=sweep.attempt_id),
+                store=store,
+            ) as run:
+                clusters = list(dedupe(records, judge="string", threshold=threshold))
+                metrics = pair_prf(clusters, gold_pairs)
+                run.log_metrics(
+                    metrics,
+                    metric_definition="pair_f1",
+                    headline_metric=metrics["f1"],
+                )
+                run.record_cost(0.0)  # zero-spend string judge; a paid judge
+                #                       records SpendMonitor.spent here instead.
+                child_f1s.append(metrics["f1"])
+                print(
+                    f"    threshold={threshold:.2f}  P={metrics['precision']:.2f} "
+                    f"R={metrics['recall']:.2f} F1={metrics['f1']:.2f}"
+                )
+        sweep.log_metrics({"best_f1": max(child_f1s)}, headline_metric=max(child_f1s))
+
+    # --- Part 2: read the runs back and compare (across sessions) -----------
+    runs = RunStore(STORE_PATH).read()  # last-wins-by-attempt_id; frozen models
+    children = [
+        r
+        for r in runs
+        if r.context.experiment == EXPERIMENT and r.context.parent_run_id is not None
+    ]
+    children.sort(key=lambda r: r.context.resolver_config["threshold"])  # type: ignore[index]
+    low, high = children
+    print(f"\n{len(runs)} run(s) persisted; comparing the {len(children)} sweep children:")
+    for record in (low, high):
+        config = record.context.resolver_config or {}
+        metrics = record.metrics or {}
+        print(
+            f"  threshold={config['threshold']:.2f}  recipe={record.recipe_id}  "
+            f"P={metrics['precision']:.2f} R={metrics['recall']:.2f} F1={metrics['f1']:.2f}"
+        )
+    delta = (high.headline_metric or 0.0) - (low.headline_metric or 0.0)
+    sha = low.context.git_sha
+    print(
+        f"  -> raising threshold changed pair-F1 by {delta:+.2f}  (git_sha {sha[:8] if sha else 'n/a'})"
+    )
+
+    # --- Part 3: the agent two-liner: idempotency + budget ------------------
+    # An agent re-running a sweep drops these two lines at the top to skip a
+    # recipe it already paid for and to check remaining budget.
+    completed = [r for r in store.read() if r.status == "completed"]
+    already_ran = compute_recipe_id(config_context(0.60)) in {r.recipe_id for r in completed}
+    spent = sum(r.spend_usd for r in completed)
+    print(
+        f"\nagent check: recipe 'threshold=0.60' already run? {already_ran}  |  "
+        f"spent ${spent:.2f} of ${BUDGET_USD:.2f} budget"
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -78,6 +78,16 @@ llm = [
 trained = [
     "scikit-learn>=1.7.2",
 ]
+# Experiment-tracking backends for the ExperimentTracker seam (core/trackers/).
+# Each is loaded lazily by its adapter (mlflow_tracker.py / wandb_tracker.py) so
+# `import langres` never pulls them -- installing the extra names the fix that
+# resolve_tracker's ImportError points at (`pip install 'langres[mlflow]'`).
+mlflow = [
+    "mlflow>=2.9",
+]
+wandb = [
+    "wandb>=0.16",
+]
 
 [build-system]
 requires = ["hatchling"]
@@ -94,6 +104,7 @@ dev = [
     # own test suite doesn't need --all-extras for a bare `uv sync`.
     "guarddog>=1.3.0",
     "langfuse>=4,<5",
+    "mlflow>=2.9",
     "mypy>=1.18.2",
     "optuna>=4.5.0",
     "optuna-integration[wandb]>=4.5.0",
@@ -210,4 +221,12 @@ follow_imports = "skip"
 # `warn_unused_ignores`). Silencing the missing-import check here is stable
 # across both — mirroring the faiss/litellm/dspy blocks above.
 module = ["sklearn.*"]
+ignore_missing_imports = true
+
+[[tool.mypy.overrides]]
+# mlflow is an optional `[mlflow]` extra: present in CI/dev, absent in a
+# core-only install, so `import mlflow` in trackers/mlflow_tracker.py flips
+# between resolvable and unresolvable. Silencing the missing-import check here
+# is stable across both — mirroring the faiss/litellm/dspy/sklearn blocks above.
+module = ["mlflow.*"]
 ignore_missing_imports = true

--- a/src/langres/clients/settings.py
+++ b/src/langres/clients/settings.py
@@ -26,6 +26,12 @@ class Settings(BaseSettings):
         AZURE_API_VERSION: Azure OpenAI API version (default: "2024-02-15-preview")
         QDRANT_URL: Qdrant vector database URL (optional)
         QDRANT_API_KEY: Qdrant API key (optional)
+        RUN_STORE_PATH: JSONL path for persisted run records (optional; when
+            unset, run capture writes nothing unless a store is passed
+            explicitly -- see langres.core.runs.capture_run)
+        MLFLOW_TRACKING_URI: MLflow tracking server URI (optional; MLflow
+            defaults to a local ./mlruns when unset)
+        MLFLOW_EXPERIMENT: MLflow experiment name (default: "langres")
 
     Example:
         # Load from environment variables
@@ -73,6 +79,11 @@ class Settings(BaseSettings):
     # Qdrant vector database (optional, for future use)
     qdrant_url: str | None = None
     qdrant_api_key: str | None = None
+
+    # Experiment tracking (S1): run-record persistence + MLflow backend config.
+    run_store_path: str | None = None
+    mlflow_tracking_uri: str | None = None
+    mlflow_experiment: str = "langres"
 
     model_config = SettingsConfigDict(
         env_file=".env",

--- a/src/langres/clients/settings.py
+++ b/src/langres/clients/settings.py
@@ -26,12 +26,19 @@ class Settings(BaseSettings):
         AZURE_API_VERSION: Azure OpenAI API version (default: "2024-02-15-preview")
         QDRANT_URL: Qdrant vector database URL (optional)
         QDRANT_API_KEY: Qdrant API key (optional)
-        RUN_STORE_PATH: JSONL path for persisted run records (optional; when
-            unset, run capture writes nothing unless a store is passed
-            explicitly -- see langres.core.runs.capture_run)
-        MLFLOW_TRACKING_URI: MLflow tracking server URI (optional; MLflow
-            defaults to a local ./mlruns when unset)
-        MLFLOW_EXPERIMENT: MLflow experiment name (default: "langres")
+        RUN_STORE_PATH: JSONL path for persisted run records (optional). NOTE:
+            not auto-wired yet -- capture_run(store=...) does NOT default to this
+            setting, so a caller must pass store= explicitly today (e.g.
+            store=Settings().run_store_path). Threading it as the zero-config
+            default store is deferred to the benchmark/harness wrap; until then
+            capture_run(store=None) writes nothing. See langres.core.runs.
+        MLFLOW_TRACKING_URI: MLflow tracking server URI (optional). Read by the
+            MLflow tracker (MlflowTracker / resolve_tracker("mlflow")), NOT by
+            capture_run directly -- it only takes effect when you use the MLflow
+            backend. Unset lets MLflow pick its own default backend (a local
+            file store; MlflowTracker enables it out of the box).
+        MLFLOW_EXPERIMENT: MLflow experiment name (default: "langres"). Read by
+            the MLflow tracker (MlflowTracker.start_run), not by capture_run.
 
     Example:
         # Load from environment variables

--- a/src/langres/clients/tracking.py
+++ b/src/langres/clients/tracking.py
@@ -1,6 +1,7 @@
 """wandb tracking client factory."""
 
 import logging
+import os
 from typing import Any
 
 import wandb
@@ -8,6 +9,10 @@ import wandb
 from langres.clients.settings import Settings
 
 logger = logging.getLogger(__name__)
+
+#: ``WANDB_MODE`` values where wandb never contacts the server, so no API key is
+#: needed (offline runs sync later; disabled runs are a full no-op).
+_KEYLESS_WANDB_MODES = frozenset({"offline", "disabled"})
 
 
 def create_wandb_tracker(settings: Settings | None = None, job_type: str = "optimization") -> Any:
@@ -25,12 +30,16 @@ def create_wandb_tracker(settings: Settings | None = None, job_type: str = "opti
         wandb run object that can be used to log metrics and artifacts.
 
     Raises:
-        ValueError: If WANDB_API_KEY environment variable is not set.
+        ValueError: If WANDB_API_KEY is not set AND wandb is in an online mode.
+            When ``WANDB_MODE`` is ``offline`` or ``disabled`` wandb needs no
+            key, so the requirement is skipped (offline/CI use).
 
     Environment variables required:
-        WANDB_API_KEY: Weights & Biases API key (required)
+        WANDB_API_KEY: Weights & Biases API key (required online; not needed
+            when ``WANDB_MODE`` is ``offline``/``disabled``)
         WANDB_PROJECT: W&B project name (optional, defaults to "langres")
         WANDB_ENTITY: W&B entity/team name (optional)
+        WANDB_MODE: ``online`` (default), ``offline``, or ``disabled``
 
     Example:
         # With explicit settings
@@ -55,8 +64,11 @@ def create_wandb_tracker(settings: Settings | None = None, job_type: str = "opti
     if settings is None:
         settings = Settings()
 
-    # Validate wandb API key is present
-    if not settings.wandb_api_key:
+    # Validate wandb API key is present -- but only for online runs. Offline /
+    # disabled modes never contact the W&B server, so demanding a key there
+    # would needlessly block offline/CI use of the tracker.
+    offline = os.environ.get("WANDB_MODE", "").strip().lower() in _KEYLESS_WANDB_MODES
+    if not offline and not settings.wandb_api_key:
         raise ValueError("WANDB_API_KEY environment variable is required")
 
     run = wandb.init(

--- a/src/langres/core/__init__.py
+++ b/src/langres/core/__init__.py
@@ -73,11 +73,25 @@ from langres.core.registry import (
 )
 from langres.core.resolver import Resolver
 from langres.core.review import ReviewItem, ReviewQueue, select_for_review
+from langres.core.runs import (
+    RunContext,
+    RunRecord,
+    RunStore,
+    capture_run,
+    compute_recipe_id,
+    resolve_store,
+)
 from langres.core.serialization import (
     ARTIFACT_VERSION,
     ArtifactManifest,
     ComponentSpec,
     SerializableState,
+)
+from langres.core.trackers import (
+    ExperimentTracker,
+    MultiTracker,
+    NoOpTracker,
+    resolve_tracker,
 )
 
 if TYPE_CHECKING:
@@ -103,6 +117,7 @@ if TYPE_CHECKING:
     from langres.core.modules.llm_judge import LLMJudge
     from langres.core.modules.random_forest_judge import RandomForestJudge
     from langres.core.modules.select_judge import SelectJudge
+    from langres.core.trackers import MlflowTracker, WandbTracker
 
 __all__ = [
     "ARTIFACT_VERSION",
@@ -179,6 +194,19 @@ __all__ = [
     "VectorBlocker",
     "VectorIndex",
     "WeightedAverageJudge",
+    # Experiment tracking (S1): run identity + persistence + pluggable trackers.
+    "capture_run",
+    "compute_recipe_id",
+    "ExperimentTracker",
+    "MlflowTracker",
+    "MultiTracker",
+    "NoOpTracker",
+    "resolve_store",
+    "resolve_tracker",
+    "RunContext",
+    "RunRecord",
+    "RunStore",
+    "WandbTracker",
 ]
 
 #: Names resolved to a *submodule of this package* on first access -- unlike
@@ -208,6 +236,10 @@ _LAZY_SYMBOLS: dict[str, str] = {
     "LLMJudge": "langres.core.modules.llm_judge",
     "RandomForestJudge": "langres.core.modules.random_forest_judge",
     "SelectJudge": "langres.core.modules.select_judge",
+    # Backend tracker adapters (S3/S4): the package's own __getattr__ pulls the
+    # concrete adapter -- and its mlflow/wandb dependency -- only on access.
+    "MlflowTracker": "langres.core.trackers",
+    "WandbTracker": "langres.core.trackers",
 }
 
 #: ``name -> extra`` for the lazy symbols a ``pip install langres[<extra>]``
@@ -218,9 +250,13 @@ _LAZY_SYMBOLS: dict[str, str] = {
 #: ``SelectJudge`` need ``[llm]`` (litellm/dspy-ai); everything else needs
 #: ``[semantic]`` (embeddings/vector index/VectorBlocker).
 _EXTRA_BY_SYMBOL: dict[str, str] = {
-    name: {"LLMJudge": "llm", "SelectJudge": "llm", "RandomForestJudge": "trained"}.get(
-        name, "semantic"
-    )
+    name: {
+        "LLMJudge": "llm",
+        "SelectJudge": "llm",
+        "RandomForestJudge": "trained",
+        "MlflowTracker": "mlflow",
+        "WandbTracker": "wandb",
+    }.get(name, "semantic")
     for name in _LAZY_SYMBOLS
 }
 

--- a/src/langres/core/judgement_log.py
+++ b/src/langres/core/judgement_log.py
@@ -15,9 +15,11 @@ the wrap entirely -- no file, no extra generator layer, byte-identical to
 pre-W0.2 behavior.
 
 Privacy (adopted DX): record content is OFF by default. Each line carries
-only ids, score, verdict, model, cost, decision_step, timestamp, and the
-schema-version field ``"v": 1`` -- never the underlying record fields or the
-judge's free-text reasoning. Pass ``features=True`` to additionally log
+only ids, score, verdict, model, cost, decision_step, timestamp, the
+enclosing run's ``run_id`` (the active ``capture_run`` attempt id, or
+``null`` outside one -- the join key to the ``RunRecord``/trace, W1 S5), and
+the schema-version field ``"v": 1`` -- never the underlying record fields or
+the judge's free-text reasoning. Pass ``features=True`` to additionally log
 ``reasoning`` and the judge's raw ``provenance`` dict (comparison levels,
 similarities, token counts, ...): **this may contain PII** -- the record
 content a judge reasoned over, verbatim -- and JSONL is plaintext on disk.
@@ -42,6 +44,7 @@ from langres.clients.openrouter import BudgetExceeded
 from langres.core.models import ERCandidate, PairwiseJudgement
 from langres.core.module import Module
 from langres.core.reports import ScoreInspectionReport
+from langres.core.runs import current_run
 
 __all__ = ["JudgementLog", "LoggingModule"]
 
@@ -69,6 +72,9 @@ class JudgementLog:
         """Append one JSON line for ``judgement`` (called by :class:`LoggingModule`)."""
         row: dict[str, Any] = {
             "v": _SCHEMA_VERSION,
+            # The enclosing tracking run (S5): joins this row to its RunRecord
+            # and any LLM trace on the attempt id; ``None`` outside a capture_run.
+            "run_id": current_run.get(),
             "left_id": judgement.left_id,
             "right_id": judgement.right_id,
             "score": judgement.score,

--- a/src/langres/core/modules/dspy_judge.py
+++ b/src/langres/core/modules/dspy_judge.py
@@ -37,7 +37,7 @@ from langres.core.module import Module, SchemaT
 from langres.core.registry import register
 from langres.core.reports import ScoreInspectionReport, _inspect_scores_impl
 from langres.core.runs import RunContext, RunStore, capture_run
-from langres.core.trackers import ExperimentTracker, NoOpTracker
+from langres.core.trackers import ExperimentTracker, resolve_tracker
 
 logger = logging.getLogger(__name__)
 
@@ -283,7 +283,7 @@ class DSPyJudge(Module[SchemaT]):
         valset: Sequence[dspy.Example] | None = None,
         *,
         optimizer: str = "bootstrap",
-        tracker: ExperimentTracker = NoOpTracker(),
+        tracker: ExperimentTracker | None = None,
         store: str | Path | RunStore | None = None,
         parent_run_id: str | None = None,
         **kwargs: Any,
@@ -295,9 +295,9 @@ class DSPyJudge(Module[SchemaT]):
         onto :attr:`_compile_run_id` so a later ``capture_run`` (the eval run that
         uses the compiled program) can thread it into ``parent_run_id`` for the
         compile→eval lineage. Persistence is opt-in: with the default
-        ``store=None`` / ``tracker=NoOpTracker()`` nothing is written and the
-        compiled program is byte-identical to the un-tracked path — only the
-        in-memory ``_compile_run_id`` carrier is stamped.
+        ``store=None`` / ``tracker=None`` (resolved to a no-op) nothing is written
+        and the compiled program is byte-identical to the un-tracked path — only
+        the in-memory ``_compile_run_id`` carrier is stamped.
 
         Args:
             trainset: Labeled ``dspy.Example`` s (``left`` / ``right`` inputs +
@@ -306,7 +306,8 @@ class DSPyJudge(Module[SchemaT]):
             optimizer: ``"bootstrap"`` (``BootstrapFewShot`` — deterministic under
                 ``DummyLM``, the zero-spend path) or ``"mipro"`` (``MIPROv2
                 auto="light"`` — the paid path, exercised only by the example).
-            tracker: Experiment tracker for the compile run (default: no-op).
+            tracker: Experiment tracker for the compile run (``None`` — the
+                default — resolves to a no-op via ``resolve_tracker``).
             store: Where to persist the compile :class:`RunRecord` (default: none).
             parent_run_id: Optional parent run this compilation belongs to (e.g. a
                 sweep) — recorded on the compile run's context.
@@ -320,6 +321,7 @@ class DSPyJudge(Module[SchemaT]):
         """
         if optimizer not in ("bootstrap", "mipro"):
             raise ValueError(f"unknown optimizer {optimizer!r}; choose 'bootstrap' or 'mipro'")
+        tracker = resolve_tracker(tracker)
         context = RunContext(
             experiment="dspy_compile",
             method="dspy_compile",

--- a/src/langres/core/modules/dspy_judge.py
+++ b/src/langres/core/modules/dspy_judge.py
@@ -24,6 +24,8 @@ plain ``import langres.core``. It is registered lazily via
 artifact imports it on demand (firing ``@register``).
 """
 
+import hashlib
+import json
 import logging
 from collections.abc import Iterator, Sequence
 from pathlib import Path
@@ -101,6 +103,27 @@ def _pair_metric(example: dspy.Example, prediction: Any, trace: Any = None) -> b
     is kept only when it reproduces the labeled match decision.
     """
     return bool(prediction.match) == bool(example.match)
+
+
+def _trainset_fingerprint(trainset: Sequence[dspy.Example]) -> str:
+    """Content-address a ``trainset`` so compiles on DIFFERENT labels get DIFFERENT ids.
+
+    Each ``dspy.Example`` is reduced to its field dict (``toDict``) and dumped to
+    canonical JSON (sorted keys, no whitespace); the per-example strings are then
+    sorted before hashing, so an identical labeled set fingerprints identically
+    regardless of row order, while any content change — a flipped label, an edited
+    field, an added/removed example — changes the digest. Fed to the compile
+    :class:`~langres.core.runs.RunContext`'s ``dataset_fingerprint`` so two
+    ``compile`` runs on different trainsets no longer collapse to the same
+    ``recipe_id``. Mirrors :func:`langres.core.runs.dataset_fingerprint`'s style.
+    """
+    digest = hashlib.sha256()
+    for line in sorted(
+        json.dumps(example.toDict(), sort_keys=True, separators=(",", ":")) for example in trainset
+    ):
+        digest.update(line.encode("utf-8"))
+        digest.update(b"\n")
+    return digest.hexdigest()
 
 
 @register("dspy_judge")
@@ -326,6 +349,12 @@ class DSPyJudge(Module[SchemaT]):
             experiment="dspy_compile",
             method="dspy_compile",
             dataset_name="dspy_trainset",
+            # Content-address the labels so two compiles on DIFFERENT trainsets
+            # get DIFFERENT recipe_ids (dataset_fingerprint feeds compute_recipe_id).
+            # Without it, a constant dataset_name collapsed distinct compiles to
+            # one id, letting a store-based replay guard treat different labels as
+            # the same run.
+            dataset_fingerprint=_trainset_fingerprint(trainset),
             llm_model=self.model,
             parent_run_id=parent_run_id,
             resolver_config={
@@ -334,6 +363,8 @@ class DSPyJudge(Module[SchemaT]):
                 **self.config,
             },
         )
+        # NOTE: this compile run records $0 spend; capturing paid DSPy-compile
+        # spend (the ``spend_usd`` seam) is deferred to issue #100 (cost-tracking).
         with capture_run(context, store=store, tracker=tracker) as run:
             with dspy.context(lm=self._get_lm()):
                 if optimizer == "bootstrap":

--- a/src/langres/core/modules/dspy_judge.py
+++ b/src/langres/core/modules/dspy_judge.py
@@ -36,6 +36,8 @@ from langres.core.models import ERCandidate, PairwiseJudgement
 from langres.core.module import Module, SchemaT
 from langres.core.registry import register
 from langres.core.reports import ScoreInspectionReport, _inspect_scores_impl
+from langres.core.runs import RunContext, RunStore, capture_run
+from langres.core.trackers import ExperimentTracker, NoOpTracker
 
 logger = logging.getLogger(__name__)
 
@@ -160,6 +162,11 @@ class DSPyJudge(Module[SchemaT]):
         # from the ``langres.clients.openrouter`` price table (unknown models stay
         # $0), or a caller may set ``judge.price_per_1k_tokens`` directly.
         self.price_per_1k_tokens = 0.0
+        # Lineage carrier: :meth:`compile` records the compilation as a tracked
+        # optimization run and stamps its ``attempt_id`` here, so a later
+        # ``capture_run`` (the eval run using this compiled program) can read it
+        # into ``parent_run_id`` — otherwise the compile→eval lineage stays None.
+        self._compile_run_id: str | None = None
 
     def _get_lm(self) -> Any:
         """Return the DSPy LM, lazily building a ``dspy.LM`` from ``model`` on first use."""
@@ -276,9 +283,21 @@ class DSPyJudge(Module[SchemaT]):
         valset: Sequence[dspy.Example] | None = None,
         *,
         optimizer: str = "bootstrap",
+        tracker: ExperimentTracker = NoOpTracker(),
+        store: str | Path | RunStore | None = None,
+        parent_run_id: str | None = None,
         **kwargs: Any,
     ) -> Self:
         """Compile (tune) the DSPy program against a gold set, in place.
+
+        The compilation is recorded as a first-class **optimization run** via
+        :func:`~langres.core.runs.capture_run`, and its ``attempt_id`` is stamped
+        onto :attr:`_compile_run_id` so a later ``capture_run`` (the eval run that
+        uses the compiled program) can thread it into ``parent_run_id`` for the
+        compile→eval lineage. Persistence is opt-in: with the default
+        ``store=None`` / ``tracker=NoOpTracker()`` nothing is written and the
+        compiled program is byte-identical to the un-tracked path — only the
+        in-memory ``_compile_run_id`` carrier is stamped.
 
         Args:
             trainset: Labeled ``dspy.Example`` s (``left`` / ``right`` inputs +
@@ -287,30 +306,52 @@ class DSPyJudge(Module[SchemaT]):
             optimizer: ``"bootstrap"`` (``BootstrapFewShot`` — deterministic under
                 ``DummyLM``, the zero-spend path) or ``"mipro"`` (``MIPROv2
                 auto="light"`` — the paid path, exercised only by the example).
-            **kwargs: Forwarded to the optimizer's ``compile``.
+            tracker: Experiment tracker for the compile run (default: no-op).
+            store: Where to persist the compile :class:`RunRecord` (default: none).
+            parent_run_id: Optional parent run this compilation belongs to (e.g. a
+                sweep) — recorded on the compile run's context.
+            **kwargs: Forwarded to the optimizer's ``compile`` (the tracking
+                params above are bound explicitly, so they never leak into it).
 
         Returns:
-            ``self`` with ``_program`` replaced by the compiled program and
-            ``_compiled`` set — so callers can chain ``judge.compile(...).forward(...)``.
+            ``self`` with ``_program`` replaced by the compiled program,
+            ``_compiled`` set, and ``_compile_run_id`` stamped — so callers can
+            chain ``judge.compile(...).forward(...)``.
         """
-        with dspy.context(lm=self._get_lm()):
-            if optimizer == "bootstrap":
-                self._program = dspy.BootstrapFewShot(metric=_pair_metric).compile(
-                    self._program, trainset=list(trainset), **kwargs
-                )
-            elif optimizer == "mipro":  # pragma: no cover - paid, non-deterministic path
-                # Exercised only by the paid example (MIPROv2 proposes+evaluates
-                # instructions via real LM calls; it is not deterministic under
-                # DummyLM, so it is kept out of the zero-spend unit suite).
-                self._program = dspy.MIPROv2(metric=_pair_metric, auto="light").compile(
-                    self._program,
-                    trainset=list(trainset),
-                    valset=list(valset) if valset is not None else None,
-                    **kwargs,
-                )
-            else:
-                raise ValueError(f"unknown optimizer {optimizer!r}; choose 'bootstrap' or 'mipro'")
+        if optimizer not in ("bootstrap", "mipro"):
+            raise ValueError(f"unknown optimizer {optimizer!r}; choose 'bootstrap' or 'mipro'")
+        context = RunContext(
+            experiment="dspy_compile",
+            method="dspy_compile",
+            dataset_name="dspy_trainset",
+            llm_model=self.model,
+            parent_run_id=parent_run_id,
+            resolver_config={
+                "type_name": self.type_name,
+                "optimizer": optimizer,
+                **self.config,
+            },
+        )
+        with capture_run(context, store=store, tracker=tracker) as run:
+            with dspy.context(lm=self._get_lm()):
+                if optimizer == "bootstrap":
+                    self._program = dspy.BootstrapFewShot(metric=_pair_metric).compile(
+                        self._program, trainset=list(trainset), **kwargs
+                    )
+                else:  # "mipro"  # pragma: no cover - paid, non-deterministic path
+                    # Exercised only by the paid example (MIPROv2 proposes+evaluates
+                    # instructions via real LM calls; it is not deterministic under
+                    # DummyLM, so it is kept out of the zero-spend unit suite).
+                    self._program = dspy.MIPROv2(metric=_pair_metric, auto="light").compile(
+                        self._program,
+                        trainset=list(trainset),
+                        valset=list(valset) if valset is not None else None,
+                        **kwargs,
+                    )
         self._compiled = True
+        # Stamp the lineage carrier AFTER a successful compile (a failed compile
+        # propagates out of ``capture_run`` before this line, so it never stamps).
+        self._compile_run_id = run.attempt_id
         return self
 
     #: Sidecar file recording whether the saved program was compiled, so a reload

--- a/src/langres/core/modules/llm_judge.py
+++ b/src/langres/core/modules/llm_judge.py
@@ -26,6 +26,7 @@ from langres.core.models import ERCandidate, PairwiseJudgement
 from langres.core.module import Module, SchemaT
 from langres.core.registry import register
 from langres.core.reports import ScoreInspectionReport, _inspect_scores_impl
+from langres.core.runs import current_run
 
 logger = logging.getLogger(__name__)
 
@@ -364,11 +365,29 @@ class LLMJudge(Module[SchemaT]):
             )
 
             # Call client (works for both LiteLLM and OpenAI)
-            response = self._get_client().completion(
+            client = self._get_client()
+            completion_kwargs = self._completion_kwargs()
+            # Run correlation (S5): stamp the active tracking run's attempt id +
+            # pair identity into litellm's first-class ``metadata`` param, so a
+            # Langfuse/OTel trace joins the RunRecord and JudgementLog on
+            # ``langres_attempt_id``. Gated on BOTH (a) an open ``capture_run``
+            # (``current_run`` set) and (b) the litellm path -- a user-supplied
+            # direct client (e.g. a raw OpenAI client) would 400 on an unknown
+            # ``metadata`` kwarg. When ``current_run`` is None the call stays
+            # byte-identical to before -- no ``metadata`` key is added.
+            attempt_id = current_run.get()
+            if attempt_id is not None and client is litellm:
+                completion_kwargs["metadata"] = {
+                    "langres_attempt_id": attempt_id,
+                    "left_id": candidate.left.id,  # type: ignore[attr-defined]
+                    "right_id": candidate.right.id,  # type: ignore[attr-defined]
+                    "decision_step": "llm_judgment",
+                }
+            response = client.completion(
                 model=self.model,
                 messages=[{"role": "user", "content": prompt}],
                 temperature=self.temperature,
-                **self._completion_kwargs(),
+                **completion_kwargs,
             )
 
             # Extract score and reasoning from response

--- a/src/langres/core/modules/llm_judge.py
+++ b/src/langres/core/modules/llm_judge.py
@@ -336,6 +336,31 @@ class LLMJudge(Module[SchemaT]):
             return real_cost, provider, True
         return self._calculate_cost(response), provider, False
 
+    def _run_correlation_metadata(
+        self, client: Any, left_id: Any, right_id: Any, decision_step: str
+    ) -> dict[str, Any] | None:
+        """Litellm ``metadata`` correlating this call to the active run, or ``None``.
+
+        S5 run correlation: when a ``capture_run`` is open (``current_run`` set)
+        AND the client is the litellm module (identity check), return the
+        ``metadata`` payload -- the run's ``attempt_id``, the pair ids, and the
+        ``decision_step`` -- so a Langfuse/OTel trace joins the ``RunRecord`` and
+        ``JudgementLog`` on ``langres_attempt_id``. Returns ``None`` otherwise
+        (no open run, or a user-supplied direct client that would 400 on an
+        unknown ``metadata`` kwarg), so the completion call stays byte-identical
+        to before when no run is active. Shared by :meth:`forward` (sync) and
+        :meth:`_call_llm_with_retry` (async) so the two paths cannot drift.
+        """
+        attempt_id = current_run.get()
+        if attempt_id is not None and client is litellm:
+            return {
+                "langres_attempt_id": attempt_id,
+                "left_id": left_id,
+                "right_id": right_id,
+                "decision_step": decision_step,
+            }
+        return None
+
     def forward(self, candidates: Iterator[ERCandidate[SchemaT]]) -> Iterator[PairwiseJudgement]:
         """Compare entity pairs using LLM judgment.
 
@@ -367,22 +392,18 @@ class LLMJudge(Module[SchemaT]):
             # Call client (works for both LiteLLM and OpenAI)
             client = self._get_client()
             completion_kwargs = self._completion_kwargs()
-            # Run correlation (S5): stamp the active tracking run's attempt id +
-            # pair identity into litellm's first-class ``metadata`` param, so a
-            # Langfuse/OTel trace joins the RunRecord and JudgementLog on
-            # ``langres_attempt_id``. Gated on BOTH (a) an open ``capture_run``
-            # (``current_run`` set) and (b) the litellm path -- a user-supplied
-            # direct client (e.g. a raw OpenAI client) would 400 on an unknown
-            # ``metadata`` kwarg. When ``current_run`` is None the call stays
-            # byte-identical to before -- no ``metadata`` key is added.
-            attempt_id = current_run.get()
-            if attempt_id is not None and client is litellm:
-                completion_kwargs["metadata"] = {
-                    "langres_attempt_id": attempt_id,
-                    "left_id": candidate.left.id,  # type: ignore[attr-defined]
-                    "right_id": candidate.right.id,  # type: ignore[attr-defined]
-                    "decision_step": "llm_judgment",
-                }
+            # Run correlation (S5): stamp the active tracking run + pair identity
+            # into litellm's ``metadata`` param (shared with the async path via
+            # ``_run_correlation_metadata``). ``None`` off a run keeps the call
+            # byte-identical -- no ``metadata`` key is added.
+            metadata = self._run_correlation_metadata(
+                client,
+                candidate.left.id,  # type: ignore[attr-defined]
+                candidate.right.id,  # type: ignore[attr-defined]
+                "llm_judgment",
+            )
+            if metadata is not None:
+                completion_kwargs["metadata"] = metadata
             response = client.completion(
                 model=self.model,
                 messages=[{"role": "user", "content": prompt}],
@@ -540,6 +561,8 @@ class LLMJudge(Module[SchemaT]):
             response = await self._call_llm_with_retry(
                 prompt=prompt,
                 max_retries=max_retries,
+                left_id=candidate.left.id,  # type: ignore[attr-defined]
+                right_id=candidate.right.id,  # type: ignore[attr-defined]
             )
 
             # Record actual token usage (thread-safe)
@@ -579,12 +602,16 @@ class LLMJudge(Module[SchemaT]):
         self,
         prompt: str,
         max_retries: int,
+        left_id: Any,
+        right_id: Any,
     ) -> Any:
         """Call LLM API with exponential backoff retry for rate limits.
 
         Args:
             prompt: The prompt to send to the LLM
             max_retries: Maximum retry attempts
+            left_id: Left record id, for the run-correlation ``metadata``
+            right_id: Right record id, for the run-correlation ``metadata``
 
         Returns:
             LLM API response
@@ -596,13 +623,20 @@ class LLMJudge(Module[SchemaT]):
             Implements exponential backoff: 1s, 2s, 4s, 8s, ... up to 60s max
         """
         client = self._get_client()
+        completion_kwargs = self._completion_kwargs()
+        # Run correlation (S5): mirror forward()'s litellm ``metadata`` injection
+        # on the async path -- async judging inside ``capture_run`` would otherwise
+        # lose trace correlation. ``None`` off a run keeps the call byte-identical.
+        metadata = self._run_correlation_metadata(client, left_id, right_id, "llm_judgment_async")
+        if metadata is not None:
+            completion_kwargs["metadata"] = metadata
         for attempt in range(max_retries):
             try:
                 response = await client.acompletion(
                     model=self.model,
                     messages=[{"role": "user", "content": prompt}],
                     temperature=self.temperature,
-                    **self._completion_kwargs(),
+                    **completion_kwargs,
                 )
                 return response
             except RateLimitError as e:

--- a/src/langres/core/resolver.py
+++ b/src/langres/core/resolver.py
@@ -636,11 +636,54 @@ class Resolver:
         slots.append(("clusterer", self.clusterer))
         return slots
 
+    def _build_manifest(self) -> ArtifactManifest:
+        """Assemble the in-memory :class:`ArtifactManifest` (no disk I/O).
+
+        Shared by :meth:`save` (which writes it, plus sidecars) and
+        :meth:`config_dict` (which returns it as a dict). Serializes each slot
+        component into a :class:`ComponentSpec` via :func:`_component_spec`,
+        which raises :class:`TypeError` for a component lacking a registry
+        ``type_name`` — that error is intentional and not swallowed here.
+        """
+        components = [
+            _component_spec(component, slot=slot_name) for slot_name, component in self._slots()
+        ]
+        return ArtifactManifest(
+            artifact_version=ARTIFACT_VERSION,
+            langres_version=langres.__version__,
+            components=components,
+        )
+
+    def config_dict(self) -> dict[str, object]:
+        """Return the resolver's full config snapshot, WITHOUT writing to disk.
+
+        Builds the same :class:`ArtifactManifest` :meth:`save` would (the ordered
+        per-slot ``type_name`` + construction config) and returns its
+        ``.model_dump()`` — a plain, JSON-serializable dict. Used by the
+        experiment-tracking layer to capture a pipeline's declared config
+        (``RunContext.resolver_config``) without materializing an artifact.
+
+        Known limitation: this captures **declared** component config, not
+        compiled/optimized in-memory state — e.g. a DSPy-compiled program's tuned
+        prompts do not appear here. Persisting that state is out of scope for the
+        config snapshot (it round-trips via :class:`SerializableState` sidecars in
+        :meth:`save`, not through this dict).
+
+        Returns:
+            The manifest as a dict: ``artifact_version``, ``langres_version``,
+            and the ordered ``components`` specs.
+
+        Raises:
+            TypeError: If a slot component lacks a registry ``type_name`` (same
+                contract as :meth:`save`; not swallowed).
+        """
+        return self._build_manifest().model_dump()
+
     def save(self, path: str | Path) -> None:
         """Persist the whole pipeline to ``path`` as a self-describing artifact.
 
-        Writes ``resolver.json`` (an :class:`ArtifactManifest`) plus, for any
-        slot component that implements
+        Writes ``resolver.json`` (an :class:`ArtifactManifest`, identical to
+        :meth:`config_dict`) plus, for any slot component that implements
         :class:`~langres.core.serialization.SerializableState`, a sidecar state
         directory named after the slot. The manifest records, per slot, the
         component ``type_name`` and config (the embedder persists by
@@ -652,9 +695,8 @@ class Resolver:
         out_dir = Path(path)
         out_dir.mkdir(parents=True, exist_ok=True)
 
-        components: list[ComponentSpec] = []
+        manifest = self._build_manifest()
         for slot_name, component in self._slots():
-            components.append(_component_spec(component, slot=slot_name))
             owner = _state_owner(component)
             if owner is not None:
                 state_dir = out_dir / slot_name
@@ -667,11 +709,6 @@ class Resolver:
                 if not any(state_dir.iterdir()):
                     state_dir.rmdir()
 
-        manifest = ArtifactManifest(
-            artifact_version=ARTIFACT_VERSION,
-            langres_version=langres.__version__,
-            components=components,
-        )
         (out_dir / _MANIFEST_FILENAME).write_text(manifest.model_dump_json(indent=2))
         logger.info("Saved Resolver artifact to %s", out_dir)
 

--- a/src/langres/core/resolver.py
+++ b/src/langres/core/resolver.py
@@ -655,13 +655,22 @@ class Resolver:
         )
 
     def config_dict(self) -> dict[str, object]:
-        """Return the resolver's full config snapshot, WITHOUT writing to disk.
+        """Return the resolver's hash-safe config snapshot, WITHOUT writing to disk.
 
-        Builds the same :class:`ArtifactManifest` :meth:`save` would (the ordered
-        per-slot ``type_name`` + construction config) and returns its
-        ``.model_dump()`` — a plain, JSON-serializable dict. Used by the
-        experiment-tracking layer to capture a pipeline's declared config
-        (``RunContext.resolver_config``) without materializing an artifact.
+        Returns only the reproducible *config* the manifest wraps — the ordered
+        per-slot ``type_name`` + construction config under a ``components`` key —
+        and deliberately **omits** the volatile version/provenance envelope
+        (``artifact_version``, ``langres_version``) that :meth:`save` writes to
+        ``resolver.json``.
+
+        This is by design: the tracking layer feeds this dict to
+        ``RunContext.resolver_config``, which is inside
+        :func:`~langres.core.runs.compute_recipe_id`'s hash domain. Emitting the
+        version fields would fork ``recipe_id`` on every package or
+        artifact-schema bump, silently defeating idempotent replay. Version and
+        provenance live on :class:`~langres.core.runs.RunContext` as separate,
+        **unhashed** fields (e.g. ``RunContext.langres_version``); :meth:`save`
+        still records them on disk for artifact reconstruction.
 
         Known limitation: this captures **declared** component config, not
         compiled/optimized in-memory state — e.g. a DSPy-compiled program's tuned
@@ -670,20 +679,23 @@ class Resolver:
         :meth:`save`, not through this dict).
 
         Returns:
-            The manifest as a dict: ``artifact_version``, ``langres_version``,
-            and the ordered ``components`` specs.
+            A plain, JSON-serializable dict with a single ``components`` key: the
+            ordered slot specs (each a ``type_name`` + ``config``). No version
+            fields — see above.
 
         Raises:
             TypeError: If a slot component lacks a registry ``type_name`` (same
                 contract as :meth:`save`; not swallowed).
         """
-        return self._build_manifest().model_dump()
+        return {"components": self._build_manifest().model_dump()["components"]}
 
     def save(self, path: str | Path) -> None:
         """Persist the whole pipeline to ``path`` as a self-describing artifact.
 
-        Writes ``resolver.json`` (an :class:`ArtifactManifest`, identical to
-        :meth:`config_dict`) plus, for any slot component that implements
+        Writes ``resolver.json`` (a full :class:`ArtifactManifest`, including the
+        ``artifact_version`` + ``langres_version`` envelope that
+        :meth:`config_dict` intentionally omits) plus, for any slot component that
+        implements
         :class:`~langres.core.serialization.SerializableState`, a sidecar state
         directory named after the slot. The manifest records, per slot, the
         component ``type_name`` and config (the embedder persists by

--- a/src/langres/core/runs.py
+++ b/src/langres/core/runs.py
@@ -27,11 +27,11 @@ is *same recipe -> same* :func:`compute_recipe_id`, **not** same metrics:
 
 from __future__ import annotations
 
-import fcntl
 import hashlib
 import importlib.metadata
 import json
 import logging
+import os
 import subprocess
 import time
 from collections.abc import Iterable, Iterator, Mapping
@@ -44,6 +44,16 @@ from typing import Any, Literal
 from pydantic import BaseModel, ConfigDict, Field
 
 from langres.core.trackers import ExperimentTracker, NoOpTracker
+
+# ``fcntl`` is Unix-only. ``runs`` sits on the bare ``import langres`` path
+# (``judgement_log`` imports ``current_run`` from it), so a hard top-level
+# import would break importing the package on Windows. Load it lazily: on a
+# platform without ``fcntl`` the store degrades to a lock-free append with a
+# one-time warning (see :meth:`RunStore.append`) rather than crashing the import.
+try:
+    import fcntl
+except ImportError:  # pragma: no cover - Windows/non-Unix platforms have no fcntl
+    fcntl = None  # type: ignore[assignment]
 
 __all__ = [
     "RunContext",
@@ -93,6 +103,9 @@ _RECIPE_FIELDS = (
 
 #: One-shot guard so a git-less environment warns exactly once per process.
 _GIT_SHA_WARNED = False
+
+#: One-shot guard so a flock-less (non-Unix) environment warns exactly once.
+_FLOCK_WARNED = False
 
 
 def _detect_langres_version() -> str | None:
@@ -268,8 +281,15 @@ def _scan_for_seeds(node: Any, seeds: dict[str, int], *, path: str) -> None:
             value = node.get(key)
             if isinstance(value, int) and not isinstance(value, bool):
                 seeds[_unique_label(f"{prefix}.{key}", seeds)] = value
-        for child_key, child in node.items():
-            _scan_for_seeds(child, seeds, path=f"{path}.{child_key}" if path else str(child_key))
+        # Traverse mapping children in canonical (sorted-key) order so the
+        # disambiguation suffixes ``_unique_label`` hands out -- and therefore
+        # the ``seeds`` map and the ``recipe_id`` that hashes it -- do not depend
+        # on the caller's raw dict-insertion order. Lists keep their index order
+        # (a list is semantically ordered data).
+        for child_key in sorted(node, key=str):
+            _scan_for_seeds(
+                node[child_key], seeds, path=f"{path}.{child_key}" if path else str(child_key)
+            )
     elif isinstance(node, (list, tuple)):
         for index, item in enumerate(node):
             _scan_for_seeds(item, seeds, path=f"{path}[{index}]")
@@ -333,28 +353,57 @@ class RunStoreError(RuntimeError):
     """A :class:`RunStore` could not persist a record (unwritable path, etc.)."""
 
 
+def _warn_flock_unavailable() -> None:
+    """Warn once that advisory file locking is unavailable on this platform."""
+    global _FLOCK_WARNED
+    if not _FLOCK_WARNED:
+        logger.warning(
+            "fcntl is unavailable on this platform; RunStore.append is writing without an "
+            "advisory file lock -- concurrent writers to the same runs file may interleave."
+        )
+        _FLOCK_WARNED = True
+
+
 class RunStore:
     """Append-only JSONL store of :class:`RunRecord` lines.
 
     ``append`` takes an exclusive ``fcntl.flock`` (cross-process safety when
     several agents write the same file) and creates parent dirs on demand
     (``JudgementLog``'s precedent). ``read`` collapses the ``running`` +
-    terminal lines of each attempt via **last-wins-by-attempt_id**.
+    terminal lines of each attempt via **last-wins-by-attempt_id** and tolerates
+    a torn trailing line from a concurrent writer. On a platform without
+    ``fcntl`` (e.g. Windows) ``append`` degrades to a lock-free write.
     """
 
     def __init__(self, path: str | Path) -> None:
         self.path = Path(path)
 
     def append(self, record: RunRecord) -> None:
-        """Append one record; wrap any OS failure as :class:`RunStoreError`."""
+        """Append one record durably; wrap any OS failure as :class:`RunStoreError`.
+
+        The bytes are ``flush``ed and ``fsync``ed to the OS *before* the advisory
+        lock is released, so the whole line lands under the lock and concurrent
+        writers cannot interleave. (A bare ``TextIOWrapper.write`` only fills a
+        Python buffer -- the real ``write(2)`` would otherwise happen at
+        ``close()``, after the lock was already dropped.) Where ``fcntl`` is
+        absent the lock is skipped with a one-time warning.
+        """
+        line = record.model_dump_json() + "\n"
         try:
             self.path.parent.mkdir(parents=True, exist_ok=True)
             with self.path.open("a", encoding="utf-8") as handle:
-                fcntl.flock(handle.fileno(), fcntl.LOCK_EX)
+                use_lock = fcntl is not None
+                if use_lock:
+                    fcntl.flock(handle.fileno(), fcntl.LOCK_EX)
+                else:
+                    _warn_flock_unavailable()
                 try:
-                    handle.write(record.model_dump_json() + "\n")
+                    handle.write(line)
+                    handle.flush()
+                    os.fsync(handle.fileno())
                 finally:
-                    fcntl.flock(handle.fileno(), fcntl.LOCK_UN)
+                    if use_lock:
+                        fcntl.flock(handle.fileno(), fcntl.LOCK_UN)
         except OSError as exc:
             raise RunStoreError(
                 f"could not append a run record to {self.path}: {exc}. Check the path is "
@@ -363,16 +412,36 @@ class RunStore:
             ) from exc
 
     def read(self) -> list[RunRecord]:
-        """Every attempt's latest record, in first-seen order (last-wins)."""
+        """Every attempt's latest record, in first-seen order (last-wins).
+
+        Tolerant of a concurrent writer: a torn/partial *trailing* line (the file
+        being appended right now) is skipped quietly, while a genuinely malformed
+        *complete* line is skipped with a ``logging`` warning rather than
+        aborting the whole read.
+        """
         if not self.path.exists():
             return []
         by_attempt: dict[str, RunRecord] = {}
         with self.path.open("r", encoding="utf-8") as handle:
-            for line in handle:
-                stripped = line.strip()
-                if stripped:
-                    record = RunRecord.model_validate_json(stripped)
-                    by_attempt[record.attempt_id] = record
+            lines = handle.readlines()
+        last_index = len(lines) - 1
+        for index, raw in enumerate(lines):
+            stripped = raw.strip()
+            if not stripped:
+                continue
+            try:
+                record = RunRecord.model_validate_json(stripped)
+            except ValueError:
+                # A trailing line with no terminating newline is almost certainly
+                # a torn write from a racing appender -- skip it silently. A
+                # complete (newline-terminated) or mid-file bad line is real
+                # corruption, worth a warning but not worth aborting the read.
+                if index == last_index and not raw.endswith("\n"):
+                    logger.debug("skipping a torn trailing line in %s", self.path)
+                else:
+                    logger.warning("skipping a malformed run record line in %s", self.path)
+                continue
+            by_attempt[record.attempt_id] = record
         return list(by_attempt.values())
 
 
@@ -461,8 +530,12 @@ def capture_run(
     Computes ``recipe_id`` + ``attempt_id``; if ``store`` resolves, appends a
     ``status="running"`` line first (a crash then leaves a visible gap); sets
     the :data:`current_run` contextvar (set/reset token, so a nested capture
-    restores the parent on exit); starts the tracker; yields a
-    :class:`_RunHandle`. On exit it finalizes the :class:`RunRecord`
+    restores the parent on exit); then, *inside* the protected block, starts the
+    tracker and yields a :class:`_RunHandle`. Starting the tracker sits inside
+    the try/finally on purpose: if ``start_run`` (or anything before the yield)
+    raises, the contextvar is still reset and a terminal ``status="failed"``
+    record is still written before the error propagates -- the ``running`` line
+    never dangles. On exit it finalizes the :class:`RunRecord`
     (status/metrics/cost/timing/artifacts + the tracker's ``run_url``), appends
     the terminal line, and finishes the tracker. ``store=None`` writes NOTHING.
     """
@@ -482,13 +555,12 @@ def capture_run(
                 status="running",
             )
         )
-    tracker.start_run(context, run_name=context.experiment)
-
     handle = _RunHandle(attempt_id, recipe_id, tracker)
     token = current_run.set(attempt_id)
     error_type: str | None = None
     error_message: str | None = None
     try:
+        tracker.start_run(context, run_name=context.experiment)
         yield handle
     except BaseException as exc:
         error_type = type(exc).__name__

--- a/src/langres/core/runs.py
+++ b/src/langres/core/runs.py
@@ -1,0 +1,529 @@
+"""Run identity, provenance capture, and JSONL persistence -- the tracking core.
+
+langres benchmark runs are otherwise *ephemeral*: rich Pydantic results are
+dumped or rendered, then lost -- no run id, no config/dataset/split snapshot, no
+persistence, no cross-run comparison. This module adds the missing spine while
+staying **dependency-free** (stdlib + pydantic only): two frozen models
+(:class:`RunContext` -- the recipe; :class:`RunRecord` -- recipe + outcomes),
+their content-addressed identity (:func:`compute_recipe_id`), a JSONL
+:class:`RunStore`, and the :func:`capture_run` context manager that ties them
+together. Result models (``MethodResult`` etc.) are stored as an **opaque dict**
+so ``import langres`` never pulls ``ranx``/``benchmark`` in.
+
+Identity split (the subtle part). LLM runs are nondeterministic, so idempotency
+is *same recipe -> same* :func:`compute_recipe_id`, **not** same metrics:
+
+* ``recipe_id`` = ``sha256(canonical_json(<recipe fields>))[:16]`` -- a dedup key
+  over the *logical experiment* (config + data + seeds). It **excludes** all
+  code/env provenance (``git_sha``, ``git_dirty``, ``lockfile_hash``,
+  ``langres_version``, timing), so a dirty tree or a ``uv.lock`` bump does NOT
+  mint a new id. That provenance is recorded for explaining a metrics move --
+  just not part of dedup identity.
+* ``attempt_id`` = ``f"{recipe_id}-{started_at}"`` = the record PK. The
+  ``running`` line and the terminal line of one attempt share it, so the reader
+  does **last-wins-by-attempt_id**. "Already paid this config?" =
+  "any record with this ``recipe_id`` and ``status == 'completed'``?".
+"""
+
+from __future__ import annotations
+
+import fcntl
+import hashlib
+import importlib.metadata
+import json
+import logging
+import subprocess
+import time
+from collections.abc import Iterable, Iterator, Mapping
+from contextlib import contextmanager
+from contextvars import ContextVar
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any, Literal
+
+from pydantic import BaseModel, ConfigDict, Field
+
+from langres.core.trackers import ExperimentTracker, NoOpTracker
+
+__all__ = [
+    "RunContext",
+    "RunRecord",
+    "RunStore",
+    "RunStoreError",
+    "capture_run",
+    "compute_recipe_id",
+    "current_run",
+    "dataset_fingerprint",
+    "git_sha",
+    "resolve_store",
+]
+
+logger = logging.getLogger(__name__)
+
+#: The active attempt id, so components deep in a resolve (the LLM judge, the
+#: judgement log) can correlate their rows to the enclosing run without the id
+#: being threaded through every call. ``None`` when no ``capture_run`` is open.
+current_run: ContextVar[str | None] = ContextVar("langres_current_run", default=None)
+
+#: Terminal states a run can finish in. ``"running"`` is written at *start* so a
+#: crashed/torn-down run leaves a visible lone ``running`` line.
+RunStatus = Literal["running", "completed", "failed", "budget_exceeded"]
+
+_RECIPE_ID_LENGTH = 16
+_MAX_ERROR_MESSAGE_LEN = 2000
+_GIT_TIMEOUT_SECONDS = 5.0
+_SEED_KEYS = ("random_state", "seed")
+
+#: The RunContext fields that DEFINE a run (the hash domain of
+#: :func:`compute_recipe_id`). Everything else on the context is provenance,
+#: recorded but deliberately excluded from identity (see the module docstring).
+_RECIPE_FIELDS = (
+    "experiment",
+    "resolver_config",
+    "llm_model",
+    "cascade_band",
+    "blocking_k",
+    "budget_usd",
+    "method",
+    "dataset_name",
+    "dataset_fingerprint",
+    "split_id",
+    "seeds",
+)
+
+#: One-shot guard so a git-less environment warns exactly once per process.
+_GIT_SHA_WARNED = False
+
+
+def _detect_langres_version() -> str | None:
+    """Best-effort installed langres version for run provenance (``None`` if absent)."""
+    try:
+        return importlib.metadata.version("langres")
+    except importlib.metadata.PackageNotFoundError:  # pragma: no cover - always installed in-repo
+        return None
+
+
+class RunContext(BaseModel):
+    """The recipe: everything that determines a run, plus code/env provenance.
+
+    Frozen. The *config/data/seed* fields feed :func:`compute_recipe_id`; the
+    code/env fields are provenance only (see :data:`_RECIPE_FIELDS`).
+    """
+
+    model_config = ConfigDict(frozen=True)
+
+    # -- Identity / organization (NOT hashed) --
+    experiment: str
+    group: str | None = None
+    parent_run_id: str | None = None
+    tags: dict[str, str] = Field(default_factory=dict)
+
+    # -- Code/env provenance (recorded, NOT hashed) --
+    git_sha: str | None = None
+    git_dirty: bool = False
+    lockfile_hash: str | None = None
+    langres_version: str | None = Field(default_factory=_detect_langres_version)
+    tracking_schema_version: int = 1
+    python_version: str | None = None
+    platform: str | None = None
+    reproduction_adapter_version: str | None = None
+
+    # -- Config (hashed) --
+    resolver_config: dict[str, Any] | None = None
+    llm_model: str | None = None
+    cascade_band: tuple[float, float] | None = None
+    blocking_k: int | None = None
+    budget_usd: float | None = None
+    method: str | None = None
+
+    # -- Data (hashed) --
+    dataset_name: str
+    dataset_fingerprint: str | None = None
+    split_id: str | None = None
+
+    # -- Seeds (hashed): named union of every source; the split seed lives in
+    #    ``seeds["split"]`` (no duplicate scalar). --
+    seeds: dict[str, int] = Field(default_factory=dict)
+
+
+class RunRecord(BaseModel):
+    """A :class:`RunContext` plus outcomes -- one JSONL line, ``"v": 1`` idiom.
+
+    Frozen. ``metrics`` is an **opaque dict** (a ``MethodResult``/``JudgePairEval``
+    ``.model_dump()``) so this module never depends on the result models.
+    """
+
+    model_config = ConfigDict(frozen=True)
+
+    attempt_id: str
+    recipe_id: str
+    context: RunContext
+    v: int = 1
+
+    # -- Timing (never hashed) --
+    started_at: str
+    finished_at: str | None = None
+    duration_seconds: float | None = None
+
+    # -- Metrics (opaque; self-labelled so comparisons can't silently mix) --
+    metrics: dict[str, Any] | None = None
+    metric_definition: str | None = None
+    per_seed_metrics: list[dict[str, Any]] | None = None
+    headline_metric: float | None = None
+
+    # -- Cost (langres-native) --
+    spend_usd: float = 0.0
+    budget_exceeded: bool = False
+
+    # -- Artifacts --
+    judgement_log_path: str | None = None
+    trace_id: str | None = None
+    artifacts: dict[str, str] = Field(default_factory=dict)
+
+    # -- Status / failure --
+    status: RunStatus
+    error_type: str | None = None
+    error_message: str | None = None
+
+
+# ---------------------------------------------------------------------------
+# Identity + fingerprint helpers
+# ---------------------------------------------------------------------------
+
+
+def _json_default(obj: Any) -> Any:
+    """Canonicalize the non-JSON-native types a corpus/gold may contain."""
+    if isinstance(obj, (set, frozenset)):
+        return sorted(obj, key=str)
+    if isinstance(obj, BaseModel):
+        return obj.model_dump(mode="json")
+    if isinstance(obj, Path):
+        return str(obj)
+    raise TypeError(f"cannot canonicalize {type(obj).__name__} for a fingerprint")
+
+
+def _canonical_json(obj: Any) -> str:
+    """Order-stable JSON: sorted keys, no whitespace -- the hashing normal form."""
+    return json.dumps(obj, sort_keys=True, separators=(",", ":"), default=_json_default)
+
+
+def compute_recipe_id(context: RunContext) -> str:
+    """Content-address the run's recipe fields (see :data:`_RECIPE_FIELDS`).
+
+    Excludes all code/env provenance and timing, so a dirty tree or dependency
+    bump keeps the same id -- ``recipe_id`` is a dedup key over the *logical*
+    experiment, stable across code churn.
+    """
+    payload = {field: getattr(context, field) for field in _RECIPE_FIELDS}
+    return hashlib.sha256(_canonical_json(payload).encode("utf-8")).hexdigest()[:_RECIPE_ID_LENGTH]
+
+
+def _to_jsonable(obj: Any) -> Any:
+    """Pydantic model -> JSON dict; anything else passes through to ``json.dumps``."""
+    if isinstance(obj, BaseModel):
+        return obj.model_dump(mode="json")
+    return obj
+
+
+def _iter_items(data: Iterable[Any]) -> list[Any]:
+    """Normalize a corpus/gold to a list of items (a mapping -> its ``items()``)."""
+    if isinstance(data, Mapping):
+        return list(data.items())
+    return list(data)
+
+
+def dataset_fingerprint(corpus: Iterable[Any], gold: Iterable[Any]) -> str:
+    """sha256 over the ALREADY-LOADED ``corpus`` + ``gold`` (order-independent).
+
+    Each item is canonicalized then sorted, so two loads in a different row
+    order fingerprint identically while any content mutation changes the hash.
+    Do NOT re-``load()`` here -- pass the in-memory objects the caller already
+    holds.
+    """
+    digest = hashlib.sha256()
+    for label, data in (("corpus", corpus), ("gold", gold)):
+        digest.update(label.encode("utf-8"))
+        for line in sorted(_canonical_json(_to_jsonable(item)) for item in _iter_items(data)):
+            digest.update(line.encode("utf-8"))
+            digest.update(b"\n")
+    return digest.hexdigest()
+
+
+def _unique_label(label: str, seeds: Mapping[str, int]) -> str:
+    """Disambiguate a seed label that already exists (two same-typed components)."""
+    if label not in seeds:
+        return label
+    suffix = 2
+    while f"{label}#{suffix}" in seeds:
+        suffix += 1
+    return f"{label}#{suffix}"
+
+
+def _scan_for_seeds(node: Any, seeds: dict[str, int], *, path: str) -> None:
+    """Recursively pull ``random_state``/``seed`` ints out of a config tree."""
+    if isinstance(node, Mapping):
+        type_name = node.get("type_name")
+        prefix = type_name if isinstance(type_name, str) else (path or "config")
+        for key in _SEED_KEYS:
+            value = node.get(key)
+            if isinstance(value, int) and not isinstance(value, bool):
+                seeds[_unique_label(f"{prefix}.{key}", seeds)] = value
+        for child_key, child in node.items():
+            _scan_for_seeds(child, seeds, path=f"{path}.{child_key}" if path else str(child_key))
+    elif isinstance(node, (list, tuple)):
+        for index, item in enumerate(node):
+            _scan_for_seeds(item, seeds, path=f"{path}[{index}]")
+
+
+def _collect_seeds(split_seed: int, resolver_config: Mapping[str, Any] | None) -> dict[str, int]:
+    """``{"split": split_seed}`` unioned with every seed found in the config tree.
+
+    Degrades to just the split seed when ``resolver_config`` is ``None``.
+    """
+    seeds: dict[str, int] = {"split": int(split_seed)}
+    if resolver_config is not None:
+        _scan_for_seeds(resolver_config, seeds, path="")
+    return seeds
+
+
+def git_sha() -> tuple[str | None, bool]:
+    """``(HEAD sha, dirty)`` for run provenance -- ``(None, False)`` without git.
+
+    ``check=False`` + a short timeout + swallowed ``FileNotFoundError`` so a
+    git-less / non-repo environment never raises; it warns once per process.
+    """
+    global _GIT_SHA_WARNED
+    cwd = str(Path(__file__).resolve().parent)
+    try:
+        head = subprocess.run(
+            ["git", "rev-parse", "HEAD"],
+            capture_output=True,
+            text=True,
+            check=False,
+            timeout=_GIT_TIMEOUT_SECONDS,
+            cwd=cwd,
+        )
+        porcelain = subprocess.run(
+            ["git", "status", "--porcelain"],
+            capture_output=True,
+            text=True,
+            check=False,
+            timeout=_GIT_TIMEOUT_SECONDS,
+            cwd=cwd,
+        )
+    except (FileNotFoundError, subprocess.SubprocessError):
+        if not _GIT_SHA_WARNED:
+            logger.warning("git unavailable; recording git_sha=None for run provenance")
+            _GIT_SHA_WARNED = True
+        return (None, False)
+    sha = head.stdout.strip() or None
+    dirty = bool(porcelain.stdout.strip())
+    if sha is None and not _GIT_SHA_WARNED:
+        logger.warning("git could not resolve HEAD (not a repo?); recording git_sha=None")
+        _GIT_SHA_WARNED = True
+    return (sha, dirty)
+
+
+# ---------------------------------------------------------------------------
+# Persistence
+# ---------------------------------------------------------------------------
+
+
+class RunStoreError(RuntimeError):
+    """A :class:`RunStore` could not persist a record (unwritable path, etc.)."""
+
+
+class RunStore:
+    """Append-only JSONL store of :class:`RunRecord` lines.
+
+    ``append`` takes an exclusive ``fcntl.flock`` (cross-process safety when
+    several agents write the same file) and creates parent dirs on demand
+    (``JudgementLog``'s precedent). ``read`` collapses the ``running`` +
+    terminal lines of each attempt via **last-wins-by-attempt_id**.
+    """
+
+    def __init__(self, path: str | Path) -> None:
+        self.path = Path(path)
+
+    def append(self, record: RunRecord) -> None:
+        """Append one record; wrap any OS failure as :class:`RunStoreError`."""
+        try:
+            self.path.parent.mkdir(parents=True, exist_ok=True)
+            with self.path.open("a", encoding="utf-8") as handle:
+                fcntl.flock(handle.fileno(), fcntl.LOCK_EX)
+                try:
+                    handle.write(record.model_dump_json() + "\n")
+                finally:
+                    fcntl.flock(handle.fileno(), fcntl.LOCK_UN)
+        except OSError as exc:
+            raise RunStoreError(
+                f"could not append a run record to {self.path}: {exc}. Check the path is "
+                "writable -- its parent must be a directory (not a file), and the process "
+                "must have permission to create/append there."
+            ) from exc
+
+    def read(self) -> list[RunRecord]:
+        """Every attempt's latest record, in first-seen order (last-wins)."""
+        if not self.path.exists():
+            return []
+        by_attempt: dict[str, RunRecord] = {}
+        with self.path.open("r", encoding="utf-8") as handle:
+            for line in handle:
+                stripped = line.strip()
+                if stripped:
+                    record = RunRecord.model_validate_json(stripped)
+                    by_attempt[record.attempt_id] = record
+        return list(by_attempt.values())
+
+
+def resolve_store(spec: str | Path | RunStore | None) -> RunStore | None:
+    """``None`` -> ``None`` (no persistence); ``str|Path`` -> ``RunStore``; store -> as-is.
+
+    ``None`` means *no files at all* -- the "``store=None`` -> nothing written"
+    invariant. Symmetric with :func:`resolve_tracker`.
+    """
+    if spec is None:
+        return None
+    if isinstance(spec, RunStore):
+        return spec
+    return RunStore(spec)
+
+
+# ---------------------------------------------------------------------------
+# capture_run
+# ---------------------------------------------------------------------------
+
+
+class _RunHandle:
+    """Yielded inside ``capture_run``: accumulates outcomes for the terminal record.
+
+    ``log_metrics``/``log_artifact`` both forward to the tracker *and* stash the
+    value for the finalized :class:`RunRecord`; ``set_status``/``record_cost``
+    only affect the record.
+    """
+
+    def __init__(self, attempt_id: str, recipe_id: str, tracker: ExperimentTracker) -> None:
+        self.attempt_id = attempt_id
+        self.recipe_id = recipe_id
+        self._tracker = tracker
+        self._metrics: dict[str, Any] | None = None
+        self._metric_definition: str | None = None
+        self._per_seed_metrics: list[dict[str, Any]] | None = None
+        self._headline_metric: float | None = None
+        self._artifacts: dict[str, str] = {}
+        self._status_override: RunStatus | None = None
+        self._spend_usd: float = 0.0
+        self._budget_exceeded: bool = False
+
+    def log_metrics(
+        self,
+        metrics: Mapping[str, Any],
+        *,
+        metric_definition: str | None = None,
+        per_seed_metrics: list[dict[str, Any]] | None = None,
+        headline_metric: float | None = None,
+        step: int | None = None,
+    ) -> None:
+        """Record metrics on the run and forward them to the tracker."""
+        self._metrics = {**(self._metrics or {}), **dict(metrics)}
+        if metric_definition is not None:
+            self._metric_definition = metric_definition
+        if per_seed_metrics is not None:
+            self._per_seed_metrics = per_seed_metrics
+        if headline_metric is not None:
+            self._headline_metric = headline_metric
+        self._tracker.log_metrics(metrics, step=step)
+
+    def log_artifact(self, key: str, value: str) -> None:
+        """Record an artifact path/URL on the run and forward it to the tracker."""
+        self._artifacts[key] = value
+        self._tracker.log_artifact(key, value)
+
+    def set_status(self, status: RunStatus) -> None:
+        """Override the terminal status (e.g. ``"budget_exceeded"``)."""
+        self._status_override = status
+
+    def record_cost(self, spend_usd: float, *, budget_exceeded: bool = False) -> None:
+        """Record the run's total spend (``SpendMonitor.spent``) and cap state."""
+        self._spend_usd = spend_usd
+        self._budget_exceeded = budget_exceeded
+
+
+@contextmanager
+def capture_run(
+    context: RunContext,
+    *,
+    store: str | Path | RunStore | None = None,
+    tracker: ExperimentTracker = NoOpTracker(),
+) -> Iterator[_RunHandle]:
+    """Capture one run: identity, a ``running`` marker, and a terminal record.
+
+    Computes ``recipe_id`` + ``attempt_id``; if ``store`` resolves, appends a
+    ``status="running"`` line first (a crash then leaves a visible gap); sets
+    the :data:`current_run` contextvar (set/reset token, so a nested capture
+    restores the parent on exit); starts the tracker; yields a
+    :class:`_RunHandle`. On exit it finalizes the :class:`RunRecord`
+    (status/metrics/cost/timing/artifacts + the tracker's ``run_url``), appends
+    the terminal line, and finishes the tracker. ``store=None`` writes NOTHING.
+    """
+    resolved_store = resolve_store(store)
+    recipe_id = compute_recipe_id(context)
+    started_at = datetime.now(UTC).isoformat()
+    attempt_id = f"{recipe_id}-{started_at}"
+    started_perf = time.perf_counter()
+
+    if resolved_store is not None:
+        resolved_store.append(
+            RunRecord(
+                attempt_id=attempt_id,
+                recipe_id=recipe_id,
+                context=context,
+                started_at=started_at,
+                status="running",
+            )
+        )
+    tracker.start_run(context, run_name=context.experiment)
+
+    handle = _RunHandle(attempt_id, recipe_id, tracker)
+    token = current_run.set(attempt_id)
+    error_type: str | None = None
+    error_message: str | None = None
+    try:
+        yield handle
+    except BaseException as exc:
+        error_type = type(exc).__name__
+        error_message = str(exc)[:_MAX_ERROR_MESSAGE_LEN]
+        raise
+    finally:
+        current_run.reset(token)
+        finished_at = datetime.now(UTC).isoformat()
+        duration_seconds = time.perf_counter() - started_perf
+        final_status: RunStatus = (
+            "failed" if error_type is not None else (handle._status_override or "completed")
+        )
+        artifacts = dict(handle._artifacts)
+        if tracker.run_url is not None:
+            artifacts.setdefault("run_url", tracker.run_url)
+        if resolved_store is not None:
+            resolved_store.append(
+                RunRecord(
+                    attempt_id=attempt_id,
+                    recipe_id=recipe_id,
+                    context=context,
+                    started_at=started_at,
+                    finished_at=finished_at,
+                    duration_seconds=duration_seconds,
+                    metrics=handle._metrics,
+                    metric_definition=handle._metric_definition,
+                    per_seed_metrics=handle._per_seed_metrics,
+                    headline_metric=handle._headline_metric,
+                    spend_usd=handle._spend_usd,
+                    budget_exceeded=handle._budget_exceeded,
+                    trace_id=attempt_id,
+                    artifacts=artifacts,
+                    status=final_status,
+                    error_type=error_type,
+                    error_message=error_message,
+                )
+            )
+        tracker.finish(status=final_status)

--- a/src/langres/core/trackers/__init__.py
+++ b/src/langres/core/trackers/__init__.py
@@ -1,0 +1,244 @@
+"""Pluggable experiment-tracker layer -- dep-free Protocol + null/fan-out impls.
+
+The tracking layer follows the Accelerate ``GeneralTracker`` shape: langres owns
+the run schema (:mod:`langres.core.runs`) and *pushes* it into whatever backend
+the caller wired, symmetrically -- there is no privileged default backend. This
+module carries only the seam: the :class:`ExperimentTracker` Protocol, the
+:class:`NoOpTracker` null object (zero overhead when unconfigured), the
+:class:`MultiTracker` fan-out (run MLflow *and* W&B together), and
+:func:`resolve_tracker` (``None|"mlflow"|"wandb"|instance|sequence`` dispatch,
+mirroring :func:`langres.core.presets.resolve_judge`).
+
+The concrete backend adapters (``MlflowTracker`` in ``mlflow_tracker.py``,
+``WandbTracker`` in ``wandb_tracker.py``) are added by later streams and pull
+their heavy dependency (``mlflow`` / ``wandb``) lazily. They are exposed here via
+a PEP 562 module ``__getattr__`` so ``from langres.core.trackers import
+MlflowTracker`` works, but importing this package -- and therefore ``import
+langres`` -- never pulls ``mlflow``/``wandb`` into ``sys.modules``. Until those
+adapter modules exist, accessing the name (or ``resolve_tracker("mlflow")``)
+raises a clear :class:`ImportError` naming the ``pip install 'langres[<backend>]'``
+extra to install -- which is the correct, testable behavior now.
+"""
+
+from __future__ import annotations
+
+import importlib
+from collections.abc import Mapping, Sequence
+from typing import TYPE_CHECKING, Any, Protocol, runtime_checkable
+
+if TYPE_CHECKING:
+    # Type-only: the tracker sees a RunContext but never imports runs at runtime
+    # (runs imports this module for its NoOpTracker default -- keep it acyclic).
+    from langres.core.runs import RunContext
+
+__all__ = [
+    "ExperimentTracker",
+    "MultiTracker",
+    "NoOpTracker",
+    "resolve_tracker",
+]
+
+#: ``backend name -> (adapter module, adapter class)`` for the lazily-loaded
+#: concrete trackers. Both the module ``__getattr__`` and
+#: :func:`resolve_tracker` resolve through :func:`_load_adapter_class` so the
+#: missing-extra ``ImportError`` message is identical from either entry point.
+_ADAPTERS: dict[str, tuple[str, str]] = {
+    "mlflow": ("langres.core.trackers.mlflow_tracker", "MlflowTracker"),
+    "wandb": ("langres.core.trackers.wandb_tracker", "WandbTracker"),
+}
+
+
+@runtime_checkable
+class ExperimentTracker(Protocol):
+    """The one seam a backend implements to receive langres runs.
+
+    Shaped after HuggingFace Accelerate's ``GeneralTracker``: langres flattens
+    the :class:`~langres.core.runs.RunContext` into params/tags the backend
+    understands and streams metrics/artifacts as the run progresses.
+    ``run_url`` deep-links back into the backend UI (threaded into
+    :attr:`~langres.core.runs.RunRecord.artifacts`); ``native`` is the escape
+    hatch to the underlying backend client for backend-specific calls.
+    """
+
+    name: str
+
+    # Interface stubs -- excluded from coverage (declarations, never executed).
+    def start_run(  # pragma: no cover
+        self, context: RunContext, *, run_name: str | None = None
+    ) -> None: ...
+
+    def log_params(self, params: Mapping[str, Any]) -> None: ...  # pragma: no cover
+
+    def log_metrics(  # pragma: no cover
+        self, metrics: Mapping[str, float], *, step: int | None = None
+    ) -> None: ...
+
+    def log_artifact(self, key: str, value: str) -> None: ...  # pragma: no cover
+
+    def set_tags(self, tags: Mapping[str, str]) -> None: ...  # pragma: no cover
+
+    def finish(self, *, status: str) -> None: ...  # pragma: no cover
+
+    @property
+    def run_url(self) -> str | None: ...  # pragma: no cover
+
+    @property
+    def native(self) -> Any: ...  # pragma: no cover
+
+
+class NoOpTracker:
+    """The null tracker: every call is a no-op. The zero-overhead default.
+
+    Used whenever no backend is configured (``resolve_tracker(None)``), so the
+    tracking seam is always present and callers never branch on ``if tracker``.
+    """
+
+    name = "noop"
+
+    def start_run(self, context: RunContext, *, run_name: str | None = None) -> None:
+        return None
+
+    def log_params(self, params: Mapping[str, Any]) -> None:
+        return None
+
+    def log_metrics(self, metrics: Mapping[str, float], *, step: int | None = None) -> None:
+        return None
+
+    def log_artifact(self, key: str, value: str) -> None:
+        return None
+
+    def set_tags(self, tags: Mapping[str, str]) -> None:
+        return None
+
+    def finish(self, *, status: str) -> None:
+        return None
+
+    @property
+    def run_url(self) -> str | None:
+        return None
+
+    @property
+    def native(self) -> Any:
+        return None
+
+
+class MultiTracker:
+    """Fan-out tracker: forward every call to N children (compose, don't merge).
+
+    Lets a single run land in MLflow *and* W&B at once. Composition, not
+    merging: children keep their own identity, reachable via :attr:`trackers`
+    so a caller can grab a specific backend (e.g. its ``native`` client) when
+    running several together.
+    """
+
+    name = "multi"
+
+    def __init__(self, trackers: Sequence[ExperimentTracker]) -> None:
+        self.trackers: list[ExperimentTracker] = list(trackers)
+
+    def start_run(self, context: RunContext, *, run_name: str | None = None) -> None:
+        for tracker in self.trackers:
+            tracker.start_run(context, run_name=run_name)
+
+    def log_params(self, params: Mapping[str, Any]) -> None:
+        for tracker in self.trackers:
+            tracker.log_params(params)
+
+    def log_metrics(self, metrics: Mapping[str, float], *, step: int | None = None) -> None:
+        for tracker in self.trackers:
+            tracker.log_metrics(metrics, step=step)
+
+    def log_artifact(self, key: str, value: str) -> None:
+        for tracker in self.trackers:
+            tracker.log_artifact(key, value)
+
+    def set_tags(self, tags: Mapping[str, str]) -> None:
+        for tracker in self.trackers:
+            tracker.set_tags(tags)
+
+    def finish(self, *, status: str) -> None:
+        for tracker in self.trackers:
+            tracker.finish(status=status)
+
+    @property
+    def run_url(self) -> str | None:
+        """The first child's deep link, if any (a single record holds one URL)."""
+        for tracker in self.trackers:
+            if tracker.run_url is not None:
+                return tracker.run_url
+        return None
+
+    @property
+    def native(self) -> Any:
+        """The child list -- reach a specific backend via :attr:`trackers` instead."""
+        return self.trackers
+
+
+def _load_adapter_class(backend: str) -> type[Any]:
+    """Import a backend adapter class, or raise a helpful missing-extra ImportError.
+
+    The adapter modules pull ``mlflow``/``wandb`` at their own module level, so
+    a missing extra (or a not-yet-added adapter module) surfaces here as an
+    ``ImportError`` naming the exact ``pip install 'langres[<backend>]'`` fix
+    instead of a raw ``ModuleNotFoundError`` two frames deep.
+    """
+    module_path, class_name = _ADAPTERS[backend]
+    try:
+        module = importlib.import_module(module_path)
+    except ImportError as exc:
+        raise ImportError(
+            f"the {backend!r} tracker requires the {backend!r} extra: "
+            f"pip install 'langres[{backend}]' (or uv add 'langres[{backend}]')"
+        ) from exc
+    return getattr(module, class_name)  # type: ignore[no-any-return]
+
+
+def resolve_tracker(
+    spec: None | str | ExperimentTracker | Sequence[Any],
+) -> ExperimentTracker:
+    """Resolve a tracker spec to a concrete :class:`ExperimentTracker`.
+
+    Mirrors :func:`langres.core.presets.resolve_judge`:
+
+    * ``None`` -> :class:`NoOpTracker` (no persistence, zero overhead).
+    * ``"mlflow"`` / ``"wandb"`` -> the lazily-loaded backend adapter (a helpful
+      :class:`ImportError` when the extra is absent).
+    * an ``ExperimentTracker`` instance -> returned as-is (dependency injection).
+    * a sequence of specs -> a :class:`MultiTracker` over the resolved children.
+
+    Raises:
+        ImportError: A ``"mlflow"``/``"wandb"`` spec whose extra is not installed.
+        ValueError: An unrecognized backend string.
+    """
+    if spec is None:
+        return NoOpTracker()
+    if isinstance(spec, str):
+        if spec not in _ADAPTERS:
+            raise ValueError(
+                f"unknown tracker backend {spec!r}; choose 'mlflow', 'wandb', "
+                "pass an ExperimentTracker instance, or a sequence of these"
+            )
+        return _load_adapter_class(spec)()  # type: ignore[no-any-return]
+    if isinstance(spec, ExperimentTracker):
+        return spec
+    if isinstance(spec, Sequence):
+        return MultiTracker([resolve_tracker(child) for child in spec])
+    raise TypeError(
+        f"cannot resolve tracker from {type(spec).__name__}; expected None, a "
+        "backend name, an ExperimentTracker, or a sequence of these"
+    )
+
+
+def __getattr__(name: str) -> Any:
+    """PEP 562: expose ``MlflowTracker``/``WandbTracker`` via lazy adapter import.
+
+    Keeps ``mlflow``/``wandb`` out of ``sys.modules`` on a bare ``import
+    langres`` -- the class object is only resolved on first attribute access,
+    and surfaces the missing-extra ``ImportError`` if the backend isn't
+    installed (or its adapter module isn't added yet).
+    """
+    if name == "MlflowTracker":
+        return _load_adapter_class("mlflow")
+    if name == "WandbTracker":
+        return _load_adapter_class("wandb")
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")

--- a/src/langres/core/trackers/__init__.py
+++ b/src/langres/core/trackers/__init__.py
@@ -23,6 +23,7 @@ extra to install -- which is the correct, testable behavior now.
 from __future__ import annotations
 
 import importlib
+import logging
 from collections.abc import Mapping, Sequence
 from typing import TYPE_CHECKING, Any, Protocol, runtime_checkable
 
@@ -30,6 +31,8 @@ if TYPE_CHECKING:
     # Type-only: the tracker sees a RunContext but never imports runs at runtime
     # (runs imports this module for its NoOpTracker default -- keep it acyclic).
     from langres.core.runs import RunContext
+
+logger = logging.getLogger(__name__)
 
 __all__ = [
     "ExperimentTracker",
@@ -136,29 +139,42 @@ class MultiTracker:
     def __init__(self, trackers: Sequence[ExperimentTracker]) -> None:
         self.trackers: list[ExperimentTracker] = list(trackers)
 
-    def start_run(self, context: RunContext, *, run_name: str | None = None) -> None:
+    def _fan_out(self, method: str, *args: Any, **kwargs: Any) -> None:
+        """Call ``method`` on every child, isolating per-child failures.
+
+        A child raising must not abort the fan-out or mask a real exception --
+        this matters most for ``finish``, which runs inside ``capture_run``'s
+        ``finally`` where a raising child would otherwise swallow the user's own
+        error. So each call is guarded: a failure is logged (never printed) and
+        the remaining children still get the call.
+        """
         for tracker in self.trackers:
-            tracker.start_run(context, run_name=run_name)
+            try:
+                getattr(tracker, method)(*args, **kwargs)
+            except Exception:
+                logger.exception(
+                    "tracker %r raised in %s(); continuing with the remaining trackers",
+                    getattr(tracker, "name", tracker),
+                    method,
+                )
+
+    def start_run(self, context: RunContext, *, run_name: str | None = None) -> None:
+        self._fan_out("start_run", context, run_name=run_name)
 
     def log_params(self, params: Mapping[str, Any]) -> None:
-        for tracker in self.trackers:
-            tracker.log_params(params)
+        self._fan_out("log_params", params)
 
     def log_metrics(self, metrics: Mapping[str, float], *, step: int | None = None) -> None:
-        for tracker in self.trackers:
-            tracker.log_metrics(metrics, step=step)
+        self._fan_out("log_metrics", metrics, step=step)
 
     def log_artifact(self, key: str, value: str) -> None:
-        for tracker in self.trackers:
-            tracker.log_artifact(key, value)
+        self._fan_out("log_artifact", key, value)
 
     def set_tags(self, tags: Mapping[str, str]) -> None:
-        for tracker in self.trackers:
-            tracker.set_tags(tags)
+        self._fan_out("set_tags", tags)
 
     def finish(self, *, status: str) -> None:
-        for tracker in self.trackers:
-            tracker.finish(status=status)
+        self._fan_out("finish", status=status)
 
     @property
     def run_url(self) -> str | None:

--- a/src/langres/core/trackers/mlflow_tracker.py
+++ b/src/langres/core/trackers/mlflow_tracker.py
@@ -31,6 +31,7 @@ or SQLAlchemy (``sqlite:``/``postgresql:``/...) backends -- including MLflow
 from __future__ import annotations
 
 import os
+import re
 from collections.abc import Mapping
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
@@ -57,14 +58,34 @@ _STATUS_TO_MLFLOW: dict[str, str] = {
 }
 
 
+#: Characters MLflow forbids in a param/metric name. MLflow allows only
+#: alphanumerics, ``_ - . space /`` (and ``:`` off Windows); we sanitize to the
+#: Windows-safe subset (no colon) so a key validates on every platform.
+_MLFLOW_UNSAFE_KEY_CHARS = re.compile(r"[^\w.\-/ ]")
+
+
+def _sanitize_key(key: str) -> str:
+    """Coerce a flattened key into an MLflow-safe param name.
+
+    MLflow rejects any name outside ``[alphanumerics _ - . space /]`` -- a raw
+    ``key[0]`` from a sequence field, or a config key carrying a stray symbol,
+    would crash ``mlflow.log_params``. Every out-of-charset character is replaced
+    with ``_`` so *any* context logs without a crash.
+    """
+    return _MLFLOW_UNSAFE_KEY_CHARS.sub("_", key)
+
+
 def _flatten(value: Any, prefix: str = "") -> dict[str, str]:
     """Flatten a nested dict/list into ``{dotted.key: str value}`` for MLflow params.
 
     MLflow params are flat, scalar key/value pairs, so nested config
     (``resolver_config``, ``seeds``) is expanded to dotted keys (``seeds.split``,
-    ``resolver_config.blocker.type_name``) and list items to indexed keys
-    (``cascade_band[0]``). Leaf scalars are stringified; the top-level call is
-    always a mapping, so the empty ``prefix`` never yields a keyless entry.
+    ``resolver_config.blocker.type_name``) and list items to dotted indices
+    (``cascade_band.0``). ``.`` is used for indices (not ``[0]``) because ``[``/``]``
+    are outside MLflow's allowed param-name charset; :func:`_sanitize_key` is the
+    backstop for any remaining out-of-charset character. Leaf scalars are
+    stringified; the top-level call is always a mapping, so the empty ``prefix``
+    never yields a keyless entry.
     """
     flat: dict[str, str] = {}
     if isinstance(value, Mapping):
@@ -73,7 +94,7 @@ def _flatten(value: Any, prefix: str = "") -> dict[str, str]:
             flat.update(_flatten(child, child_prefix))
     elif isinstance(value, (list, tuple)):
         for index, child in enumerate(value):
-            child_prefix = f"{prefix}[{index}]" if prefix else str(index)
+            child_prefix = f"{prefix}.{index}" if prefix else str(index)
             flat.update(_flatten(child, child_prefix))
     elif prefix:
         flat[prefix] = str(value)
@@ -125,7 +146,10 @@ class MlflowTracker:
         if self._tracking_uri is not None:
             mlflow.set_tracking_uri(self._tracking_uri)
         mlflow.set_experiment(self._settings.mlflow_experiment)
-        self._run = mlflow.start_run(run_name=run_name)
+        # nested=True when a run is already active, so a nested capture_run (e.g. a
+        # DSPy compile() run inside an outer benchmark run) does not trip MLflow's
+        # "Run ... is already active" guard.
+        self._run = mlflow.start_run(run_name=run_name, nested=mlflow.active_run() is not None)
         self._run_id = self._run.info.run_id
         self._experiment_id = self._run.info.experiment_id
 
@@ -135,9 +159,14 @@ class MlflowTracker:
         self.set_tags(tags)
 
     def log_params(self, params: Mapping[str, Any]) -> None:
-        """Log flat params (stringified -- MLflow params are immutable strings)."""
+        """Log flat params (keys sanitized MLflow-safe, values stringified).
+
+        Keys pass through :func:`_sanitize_key` -- MLflow param names allow only a
+        restricted charset, so any out-of-charset character (e.g. from a sequence
+        or a config key) is coerced to ``_`` rather than crashing the run.
+        """
         if params:
-            mlflow.log_params({key: str(value) for key, value in params.items()})
+            mlflow.log_params({_sanitize_key(key): str(value) for key, value in params.items()})
 
     def log_metrics(self, metrics: Mapping[str, float], *, step: int | None = None) -> None:
         """Stream numeric metrics, optionally at a training ``step``."""

--- a/src/langres/core/trackers/mlflow_tracker.py
+++ b/src/langres/core/trackers/mlflow_tracker.py
@@ -1,0 +1,163 @@
+"""MLflow adapter for the langres :class:`ExperimentTracker` seam (Stream S3).
+
+Lazily loaded: ``import mlflow`` sits at this module's top level, but the module
+itself is only imported on first attribute access -- via the package
+``__getattr__`` / :func:`~langres.core.trackers.resolve_tracker` in
+``langres.core.trackers.__init__`` (see its ``_ADAPTERS`` table). So a bare
+``import langres`` never pulls ``mlflow`` into ``sys.modules``; only wiring a
+``"mlflow"`` tracker does (guarded by ``tests/test_import_budget.py``). Install
+with ``pip install 'langres[mlflow]'``.
+
+The adapter flattens a :class:`~langres.core.runs.RunContext` into MLflow params
+itself (nested dicts/lists -> dotted keys; ``context.tags`` -> MLflow tags),
+streams metrics as the run progresses, uploads local file/dir artifacts (and
+records URL/reference artifacts as tags), and derives a deep-link ``run_url``
+when the tracking URI is an HTTP server.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from pathlib import Path
+from typing import TYPE_CHECKING, Any
+
+import mlflow
+
+from langres.clients.settings import Settings
+
+if TYPE_CHECKING:
+    # Type-only: the adapter receives a RunContext but never imports runs at
+    # runtime (runs imports the trackers package for its NoOpTracker default).
+    from langres.core.runs import RunContext
+
+#: langres run status -> MLflow ``RunStatus`` enum value. MLflow has no
+#: "budget capped" state, so ``budget_exceeded`` maps to ``KILLED`` (a
+#: deliberate termination); the precise langres status is preserved losslessly
+#: as a ``langres.status`` tag in :meth:`MlflowTracker.finish`.
+_STATUS_TO_MLFLOW: dict[str, str] = {
+    "running": "RUNNING",
+    "completed": "FINISHED",
+    "failed": "FAILED",
+    "budget_exceeded": "KILLED",
+}
+
+
+def _flatten(value: Any, prefix: str = "") -> dict[str, str]:
+    """Flatten a nested dict/list into ``{dotted.key: str value}`` for MLflow params.
+
+    MLflow params are flat, scalar key/value pairs, so nested config
+    (``resolver_config``, ``seeds``) is expanded to dotted keys (``seeds.split``,
+    ``resolver_config.blocker.type_name``) and list items to indexed keys
+    (``cascade_band[0]``). Leaf scalars are stringified; the top-level call is
+    always a mapping, so the empty ``prefix`` never yields a keyless entry.
+    """
+    flat: dict[str, str] = {}
+    if isinstance(value, Mapping):
+        for key, child in value.items():
+            child_prefix = f"{prefix}.{key}" if prefix else str(key)
+            flat.update(_flatten(child, child_prefix))
+    elif isinstance(value, (list, tuple)):
+        for index, child in enumerate(value):
+            child_prefix = f"{prefix}[{index}]" if prefix else str(index)
+            flat.update(_flatten(child, child_prefix))
+    elif prefix:
+        flat[prefix] = str(value)
+    return flat
+
+
+class MlflowTracker:
+    """Push langres runs into MLflow -- one adapter instance per :func:`capture_run`.
+
+    Reads its store config from :class:`~langres.clients.settings.Settings`
+    (``mlflow_tracking_uri`` -- unset means MLflow's local ``./mlruns`` file
+    store -- and ``mlflow_experiment``). ``start_run`` flattens the
+    :class:`~langres.core.runs.RunContext` into params/tags itself, since the
+    :func:`capture_run` driver only calls ``start_run`` / ``log_metrics`` /
+    ``log_artifact`` / ``finish``.
+    """
+
+    name = "mlflow"
+
+    def __init__(self, settings: Settings | None = None) -> None:
+        self._settings = settings or Settings()
+        self._tracking_uri = self._settings.mlflow_tracking_uri
+        self._run: Any = None
+        self._run_id: str | None = None
+        self._experiment_id: str | None = None
+
+    def start_run(self, context: RunContext, *, run_name: str | None = None) -> None:
+        """Open an MLflow run and stamp the flattened context onto it as params/tags."""
+        if self._tracking_uri is not None:
+            mlflow.set_tracking_uri(self._tracking_uri)
+        mlflow.set_experiment(self._settings.mlflow_experiment)
+        self._run = mlflow.start_run(run_name=run_name)
+        self._run_id = self._run.info.run_id
+        self._experiment_id = self._run.info.experiment_id
+
+        dumped = context.model_dump(mode="json", exclude_none=True)
+        tags = dumped.pop("tags", {})
+        self.log_params(_flatten(dumped))
+        self.set_tags(tags)
+
+    def log_params(self, params: Mapping[str, Any]) -> None:
+        """Log flat params (stringified -- MLflow params are immutable strings)."""
+        if params:
+            mlflow.log_params({key: str(value) for key, value in params.items()})
+
+    def log_metrics(self, metrics: Mapping[str, float], *, step: int | None = None) -> None:
+        """Stream numeric metrics, optionally at a training ``step``."""
+        if metrics:
+            mlflow.log_metrics(dict(metrics), step=step)
+
+    def log_artifact(self, key: str, value: str) -> None:
+        """Upload a local file/dir artifact; record a URL/reference as a tag.
+
+        ``value`` may be a local path (``resolver.save`` dir, a report file) or a
+        reference (a backend URL). Real local paths are uploaded to the MLflow
+        artifact store; anything else (a URL, a missing path) is kept as a tag so
+        the reference still surfaces in the run.
+        """
+        path = Path(value)
+        if path.is_dir():
+            mlflow.log_artifacts(str(path))
+        elif path.is_file():
+            mlflow.log_artifact(str(path))
+        else:
+            mlflow.set_tag(key, value)
+
+    def set_tags(self, tags: Mapping[str, str]) -> None:
+        """Attach searchable tags to the active run."""
+        if tags:
+            mlflow.set_tags(dict(tags))
+
+    def finish(self, *, status: str) -> None:
+        """Close the run, mapping the langres status to MLflow's ``RunStatus``.
+
+        A no-op if no run was ever started. The exact langres status (which can
+        be finer-grained than MLflow's enum, e.g. ``budget_exceeded``) is also
+        stamped as a ``langres.status`` tag so it stays queryable.
+        """
+        if self._run is None:
+            return
+        mlflow.set_tag("langres.status", status)
+        mlflow.end_run(status=_STATUS_TO_MLFLOW.get(status, "FINISHED"))
+
+    @property
+    def run_url(self) -> str | None:
+        """Deep link into the MLflow UI, or ``None`` for a local file store.
+
+        Buildable only against an HTTP tracking server (``http(s)://``); the
+        default local ``./mlruns`` store has no browsable URL, so this returns
+        ``None`` and no ``run_url`` artifact is threaded into the record.
+        """
+        if self._run_id is None or self._experiment_id is None:
+            return None
+        uri = self._tracking_uri
+        if uri and (uri.startswith("http://") or uri.startswith("https://")):
+            return f"{uri.rstrip('/')}/#/experiments/{self._experiment_id}/runs/{self._run_id}"
+        return None
+
+    @property
+    def native(self) -> Any:
+        """The underlying MLflow run object -- the escape hatch (``None`` pre-start)."""
+        return self._run

--- a/src/langres/core/trackers/mlflow_tracker.py
+++ b/src/langres/core/trackers/mlflow_tracker.py
@@ -13,13 +13,28 @@ itself (nested dicts/lists -> dotted keys; ``context.tags`` -> MLflow tags),
 streams metrics as the run progresses, uploads local file/dir artifacts (and
 records URL/reference artifacts as tags), and derives a deep-link ``run_url``
 when the tracking URI is an HTTP server.
+
+Local-store default (the F1 fix): with no ``mlflow_tracking_uri`` configured the
+adapter leaves MLflow to its own default backend, which is version-dependent --
+MLflow <3.14 uses the local ``./mlruns`` FileStore, MLflow 3.14+ a local
+``sqlite:///mlflow.db``. MLflow 3.14 also puts *any* local FileStore in
+"maintenance mode" and refuses to open a run against it unless
+``MLFLOW_ALLOW_FILE_STORE=true``. So :meth:`MlflowTracker.start_run` sets that
+flag (via ``os.environ.setdefault`` -- an explicit user value is never clobbered)
+whenever the configured store is a local file store: an unset URI (the old
+``./mlruns`` fallback still in play on MLflow <3.14) or an explicit ``file:`` /
+local-path ``mlflow_tracking_uri``. It is **not** set for HTTP tracking servers
+or SQLAlchemy (``sqlite:``/``postgresql:``/...) backends -- including MLflow
+3.14's own sqlite default -- which don't need it.
 """
 
 from __future__ import annotations
 
+import os
 from collections.abc import Mapping
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
+from urllib.parse import urlparse
 
 import mlflow
 
@@ -65,12 +80,27 @@ def _flatten(value: Any, prefix: str = "") -> dict[str, str]:
     return flat
 
 
+def _is_local_file_store(tracking_uri: str | None) -> bool:
+    """True when the configured tracking URI selects (or falls back to) a FileStore.
+
+    An unset URI (``None``) is treated as a file store: on MLflow <3.14 it falls
+    back to the local ``./mlruns`` FileStore, so we proactively allow it. A
+    scheme-less local path or an explicit ``file:`` URI is a FileStore too.
+    HTTP(S) tracking servers and SQLAlchemy (``sqlite:``/``postgresql:``/...)
+    backends are NOT file stores -- they don't need the maintenance-mode flag.
+    """
+    if tracking_uri is None:
+        return True
+    return urlparse(tracking_uri).scheme in ("", "file")
+
+
 class MlflowTracker:
     """Push langres runs into MLflow -- one adapter instance per :func:`capture_run`.
 
     Reads its store config from :class:`~langres.clients.settings.Settings`
-    (``mlflow_tracking_uri`` -- unset means MLflow's local ``./mlruns`` file
-    store -- and ``mlflow_experiment``). ``start_run`` flattens the
+    (``mlflow_tracking_uri`` -- unset lets MLflow pick its own default backend,
+    a local sqlite db on MLflow 3.14 -- and ``mlflow_experiment``; see the module
+    docstring for the local-file-store handling). ``start_run`` flattens the
     :class:`~langres.core.runs.RunContext` into params/tags itself, since the
     :func:`capture_run` driver only calls ``start_run`` / ``log_metrics`` /
     ``log_artifact`` / ``finish``.
@@ -87,6 +117,11 @@ class MlflowTracker:
 
     def start_run(self, context: RunContext, *, run_name: str | None = None) -> None:
         """Open an MLflow run and stamp the flattened context onto it as params/tags."""
+        if _is_local_file_store(self._tracking_uri):
+            # MLflow >=3.14 puts the local ./mlruns FileStore in "maintenance
+            # mode" and refuses to open a run unless this flag is set. setdefault
+            # so an explicit user override wins; never set it for http/sql stores.
+            os.environ.setdefault("MLFLOW_ALLOW_FILE_STORE", "true")
         if self._tracking_uri is not None:
             mlflow.set_tracking_uri(self._tracking_uri)
         mlflow.set_experiment(self._settings.mlflow_experiment)

--- a/src/langres/core/trackers/wandb_tracker.py
+++ b/src/langres/core/trackers/wandb_tracker.py
@@ -1,0 +1,118 @@
+"""W&B (Weights & Biases) :class:`ExperimentTracker` adapter (Stream S4).
+
+Lazily loaded by :func:`langres.core.trackers.resolve_tracker` and
+``from langres.core.trackers import WandbTracker`` -- so ``import wandb`` (at this
+module's top) never lands on the eager ``import langres`` path (asserted by
+``tests/test_import_budget.py``). The adapter reuses langres's existing
+:func:`langres.clients.tracking.create_wandb_tracker` for the ``wandb.init``
+(project/entity/api-key resolution from :class:`~langres.clients.settings.Settings`)
+and enriches that run with the flattened :class:`~langres.core.runs.RunContext`.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import TYPE_CHECKING, Any
+
+import wandb
+
+from langres.clients.settings import Settings
+from langres.clients.tracking import create_wandb_tracker
+
+if TYPE_CHECKING:
+    # Type-only: the adapter receives a RunContext but never imports runs at
+    # runtime (runs imports the trackers package -- keep the dependency acyclic).
+    from langres.core.runs import RunContext
+
+__all__ = ["WandbTracker"]
+
+
+def _flatten(obj: Any, prefix: str = "") -> dict[str, Any]:
+    """Flatten a nested mapping/sequence into dotted-key scalars (dropping ``None``).
+
+    ``{"seeds": {"split": 1}}`` -> ``{"seeds.split": 1}``; a list/tuple ->
+    ``prefix[0]``, ``prefix[1]``, ... . ``None`` values are dropped so the W&B
+    config table stays a signal of what was actually set. This keeps the flat
+    W&B config aligned with the flat MLflow params for cross-backend comparison.
+    """
+    flat: dict[str, Any] = {}
+    if isinstance(obj, Mapping):
+        for key, value in obj.items():
+            child = f"{prefix}.{key}" if prefix else str(key)
+            flat.update(_flatten(value, child))
+    elif isinstance(obj, (list, tuple)):
+        for index, value in enumerate(obj):
+            flat.update(_flatten(value, f"{prefix}[{index}]"))
+    elif obj is not None:
+        flat[prefix] = obj
+    return flat
+
+
+class WandbTracker:
+    """Push langres runs into Weights & Biases (the ``"wandb"`` backend).
+
+    One :class:`~langres.core.runs.RunContext` becomes one W&B run: the context
+    is flattened into ``run.config``, metrics stream via :func:`wandb.log`, and
+    artifact pointers land in ``run.summary``. :attr:`run_url` deep-links the W&B
+    UI (threaded into :attr:`~langres.core.runs.RunRecord.artifacts`);
+    :attr:`native` is the escape hatch to the underlying ``wandb`` run.
+    """
+
+    name = "wandb"
+
+    def __init__(self, settings: Settings | None = None, *, job_type: str = "experiment") -> None:
+        """Configure the adapter; ``wandb.init`` is deferred to :meth:`start_run`.
+
+        Args:
+            settings: Source of ``wandb`` project/entity/api-key. ``None`` ->
+                :class:`~langres.clients.settings.Settings` from the environment.
+            job_type: W&B ``job_type`` categorization for the run.
+        """
+        self._settings = settings
+        self._job_type = job_type
+        self._run: Any = None
+
+    def start_run(self, context: RunContext, *, run_name: str | None = None) -> None:
+        """Open a W&B run and seed its config from the flattened ``context``."""
+        self._run = create_wandb_tracker(self._settings, job_type=self._job_type)
+        if run_name is not None:
+            self._run.name = run_name
+        self._run.config.update(_flatten(context.model_dump(mode="json")), allow_val_change=True)
+
+    def log_params(self, params: Mapping[str, Any]) -> None:
+        """Merge extra (flattened) params into the run config."""
+        if self._run is not None:
+            self._run.config.update(_flatten(dict(params)), allow_val_change=True)
+
+    def log_metrics(self, metrics: Mapping[str, float], *, step: int | None = None) -> None:
+        """Stream metrics to the active W&B run (:func:`wandb.log`)."""
+        wandb.log(dict(metrics), step=step)
+
+    def log_artifact(self, key: str, value: str) -> None:
+        """Record an artifact path/URL as a run-summary entry (an output pointer)."""
+        if self._run is not None:
+            self._run.summary[key] = value
+
+    def set_tags(self, tags: Mapping[str, str]) -> None:
+        """Attach ``key:value`` labels to the W&B run (W&B tags are flat labels)."""
+        if self._run is not None:
+            self._run.tags = tuple(f"{key}:{value}" for key, value in tags.items())
+
+    def finish(self, *, status: str) -> None:
+        """Close the W&B run, mapping status -> exit code (``0`` ok, ``1`` otherwise)."""
+        if self._run is not None:
+            self._run.summary["status"] = status
+        wandb.finish(exit_code=0 if status == "completed" else 1)
+
+    @property
+    def run_url(self) -> str | None:
+        """Deep link to the W&B run UI (``None`` before start / when offline)."""
+        if self._run is None:
+            return None
+        url = getattr(self._run, "url", None)
+        return url if isinstance(url, str) else None
+
+    @property
+    def native(self) -> Any:
+        """The underlying ``wandb`` run object (escape hatch), or ``None``."""
+        return self._run

--- a/src/langres/core/trackers/wandb_tracker.py
+++ b/src/langres/core/trackers/wandb_tracker.py
@@ -1,20 +1,21 @@
 """W&B (Weights & Biases) :class:`ExperimentTracker` adapter (Stream S4).
 
 Lazily loaded by :func:`langres.core.trackers.resolve_tracker` and
-``from langres.core.trackers import WandbTracker`` -- so ``import wandb`` (at this
-module's top) never lands on the eager ``import langres`` path (asserted by
-``tests/test_import_budget.py``). The adapter reuses langres's existing
-:func:`langres.clients.tracking.create_wandb_tracker` for the ``wandb.init``
-(project/entity/api-key resolution from :class:`~langres.clients.settings.Settings`)
-and enriches that run with the flattened :class:`~langres.core.runs.RunContext`.
+``from langres.core.trackers import WandbTracker`` -- it pulls ``wandb`` only
+transitively (via :func:`langres.clients.tracking.create_wandb_tracker`), so it
+never lands on the eager ``import langres`` path (asserted by
+``tests/test_import_budget.py``). The adapter reuses that helper for the
+``wandb.init`` (project/entity/api-key resolution from
+:class:`~langres.clients.settings.Settings`) and enriches the returned run --
+logging, metrics, and finish all go through *that* run object, never the
+module-global ``wandb.*`` functions -- with the flattened
+:class:`~langres.core.runs.RunContext`.
 """
 
 from __future__ import annotations
 
 from collections.abc import Mapping
 from typing import TYPE_CHECKING, Any
-
-import wandb
 
 from langres.clients.settings import Settings
 from langres.clients.tracking import create_wandb_tracker
@@ -52,7 +53,7 @@ class WandbTracker:
     """Push langres runs into Weights & Biases (the ``"wandb"`` backend).
 
     One :class:`~langres.core.runs.RunContext` becomes one W&B run: the context
-    is flattened into ``run.config``, metrics stream via :func:`wandb.log`, and
+    is flattened into ``run.config``, metrics stream via ``run.log``, and
     artifact pointers land in ``run.summary``. :attr:`run_url` deep-links the W&B
     UI (threaded into :attr:`~langres.core.runs.RunRecord.artifacts`);
     :attr:`native` is the escape hatch to the underlying ``wandb`` run.
@@ -85,8 +86,14 @@ class WandbTracker:
             self._run.config.update(_flatten(dict(params)), allow_val_change=True)
 
     def log_metrics(self, metrics: Mapping[str, float], *, step: int | None = None) -> None:
-        """Stream metrics to the active W&B run (:func:`wandb.log`)."""
-        wandb.log(dict(metrics), step=step)
+        """Stream metrics to *this* run (``run.log``), not the module-global run.
+
+        Routed through ``self._run`` so a nested/second ``WandbTracker`` logs to its
+        own run instead of whatever run is globally active (possibly the parent's).
+        A no-op before :meth:`start_run`.
+        """
+        if self._run is not None:
+            self._run.log(dict(metrics), step=step)
 
     def log_artifact(self, key: str, value: str) -> None:
         """Record an artifact path/URL as a run-summary entry (an output pointer)."""
@@ -99,10 +106,15 @@ class WandbTracker:
             self._run.tags = tuple(f"{key}:{value}" for key, value in tags.items())
 
     def finish(self, *, status: str) -> None:
-        """Close the W&B run, mapping status -> exit code (``0`` ok, ``1`` otherwise)."""
+        """Close *this* run (``run.finish``), mapping status -> exit code (``0``/``1``).
+
+        Routed through ``self._run`` so a child's ``finish()`` ends only its own run
+        -- ``wandb.finish()`` (module-global) would end whatever run is globally
+        active, possibly the parent's. A no-op before :meth:`start_run`.
+        """
         if self._run is not None:
             self._run.summary["status"] = status
-        wandb.finish(exit_code=0 if status == "completed" else 1)
+            self._run.finish(exit_code=0 if status == "completed" else 1)
 
     @property
     def run_url(self) -> str | None:

--- a/tests/clients/test_tracking.py
+++ b/tests/clients/test_tracking.py
@@ -108,8 +108,30 @@ class TestCreateWandbTracker:
             call_kwargs = mock_wandb.init.call_args.kwargs
             assert call_kwargs["entity"] is None
 
-    def test_create_wandb_tracker_raises_error_if_api_key_missing(self):
-        """Test create_wandb_tracker raises ValueError if WANDB_API_KEY missing."""
+    def test_create_wandb_tracker_raises_error_if_api_key_missing(
+        self, monkeypatch: pytest.MonkeyPatch
+    ):
+        """Online (default) mode still requires WANDB_API_KEY -- the guard is intact."""
+        monkeypatch.delenv("WANDB_MODE", raising=False)
         settings = Settings(wandb_api_key=None)
         with pytest.raises(ValueError, match="WANDB_API_KEY environment variable is required"):
             create_wandb_tracker(settings)
+
+    @pytest.mark.parametrize("mode", ["offline", "disabled", "OFFLINE", " offline "])
+    def test_create_wandb_tracker_skips_api_key_when_offline(
+        self, monkeypatch: pytest.MonkeyPatch, mode: str
+    ):
+        """WANDB_MODE offline/disabled needs no key -- the requirement is skipped (F2)."""
+        monkeypatch.setenv("WANDB_MODE", mode)
+        settings = Settings(wandb_api_key=None, wandb_project="offline-proj")
+
+        with patch("langres.clients.tracking.wandb") as mock_wandb:
+            mock_run = MagicMock()
+            mock_wandb.init.return_value = mock_run
+
+            run = create_wandb_tracker(settings)  # must NOT raise without a key
+
+            assert run is mock_run
+            mock_wandb.init.assert_called_once_with(
+                project="offline-proj", entity=None, job_type="optimization"
+            )

--- a/tests/core/modules/test_dspy_judge.py
+++ b/tests/core/modules/test_dspy_judge.py
@@ -274,6 +274,14 @@ def _trainset(n: int = 4) -> list[dspy.Example]:
     ]
 
 
+def _other_trainset(n: int = 4) -> list[dspy.Example]:
+    """A trainset with DIFFERENT labeled content than :func:`_trainset`."""
+    return [
+        dspy.Example(left="Beta", right="Beta LLC", match=False).with_inputs("left", "right")
+        for _ in range(n)
+    ]
+
+
 def test_compile_bootstrap_populates_demos_and_sets_flag() -> None:
     """``compile(optimizer='bootstrap')`` tunes the program (adds demos) in place."""
     judge = _dummy_judge(_answers(50))
@@ -335,6 +343,38 @@ def test_compile_records_run_and_stamps_compile_run_id(tmp_path: Path) -> None:
     assert record.context.resolver_config["optimizer"] == "bootstrap"
     # The stamped carrier is exactly the persisted run's PK.
     assert judge._compile_run_id == record.attempt_id
+
+
+def test_compile_fingerprints_trainset_into_recipe_id(tmp_path: Path) -> None:
+    """Different labeled trainsets get different recipe_ids; an identical one, the same.
+
+    Regression: ``compile`` used a constant ``dataset_name`` and left
+    ``dataset_fingerprint`` unset, so two compiles on DIFFERENT labels collapsed to
+    the SAME ``recipe_id`` (a store-based replay guard could treat them as one run).
+    The trainset now feeds ``dataset_fingerprint`` -> ``compute_recipe_id``.
+    """
+    store_a = RunStore(tmp_path / "a.jsonl")
+    store_b = RunStore(tmp_path / "b.jsonl")
+    store_c = RunStore(tmp_path / "c.jsonl")
+
+    _dummy_judge(_answers(50)).compile(_trainset(), optimizer="bootstrap", store=store_a)
+    _dummy_judge(_answers(50)).compile(_other_trainset(), optimizer="bootstrap", store=store_b)
+    _dummy_judge(_answers(50)).compile(_trainset(), optimizer="bootstrap", store=store_c)
+
+    [ra] = store_a.read()
+    [rb] = store_b.read()
+    [rc] = store_c.read()
+
+    # A content fingerprint is now stamped (no longer left None).
+    assert ra.context.dataset_fingerprint is not None
+    # Different labeled trainsets -> different fingerprint -> different recipe_id.
+    assert ra.context.dataset_fingerprint != rb.context.dataset_fingerprint
+    assert ra.recipe_id != rb.recipe_id
+    # An identical trainset -> identical fingerprint -> identical recipe_id (only
+    # the timestamped attempt_id differs), so genuine replays still dedup.
+    assert ra.context.dataset_fingerprint == rc.context.dataset_fingerprint
+    assert ra.recipe_id == rc.recipe_id
+    assert ra.attempt_id != rc.attempt_id
 
 
 def test_compile_threads_parent_run_id_onto_the_run(tmp_path: Path) -> None:

--- a/tests/core/modules/test_dspy_judge.py
+++ b/tests/core/modules/test_dspy_judge.py
@@ -25,6 +25,7 @@ from langres.core.modules.dspy_judge import (
     _salvage_usage,
 )
 from langres.core.registry import get_component
+from langres.core.runs import RunStore
 
 
 def _answers(n: int, *, match: str = "True", prob: str = "0.9") -> list[dict[str, str]]:
@@ -301,6 +302,88 @@ def test_compile_unknown_optimizer_raises() -> None:
     judge = _dummy_judge(_answers(10))
     with pytest.raises(ValueError, match="unknown optimizer"):
         judge.compile(_trainset(), optimizer="nope")
+
+
+# ---------------------------------------------------------------------------
+# Compile-run lineage (S6 tracking seam)
+# ---------------------------------------------------------------------------
+
+
+def test_fresh_judge_has_no_compile_run_id() -> None:
+    """The lineage carrier starts unset — the read contract for a later capture_run."""
+    assert _dummy_judge()._compile_run_id is None
+
+
+def test_compile_records_run_and_stamps_compile_run_id(tmp_path: Path) -> None:
+    """``compile(store=...)`` persists one completed compile run and stamps its id.
+
+    Read contract for Stream C: ``judge._compile_run_id`` equals the recorded
+    ``attempt_id``, which a later ``capture_run`` threads into ``parent_run_id``.
+    """
+    store = RunStore(tmp_path / "runs.jsonl")
+    judge = _dummy_judge(_answers(50))
+    judge.compile(_trainset(), optimizer="bootstrap", store=store)
+
+    records = store.read()
+    assert len(records) == 1  # the running + terminal lines collapse (last-wins)
+    record = records[0]
+    assert record.status == "completed"
+    assert record.context.method == "dspy_compile"
+    assert record.context.experiment == "dspy_compile"
+    assert record.context.llm_model == judge.model
+    assert record.context.resolver_config is not None
+    assert record.context.resolver_config["optimizer"] == "bootstrap"
+    # The stamped carrier is exactly the persisted run's PK.
+    assert judge._compile_run_id == record.attempt_id
+
+
+def test_compile_threads_parent_run_id_onto_the_run(tmp_path: Path) -> None:
+    """A ``parent_run_id`` passed to compile is recorded on the compile run's context."""
+    store = RunStore(tmp_path / "runs.jsonl")
+    judge = _dummy_judge(_answers(50))
+    judge.compile(_trainset(), store=store, parent_run_id="sweep-abc")
+    [record] = store.read()
+    assert record.context.parent_run_id == "sweep-abc"
+
+
+def test_compile_stamps_run_id_even_without_a_store() -> None:
+    """The carrier is stamped even when nothing is persisted (default ``store=None``)."""
+    judge = _dummy_judge(_answers(50))
+    judge.compile(_trainset(), optimizer="bootstrap")
+    assert isinstance(judge._compile_run_id, str)
+    assert judge._compiled is True
+    # Default path is behavior-unchanged: demos were still bootstrapped.
+    assert sum(len(p.demos) for _, p in judge._program.named_predictors()) > 0
+
+
+def test_compile_tracking_params_do_not_leak_into_optimizer_kwargs(  # type: ignore[no-untyped-def]
+    tmp_path: Path,
+    mocker,
+) -> None:
+    """tracker/store/parent_run_id are bound params — never forwarded to the optimizer.
+
+    A real ``**kwargs`` (``max_bootstrapped_demos``) DOES reach the optimizer's
+    ``compile``; the tracking params do NOT (they are explicit, before ``**kwargs``).
+    """
+    fake_optimizer = mocker.MagicMock()
+    fake_optimizer.compile.return_value = dspy.ChainOfThought("left, right -> match")
+    mocker.patch("dspy.BootstrapFewShot", return_value=fake_optimizer)
+
+    judge = _dummy_judge(_answers(10))
+    judge.compile(
+        _trainset(),
+        store=RunStore(tmp_path / "runs.jsonl"),
+        parent_run_id="p",
+        max_bootstrapped_demos=2,
+    )
+
+    _, kwargs = fake_optimizer.compile.call_args
+    assert "store" not in kwargs
+    assert "tracker" not in kwargs
+    assert "parent_run_id" not in kwargs
+    assert kwargs["max_bootstrapped_demos"] == 2  # real optimizer kwargs still forwarded
+    # Even with the optimizer mocked, the run seam still fired and stamped the carrier.
+    assert isinstance(judge._compile_run_id, str)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/core/modules/test_llm_judge_correlation.py
+++ b/tests/core/modules/test_llm_judge_correlation.py
@@ -1,0 +1,90 @@
+"""S5: LLMJudge run correlation -- litellm ``metadata`` passthrough.
+
+The judge stamps the active ``capture_run`` attempt id (plus pair identity and
+decision step) into litellm's first-class ``metadata`` param, so a Langfuse/OTel
+trace joins the ``RunRecord`` and ``JudgementLog`` on ``langres_attempt_id``.
+
+Two invariants are load-bearing and both are locked here:
+1. ``metadata`` is added ONLY on the litellm path (``client is litellm``) and
+   ONLY inside an open run (``current_run`` set).
+2. With no run open, the ``completion()`` call is **byte-identical** to before
+   -- no ``metadata`` kwarg at all. This is the key regression guard.
+
+The client is mocked throughout -- no network, no real spend.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import Mock
+
+import litellm
+
+from langres.core.models import CompanySchema, ERCandidate
+from langres.core.modules.llm_judge import LLMJudge
+from langres.core.runs import RunContext, capture_run
+
+
+def _pair() -> ERCandidate[CompanySchema]:
+    return ERCandidate(
+        left=CompanySchema(id="c1", name="Acme Corporation"),
+        right=CompanySchema(id="c2", name="Acme Corp"),
+        blocker_name="test",
+    )
+
+
+def _response(content: str = "MATCH\nScore: 0.9\nReasoning: same company") -> Mock:
+    """A minimal completion response (mirrors test_llm_judge.py's shape)."""
+    resp = Mock()
+    resp.choices = [Mock()]
+    resp.choices[0].message.content = content
+    resp.usage = Mock()
+    resp.usage.prompt_tokens = 100
+    resp.usage.completion_tokens = 50
+    return resp
+
+
+def _context() -> RunContext:
+    return RunContext(experiment="s5-llm-correlation", dataset_name="fake")
+
+
+def test_metadata_stamped_on_litellm_path_inside_capture_run(mocker: Any) -> None:
+    """Inside a run on the litellm path, ``completion()`` receives ``metadata``
+    with the attempt id, both pair ids, and the decision step."""
+    mocker.patch.object(litellm, "completion", return_value=_response())
+    module = LLMJudge(client=litellm, model="gpt-4o-mini")
+
+    with capture_run(_context(), store=None) as handle:
+        list(module.forward([_pair()]))
+
+    metadata = litellm.completion.call_args.kwargs["metadata"]
+    assert metadata == {
+        "langres_attempt_id": handle.attempt_id,
+        "left_id": "c1",
+        "right_id": "c2",
+        "decision_step": "llm_judgment",
+    }
+
+
+def test_no_metadata_kwarg_when_no_capture_run(mocker: Any) -> None:
+    """Byte-identical invariant: with no open run, ``completion()`` is called
+    exactly as before -- NO ``metadata`` kwarg (key regression guard)."""
+    mocker.patch.object(litellm, "completion", return_value=_response())
+    module = LLMJudge(client=litellm, model="gpt-4o-mini")
+
+    list(module.forward([_pair()]))  # not inside any capture_run
+
+    assert "metadata" not in litellm.completion.call_args.kwargs
+
+
+def test_direct_client_never_receives_metadata_even_inside_capture_run() -> None:
+    """A user-supplied direct (non-litellm) client -- one that would 400 on an
+    unknown ``metadata`` kwarg -- never receives it, even inside a run."""
+    client = Mock()  # NOT the litellm module
+    client.completion.return_value = _response()
+    module = LLMJudge(client=client, model="gpt-4o-mini")
+
+    with capture_run(_context(), store=None):
+        list(module.forward([_pair()]))
+
+    assert "metadata" not in client.completion.call_args.kwargs

--- a/tests/core/modules/test_llm_judge_correlation.py
+++ b/tests/core/modules/test_llm_judge_correlation.py
@@ -18,11 +18,16 @@ from __future__ import annotations
 from typing import Any
 from unittest.mock import Mock
 
-import litellm
+import pytest
 
-from langres.core.models import CompanySchema, ERCandidate
-from langres.core.modules.llm_judge import LLMJudge
-from langres.core.runs import RunContext, capture_run
+# The litellm-path gate is identity (``client is litellm``), so these tests need
+# the real litellm module. It lives in the optional ``[llm]`` extra and is not
+# guaranteed installed (the bare-core CI job) -- skip the whole file if absent.
+litellm = pytest.importorskip("litellm")
+
+from langres.core.models import CompanySchema, ERCandidate  # noqa: E402
+from langres.core.modules.llm_judge import LLMJudge  # noqa: E402
+from langres.core.runs import RunContext, capture_run  # noqa: E402
 
 
 def _pair() -> ERCandidate[CompanySchema]:

--- a/tests/core/modules/test_llm_judge_correlation.py
+++ b/tests/core/modules/test_llm_judge_correlation.py
@@ -3,11 +3,14 @@
 The judge stamps the active ``capture_run`` attempt id (plus pair identity and
 decision step) into litellm's first-class ``metadata`` param, so a Langfuse/OTel
 trace joins the ``RunRecord`` and ``JudgementLog`` on ``langres_attempt_id``.
+This holds on **both** paths -- the sync ``forward()`` (``completion``) and the
+async ``forward_async()`` (``acompletion``, via the retry helper) -- which share
+``_run_correlation_metadata`` so they cannot drift.
 
-Two invariants are load-bearing and both are locked here:
+Two invariants are load-bearing and locked here for each path:
 1. ``metadata`` is added ONLY on the litellm path (``client is litellm``) and
    ONLY inside an open run (``current_run`` set).
-2. With no run open, the ``completion()`` call is **byte-identical** to before
+2. With no run open, the completion call is **byte-identical** to before
    -- no ``metadata`` kwarg at all. This is the key regression guard.
 
 The client is mocked throughout -- no network, no real spend.
@@ -16,7 +19,7 @@ The client is mocked throughout -- no network, no real spend.
 from __future__ import annotations
 
 from typing import Any
-from unittest.mock import Mock
+from unittest.mock import AsyncMock, Mock
 
 import pytest
 
@@ -93,3 +96,51 @@ def test_direct_client_never_receives_metadata_even_inside_capture_run() -> None
         list(module.forward([_pair()]))
 
     assert "metadata" not in client.completion.call_args.kwargs
+
+
+# --- Async path (forward_async) -- same three invariants on ``acompletion``. ---
+
+
+@pytest.mark.asyncio
+async def test_async_metadata_stamped_on_litellm_path_inside_capture_run(mocker: Any) -> None:
+    """Async mirror: inside a run on the litellm path, ``acompletion()`` receives
+    ``metadata`` with the attempt id, both pair ids, and the async decision step."""
+    mocker.patch.object(litellm, "acompletion", AsyncMock(return_value=_response()))
+    module = LLMJudge(client=litellm, model="gpt-4o-mini")
+
+    with capture_run(_context(), store=None) as handle:
+        await module.forward_async([_pair()])
+
+    metadata = litellm.acompletion.call_args.kwargs["metadata"]
+    assert metadata == {
+        "langres_attempt_id": handle.attempt_id,
+        "left_id": "c1",
+        "right_id": "c2",
+        "decision_step": "llm_judgment_async",
+    }
+
+
+@pytest.mark.asyncio
+async def test_async_no_metadata_kwarg_when_no_capture_run(mocker: Any) -> None:
+    """Async byte-identical invariant: with no open run, ``acompletion()`` is
+    called with NO ``metadata`` kwarg (the async regression guard)."""
+    mocker.patch.object(litellm, "acompletion", AsyncMock(return_value=_response()))
+    module = LLMJudge(client=litellm, model="gpt-4o-mini")
+
+    await module.forward_async([_pair()])  # not inside any capture_run
+
+    assert "metadata" not in litellm.acompletion.call_args.kwargs
+
+
+@pytest.mark.asyncio
+async def test_async_direct_client_never_receives_metadata_even_inside_capture_run() -> None:
+    """A user-supplied direct (non-litellm) client never receives ``metadata`` on
+    the async path either, even inside a run."""
+    client = Mock()  # NOT the litellm module
+    client.acompletion = AsyncMock(return_value=_response())
+    module = LLMJudge(client=client, model="gpt-4o-mini")
+
+    with capture_run(_context(), store=None):
+        await module.forward_async([_pair()])
+
+    assert "metadata" not in client.acompletion.call_args.kwargs

--- a/tests/core/test_judgement_log.py
+++ b/tests/core/test_judgement_log.py
@@ -22,6 +22,7 @@ from langres.core.judgement_log import JudgementLog, LoggingModule
 from langres.core.models import ERCandidate, PairwiseJudgement
 from langres.core.module import Module
 from langres.core.reports import ScoreInspectionReport
+from langres.core.runs import RunContext, capture_run
 
 
 def _judgement(
@@ -179,6 +180,53 @@ class TestJudgementLogAppend:
         row = log.read()[0]
         assert row["reasoning"] == "looks like a match"
         assert row["provenance"] == {"similarities": {"name": 1.0}}
+
+
+# ---------------------------------------------------------------------------
+# JudgementLog run correlation (S5): nullable run_id = active attempt id
+# ---------------------------------------------------------------------------
+
+
+def _run_context() -> RunContext:
+    """A minimal, git/dataset-free RunContext (no subprocess, no files)."""
+    return RunContext(experiment="s5-judgement-log", dataset_name="fake")
+
+
+class TestJudgementLogRunCorrelation:
+    def test_append_stamps_run_id_from_active_capture_run(self, tmp_path: Path) -> None:
+        """Inside a capture_run, the row's run_id equals that run's attempt_id --
+        the exact three-way join (RunRecord.attempt_id == JudgementLog.run_id)."""
+        log = JudgementLog(tmp_path / "log.jsonl")
+        with capture_run(_run_context(), store=None) as handle:
+            log.append(_judgement(), verdict=True)
+        row = log.read()[0]
+        assert row["run_id"] == handle.attempt_id
+
+    def test_append_run_id_is_none_outside_capture_run(self, tmp_path: Path) -> None:
+        """Outside any capture_run, run_id is null -- the field is always present."""
+        log = JudgementLog(tmp_path / "log.jsonl")
+        log.append(_judgement(), verdict=True)
+        row = log.read()[0]
+        assert row["run_id"] is None
+
+    def test_run_id_resets_when_capture_run_exits(self, tmp_path: Path) -> None:
+        """A row logged after the run closes carries run_id=None again."""
+        log = JudgementLog(tmp_path / "log.jsonl")
+        with capture_run(_run_context(), store=None):
+            log.append(_judgement("in", "run"), verdict=True)
+        log.append(_judgement("after", "run"), verdict=True)
+        rows = log.read()
+        assert rows[0]["run_id"] is not None
+        assert rows[1]["run_id"] is None
+
+    def test_pre_s5_rows_without_run_id_still_parse(self, tmp_path: Path) -> None:
+        """Additive under ``"v": 1``: an old row (no run_id key) still reads back;
+        a reader simply sees the key absent (``.get`` -> None)."""
+        path = tmp_path / "log.jsonl"
+        path.write_text('{"v": 1, "left_id": "a", "right_id": "b", "score": 0.9}\n')
+        rows = JudgementLog(path).read()
+        assert len(rows) == 1
+        assert rows[0].get("run_id") is None
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_import_budget.py
+++ b/tests/test_import_budget.py
@@ -98,8 +98,7 @@ def test_import_langres_excludes_tracking_deps_from_sys_modules() -> None:
         text=True,
     )
     assert result.returncode == 0, (
-        f"tracking import-budget check failed.\n"
-        f"STDOUT:\n{result.stdout}\nSTDERR:\n{result.stderr}"
+        f"tracking import-budget check failed.\nSTDOUT:\n{result.stdout}\nSTDERR:\n{result.stderr}"
     )
 
 

--- a/tests/test_import_budget.py
+++ b/tests/test_import_budget.py
@@ -43,7 +43,17 @@ def _import_ok(module_name: str) -> bool:
 # Import weight: heavy/optional deps must stay out of sys.modules.
 # ---------------------------------------------------------------------------
 
-_HEAVY_MODULES = ["torch", "litellm", "faiss", "sentence_transformers", "sklearn"]
+_HEAVY_MODULES = [
+    "torch",
+    "litellm",
+    "faiss",
+    "sentence_transformers",
+    "sklearn",
+    # Tracking backends (S1): the ExperimentTracker adapters must load mlflow/
+    # wandb lazily, never on a bare `import langres`.
+    "mlflow",
+    "wandb",
+]
 
 _CHECK_SCRIPT = (
     "import sys; import langres; "
@@ -62,6 +72,34 @@ def test_import_langres_excludes_heavy_modules_from_sys_modules() -> None:
     )
     assert result.returncode == 0, (
         f"import-budget check failed.\nSTDOUT:\n{result.stdout}\nSTDERR:\n{result.stderr}"
+    )
+
+
+_TRACKING_MODULES = ["ranx", "mlflow", "wandb"]
+
+_TRACKING_CHECK_SCRIPT = (
+    "import sys; import langres; "
+    "leaked = [m for m in {modules!r} if m in sys.modules]; "
+    "assert not leaked, f'tracking deps leaked into sys.modules: {{leaked}}'; "
+    "print('OK')"
+).format(modules=_TRACKING_MODULES)
+
+
+def test_import_langres_excludes_tracking_deps_from_sys_modules() -> None:
+    """The S1 tracking layer must not pull ranx/mlflow/wandb on a bare import.
+
+    ``core/runs.py`` refs the result models (which need ``ranx``) only under
+    ``TYPE_CHECKING``, and the ``ExperimentTracker`` adapters import
+    ``mlflow``/``wandb`` lazily -- so eager ``import langres`` stays clean.
+    """
+    result = subprocess.run(
+        [sys.executable, "-c", _TRACKING_CHECK_SCRIPT],
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode == 0, (
+        f"tracking import-budget check failed.\n"
+        f"STDOUT:\n{result.stdout}\nSTDERR:\n{result.stderr}"
     )
 
 

--- a/tests/test_mlflow_tracker.py
+++ b/tests/test_mlflow_tracker.py
@@ -19,6 +19,7 @@ them).
 from __future__ import annotations
 
 import importlib
+import os
 import sys
 from types import ModuleType, SimpleNamespace
 from typing import Any
@@ -90,6 +91,9 @@ def _clean_mlflow_env(monkeypatch: pytest.MonkeyPatch) -> None:
     """Isolate Settings from any ambient MLflow env so tests are deterministic."""
     monkeypatch.delenv("MLFLOW_TRACKING_URI", raising=False)
     monkeypatch.delenv("MLFLOW_EXPERIMENT", raising=False)
+    # The file-store maintenance-mode flag (F1) -- cleared so each test observes
+    # the adapter's own setdefault, not a leaked value. monkeypatch restores it.
+    monkeypatch.delenv("MLFLOW_ALLOW_FILE_STORE", raising=False)
 
 
 @pytest.fixture
@@ -196,6 +200,68 @@ def test_start_run_without_tracking_uri_skips_set_tracking_uri(
 
     assert fake.tracking_uri is None
     assert fake.experiment == "langres"  # the Settings default
+
+
+# ---------------------------------------------------------------------------
+# start_run: MLflow 3.14 local-file-store maintenance-mode flag (F1)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "uri",
+    [
+        None,  # unset -> file-store fallback (MLflow <3.14's ./mlruns); allow it
+        "file:///tmp/mlruns",  # explicit file: URI
+        "./mlruns",  # scheme-less local path
+    ],
+)
+def test_start_run_allows_local_file_store_out_of_the_box(
+    mlflow_env: tuple[ModuleType, _FakeMlflow], uri: str | None
+) -> None:
+    """Unset/local-file config -> adapter sets MLFLOW_ALLOW_FILE_STORE.
+
+    So a file-store fallback never trips MLflow 3.14's maintenance-mode guard.
+    """
+    module, _ = mlflow_env
+    tracker = module.MlflowTracker(_settings(mlflow_tracking_uri=uri))
+
+    tracker.start_run(_make_context())
+
+    assert os.environ["MLFLOW_ALLOW_FILE_STORE"] == "true"
+
+
+@pytest.mark.parametrize(
+    "uri",
+    [
+        "https://mlflow.example.com",  # HTTP tracking server
+        "http://localhost:5000",
+        "sqlite:///mlflow.db",  # SQLAlchemy backend
+        "postgresql://user@host/db",
+    ],
+)
+def test_start_run_does_not_set_file_store_flag_for_http_or_sql(
+    mlflow_env: tuple[ModuleType, _FakeMlflow], uri: str
+) -> None:
+    """HTTP/SQL backends aren't file stores -> the maintenance-mode flag is never set."""
+    module, _ = mlflow_env
+    tracker = module.MlflowTracker(_settings(mlflow_tracking_uri=uri))
+
+    tracker.start_run(_make_context())
+
+    assert "MLFLOW_ALLOW_FILE_STORE" not in os.environ
+
+
+def test_start_run_preserves_explicit_file_store_flag(
+    mlflow_env: tuple[ModuleType, _FakeMlflow], monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """setdefault semantics: an explicit user value is never clobbered by the adapter."""
+    module, _ = mlflow_env
+    monkeypatch.setenv("MLFLOW_ALLOW_FILE_STORE", "false")
+    tracker = module.MlflowTracker(_settings(mlflow_tracking_uri=None))
+
+    tracker.start_run(_make_context())
+
+    assert os.environ["MLFLOW_ALLOW_FILE_STORE"] == "false"
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_mlflow_tracker.py
+++ b/tests/test_mlflow_tracker.py
@@ -1,0 +1,372 @@
+"""Behavior/smoke tests for the MLflow ``ExperimentTracker`` adapter (Stream S3).
+
+``mlflow`` is an optional extra and is **not installed** in the core test
+environment, so the whole file mocks it: a fake ``mlflow`` module is injected
+into ``sys.modules`` and the adapter module is (re)imported so its top-level
+``import mlflow`` binds to the fake. The tests then assert the adapter drives
+the right MLflow APIs -- start/params/tags/metrics/artifacts/finish -- with the
+context flattened into dotted params, ``run_url`` derived from an HTTP tracking
+server, ``finish(status=...)`` mapped to MLflow's ``RunStatus``, and that
+``resolve_tracker("mlflow")`` yields a real ``MlflowTracker`` once the (mocked)
+module is importable.
+
+Per the tiered coverage policy these are behavior/smoke tests: adapter bodies
+are exercised through the fake, with ``# pragma: no cover`` reserved for
+genuinely un-mockable external calls (there are none here -- the fake covers
+them).
+"""
+
+from __future__ import annotations
+
+import importlib
+import sys
+from types import ModuleType, SimpleNamespace
+from typing import Any
+
+import pytest
+
+from langres.clients.settings import Settings
+from langres.core.runs import RunContext
+
+_TRACKER_MODULE = "langres.core.trackers.mlflow_tracker"
+
+
+class _FakeRun:
+    """Stand-in for an MLflow ``ActiveRun`` -- only ``.info`` ids are read."""
+
+    def __init__(self, run_id: str = "run-abc123", experiment_id: str = "exp-1") -> None:
+        self.info = SimpleNamespace(run_id=run_id, experiment_id=experiment_id)
+
+
+class _FakeMlflow:
+    """Records every MLflow call the adapter makes, for assertions."""
+
+    def __init__(self) -> None:
+        self.tracking_uri: str | None = None
+        self.experiment: str | None = None
+        self.run_name: str | None = None
+        self.params: dict[str, str] = {}
+        self.metrics: list[tuple[dict[str, float], int | None]] = []
+        self.tags: dict[str, str] = {}
+        self.artifact_files: list[str] = []
+        self.artifact_dirs: list[str] = []
+        self.ended_status: str | None = None
+        self._run = _FakeRun()
+
+    def set_tracking_uri(self, uri: str) -> None:
+        self.tracking_uri = uri
+
+    def set_experiment(self, name: str) -> None:
+        self.experiment = name
+
+    def start_run(self, run_name: str | None = None) -> _FakeRun:
+        self.run_name = run_name
+        return self._run
+
+    def log_params(self, params: dict[str, str]) -> None:
+        self.params.update(params)
+
+    def log_metrics(self, metrics: dict[str, float], step: int | None = None) -> None:
+        self.metrics.append((dict(metrics), step))
+
+    def log_artifact(self, local_path: str) -> None:
+        self.artifact_files.append(local_path)
+
+    def log_artifacts(self, local_dir: str) -> None:
+        self.artifact_dirs.append(local_dir)
+
+    def set_tag(self, key: str, value: str) -> None:
+        self.tags[key] = value
+
+    def set_tags(self, tags: dict[str, str]) -> None:
+        self.tags.update(tags)
+
+    def end_run(self, status: str | None = None) -> None:
+        self.ended_status = status
+
+
+@pytest.fixture(autouse=True)
+def _clean_mlflow_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Isolate Settings from any ambient MLflow env so tests are deterministic."""
+    monkeypatch.delenv("MLFLOW_TRACKING_URI", raising=False)
+    monkeypatch.delenv("MLFLOW_EXPERIMENT", raising=False)
+
+
+@pytest.fixture
+def mlflow_env(monkeypatch: pytest.MonkeyPatch) -> tuple[ModuleType, _FakeMlflow]:
+    """Inject a fake ``mlflow`` and (re)import the adapter module against it.
+
+    Returns ``(adapter_module, fake_mlflow)``. monkeypatch restores both
+    ``sys.modules["mlflow"]`` and the adapter module entry on teardown, so the
+    fake never leaks into other tests.
+    """
+    fake = _FakeMlflow()
+    monkeypatch.setitem(sys.modules, "mlflow", fake)  # type: ignore[misc]
+    # Drop any real/prior import so the top-level `import mlflow` rebinds to fake.
+    monkeypatch.delitem(sys.modules, _TRACKER_MODULE, raising=False)
+    module = importlib.import_module(_TRACKER_MODULE)
+    return module, fake
+
+
+def _settings(**overrides: Any) -> Settings:
+    """A Settings that ignores ``.env`` so overrides fully control the config."""
+    return Settings(_env_file=None, **overrides)  # type: ignore[call-arg]
+
+
+def _make_context() -> RunContext:
+    """A representative context with nested config, seeds, tuple, and tags."""
+    return RunContext(
+        experiment="er-poc",
+        tags={"team": "er", "phase": "poc"},
+        llm_model="deepseek/deepseek-chat",
+        blocking_k=5,
+        cascade_band=(0.3, 0.7),
+        resolver_config={"blocker": {"type_name": "AllPairsBlocker", "random_state": 42}},
+        dataset_name="febrl4",
+        dataset_fingerprint="fp-deadbeef",
+        split_id="test",
+        seeds={"split": 7, "blocker.random_state": 42},
+    )
+
+
+# ---------------------------------------------------------------------------
+# start_run: store config + flattened params/tags
+# ---------------------------------------------------------------------------
+
+
+def test_start_run_configures_store_and_opens_run(
+    mlflow_env: tuple[ModuleType, _FakeMlflow],
+) -> None:
+    module, fake = mlflow_env
+    tracker = module.MlflowTracker(
+        _settings(mlflow_tracking_uri="https://mlflow.example.com", mlflow_experiment="er-exp")
+    )
+
+    tracker.start_run(_make_context(), run_name="er-poc")
+
+    assert fake.tracking_uri == "https://mlflow.example.com"
+    assert fake.experiment == "er-exp"
+    assert fake.run_name == "er-poc"
+    assert tracker.name == "mlflow"
+
+
+def test_start_run_flattens_context_into_dotted_params(
+    mlflow_env: tuple[ModuleType, _FakeMlflow],
+) -> None:
+    module, fake = mlflow_env
+    tracker = module.MlflowTracker(_settings(mlflow_tracking_uri="https://mlflow.example.com"))
+
+    tracker.start_run(_make_context())
+
+    # Scalars, nested config, seeds.*, and the tuple all flatten to params.
+    assert fake.params["experiment"] == "er-poc"
+    assert fake.params["llm_model"] == "deepseek/deepseek-chat"
+    assert fake.params["blocking_k"] == "5"
+    assert fake.params["dataset_fingerprint"] == "fp-deadbeef"
+    assert fake.params["seeds.split"] == "7"
+    assert fake.params["seeds.blocker.random_state"] == "42"
+    assert fake.params["resolver_config.blocker.type_name"] == "AllPairsBlocker"
+    assert fake.params["cascade_band[0]"] == "0.3"
+    assert fake.params["cascade_band[1]"] == "0.7"
+    # tags are routed to MLflow tags, NOT duplicated as params.
+    assert "tags.team" not in fake.params
+    assert "tags" not in fake.params
+
+
+def test_start_run_routes_context_tags_to_mlflow_tags(
+    mlflow_env: tuple[ModuleType, _FakeMlflow],
+) -> None:
+    module, fake = mlflow_env
+    tracker = module.MlflowTracker(_settings())
+
+    tracker.start_run(_make_context())
+
+    assert fake.tags["team"] == "er"
+    assert fake.tags["phase"] == "poc"
+
+
+def test_start_run_without_tracking_uri_skips_set_tracking_uri(
+    mlflow_env: tuple[ModuleType, _FakeMlflow],
+) -> None:
+    """Unset URI -> MLflow's own local ./mlruns default; adapter must not force one."""
+    module, fake = mlflow_env
+    tracker = module.MlflowTracker(_settings(mlflow_tracking_uri=None))
+
+    tracker.start_run(_make_context())
+
+    assert fake.tracking_uri is None
+    assert fake.experiment == "langres"  # the Settings default
+
+
+# ---------------------------------------------------------------------------
+# log_params / log_metrics / log_artifact
+# ---------------------------------------------------------------------------
+
+
+def test_log_params_stringifies_and_skips_empty(
+    mlflow_env: tuple[ModuleType, _FakeMlflow],
+) -> None:
+    module, fake = mlflow_env
+    tracker = module.MlflowTracker(_settings())
+
+    tracker.log_params({})  # empty -> no MLflow call, no crash
+    assert fake.params == {}
+
+    tracker.log_params({"blocking_k": 5, "flag": True})
+    assert fake.params == {"blocking_k": "5", "flag": "True"}
+
+
+def test_log_metrics_forwards_with_step(
+    mlflow_env: tuple[ModuleType, _FakeMlflow],
+) -> None:
+    module, fake = mlflow_env
+    tracker = module.MlflowTracker(_settings())
+
+    tracker.log_metrics({})  # empty -> skipped
+    tracker.log_metrics({"pair_f1": 0.91}, step=3)
+    tracker.log_metrics({"bcubed_f1": 0.87})
+
+    assert fake.metrics == [({"pair_f1": 0.91}, 3), ({"bcubed_f1": 0.87}, None)]
+
+
+def test_log_artifact_dir_file_and_url(
+    mlflow_env: tuple[ModuleType, _FakeMlflow], tmp_path: Any
+) -> None:
+    module, fake = mlflow_env
+    tracker = module.MlflowTracker(_settings())
+
+    a_dir = tmp_path / "resolver_save"
+    a_dir.mkdir()
+    a_file = tmp_path / "report.md"
+    a_file.write_text("# report\n")
+
+    tracker.log_artifact("resolver", str(a_dir))
+    tracker.log_artifact("report", str(a_file))
+    tracker.log_artifact("wandb_run_url", "https://wandb.ai/x/y/runs/z")
+
+    assert fake.artifact_dirs == [str(a_dir)]
+    assert fake.artifact_files == [str(a_file)]
+    # A URL/reference (not a local path) is recorded as a tag, never uploaded.
+    assert fake.tags["wandb_run_url"] == "https://wandb.ai/x/y/runs/z"
+
+
+# ---------------------------------------------------------------------------
+# finish: status mapping
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    ("status", "expected"),
+    [
+        ("completed", "FINISHED"),
+        ("failed", "FAILED"),
+        ("budget_exceeded", "KILLED"),
+        ("running", "RUNNING"),
+    ],
+)
+def test_finish_maps_status_and_stamps_langres_status_tag(
+    mlflow_env: tuple[ModuleType, _FakeMlflow], status: str, expected: str
+) -> None:
+    module, fake = mlflow_env
+    tracker = module.MlflowTracker(_settings())
+    tracker.start_run(_make_context())
+
+    tracker.finish(status=status)
+
+    assert fake.ended_status == expected
+    assert fake.tags["langres.status"] == status
+
+
+def test_finish_maps_unknown_status_to_finished(
+    mlflow_env: tuple[ModuleType, _FakeMlflow],
+) -> None:
+    module, fake = mlflow_env
+    tracker = module.MlflowTracker(_settings())
+    tracker.start_run(_make_context())
+
+    tracker.finish(status="something-unexpected")
+
+    assert fake.ended_status == "FINISHED"
+
+
+def test_finish_is_noop_before_start(mlflow_env: tuple[ModuleType, _FakeMlflow]) -> None:
+    module, fake = mlflow_env
+    tracker = module.MlflowTracker(_settings())
+
+    tracker.finish(status="completed")
+
+    assert fake.ended_status is None
+    assert "langres.status" not in fake.tags
+
+
+# ---------------------------------------------------------------------------
+# run_url + native
+# ---------------------------------------------------------------------------
+
+
+def test_run_url_derives_deep_link_from_http_server(
+    mlflow_env: tuple[ModuleType, _FakeMlflow],
+) -> None:
+    module, _ = mlflow_env
+    tracker = module.MlflowTracker(
+        _settings(mlflow_tracking_uri="https://mlflow.example.com/")  # trailing slash
+    )
+    tracker.start_run(_make_context())
+
+    assert tracker.run_url == "https://mlflow.example.com/#/experiments/exp-1/runs/run-abc123"
+
+
+def test_run_url_is_none_for_local_file_store(
+    mlflow_env: tuple[ModuleType, _FakeMlflow],
+) -> None:
+    module, _ = mlflow_env
+    tracker = module.MlflowTracker(_settings(mlflow_tracking_uri=None))
+    tracker.start_run(_make_context())
+
+    assert tracker.run_url is None
+
+
+def test_run_url_is_none_before_start(mlflow_env: tuple[ModuleType, _FakeMlflow]) -> None:
+    module, _ = mlflow_env
+    tracker = module.MlflowTracker(_settings(mlflow_tracking_uri="https://mlflow.example.com"))
+
+    assert tracker.run_url is None
+
+
+def test_native_returns_the_underlying_run(
+    mlflow_env: tuple[ModuleType, _FakeMlflow],
+) -> None:
+    module, fake = mlflow_env
+    tracker = module.MlflowTracker(_settings())
+
+    assert tracker.native is None  # pre-start escape hatch
+    tracker.start_run(_make_context())
+    assert tracker.native is fake._run
+
+
+# ---------------------------------------------------------------------------
+# resolve_tracker wiring (the S1 seam -> S3 adapter)
+# ---------------------------------------------------------------------------
+
+
+def test_resolve_tracker_returns_real_mlflow_tracker(
+    mlflow_env: tuple[ModuleType, _FakeMlflow],
+) -> None:
+    """With the (mocked) module importable, resolve_tracker('mlflow') returns it."""
+    module, _ = mlflow_env
+    from langres.core.trackers import resolve_tracker
+
+    tracker = resolve_tracker("mlflow")
+
+    assert isinstance(tracker, module.MlflowTracker)
+    assert tracker.name == "mlflow"
+
+
+def test_getattr_exposes_mlflow_tracker_class(
+    mlflow_env: tuple[ModuleType, _FakeMlflow],
+) -> None:
+    """`from langres.core.trackers import MlflowTracker` resolves via lazy __getattr__."""
+    module, _ = mlflow_env
+    import langres.core.trackers as trackers
+
+    assert trackers.MlflowTracker is module.MlflowTracker

--- a/tests/test_mlflow_tracker.py
+++ b/tests/test_mlflow_tracker.py
@@ -21,6 +21,7 @@ from __future__ import annotations
 import importlib
 import os
 import sys
+from collections.abc import Iterator
 from types import ModuleType, SimpleNamespace
 from typing import Any
 
@@ -52,7 +53,9 @@ class _FakeMlflow:
         self.artifact_files: list[str] = []
         self.artifact_dirs: list[str] = []
         self.ended_status: str | None = None
+        self.nested_flags: list[bool] = []
         self._run = _FakeRun()
+        self._active: _FakeRun | None = None
 
     def set_tracking_uri(self, uri: str) -> None:
         self.tracking_uri = uri
@@ -60,9 +63,14 @@ class _FakeMlflow:
     def set_experiment(self, name: str) -> None:
         self.experiment = name
 
-    def start_run(self, run_name: str | None = None) -> _FakeRun:
+    def start_run(self, run_name: str | None = None, nested: bool = False) -> _FakeRun:
         self.run_name = run_name
+        self.nested_flags.append(nested)
+        self._active = self._run
         return self._run
+
+    def active_run(self) -> _FakeRun | None:
+        return self._active
 
     def log_params(self, params: dict[str, str]) -> None:
         self.params.update(params)
@@ -84,6 +92,7 @@ class _FakeMlflow:
 
     def end_run(self, status: str | None = None) -> None:
         self.ended_status = status
+        self._active = None
 
 
 @pytest.fixture(autouse=True)
@@ -97,19 +106,29 @@ def _clean_mlflow_env(monkeypatch: pytest.MonkeyPatch) -> None:
 
 
 @pytest.fixture
-def mlflow_env(monkeypatch: pytest.MonkeyPatch) -> tuple[ModuleType, _FakeMlflow]:
+def mlflow_env(monkeypatch: pytest.MonkeyPatch) -> Iterator[tuple[ModuleType, _FakeMlflow]]:
     """Inject a fake ``mlflow`` and (re)import the adapter module against it.
 
-    Returns ``(adapter_module, fake_mlflow)``. monkeypatch restores both
-    ``sys.modules["mlflow"]`` and the adapter module entry on teardown, so the
-    fake never leaks into other tests.
+    Yields ``(adapter_module, fake_mlflow)``. monkeypatch restores
+    ``sys.modules["mlflow"]``; the adapter-module entry is saved/restored *by hand*
+    -- NOT via ``monkeypatch.delitem``, whose no-op-on-absent-key semantics would
+    leave the fake-bound adapter leaked into later tests (the real-mlflow tests
+    below would then import the fake and read a nonexistent ``run-abc123``). This
+    guarantees the next import always re-binds against the current ``mlflow``.
     """
     fake = _FakeMlflow()
     monkeypatch.setitem(sys.modules, "mlflow", fake)  # type: ignore[misc]
-    # Drop any real/prior import so the top-level `import mlflow` rebinds to fake.
-    monkeypatch.delitem(sys.modules, _TRACKER_MODULE, raising=False)
+    # Drop any prior import so the top-level `import mlflow` rebinds to the fake,
+    # remembering what was there to restore it on teardown.
+    saved_adapter = sys.modules.pop(_TRACKER_MODULE, None)
     module = importlib.import_module(_TRACKER_MODULE)
-    return module, fake
+    try:
+        yield module, fake
+    finally:
+        if saved_adapter is not None:
+            sys.modules[_TRACKER_MODULE] = saved_adapter
+        else:
+            sys.modules.pop(_TRACKER_MODULE, None)
 
 
 def _settings(**overrides: Any) -> Settings:
@@ -170,8 +189,11 @@ def test_start_run_flattens_context_into_dotted_params(
     assert fake.params["seeds.split"] == "7"
     assert fake.params["seeds.blocker.random_state"] == "42"
     assert fake.params["resolver_config.blocker.type_name"] == "AllPairsBlocker"
-    assert fake.params["cascade_band[0]"] == "0.3"
-    assert fake.params["cascade_band[1]"] == "0.7"
+    # Sequence fields flatten to dotted indices (``cascade_band.0``), never
+    # ``cascade_band[0]`` -- ``[``/``]`` are outside MLflow's param-name charset.
+    assert fake.params["cascade_band.0"] == "0.3"
+    assert fake.params["cascade_band.1"] == "0.7"
+    assert not any("[" in key or "]" in key for key in fake.params)
     # tags are routed to MLflow tags, NOT duplicated as params.
     assert "tags.team" not in fake.params
     assert "tags" not in fake.params
@@ -436,3 +458,102 @@ def test_getattr_exposes_mlflow_tracker_class(
     import langres.core.trackers as trackers
 
     assert trackers.MlflowTracker is module.MlflowTracker
+
+
+# ---------------------------------------------------------------------------
+# Param-key sanitization (Codex#1): dotted indices + out-of-charset coercion
+# ---------------------------------------------------------------------------
+
+
+def test_flatten_uses_dotted_indices_never_brackets(
+    mlflow_env: tuple[ModuleType, _FakeMlflow],
+) -> None:
+    """Sequence/nested fields flatten to dotted indices (``k.0``), never ``k[0]``."""
+    module, _ = mlflow_env
+
+    flat = module._flatten({"cascade_band": [0.3, 0.7], "cfg": {"bands": [1]}})
+
+    assert flat == {"cascade_band.0": "0.3", "cascade_band.1": "0.7", "cfg.bands.0": "1"}
+    assert not any("[" in key or "]" in key for key in flat)
+    # A bare top-level scalar (empty prefix) yields nothing -- no keyless entry.
+    assert module._flatten("bare-scalar") == {}
+
+
+def test_sanitize_key_coerces_out_of_charset_to_underscore(
+    mlflow_env: tuple[ModuleType, _FakeMlflow],
+) -> None:
+    """Any char outside MLflow's ``[alphanumerics _ - . space /]`` becomes ``_``."""
+    module, _ = mlflow_env
+
+    assert module._sanitize_key("cascade_band.0") == "cascade_band.0"  # safe -> unchanged
+    assert module._sanitize_key("a/b-c.d e") == "a/b-c.d e"  # every allowed char kept
+    assert module._sanitize_key("weird[0]:x!") == "weird_0__x_"  # []/:/! -> _
+
+
+# ---------------------------------------------------------------------------
+# Real mlflow against a local file store: nested runs (M4) + safe keys (Codex#1)
+# ---------------------------------------------------------------------------
+
+
+def _drain_active_mlflow_runs() -> None:
+    """End any still-active real mlflow run so global state can't leak across tests."""
+    import mlflow
+
+    while mlflow.active_run() is not None:
+        mlflow.end_run()
+
+
+def test_real_mlflow_nested_start_run_does_not_raise(tmp_path: Any) -> None:
+    """M4: opening a run while one is already active must not raise (nested=True).
+
+    Uses the REAL mlflow adapter against a local file store -- reproduces a nested
+    ``capture_run`` (a DSPy ``compile()`` run inside an outer benchmark run).
+    """
+    from langres.core.trackers.mlflow_tracker import MlflowTracker
+
+    uri = f"file://{tmp_path}/mlruns"
+    outer = MlflowTracker(_settings(mlflow_tracking_uri=uri, mlflow_experiment="nested-check"))
+    inner = MlflowTracker(_settings(mlflow_tracking_uri=uri, mlflow_experiment="nested-check"))
+    try:
+        outer.start_run(_make_context(), run_name="outer")
+        # A second run while the outer is active -- would raise "Run ... is already
+        # active" without nested=True.
+        inner.start_run(_make_context(), run_name="inner")
+        assert inner.native is not None
+        inner.finish(status="completed")
+        outer.finish(status="completed")
+    finally:
+        _drain_active_mlflow_runs()
+
+
+def test_real_mlflow_sequence_field_yields_safe_param_keys(tmp_path: Any) -> None:
+    """Codex#1: a context with a sequence/nested field logs only MLflow-safe keys.
+
+    ``cascade_band`` (a tuple) and a nested list under ``resolver_config`` would
+    naively flatten to ``cascade_band[0]`` -- which real mlflow rejects. With the
+    fix, ``start_run`` succeeds and every stored key is bracket-free.
+    """
+    from mlflow import MlflowClient
+
+    from langres.core.trackers.mlflow_tracker import MlflowTracker
+
+    uri = f"file://{tmp_path}/mlruns"
+    tracker = MlflowTracker(_settings(mlflow_tracking_uri=uri, mlflow_experiment="seq-keys"))
+    context = RunContext(
+        experiment="seq-keys",
+        dataset_name="febrl4",
+        cascade_band=(0.3, 0.7),  # tuple -> sequence field
+        resolver_config={"blocker": {"bands": [0.1, 0.2]}},  # nested list
+    )
+    try:
+        tracker.start_run(context)  # real mlflow validates every key -> must not raise
+        run_id = tracker.native.info.run_id
+        tracker.finish(status="completed")
+
+        params = MlflowClient(tracking_uri=uri).get_run(run_id).data.params
+        assert params["cascade_band.0"] == "0.3"
+        assert params["cascade_band.1"] == "0.7"
+        assert params["resolver_config.blocker.bands.0"] == "0.1"
+        assert not any("[" in key or "]" in key for key in params)
+    finally:
+        _drain_active_mlflow_runs()

--- a/tests/test_resolver_config_dict.py
+++ b/tests/test_resolver_config_dict.py
@@ -1,0 +1,146 @@
+"""S2 — ``Resolver.config_dict()``: in-memory config snapshot, no disk I/O.
+
+``config_dict()`` factors the in-memory :class:`ArtifactManifest` assembly out of
+:meth:`Resolver.save` so the experiment-tracking layer can snapshot a pipeline's
+declared config (``RunContext.resolver_config``) **without** writing an artifact.
+These tests lock the S2 acceptance invariants:
+
+1. ``config_dict()`` == the dict ``save()`` manifests (equal to ``resolver.json``),
+   and it round-trips through the registry contract.
+2. ``config_dict()`` writes **nothing** to disk.
+3. It composes with the existing ``save``/``load`` round-trip unchanged.
+4. An unserializable slot component raises ``TypeError`` (NOT swallowed here —
+   the best-effort catch lives in the tracking capture path, a different stream).
+"""
+
+import json
+from pathlib import Path
+
+import pytest
+
+
+def _company_resolver() -> "object":
+    """A 4-slot Resolver over built-in, registered components."""
+    from langres.core import (
+        AllPairsBlocker,
+        Clusterer,
+        Comparator,
+        Resolver,
+        WeightedAverageJudge,
+    )
+    from langres.core.models import CompanySchema
+
+    comparator = Comparator.from_schema(CompanySchema)
+    return Resolver(
+        blocker=AllPairsBlocker(schema=CompanySchema),
+        comparator=comparator,
+        module=WeightedAverageJudge(feature_specs=comparator.feature_specs),
+        clusterer=Clusterer(threshold=0.7),
+    )
+
+
+def test_config_dict_matches_saved_manifest(tmp_path: Path) -> None:
+    """The snapshot equals the exact dict ``save()`` writes to ``resolver.json``."""
+    resolver = _company_resolver()
+    snapshot = resolver.config_dict()  # type: ignore[attr-defined]
+
+    resolver.save(tmp_path)  # type: ignore[attr-defined]
+    on_disk = json.loads((tmp_path / "resolver.json").read_text())
+
+    assert snapshot == on_disk
+
+
+def test_config_dict_has_expected_shape() -> None:
+    """Snapshot carries the artifact metadata + ordered slot specs."""
+    import langres
+
+    snapshot = _company_resolver().config_dict()  # type: ignore[attr-defined]
+
+    assert snapshot["artifact_version"] == "1"
+    assert snapshot["langres_version"] == langres.__version__
+    assert [c["type_name"] for c in snapshot["components"]] == [
+        "all_pairs_blocker",
+        "comparator",
+        "weighted_average_judge",
+        "clusterer",
+    ]
+    assert [c["slot"] for c in snapshot["components"]] == [
+        "blocker",
+        "comparator",
+        "module",
+        "clusterer",
+    ]
+    # Clusterer config carries its threshold verbatim (declared config, no I/O).
+    clusterer_spec = next(c for c in snapshot["components"] if c["slot"] == "clusterer")
+    assert clusterer_spec["config"]["threshold"] == 0.7
+
+
+def test_config_dict_is_json_serializable() -> None:
+    """The snapshot is plain JSON data — the tracking layer hashes it via json.dumps."""
+    snapshot = _company_resolver().config_dict()  # type: ignore[attr-defined]
+    # Must not raise: recipe_id hashing canonicalizes this with json.dumps().
+    round_tripped = json.loads(json.dumps(snapshot))
+    assert round_tripped == snapshot
+
+
+def test_config_dict_writes_nothing_to_disk(tmp_path: Path) -> None:
+    """Building the snapshot creates no files — it is a pure in-memory read."""
+    resolver = _company_resolver()
+
+    snapshot = resolver.config_dict()  # type: ignore[attr-defined]
+
+    assert list(tmp_path.iterdir()) == []  # target dir untouched
+    assert not (tmp_path / "resolver.json").exists()
+    assert snapshot["components"]  # returned a real, populated manifest
+
+
+def test_config_dict_omits_absent_comparator() -> None:
+    """``comparator=None`` yields a 3-slot snapshot, mirroring ``save()``'s ``_slots``."""
+    from langres.core import AllPairsBlocker, Clusterer, Resolver, WeightedAverageJudge
+    from langres.core.feature import FeatureSpec
+    from langres.core.models import CompanySchema
+
+    resolver = Resolver(
+        blocker=AllPairsBlocker(schema=CompanySchema),
+        comparator=None,
+        module=WeightedAverageJudge(feature_specs=[FeatureSpec(name="name")]),
+        clusterer=Clusterer(threshold=0.7),
+    )
+
+    assert [c["slot"] for c in resolver.config_dict()["components"]] == [
+        "blocker",
+        "module",
+        "clusterer",
+    ]
+
+
+def test_config_dict_composes_with_save_load_round_trip(tmp_path: Path) -> None:
+    """save/load still works and reloads to an identical snapshot (parity guard)."""
+    from langres.core import Resolver
+    from langres.core.serialization import ArtifactManifest
+
+    resolver = _company_resolver()
+    snapshot = resolver.config_dict()  # type: ignore[attr-defined]
+
+    # The snapshot validates as the very contract load() reads.
+    assert ArtifactManifest.model_validate(snapshot).artifact_version == "1"
+
+    resolver.save(tmp_path)  # type: ignore[attr-defined]
+    reloaded = Resolver.load(tmp_path)
+    assert reloaded.config_dict() == snapshot
+
+
+def test_config_dict_raises_on_unserializable_component() -> None:
+    """An unregistered slot component raises ``TypeError`` (not swallowed here)."""
+    from langres.core import Resolver
+    from langres.core.models import CompanySchema
+
+    resolver = Resolver.from_schema(CompanySchema)
+
+    class _UnregisteredModule:
+        """Stands in for any component lacking ``type_name``/@register."""
+
+    resolver.module = _UnregisteredModule()  # type: ignore[assignment]
+
+    with pytest.raises(TypeError, match="_UnregisteredModule is not serializable"):
+        resolver.config_dict()

--- a/tests/test_resolver_config_dict.py
+++ b/tests/test_resolver_config_dict.py
@@ -1,14 +1,19 @@
-"""S2 — ``Resolver.config_dict()``: in-memory config snapshot, no disk I/O.
+"""S2 — ``Resolver.config_dict()``: hash-safe config snapshot, no disk I/O.
 
 ``config_dict()`` factors the in-memory :class:`ArtifactManifest` assembly out of
 :meth:`Resolver.save` so the experiment-tracking layer can snapshot a pipeline's
 declared config (``RunContext.resolver_config``) **without** writing an artifact.
-These tests lock the S2 acceptance invariants:
+These tests lock its acceptance invariants:
 
-1. ``config_dict()`` == the dict ``save()`` manifests (equal to ``resolver.json``),
-   and it round-trips through the registry contract.
+1. ``config_dict()`` returns only the reproducible ``components`` payload and
+   **omits** the volatile version/provenance envelope (``artifact_version`` /
+   ``langres_version``) that ``save()`` still writes to ``resolver.json``. Because
+   the snapshot feeds ``RunContext.resolver_config`` — inside
+   :func:`compute_recipe_id`'s hash domain — the resulting ``recipe_id`` must be
+   **stable across a package / artifact-schema version bump** (idempotent replay).
 2. ``config_dict()`` writes **nothing** to disk.
-3. It composes with the existing ``save``/``load`` round-trip unchanged.
+3. It composes with the existing ``save``/``load`` round-trip unchanged, and
+   ``save()`` still records the version provenance on disk.
 4. An unserializable slot component raises ``TypeError`` (NOT swallowed here —
    the best-effort catch lives in the tracking capture path, a different stream).
 """
@@ -39,25 +44,32 @@ def _company_resolver() -> "object":
     )
 
 
-def test_config_dict_matches_saved_manifest(tmp_path: Path) -> None:
-    """The snapshot equals the exact dict ``save()`` writes to ``resolver.json``."""
+def test_config_dict_components_match_saved_manifest_minus_version(tmp_path: Path) -> None:
+    """The snapshot's ``components`` equal ``resolver.json``'s, minus the version envelope.
+
+    ``config_dict()`` is the reproducible config only: it carries the same ordered
+    component specs ``save()`` writes, but omits the volatile ``artifact_version``
+    / ``langres_version`` fields (those stay on disk / on the RunContext, unhashed).
+    """
     resolver = _company_resolver()
     snapshot = resolver.config_dict()  # type: ignore[attr-defined]
 
     resolver.save(tmp_path)  # type: ignore[attr-defined]
     on_disk = json.loads((tmp_path / "resolver.json").read_text())
 
-    assert snapshot == on_disk
+    # Same reproducible payload...
+    assert snapshot == {"components": on_disk["components"]}
+    # ...but the snapshot deliberately drops the version/provenance envelope.
+    assert "artifact_version" not in snapshot
+    assert "langres_version" not in snapshot
 
 
 def test_config_dict_has_expected_shape() -> None:
-    """Snapshot carries the artifact metadata + ordered slot specs."""
-    import langres
-
+    """Snapshot carries the ordered slot specs and NO version/provenance envelope."""
     snapshot = _company_resolver().config_dict()  # type: ignore[attr-defined]
 
-    assert snapshot["artifact_version"] == "1"
-    assert snapshot["langres_version"] == langres.__version__
+    # Hash-safe: only the reproducible component payload, no volatile version keys.
+    assert set(snapshot.keys()) == {"components"}
     assert [c["type_name"] for c in snapshot["components"]] == [
         "all_pairs_blocker",
         "comparator",
@@ -122,12 +134,65 @@ def test_config_dict_composes_with_save_load_round_trip(tmp_path: Path) -> None:
     resolver = _company_resolver()
     snapshot = resolver.config_dict()  # type: ignore[attr-defined]
 
-    # The snapshot validates as the very contract load() reads.
-    assert ArtifactManifest.model_validate(snapshot).artifact_version == "1"
-
     resolver.save(tmp_path)  # type: ignore[attr-defined]
+
+    # The written artifact validates as the full contract load() reads (with the
+    # version envelope config_dict() omits).
+    manifest = ArtifactManifest.model_validate_json((tmp_path / "resolver.json").read_text())
+    assert manifest.artifact_version == "1"
+
     reloaded = Resolver.load(tmp_path)
     assert reloaded.config_dict() == snapshot
+
+
+def test_config_dict_recipe_id_stable_across_version_bump(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """recipe_id must NOT change when ``langres``/``ARTIFACT_VERSION`` bump.
+
+    This is the core hygiene invariant: ``config_dict()`` feeds
+    ``RunContext.resolver_config``, which is inside ``compute_recipe_id``'s hash
+    domain. If the snapshot leaked the version envelope, a package or
+    artifact-schema bump would silently fork ``recipe_id`` and break idempotent
+    replay. Version/provenance live on the RunContext, unhashed.
+    """
+    import langres
+    from langres.core import resolver as resolver_mod
+    from langres.core.runs import RunContext, compute_recipe_id
+
+    resolver = _company_resolver()
+
+    def _recipe_id() -> str:
+        context = RunContext(
+            experiment="exp",
+            dataset_name="ds",
+            resolver_config=resolver.config_dict(),  # type: ignore[attr-defined]
+        )
+        return compute_recipe_id(context)
+
+    baseline = _recipe_id()
+
+    # Simulate a package release + artifact-schema bump.
+    monkeypatch.setattr(langres, "__version__", "999.999.999")
+    monkeypatch.setattr(resolver_mod, "ARTIFACT_VERSION", "999")
+
+    assert _recipe_id() == baseline
+
+
+def test_save_manifest_still_carries_version_provenance(tmp_path: Path) -> None:
+    """``save()`` STILL writes ``artifact_version`` + ``langres_version`` to disk.
+
+    The hash-safe ``config_dict()`` drops them, but the on-disk artifact must keep
+    them for reconstruction / ``_check_versions`` (unchanged provenance).
+    """
+    import langres
+
+    resolver = _company_resolver()
+    resolver.save(tmp_path)  # type: ignore[attr-defined]
+    on_disk = json.loads((tmp_path / "resolver.json").read_text())
+
+    assert on_disk["artifact_version"] == "1"
+    assert on_disk["langres_version"] == langres.__version__
 
 
 def test_config_dict_raises_on_unserializable_component() -> None:

--- a/tests/test_runs.py
+++ b/tests/test_runs.py
@@ -1,0 +1,509 @@
+"""Tests for the dep-free run-identity + persistence layer (Stream S1).
+
+Targets 95-100% on the pure logic: ``RunContext``/``RunRecord``,
+``compute_recipe_id`` (the identity split -- recipe fields hashed, provenance
+excluded), ``RunStore`` (JSONL round-trip, last-wins-by-attempt_id, flock,
+mkdir-parents, ``RunStoreError``), ``resolve_store``, the ``git_sha`` /
+``dataset_fingerprint`` / ``_collect_seeds`` helpers, and ``capture_run``
+(running->terminal line, the ``current_run`` contextvar set/reset, tracker
+fan-out, failure path).
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import types
+from pathlib import Path
+from typing import Any
+
+import pydantic
+import pytest
+
+from langres.core import runs
+from langres.core.runs import (
+    RunContext,
+    RunRecord,
+    RunStore,
+    RunStoreError,
+    capture_run,
+    compute_recipe_id,
+    current_run,
+    dataset_fingerprint,
+    git_sha,
+    resolve_store,
+)
+
+
+def _context(**overrides: Any) -> RunContext:
+    """A minimal, fully-specified RunContext; override any field per test."""
+    base: dict[str, Any] = {
+        "experiment": "exp-a",
+        "dataset_name": "febrl4",
+        "seeds": {"split": 7},
+    }
+    base.update(overrides)
+    return RunContext(**base)
+
+
+class _SpyTracker:
+    name = "spy"
+
+    def __init__(self, *, url: str | None = None) -> None:
+        self._url = url
+        self.calls: list[tuple[str, Any]] = []
+
+    def start_run(self, context: Any, *, run_name: str | None = None) -> None:
+        self.calls.append(("start_run", run_name))
+
+    def log_params(self, params: Any) -> None:
+        self.calls.append(("log_params", dict(params)))
+
+    def log_metrics(self, metrics: Any, *, step: int | None = None) -> None:
+        self.calls.append(("log_metrics", (dict(metrics), step)))
+
+    def log_artifact(self, key: str, value: str) -> None:
+        self.calls.append(("log_artifact", (key, value)))
+
+    def set_tags(self, tags: Any) -> None:
+        self.calls.append(("set_tags", dict(tags)))
+
+    def finish(self, *, status: str) -> None:
+        self.calls.append(("finish", status))
+
+    @property
+    def run_url(self) -> str | None:
+        return self._url
+
+    @property
+    def native(self) -> Any:
+        return self
+
+
+# ---------------------------------------------------------------------------
+# RunContext / RunRecord models
+# ---------------------------------------------------------------------------
+
+
+class TestRunContext:
+    def test_minimal_construction_and_defaults(self) -> None:
+        ctx = _context()
+        assert ctx.experiment == "exp-a"
+        assert ctx.dataset_name == "febrl4"
+        assert ctx.tags == {}
+        assert ctx.git_dirty is False
+        assert ctx.tracking_schema_version == 1
+
+    def test_is_frozen(self) -> None:
+        ctx = _context()
+        with pytest.raises(pydantic.ValidationError):
+            ctx.experiment = "mutated"  # type: ignore[misc]
+
+    def test_langres_version_is_populated(self) -> None:
+        # default_factory reads importlib.metadata -- present in this editable install.
+        assert _context().langres_version is not None
+
+
+class TestRunRecord:
+    def test_round_trips_through_json(self) -> None:
+        ctx = _context()
+        record = RunRecord(
+            attempt_id="abc-2026",
+            recipe_id="abc",
+            context=ctx,
+            started_at="2026-07-08T00:00:00+00:00",
+            status="completed",
+            metrics={"pair_f1": 0.9},
+        )
+        reloaded = RunRecord.model_validate_json(record.model_dump_json())
+        assert reloaded == record
+        assert reloaded.context.experiment == "exp-a"
+        assert reloaded.v == 1
+
+
+# ---------------------------------------------------------------------------
+# compute_recipe_id -- the identity split
+# ---------------------------------------------------------------------------
+
+
+class TestComputeRecipeId:
+    def test_is_deterministic_16_hex(self) -> None:
+        rid = compute_recipe_id(_context())
+        assert rid == compute_recipe_id(_context())
+        assert len(rid) == 16
+        int(rid, 16)  # valid hex
+
+    def test_excludes_git_dirty_and_git_sha(self) -> None:
+        # HIGH-1 regression guard: a dirty tree / different commit must NOT
+        # mint a new recipe_id.
+        clean = _context(git_sha="a" * 40, git_dirty=False)
+        dirty = _context(git_sha="b" * 40, git_dirty=True)
+        assert compute_recipe_id(clean) == compute_recipe_id(dirty)
+
+    def test_excludes_lockfile_version_and_timing_provenance(self) -> None:
+        a = _context(lockfile_hash="h1", langres_version="0.1.0", python_version="3.12")
+        b = _context(lockfile_hash="h2", langres_version="9.9.9", python_version="3.13")
+        assert compute_recipe_id(a) == compute_recipe_id(b)
+
+    def test_distinct_seeds_give_distinct_recipe_id(self) -> None:
+        a = _context(seeds={"split": 1})
+        b = _context(seeds={"split": 2})
+        assert compute_recipe_id(a) != compute_recipe_id(b)
+
+    def test_distinct_dataset_fingerprint_gives_distinct_recipe_id(self) -> None:
+        a = _context(dataset_fingerprint="fp1")
+        b = _context(dataset_fingerprint="fp2")
+        assert compute_recipe_id(a) != compute_recipe_id(b)
+
+    def test_distinct_config_gives_distinct_recipe_id(self) -> None:
+        a = _context(llm_model="gpt-4o-mini", blocking_k=10)
+        b = _context(llm_model="gpt-4o-mini", blocking_k=20)
+        assert compute_recipe_id(a) != compute_recipe_id(b)
+
+
+# ---------------------------------------------------------------------------
+# RunStore
+# ---------------------------------------------------------------------------
+
+
+def _record(attempt_id: str, *, status: str = "completed", **kw: Any) -> RunRecord:
+    return RunRecord(
+        attempt_id=attempt_id,
+        recipe_id=attempt_id.split("-")[0],
+        context=_context(),
+        started_at="2026-07-08T00:00:00+00:00",
+        status=status,  # type: ignore[arg-type]
+        **kw,
+    )
+
+
+class TestRunStore:
+    def test_append_read_round_trip(self, tmp_path: Path) -> None:
+        store = RunStore(tmp_path / "runs.jsonl")
+        r1 = _record("r1-t")
+        r2 = _record("r2-t")
+        store.append(r1)
+        store.append(r2)
+        rows = store.read()
+        assert [r.attempt_id for r in rows] == ["r1-t", "r2-t"]
+        assert rows[0] == r1
+
+    def test_last_wins_by_attempt_id(self, tmp_path: Path) -> None:
+        store = RunStore(tmp_path / "runs.jsonl")
+        store.append(_record("same-id", status="running"))
+        store.append(_record("same-id", status="completed"))
+        rows = store.read()
+        assert len(rows) == 1
+        assert rows[0].status == "completed"
+
+    def test_read_missing_file_returns_empty(self, tmp_path: Path) -> None:
+        assert RunStore(tmp_path / "nope.jsonl").read() == []
+
+    def test_append_creates_parent_dirs(self, tmp_path: Path) -> None:
+        store = RunStore(tmp_path / "deep" / "nested" / "runs.jsonl")
+        store.append(_record("r1-t"))
+        assert store.path.exists()
+
+    def test_unwritable_path_raises_run_store_error(self, tmp_path: Path) -> None:
+        # A path whose parent is a regular file cannot be mkdir'd -> RunStoreError.
+        blocker = tmp_path / "afile"
+        blocker.write_text("x")
+        store = RunStore(blocker / "sub" / "runs.jsonl")
+        with pytest.raises(RunStoreError):
+            store.append(_record("r1-t"))
+
+    def test_read_skips_blank_lines(self, tmp_path: Path) -> None:
+        path = tmp_path / "runs.jsonl"
+        store = RunStore(path)
+        store.append(_record("r1-t"))
+        with path.open("a", encoding="utf-8") as fh:
+            fh.write("\n")  # a stray blank line must be ignored, not parsed
+        store.append(_record("r2-t"))
+        assert [r.attempt_id for r in store.read()] == ["r1-t", "r2-t"]
+
+    def test_each_line_is_independently_valid_json(self, tmp_path: Path) -> None:
+        store = RunStore(tmp_path / "runs.jsonl")
+        store.append(_record("r1-t"))
+        store.append(_record("r2-t"))
+        lines = (tmp_path / "runs.jsonl").read_text().splitlines()
+        assert len(lines) == 2
+        for line in lines:
+            assert json.loads(line)["v"] == 1
+
+
+class TestResolveStore:
+    def test_none_returns_none(self) -> None:
+        assert resolve_store(None) is None
+
+    def test_str_becomes_store(self, tmp_path: Path) -> None:
+        store = resolve_store(str(tmp_path / "runs.jsonl"))
+        assert isinstance(store, RunStore)
+
+    def test_path_becomes_store(self, tmp_path: Path) -> None:
+        store = resolve_store(tmp_path / "runs.jsonl")
+        assert isinstance(store, RunStore)
+        assert store.path == tmp_path / "runs.jsonl"
+
+    def test_store_passed_through(self, tmp_path: Path) -> None:
+        original = RunStore(tmp_path / "runs.jsonl")
+        assert resolve_store(original) is original
+
+
+# ---------------------------------------------------------------------------
+# git_sha
+# ---------------------------------------------------------------------------
+
+
+class TestGitSha:
+    def test_returns_sha_and_dirty_flag_in_a_repo(self) -> None:
+        sha, dirty = git_sha()
+        # This worktree is a real git repo, so a sha is available.
+        assert sha is not None
+        assert len(sha) == 40
+        assert isinstance(dirty, bool)
+
+    def test_missing_git_returns_none_and_warns_once(
+        self, monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        def _no_git(*args: Any, **kwargs: Any) -> Any:
+            raise FileNotFoundError("git not found")
+
+        monkeypatch.setattr(runs.subprocess, "run", _no_git)
+        monkeypatch.setattr(runs, "_GIT_SHA_WARNED", False)
+        with caplog.at_level(logging.WARNING):
+            assert git_sha() == (None, False)
+            git_sha()  # second call: must NOT warn again
+        warnings = [r for r in caplog.records if r.levelno == logging.WARNING]
+        assert len(warnings) == 1
+
+    def test_non_repo_returns_none_sha_and_warns(
+        self, monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        # git present but cwd is not a repo: empty stdout -> sha None, warn once.
+        def _empty(*args: Any, **kwargs: Any) -> Any:
+            return types.SimpleNamespace(stdout="", returncode=128)
+
+        monkeypatch.setattr(runs.subprocess, "run", _empty)
+        monkeypatch.setattr(runs, "_GIT_SHA_WARNED", False)
+        with caplog.at_level(logging.WARNING):
+            sha, dirty = git_sha()
+        assert sha is None
+        assert dirty is False
+        assert any(r.levelno == logging.WARNING for r in caplog.records)
+
+
+# ---------------------------------------------------------------------------
+# dataset_fingerprint
+# ---------------------------------------------------------------------------
+
+
+class TestDatasetFingerprint:
+    def test_is_deterministic(self) -> None:
+        corpus = [{"id": "1", "name": "acme"}, {"id": "2", "name": "globex"}]
+        gold = [("1", "2")]
+        assert dataset_fingerprint(corpus, gold) == dataset_fingerprint(corpus, gold)
+
+    def test_is_order_independent(self) -> None:
+        a = [{"id": "1"}, {"id": "2"}]
+        b = [{"id": "2"}, {"id": "1"}]
+        assert dataset_fingerprint(a, []) == dataset_fingerprint(b, [])
+
+    def test_mutation_changes_fingerprint(self) -> None:
+        corpus = [{"id": "1", "name": "acme"}]
+        mutated = [{"id": "1", "name": "ACME CORP"}]
+        assert dataset_fingerprint(corpus, []) != dataset_fingerprint(mutated, [])
+
+    def test_gold_participates_in_fingerprint(self) -> None:
+        corpus = [{"id": "1"}]
+        assert dataset_fingerprint(corpus, [("1", "2")]) != dataset_fingerprint(
+            corpus, [("1", "3")]
+        )
+
+    def test_handles_pydantic_records(self) -> None:
+        class Rec(pydantic.BaseModel):
+            id: str
+            name: str
+
+        recs = [Rec(id="1", name="acme")]
+        dicts = [{"id": "1", "name": "acme"}]
+        assert dataset_fingerprint(recs, []) == dataset_fingerprint(dicts, [])
+
+    def test_handles_set_gold_clusters(self) -> None:
+        # gold as clusters (a set of frozensets) exercises the set/frozenset
+        # canonicalization branch, order-independently.
+        gold_a = {frozenset({"1", "2"}), frozenset({"3", "4"})}
+        gold_b = {frozenset({"3", "4"}), frozenset({"1", "2"})}
+        assert dataset_fingerprint([], gold_a) == dataset_fingerprint([], gold_b)
+
+    def test_handles_mapping_gold(self) -> None:
+        # a mapping is normalized to its sorted items, deterministically.
+        gold = {"1": "cluster-a", "2": "cluster-b"}
+        assert dataset_fingerprint([], gold) == dataset_fingerprint([], dict(gold))
+
+    def test_handles_path_and_nested_model_values(self) -> None:
+        class Rec(pydantic.BaseModel):
+            id: str
+
+        corpus = [{"path": Path("/data/x.csv"), "rec": Rec(id="1")}]
+        # deterministic and does not raise on Path / nested-model values.
+        assert dataset_fingerprint(corpus, []) == dataset_fingerprint(corpus, [])
+
+    def test_uncanonicalizable_item_raises_type_error(self) -> None:
+        class Opaque:
+            pass
+
+        with pytest.raises(TypeError, match="cannot canonicalize"):
+            dataset_fingerprint([{"x": Opaque()}], [])
+
+
+# ---------------------------------------------------------------------------
+# _collect_seeds
+# ---------------------------------------------------------------------------
+
+
+class TestCollectSeeds:
+    def test_none_config_degrades_to_split_seed(self) -> None:
+        assert runs._collect_seeds(42, None) == {"split": 42}
+
+    def test_scans_config_for_random_state_and_seed(self) -> None:
+        config = {
+            "type_name": "root",
+            "blocker": {"type_name": "VectorBlocker", "random_state": 5},
+            "module": {"type_name": "RandomForestJudge", "seed": 9},
+        }
+        seeds = runs._collect_seeds(1, config)
+        assert seeds["split"] == 1
+        assert 5 in seeds.values()
+        assert 9 in seeds.values()
+
+    def test_ignores_bool_and_non_int_seed_values(self) -> None:
+        config = {"seed": True, "random_state": "not-an-int"}
+        assert runs._collect_seeds(3, config) == {"split": 3}
+
+    def test_scans_list_nested_components(self) -> None:
+        # a list of sub-configs (e.g. a CompositeBlocker's children) is walked.
+        config = {
+            "type_name": "Composite",
+            "children": [
+                {"type_name": "A", "seed": 11},
+                {"type_name": "B", "random_state": 22},
+            ],
+        }
+        seeds = runs._collect_seeds(1, config)
+        assert 11 in seeds.values()
+        assert 22 in seeds.values()
+
+    def test_duplicate_component_seeds_get_unique_labels(self) -> None:
+        # three same-typed components -> three distinct labels (the suffix must
+        # keep climbing past the first collision), all values retained.
+        config = {
+            "a": {"type_name": "Judge", "seed": 4},
+            "b": {"type_name": "Judge", "seed": 5},
+            "c": {"type_name": "Judge", "seed": 6},
+        }
+        seeds = runs._collect_seeds(0, config)
+        judge_seeds = {label: v for label, v in seeds.items() if label.startswith("Judge.")}
+        assert sorted(judge_seeds.values()) == [4, 5, 6]
+        assert len(judge_seeds) == 3
+
+
+# ---------------------------------------------------------------------------
+# capture_run
+# ---------------------------------------------------------------------------
+
+
+class TestCaptureRun:
+    def test_store_none_writes_no_files(self, tmp_path: Path) -> None:
+        # store=None -> no persistence at all (the headline invariant).
+        with capture_run(_context()) as handle:
+            handle.log_metrics({"m": 1.0})
+        assert list(tmp_path.iterdir()) == []
+
+    def test_sets_and_resets_contextvar(self) -> None:
+        assert current_run.get() is None
+        with capture_run(_context()) as handle:
+            assert current_run.get() == handle.attempt_id
+        assert current_run.get() is None
+
+    def test_nested_capture_restores_parent(self) -> None:
+        with capture_run(_context(experiment="outer")) as outer:
+            assert current_run.get() == outer.attempt_id
+            with capture_run(_context(experiment="inner")) as inner:
+                assert current_run.get() == inner.attempt_id
+            assert current_run.get() == outer.attempt_id
+
+    def test_writes_running_then_terminal_line(self, tmp_path: Path) -> None:
+        path = tmp_path / "runs.jsonl"
+        with capture_run(_context(), store=RunStore(path)) as handle:
+            attempt = handle.attempt_id
+        lines = [json.loads(x) for x in path.read_text().splitlines()]
+        assert len(lines) == 2
+        assert lines[0]["status"] == "running"
+        assert lines[1]["status"] == "completed"
+        assert lines[0]["attempt_id"] == lines[1]["attempt_id"] == attempt
+        # last-wins collapses the pair to one terminal record.
+        rows = RunStore(path).read()
+        assert len(rows) == 1
+        assert rows[0].status == "completed"
+
+    def test_records_metrics_artifacts_and_status_from_handle(self, tmp_path: Path) -> None:
+        path = tmp_path / "runs.jsonl"
+        with capture_run(_context(), store=RunStore(path)) as handle:
+            handle.log_metrics(
+                {"pair_f1": 0.9},
+                metric_definition="pair_f1@best_threshold",
+                per_seed_metrics=[{"seed": 0, "pair_f1": 0.9}],
+                headline_metric=0.9,
+            )
+            handle.log_artifact("report", "runs/report.md")
+            handle.record_cost(0.42, budget_exceeded=True)
+        record = RunStore(path).read()[0]
+        assert record.metrics == {"pair_f1": 0.9}
+        assert record.metric_definition == "pair_f1@best_threshold"
+        assert record.per_seed_metrics == [{"seed": 0, "pair_f1": 0.9}]
+        assert record.headline_metric == 0.9
+        assert record.artifacts["report"] == "runs/report.md"
+        assert record.spend_usd == 0.42
+        assert record.budget_exceeded is True
+        assert record.finished_at is not None
+        assert record.duration_seconds is not None
+        assert record.recipe_id == compute_recipe_id(_context())
+        assert record.trace_id == record.attempt_id
+
+    def test_set_status_overrides_terminal_status(self, tmp_path: Path) -> None:
+        path = tmp_path / "runs.jsonl"
+        with capture_run(_context(), store=RunStore(path)) as handle:
+            handle.set_status("budget_exceeded")
+        assert RunStore(path).read()[0].status == "budget_exceeded"
+
+    def test_failure_records_failed_status_and_reraises(self, tmp_path: Path) -> None:
+        path = tmp_path / "runs.jsonl"
+        with pytest.raises(ValueError, match="boom"):
+            with capture_run(_context(), store=RunStore(path)):
+                raise ValueError("boom")
+        record = RunStore(path).read()[0]
+        assert record.status == "failed"
+        assert record.error_type == "ValueError"
+        assert record.error_message is not None and "boom" in record.error_message
+        # contextvar still reset after an exception.
+        assert current_run.get() is None
+
+    def test_drives_the_tracker(self, tmp_path: Path) -> None:
+        spy = _SpyTracker(url="http://mlflow/run/1")
+        with capture_run(_context(), tracker=spy) as handle:
+            handle.log_metrics({"m": 1.0}, step=2)
+            handle.log_artifact("k", "v")
+        kinds = [c[0] for c in spy.calls]
+        assert kinds[0] == "start_run"
+        assert kinds[-1] == "finish"
+        assert ("log_metrics", ({"m": 1.0}, 2)) in spy.calls
+        assert ("log_artifact", ("k", "v")) in spy.calls
+        assert spy.calls[-1] == ("finish", "completed")
+
+    def test_run_url_threaded_into_artifacts(self, tmp_path: Path) -> None:
+        path = tmp_path / "runs.jsonl"
+        spy = _SpyTracker(url="http://mlflow/run/1")
+        with capture_run(_context(), store=RunStore(path), tracker=spy):
+            pass
+        record = RunStore(path).read()[0]
+        assert "http://mlflow/run/1" in record.artifacts.values()

--- a/tests/test_runs.py
+++ b/tests/test_runs.py
@@ -13,6 +13,8 @@ from __future__ import annotations
 
 import json
 import logging
+import subprocess
+import sys
 import types
 from pathlib import Path
 from typing import Any
@@ -160,6 +162,22 @@ class TestComputeRecipeId:
         b = _context(llm_model="gpt-4o-mini", blocking_k=20)
         assert compute_recipe_id(a) != compute_recipe_id(b)
 
+    def test_permuted_config_keys_give_same_recipe_id(self) -> None:
+        # L2: the order-stable seeds map (see TestCollectSeeds) feeds the
+        # recipe_id, so two key-permuted builds of the same logical experiment
+        # content-address identically.
+        cfg_a = {
+            "alpha": {"type_name": "Judge", "seed": 4},
+            "beta": {"type_name": "Judge", "seed": 5},
+        }
+        cfg_b = {
+            "beta": {"type_name": "Judge", "seed": 5},
+            "alpha": {"type_name": "Judge", "seed": 4},
+        }
+        a = _context(resolver_config=cfg_a, seeds=runs._collect_seeds(7, cfg_a))
+        b = _context(resolver_config=cfg_b, seeds=runs._collect_seeds(7, cfg_b))
+        assert compute_recipe_id(a) == compute_recipe_id(b)
+
 
 # ---------------------------------------------------------------------------
 # RunStore
@@ -229,6 +247,113 @@ class TestRunStore:
         assert len(lines) == 2
         for line in lines:
             assert json.loads(line)["v"] == 1
+
+    def test_append_flushes_and_fsyncs_before_releasing_lock(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # HIGH-1 regression: the bytes must reach the OS (flush + fsync) *under*
+        # the exclusive lock, so a concurrent writer cannot interleave. Record
+        # the syscall order and assert fsync lands before the LOCK_UN.
+        events: list[str] = []
+
+        class _RecordingFcntl:
+            LOCK_EX = 2
+            LOCK_UN = 8
+
+            @staticmethod
+            def flock(fileno: int, op: int) -> None:
+                events.append(f"flock:{op}")
+
+        real_fsync = runs.os.fsync
+
+        def _spy_fsync(fd: int) -> None:
+            events.append("fsync")
+            real_fsync(fd)
+
+        monkeypatch.setattr(runs, "fcntl", _RecordingFcntl)
+        monkeypatch.setattr(runs.os, "fsync", _spy_fsync)
+
+        store = RunStore(tmp_path / "runs.jsonl")
+        store.append(_record("r1-t"))
+
+        assert events == [
+            f"flock:{_RecordingFcntl.LOCK_EX}",
+            "fsync",
+            f"flock:{_RecordingFcntl.LOCK_UN}",
+        ]
+        assert RunStore(tmp_path / "runs.jsonl").read()[0].attempt_id == "r1-t"
+
+    def test_read_tolerates_torn_trailing_line(self, tmp_path: Path) -> None:
+        # A concurrent writer mid-append leaves a partial JSON line with no
+        # terminating newline; read() must skip it, not raise.
+        path = tmp_path / "runs.jsonl"
+        store = RunStore(path)
+        store.append(_record("r1-t"))
+        with path.open("a", encoding="utf-8") as fh:
+            fh.write('{"attempt_id": "r2-t", "recipe')  # torn write, no newline
+        rows = store.read()
+        assert [r.attempt_id for r in rows] == ["r1-t"]
+
+    def test_read_warns_on_malformed_complete_line(
+        self, tmp_path: Path, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        # A complete (newline-terminated) garbage line is genuine corruption:
+        # skip it but surface a warning instead of silently swallowing it.
+        path = tmp_path / "runs.jsonl"
+        store = RunStore(path)
+        store.append(_record("r1-t"))
+        with path.open("a", encoding="utf-8") as fh:
+            fh.write("this is not valid json\n")
+        store.append(_record("r2-t"))
+        with caplog.at_level(logging.WARNING):
+            rows = store.read()
+        assert [r.attempt_id for r in rows] == ["r1-t", "r2-t"]
+        assert any("malformed run record" in r.message for r in caplog.records)
+
+    def test_append_without_fcntl_warns_once_and_still_writes(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        # Codex#2: on a platform without fcntl (e.g. Windows), append degrades
+        # to a lock-free write and warns exactly once -- it never crashes.
+        monkeypatch.setattr(runs, "fcntl", None)
+        monkeypatch.setattr(runs, "_FLOCK_WARNED", False)
+        store = RunStore(tmp_path / "runs.jsonl")
+        with caplog.at_level(logging.WARNING):
+            store.append(_record("r1-t"))
+            store.append(_record("r2-t"))
+        assert [r.attempt_id for r in store.read()] == ["r1-t", "r2-t"]
+        flock_warnings = [r for r in caplog.records if "advisory file lock" in r.message]
+        assert len(flock_warnings) == 1  # warned once, not once per append
+
+
+def test_import_langres_does_not_eagerly_require_fcntl(tmp_path: Path) -> None:
+    """Codex#2: ``import langres`` (which imports ``core.runs``) must not need fcntl.
+
+    ``fcntl`` is Unix-only; a hard top-level import would break ``import langres``
+    on Windows. Simulate fcntl being unimportable (``sys.modules['fcntl'] = None``
+    makes ``import fcntl`` raise ``ImportError``) in a fresh subprocess and assert
+    the package still imports and ``RunStore`` still round-trips.
+    """
+    script = (
+        "import sys; sys.modules['fcntl'] = None; "
+        "import langres; from langres.core import runs; "
+        "assert runs.fcntl is None, runs.fcntl; "
+        "from langres.core.runs import RunStore, RunContext, RunRecord; "
+        "store = RunStore(sys.argv[1]); "
+        "ctx = RunContext(experiment='e', dataset_name='d'); "
+        "rec = RunRecord(attempt_id='a-t', recipe_id='a', context=ctx, "
+        "started_at='2026-07-08T00:00:00+00:00', status='completed'); "
+        "store.append(rec); "
+        "assert [r.attempt_id for r in store.read()] == ['a-t']; "
+        "print('OK')"
+    )
+    result = subprocess.run(
+        [sys.executable, "-c", script, str(tmp_path / "runs.jsonl")],
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode == 0, f"STDOUT:\n{result.stdout}\nSTDERR:\n{result.stderr}"
+    assert "OK" in result.stdout
 
 
 class TestResolveStore:
@@ -406,6 +531,21 @@ class TestCollectSeeds:
         assert sorted(judge_seeds.values()) == [4, 5, 6]
         assert len(judge_seeds) == 3
 
+    def test_seed_labels_are_order_stable(self) -> None:
+        # L2 regression: two semantically identical configs built with permuted
+        # dict-key order must yield the SAME seeds map. Disambiguation suffixes
+        # are assigned in canonical (sorted) traversal order, not raw
+        # dict-insertion order, so the derived recipe_id can't drift.
+        config_a = {
+            "alpha": {"type_name": "Judge", "seed": 4},
+            "beta": {"type_name": "Judge", "seed": 5},
+        }
+        config_b = {
+            "beta": {"type_name": "Judge", "seed": 5},
+            "alpha": {"type_name": "Judge", "seed": 4},
+        }
+        assert runs._collect_seeds(7, config_a) == runs._collect_seeds(7, config_b)
+
 
 # ---------------------------------------------------------------------------
 # capture_run
@@ -486,6 +626,27 @@ class TestCaptureRun:
         assert record.error_type == "ValueError"
         assert record.error_message is not None and "boom" in record.error_message
         # contextvar still reset after an exception.
+        assert current_run.get() is None
+
+    def test_tracker_start_run_failure_writes_failed_record_and_resets_contextvar(
+        self, tmp_path: Path
+    ) -> None:
+        # HIGH-2 regression: start_run runs inside the protected block, so a
+        # failure there still writes a terminal "failed" record for the attempt
+        # and restores the contextvar -- the "running" line never dangles.
+        class _BoomTracker(_SpyTracker):
+            def start_run(self, context: Any, *, run_name: str | None = None) -> None:
+                raise RuntimeError("start boom")
+
+        path = tmp_path / "runs.jsonl"
+        assert current_run.get() is None
+        with pytest.raises(RuntimeError, match="start boom"):
+            with capture_run(_context(), store=RunStore(path), tracker=_BoomTracker()):
+                pass  # pragma: no cover - start_run raises before the body runs
+        record = RunStore(path).read()[0]
+        assert record.status == "failed"
+        assert record.error_type == "RuntimeError"
+        assert record.error_message is not None and "start boom" in record.error_message
         assert current_run.get() is None
 
     def test_drives_the_tracker(self, tmp_path: Path) -> None:

--- a/tests/test_trackers.py
+++ b/tests/test_trackers.py
@@ -3,8 +3,10 @@
 Covers the pure logic: the ``NoOpTracker`` null object, ``MultiTracker``
 fan-out, ``resolve_tracker`` dispatch (every branch), and the lazy
 ``MlflowTracker``/``WandbTracker`` module ``__getattr__`` -- which must raise a
-helpful ``ImportError`` naming the real extra while the adapter modules are
-still absent (S3/S4 add them).
+helpful ``ImportError`` naming the real extra when the backend/adapter is
+absent. S3 landed the ``mlflow`` adapter (and made ``mlflow`` a real dev dep),
+so its missing-extra case is now *simulated*; ``wandb``'s adapter is still
+absent until S4.
 """
 
 from __future__ import annotations
@@ -149,7 +151,26 @@ class TestResolveTracker:
         assert isinstance(resolved.trackers[0], NoOpTracker)
         assert resolved.trackers[1] is spy
 
-    def test_mlflow_string_raises_helpful_import_error_when_absent(self) -> None:
+    def test_mlflow_string_raises_helpful_import_error_when_absent(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A missing ``mlflow`` extra -> a helpful ``langres[mlflow]`` ImportError.
+
+        S3 landed the adapter module and made ``mlflow`` a real dev/CI dependency,
+        so genuine absence no longer occurs in this env. Simulate it by forcing the
+        adapter import to fail (mirrors ``_fake_import`` below) -- the missing-extra
+        translation is what ``resolve_tracker`` must surface either way.
+        """
+        import langres.core.trackers as trackers_mod
+
+        real_import = trackers_mod.importlib.import_module
+
+        def _fail_mlflow_import(path: str, *a: Any, **k: Any) -> Any:
+            if path == "langres.core.trackers.mlflow_tracker":
+                raise ImportError("No module named 'mlflow'")
+            return real_import(path, *a, **k)
+
+        monkeypatch.setattr(trackers_mod.importlib, "import_module", _fail_mlflow_import)
         with pytest.raises(ImportError, match=r"langres\[mlflow\]"):
             resolve_tracker("mlflow")
 
@@ -187,9 +208,24 @@ class TestResolveTracker:
 
 
 class TestLazyAdapterGetattr:
-    def test_mlflow_tracker_attribute_raises_helpful_import_error(self) -> None:
+    def test_mlflow_tracker_attribute_raises_helpful_import_error(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """``trackers.MlflowTracker`` -> helpful ImportError when the extra is absent.
+
+        Absence is simulated (see the ``resolve_tracker`` twin above): S3 made the
+        adapter module + ``mlflow`` present, so the raw missing case is forced here.
+        """
         import langres.core.trackers as trackers
 
+        real_import = trackers.importlib.import_module
+
+        def _fail_mlflow_import(path: str, *a: Any, **k: Any) -> Any:
+            if path == "langres.core.trackers.mlflow_tracker":
+                raise ImportError("No module named 'mlflow'")
+            return real_import(path, *a, **k)
+
+        monkeypatch.setattr(trackers.importlib, "import_module", _fail_mlflow_import)
         with pytest.raises(ImportError, match=r"langres\[mlflow\]"):
             trackers.MlflowTracker  # noqa: B018
 

--- a/tests/test_trackers.py
+++ b/tests/test_trackers.py
@@ -11,7 +11,9 @@ absent until S4.
 
 from __future__ import annotations
 
+import logging
 import types
+from collections.abc import Callable
 from typing import Any
 
 import pytest
@@ -82,6 +84,49 @@ class TestNoOpTracker:
         assert isinstance(NoOpTracker().name, str)
 
 
+class _BoomTracker:
+    """A Protocol-satisfying tracker that raises on one named method.
+
+    Used to prove :class:`MultiTracker` isolates a raising child so the remaining
+    children still get the call and the exception never propagates.
+    """
+
+    name = "boom"
+
+    def __init__(self, method: str) -> None:
+        self._method = method
+
+    def _maybe_boom(self, method: str) -> None:
+        if method == self._method:
+            raise RuntimeError(f"boom in {method}")
+
+    def start_run(self, context: Any, *, run_name: str | None = None) -> None:
+        self._maybe_boom("start_run")
+
+    def log_params(self, params: Any) -> None:
+        self._maybe_boom("log_params")
+
+    def log_metrics(self, metrics: Any, *, step: int | None = None) -> None:
+        self._maybe_boom("log_metrics")
+
+    def log_artifact(self, key: str, value: str) -> None:
+        self._maybe_boom("log_artifact")
+
+    def set_tags(self, tags: Any) -> None:
+        self._maybe_boom("set_tags")
+
+    def finish(self, *, status: str) -> None:
+        self._maybe_boom("finish")
+
+    @property
+    def run_url(self) -> str | None:
+        return None
+
+    @property
+    def native(self) -> Any:
+        return self
+
+
 class TestMultiTracker:
     def test_exposes_trackers_list(self) -> None:
         children = [_SpyTracker(), _SpyTracker()]
@@ -122,6 +167,39 @@ class TestMultiTracker:
     def test_native_exposes_child_list(self) -> None:
         children = [_SpyTracker(), _SpyTracker()]
         assert MultiTracker(children).native == children
+
+
+class TestMultiTrackerErrorIsolation:
+    """M3: one child raising must not abort the fan-out or propagate."""
+
+    def test_child_raising_on_finish_still_finishes_others_and_does_not_propagate(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        boom, spy = _BoomTracker("finish"), _SpyTracker()
+        multi = MultiTracker([boom, spy])
+
+        with caplog.at_level(logging.ERROR, logger="langres.core.trackers"):
+            multi.finish(status="completed")  # must NOT raise
+
+        # The second child still received finish despite the first raising.
+        assert ("finish", "completed") in spy.calls
+        # The failure was logged (not printed), naming the failing method.
+        assert any("finish" in record.getMessage() for record in caplog.records)
+
+    def test_every_fanout_method_isolates_a_raising_child(self) -> None:
+        cases: list[tuple[str, Callable[[MultiTracker], None]]] = [
+            ("start_run", lambda m: m.start_run("ctx", run_name="r")),
+            ("log_params", lambda m: m.log_params({"p": 1})),
+            ("log_metrics", lambda m: m.log_metrics({"x": 1.0}, step=1)),
+            ("log_artifact", lambda m: m.log_artifact("k", "v")),
+            ("set_tags", lambda m: m.set_tags({"t": "v"})),
+            ("finish", lambda m: m.finish(status="completed")),
+        ]
+        for method, call in cases:
+            spy = _SpyTracker()
+            multi = MultiTracker([_BoomTracker(method), spy])
+            call(multi)  # must NOT raise for any method
+            assert spy.calls and spy.calls[-1][0] == method
 
 
 class TestResolveTracker:

--- a/tests/test_trackers.py
+++ b/tests/test_trackers.py
@@ -174,7 +174,26 @@ class TestResolveTracker:
         with pytest.raises(ImportError, match=r"langres\[mlflow\]"):
             resolve_tracker("mlflow")
 
-    def test_wandb_string_raises_helpful_import_error_when_absent(self) -> None:
+    def test_wandb_string_raises_helpful_import_error_when_absent(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A missing ``wandb`` extra -> a helpful ``langres[wandb]`` ImportError.
+
+        S4 landed the adapter module and ``wandb`` is a real dev dependency, so
+        genuine absence no longer occurs in this env. Simulate it by forcing the
+        adapter import to fail (mirrors the ``mlflow`` twin above) -- the
+        missing-extra translation is what ``resolve_tracker`` must surface either way.
+        """
+        import langres.core.trackers as trackers_mod
+
+        real_import = trackers_mod.importlib.import_module
+
+        def _fail_wandb_import(path: str, *a: Any, **k: Any) -> Any:
+            if path == "langres.core.trackers.wandb_tracker":
+                raise ImportError("No module named 'wandb'")
+            return real_import(path, *a, **k)
+
+        monkeypatch.setattr(trackers_mod.importlib, "import_module", _fail_wandb_import)
         with pytest.raises(ImportError, match=r"langres\[wandb\]"):
             resolve_tracker("wandb")
 
@@ -229,9 +248,24 @@ class TestLazyAdapterGetattr:
         with pytest.raises(ImportError, match=r"langres\[mlflow\]"):
             trackers.MlflowTracker  # noqa: B018
 
-    def test_wandb_tracker_attribute_raises_helpful_import_error(self) -> None:
+    def test_wandb_tracker_attribute_raises_helpful_import_error(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """``trackers.WandbTracker`` -> helpful ImportError when the extra is absent.
+
+        Absence is simulated (see the ``resolve_tracker`` twin above): S4 made the
+        adapter module + ``wandb`` present, so the raw missing case is forced here.
+        """
         import langres.core.trackers as trackers
 
+        real_import = trackers.importlib.import_module
+
+        def _fail_wandb_import(path: str, *a: Any, **k: Any) -> Any:
+            if path == "langres.core.trackers.wandb_tracker":
+                raise ImportError("No module named 'wandb'")
+            return real_import(path, *a, **k)
+
+        monkeypatch.setattr(trackers.importlib, "import_module", _fail_wandb_import)
         with pytest.raises(ImportError, match=r"langres\[wandb\]"):
             trackers.WandbTracker  # noqa: B018
 

--- a/tests/test_trackers.py
+++ b/tests/test_trackers.py
@@ -1,0 +1,206 @@
+"""Tests for the dep-free ``ExperimentTracker`` layer (Stream S1).
+
+Covers the pure logic: the ``NoOpTracker`` null object, ``MultiTracker``
+fan-out, ``resolve_tracker`` dispatch (every branch), and the lazy
+``MlflowTracker``/``WandbTracker`` module ``__getattr__`` -- which must raise a
+helpful ``ImportError`` naming the real extra while the adapter modules are
+still absent (S3/S4 add them).
+"""
+
+from __future__ import annotations
+
+import types
+from typing import Any
+
+import pytest
+
+from langres.core.trackers import (
+    ExperimentTracker,
+    MultiTracker,
+    NoOpTracker,
+    resolve_tracker,
+)
+
+
+class _SpyTracker:
+    """Minimal in-memory tracker implementing the Protocol -- records every call."""
+
+    name = "spy"
+
+    def __init__(self, *, url: str | None = None) -> None:
+        self._url = url
+        self.calls: list[tuple[str, Any]] = []
+
+    def start_run(self, context: Any, *, run_name: str | None = None) -> None:
+        self.calls.append(("start_run", run_name))
+
+    def log_params(self, params: Any) -> None:
+        self.calls.append(("log_params", dict(params)))
+
+    def log_metrics(self, metrics: Any, *, step: int | None = None) -> None:
+        self.calls.append(("log_metrics", (dict(metrics), step)))
+
+    def log_artifact(self, key: str, value: str) -> None:
+        self.calls.append(("log_artifact", (key, value)))
+
+    def set_tags(self, tags: Any) -> None:
+        self.calls.append(("set_tags", dict(tags)))
+
+    def finish(self, *, status: str) -> None:
+        self.calls.append(("finish", status))
+
+    @property
+    def run_url(self) -> str | None:
+        return self._url
+
+    @property
+    def native(self) -> Any:
+        return self
+
+
+class TestNoOpTracker:
+    def test_satisfies_protocol(self) -> None:
+        assert isinstance(NoOpTracker(), ExperimentTracker)
+
+    def test_methods_are_noops_and_return_none(self) -> None:
+        tracker = NoOpTracker()
+        assert tracker.start_run(None, run_name="x") is None
+        assert tracker.log_params({"a": 1}) is None
+        assert tracker.log_metrics({"m": 1.0}, step=3) is None
+        assert tracker.log_artifact("k", "v") is None
+        assert tracker.set_tags({"t": "v"}) is None
+        assert tracker.finish(status="completed") is None
+
+    def test_run_url_and_native_are_none(self) -> None:
+        tracker = NoOpTracker()
+        assert tracker.run_url is None
+        assert tracker.native is None
+
+    def test_has_a_name(self) -> None:
+        assert isinstance(NoOpTracker().name, str)
+
+
+class TestMultiTracker:
+    def test_exposes_trackers_list(self) -> None:
+        children = [_SpyTracker(), _SpyTracker()]
+        multi = MultiTracker(children)
+        assert multi.trackers == children
+        assert isinstance(multi.trackers, list)
+
+    def test_fans_out_every_call_to_children(self) -> None:
+        a, b = _SpyTracker(), _SpyTracker()
+        multi = MultiTracker([a, b])
+        multi.start_run("ctx", run_name="r")
+        multi.log_params({"p": 1})
+        multi.log_metrics({"m": 2.0}, step=1)
+        multi.log_artifact("k", "v")
+        multi.set_tags({"t": "x"})
+        multi.finish(status="completed")
+        for child in (a, b):
+            kinds = [c[0] for c in child.calls]
+            assert kinds == [
+                "start_run",
+                "log_params",
+                "log_metrics",
+                "log_artifact",
+                "set_tags",
+                "finish",
+            ]
+
+    def test_run_url_returns_first_non_none_child_url(self) -> None:
+        multi = MultiTracker([_SpyTracker(url=None), _SpyTracker(url="http://x")])
+        assert multi.run_url == "http://x"
+
+    def test_run_url_none_when_no_child_has_one(self) -> None:
+        assert MultiTracker([_SpyTracker(), _SpyTracker()]).run_url is None
+
+    def test_satisfies_protocol(self) -> None:
+        assert isinstance(MultiTracker([]), ExperimentTracker)
+
+    def test_native_exposes_child_list(self) -> None:
+        children = [_SpyTracker(), _SpyTracker()]
+        assert MultiTracker(children).native == children
+
+
+class TestResolveTracker:
+    def test_none_returns_noop(self) -> None:
+        assert isinstance(resolve_tracker(None), NoOpTracker)
+
+    def test_instance_passed_through(self) -> None:
+        spy = _SpyTracker()
+        assert resolve_tracker(spy) is spy
+
+    def test_sequence_becomes_multitracker(self) -> None:
+        a, b = _SpyTracker(), _SpyTracker()
+        resolved = resolve_tracker([a, b])
+        assert isinstance(resolved, MultiTracker)
+        assert resolved.trackers == [a, b]
+
+    def test_tuple_becomes_multitracker(self) -> None:
+        a, b = _SpyTracker(), _SpyTracker()
+        resolved = resolve_tracker((a, b))
+        assert isinstance(resolved, MultiTracker)
+        assert list(resolved.trackers) == [a, b]
+
+    def test_sequence_of_specs_is_resolved_recursively(self) -> None:
+        spy = _SpyTracker()
+        resolved = resolve_tracker([None, spy])
+        assert isinstance(resolved, MultiTracker)
+        assert isinstance(resolved.trackers[0], NoOpTracker)
+        assert resolved.trackers[1] is spy
+
+    def test_mlflow_string_raises_helpful_import_error_when_absent(self) -> None:
+        with pytest.raises(ImportError, match=r"langres\[mlflow\]"):
+            resolve_tracker("mlflow")
+
+    def test_wandb_string_raises_helpful_import_error_when_absent(self) -> None:
+        with pytest.raises(ImportError, match=r"langres\[wandb\]"):
+            resolve_tracker("wandb")
+
+    def test_unknown_backend_string_raises_value_error(self) -> None:
+        with pytest.raises(ValueError, match="unknown"):
+            resolve_tracker("not-a-backend")
+
+    def test_non_spec_object_raises_type_error(self) -> None:
+        with pytest.raises(TypeError, match="cannot resolve tracker"):
+            resolve_tracker(42)  # type: ignore[arg-type]
+
+    def test_mlflow_string_instantiates_adapter_when_present(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """The success path: a present adapter module is imported + instantiated."""
+        import langres.core.trackers as trackers_mod
+
+        class _FakeMlflow(NoOpTracker):
+            name = "fake-mlflow"
+
+        fake_module = types.SimpleNamespace(MlflowTracker=_FakeMlflow)
+        real_import = trackers_mod.importlib.import_module
+
+        def _fake_import(path: str, *a: Any, **k: Any) -> Any:
+            if path == "langres.core.trackers.mlflow_tracker":
+                return fake_module
+            return real_import(path, *a, **k)
+
+        monkeypatch.setattr(trackers_mod.importlib, "import_module", _fake_import)
+        assert isinstance(resolve_tracker("mlflow"), _FakeMlflow)
+
+
+class TestLazyAdapterGetattr:
+    def test_mlflow_tracker_attribute_raises_helpful_import_error(self) -> None:
+        import langres.core.trackers as trackers
+
+        with pytest.raises(ImportError, match=r"langres\[mlflow\]"):
+            trackers.MlflowTracker  # noqa: B018
+
+    def test_wandb_tracker_attribute_raises_helpful_import_error(self) -> None:
+        import langres.core.trackers as trackers
+
+        with pytest.raises(ImportError, match=r"langres\[wandb\]"):
+            trackers.WandbTracker  # noqa: B018
+
+    def test_unknown_attribute_raises_attribute_error(self) -> None:
+        import langres.core.trackers as trackers
+
+        with pytest.raises(AttributeError, match="not_a_real_attribute"):
+            trackers.not_a_real_attribute  # noqa: B018

--- a/tests/test_wandb_tracker.py
+++ b/tests/test_wandb_tracker.py
@@ -133,9 +133,7 @@ class TestStartRun:
         }
         assert fake_wandb.run.name == "dedupe-ag"
 
-    def test_flattens_context_into_config(
-        self, fake_wandb: _FakeWandb, settings: Settings
-    ) -> None:
+    def test_flattens_context_into_config(self, fake_wandb: _FakeWandb, settings: Settings) -> None:
         tracker = WandbTracker(settings)
         tracker.start_run(_context())
 
@@ -237,9 +235,7 @@ class TestFinish:
 
 
 class TestRunUrlAndNative:
-    def test_run_url_from_underlying_run(
-        self, fake_wandb: _FakeWandb, settings: Settings
-    ) -> None:
+    def test_run_url_from_underlying_run(self, fake_wandb: _FakeWandb, settings: Settings) -> None:
         tracker = WandbTracker(settings)
         tracker.start_run(_context())
         assert tracker.run_url == "https://wandb.ai/acme/langres/runs/abc123"
@@ -267,9 +263,7 @@ class TestRunUrlAndNative:
 
 
 class TestResolveTracker:
-    def test_resolve_tracker_wandb_returns_real_wandb_tracker(
-        self, fake_wandb: _FakeWandb
-    ) -> None:
+    def test_resolve_tracker_wandb_returns_real_wandb_tracker(self, fake_wandb: _FakeWandb) -> None:
         resolved = resolve_tracker("wandb")
         assert isinstance(resolved, WandbTracker)
         assert resolved.name == "wandb"

--- a/tests/test_wandb_tracker.py
+++ b/tests/test_wandb_tracker.py
@@ -32,7 +32,7 @@ class _FakeConfig:
 
 
 class _FakeRun:
-    """Stand-in for a ``wandb`` run object."""
+    """Stand-in for a ``wandb`` run object -- records ``log``/``finish`` on itself."""
 
     def __init__(self, *, url: str | None = "https://wandb.ai/acme/langres/runs/abc123") -> None:
         self.config = _FakeConfig()
@@ -40,10 +40,23 @@ class _FakeRun:
         self.name: str | None = None
         self.tags: tuple[str, ...] = ()
         self.url = url
+        self.log_calls: list[tuple[dict[str, Any], int | None]] = []
+        self.finish_calls: list[int | None] = []
+
+    def log(self, data: dict[str, Any], step: int | None = None) -> None:
+        self.log_calls.append((dict(data), step))
+
+    def finish(self, exit_code: int | None = None) -> None:
+        self.finish_calls.append(exit_code)
 
 
 class _FakeWandb:
-    """Minimal fake ``wandb`` module: records init/log/finish calls."""
+    """Minimal fake ``wandb`` module: ``init`` returns the run; ``log``/``finish``.
+
+    The module-global ``log``/``finish`` here are the *tripwire* for M5: the
+    adapter must route through ``run.log``/``run.finish`` (recorded on
+    :class:`_FakeRun`), so these ``log_calls``/``finish_calls`` must stay empty.
+    """
 
     def __init__(self, run: _FakeRun | None = None) -> None:
         self.run = run if run is not None else _FakeRun()
@@ -64,13 +77,16 @@ class _FakeWandb:
 
 @pytest.fixture
 def fake_wandb(monkeypatch: pytest.MonkeyPatch) -> _FakeWandb:
-    """Patch the fake over BOTH modules that reference ``wandb`` in this path."""
+    """Patch the fake over the ``wandb`` the reused ``create_wandb_tracker`` init uses.
+
+    The adapter itself no longer references a module-global ``wandb`` (log/finish
+    route through ``self._run``), so only ``langres.clients.tracking.wandb`` -- the
+    ``wandb.init`` seam -- needs patching.
+    """
     fake = _FakeWandb()
     import langres.clients.tracking as tracking_mod
-    from langres.core.trackers import wandb_tracker
 
     monkeypatch.setattr(tracking_mod, "wandb", fake)
-    monkeypatch.setattr(wandb_tracker, "wandb", fake)
     return fake
 
 
@@ -152,14 +168,16 @@ class TestStartRun:
 
 
 class TestLogging:
-    def test_log_metrics_forwards_to_wandb_log(
+    def test_log_metrics_routes_to_run_log_not_module_global(
         self, fake_wandb: _FakeWandb, settings: Settings
     ) -> None:
         tracker = WandbTracker(settings)
         tracker.start_run(_context())
         tracker.log_metrics({"f1": 0.91, "recall": 0.88}, step=3)
 
-        assert fake_wandb.log_calls == [({"f1": 0.91, "recall": 0.88}, 3)]
+        # Routed to THIS run (M5), not the module-global wandb.log.
+        assert fake_wandb.run.log_calls == [({"f1": 0.91, "recall": 0.88}, 3)]
+        assert fake_wandb.log_calls == []
 
     def test_log_metrics_defaults_step_to_none(
         self, fake_wandb: _FakeWandb, settings: Settings
@@ -168,7 +186,12 @@ class TestLogging:
         tracker.start_run(_context())
         tracker.log_metrics({"f1": 0.5})
 
-        assert fake_wandb.log_calls == [({"f1": 0.5}, None)]
+        assert fake_wandb.run.log_calls == [({"f1": 0.5}, None)]
+
+    def test_log_metrics_noop_before_start(self, fake_wandb: _FakeWandb) -> None:
+        # No run yet -> nothing logged, and no crash (must not hit the module global).
+        WandbTracker().log_metrics({"f1": 0.5})
+        assert fake_wandb.log_calls == []
 
     def test_log_params_merges_into_config(
         self, fake_wandb: _FakeWandb, settings: Settings
@@ -216,7 +239,9 @@ class TestFinish:
         tracker.start_run(_context())
         tracker.finish(status="completed")
 
-        assert fake_wandb.finish_calls == [0]
+        # Ends THIS run (M5), not the module-global wandb.finish.
+        assert fake_wandb.run.finish_calls == [0]
+        assert fake_wandb.finish_calls == []
         assert fake_wandb.run.summary["status"] == "completed"
 
     @pytest.mark.parametrize("status", ["failed", "budget_exceeded"])
@@ -227,11 +252,14 @@ class TestFinish:
         tracker.start_run(_context())
         tracker.finish(status=status)
 
-        assert fake_wandb.finish_calls == [1]
+        assert fake_wandb.run.finish_calls == [1]
+        assert fake_wandb.finish_calls == []
 
-    def test_finish_before_start_still_calls_wandb_finish(self, fake_wandb: _FakeWandb) -> None:
+    def test_finish_before_start_is_noop(self, fake_wandb: _FakeWandb) -> None:
+        # No run was started -> nothing to finish; must not touch the module global.
         WandbTracker().finish(status="completed")
-        assert fake_wandb.finish_calls == [0]
+        assert fake_wandb.run.finish_calls == []
+        assert fake_wandb.finish_calls == []
 
 
 class TestRunUrlAndNative:
@@ -245,10 +273,8 @@ class TestRunUrlAndNative:
     ) -> None:
         fake = _FakeWandb(_FakeRun(url=None))
         import langres.clients.tracking as tracking_mod
-        from langres.core.trackers import wandb_tracker
 
         monkeypatch.setattr(tracking_mod, "wandb", fake)
-        monkeypatch.setattr(wandb_tracker, "wandb", fake)
 
         tracker = WandbTracker(settings)
         tracker.start_run(_context())

--- a/tests/test_wandb_tracker.py
+++ b/tests/test_wandb_tracker.py
@@ -1,0 +1,275 @@
+"""Tests for the W&B ``ExperimentTracker`` adapter (Stream S4).
+
+Behavior/smoke tier: ``wandb`` is fully mocked (a fake module patched over both
+``langres.clients.tracking.wandb`` -- used by the reused ``create_wandb_tracker``
+init -- and ``langres.core.trackers.wandb_tracker.wandb``), so no test touches the
+network or a real W&B login. We assert that start_run -> log -> finish call the
+right W&B APIs with the flattened context, that ``run_url``/``native`` derive from
+the underlying run, that status maps to an exit code, and that
+``resolve_tracker("wandb")`` returns a real :class:`WandbTracker`.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from langres.clients.settings import Settings
+from langres.core.runs import RunContext
+from langres.core.trackers import ExperimentTracker, resolve_tracker
+from langres.core.trackers.wandb_tracker import WandbTracker, _flatten
+
+
+class _FakeConfig:
+    """Stand-in for ``wandb.Run.config`` -- records the merged config dict."""
+
+    def __init__(self) -> None:
+        self.data: dict[str, Any] = {}
+
+    def update(self, values: dict[str, Any], allow_val_change: bool | None = None) -> None:
+        self.data.update(values)
+
+
+class _FakeRun:
+    """Stand-in for a ``wandb`` run object."""
+
+    def __init__(self, *, url: str | None = "https://wandb.ai/acme/langres/runs/abc123") -> None:
+        self.config = _FakeConfig()
+        self.summary: dict[str, Any] = {}
+        self.name: str | None = None
+        self.tags: tuple[str, ...] = ()
+        self.url = url
+
+
+class _FakeWandb:
+    """Minimal fake ``wandb`` module: records init/log/finish calls."""
+
+    def __init__(self, run: _FakeRun | None = None) -> None:
+        self.run = run if run is not None else _FakeRun()
+        self.init_kwargs: dict[str, Any] | None = None
+        self.log_calls: list[tuple[dict[str, Any], int | None]] = []
+        self.finish_calls: list[int | None] = []
+
+    def init(self, **kwargs: Any) -> _FakeRun:
+        self.init_kwargs = kwargs
+        return self.run
+
+    def log(self, data: dict[str, Any], step: int | None = None) -> None:
+        self.log_calls.append((data, step))
+
+    def finish(self, exit_code: int | None = None) -> None:
+        self.finish_calls.append(exit_code)
+
+
+@pytest.fixture
+def fake_wandb(monkeypatch: pytest.MonkeyPatch) -> _FakeWandb:
+    """Patch the fake over BOTH modules that reference ``wandb`` in this path."""
+    fake = _FakeWandb()
+    import langres.clients.tracking as tracking_mod
+    from langres.core.trackers import wandb_tracker
+
+    monkeypatch.setattr(tracking_mod, "wandb", fake)
+    monkeypatch.setattr(wandb_tracker, "wandb", fake)
+    return fake
+
+
+@pytest.fixture
+def settings() -> Settings:
+    """Explicit settings so ``create_wandb_tracker``'s api-key check passes offline."""
+    return Settings(wandb_api_key="test-key", wandb_project="test-proj", wandb_entity="acme")
+
+
+def _context() -> RunContext:
+    return RunContext(
+        experiment="dedupe-ag",
+        tags={"env": "ci"},
+        git_sha="deadbeef",
+        llm_model="deepseek/deepseek-chat",
+        cascade_band=(0.3, 0.7),
+        blocking_k=5,
+        dataset_name="amazon-google",
+        seeds={"split": 42},
+        resolver_config={"type_name": "Resolver", "seed": 7},
+    )
+
+
+class TestFlatten:
+    def test_dots_nested_and_drops_none(self) -> None:
+        flat = _flatten({"a": {"b": 1}, "c": None, "d": 2})
+        assert flat == {"a.b": 1, "d": 2}
+
+    def test_indexes_sequences(self) -> None:
+        assert _flatten({"band": [0.3, 0.7]}) == {"band[0]": 0.3, "band[1]": 0.7}
+
+    def test_empty_mapping_yields_nothing(self) -> None:
+        assert _flatten({"tags": {}}) == {}
+
+
+class TestProtocolAndConstruction:
+    def test_satisfies_protocol(self) -> None:
+        assert isinstance(WandbTracker(), ExperimentTracker)
+
+    def test_name_is_wandb(self) -> None:
+        assert WandbTracker().name == "wandb"
+
+    def test_no_run_before_start(self) -> None:
+        tracker = WandbTracker()
+        assert tracker.native is None
+        assert tracker.run_url is None
+
+
+class TestStartRun:
+    def test_inits_with_settings_project_entity_and_job_type(
+        self, fake_wandb: _FakeWandb, settings: Settings
+    ) -> None:
+        tracker = WandbTracker(settings, job_type="evaluation")
+        tracker.start_run(_context(), run_name="dedupe-ag")
+
+        assert fake_wandb.init_kwargs == {
+            "project": "test-proj",
+            "entity": "acme",
+            "job_type": "evaluation",
+        }
+        assert fake_wandb.run.name == "dedupe-ag"
+
+    def test_flattens_context_into_config(
+        self, fake_wandb: _FakeWandb, settings: Settings
+    ) -> None:
+        tracker = WandbTracker(settings)
+        tracker.start_run(_context())
+
+        config = fake_wandb.run.config.data
+        assert config["experiment"] == "dedupe-ag"
+        assert config["llm_model"] == "deepseek/deepseek-chat"
+        assert config["blocking_k"] == 5
+        assert config["seeds.split"] == 42
+        assert config["tags.env"] == "ci"
+        assert config["git_sha"] == "deadbeef"
+        assert config["cascade_band[0]"] == 0.3
+        assert config["cascade_band[1]"] == 0.7
+        assert config["resolver_config.seed"] == 7
+        # None-valued context fields are dropped, not surfaced as "None".
+        assert "group" not in config
+
+
+class TestLogging:
+    def test_log_metrics_forwards_to_wandb_log(
+        self, fake_wandb: _FakeWandb, settings: Settings
+    ) -> None:
+        tracker = WandbTracker(settings)
+        tracker.start_run(_context())
+        tracker.log_metrics({"f1": 0.91, "recall": 0.88}, step=3)
+
+        assert fake_wandb.log_calls == [({"f1": 0.91, "recall": 0.88}, 3)]
+
+    def test_log_metrics_defaults_step_to_none(
+        self, fake_wandb: _FakeWandb, settings: Settings
+    ) -> None:
+        tracker = WandbTracker(settings)
+        tracker.start_run(_context())
+        tracker.log_metrics({"f1": 0.5})
+
+        assert fake_wandb.log_calls == [({"f1": 0.5}, None)]
+
+    def test_log_params_merges_into_config(
+        self, fake_wandb: _FakeWandb, settings: Settings
+    ) -> None:
+        tracker = WandbTracker(settings)
+        tracker.start_run(_context())
+        tracker.log_params({"extra": {"nested": 1}})
+
+        assert fake_wandb.run.config.data["extra.nested"] == 1
+
+    def test_log_params_noop_before_start(self, fake_wandb: _FakeWandb) -> None:
+        # No run yet -> nothing to update, and no crash.
+        WandbTracker().log_params({"a": 1})
+
+    def test_log_artifact_records_in_summary(
+        self, fake_wandb: _FakeWandb, settings: Settings
+    ) -> None:
+        tracker = WandbTracker(settings)
+        tracker.start_run(_context())
+        tracker.log_artifact("report_md", "runs/report.md")
+
+        assert fake_wandb.run.summary["report_md"] == "runs/report.md"
+
+    def test_log_artifact_noop_before_start(self, fake_wandb: _FakeWandb) -> None:
+        WandbTracker().log_artifact("k", "v")
+
+    def test_set_tags_sets_key_value_labels(
+        self, fake_wandb: _FakeWandb, settings: Settings
+    ) -> None:
+        tracker = WandbTracker(settings)
+        tracker.start_run(_context())
+        tracker.set_tags({"env": "ci", "team": "er"})
+
+        assert fake_wandb.run.tags == ("env:ci", "team:er")
+
+    def test_set_tags_noop_before_start(self, fake_wandb: _FakeWandb) -> None:
+        WandbTracker().set_tags({"a": "b"})
+
+
+class TestFinish:
+    def test_completed_maps_to_exit_code_zero(
+        self, fake_wandb: _FakeWandb, settings: Settings
+    ) -> None:
+        tracker = WandbTracker(settings)
+        tracker.start_run(_context())
+        tracker.finish(status="completed")
+
+        assert fake_wandb.finish_calls == [0]
+        assert fake_wandb.run.summary["status"] == "completed"
+
+    @pytest.mark.parametrize("status", ["failed", "budget_exceeded"])
+    def test_non_completed_maps_to_exit_code_one(
+        self, fake_wandb: _FakeWandb, settings: Settings, status: str
+    ) -> None:
+        tracker = WandbTracker(settings)
+        tracker.start_run(_context())
+        tracker.finish(status=status)
+
+        assert fake_wandb.finish_calls == [1]
+
+    def test_finish_before_start_still_calls_wandb_finish(self, fake_wandb: _FakeWandb) -> None:
+        WandbTracker().finish(status="completed")
+        assert fake_wandb.finish_calls == [0]
+
+
+class TestRunUrlAndNative:
+    def test_run_url_from_underlying_run(
+        self, fake_wandb: _FakeWandb, settings: Settings
+    ) -> None:
+        tracker = WandbTracker(settings)
+        tracker.start_run(_context())
+        assert tracker.run_url == "https://wandb.ai/acme/langres/runs/abc123"
+
+    def test_run_url_none_when_run_has_no_url(
+        self, monkeypatch: pytest.MonkeyPatch, settings: Settings
+    ) -> None:
+        fake = _FakeWandb(_FakeRun(url=None))
+        import langres.clients.tracking as tracking_mod
+        from langres.core.trackers import wandb_tracker
+
+        monkeypatch.setattr(tracking_mod, "wandb", fake)
+        monkeypatch.setattr(wandb_tracker, "wandb", fake)
+
+        tracker = WandbTracker(settings)
+        tracker.start_run(_context())
+        assert tracker.run_url is None
+
+    def test_native_returns_underlying_run(
+        self, fake_wandb: _FakeWandb, settings: Settings
+    ) -> None:
+        tracker = WandbTracker(settings)
+        tracker.start_run(_context())
+        assert tracker.native is fake_wandb.run
+
+
+class TestResolveTracker:
+    def test_resolve_tracker_wandb_returns_real_wandb_tracker(
+        self, fake_wandb: _FakeWandb
+    ) -> None:
+        resolved = resolve_tracker("wandb")
+        assert isinstance(resolved, WandbTracker)
+        assert resolved.name == "wandb"


### PR DESCRIPTION
## What & why

langres benchmark runs are **ephemeral**: `run_method`/`run_methods` produce rich Pydantic
results (`MethodResult`, `CostTrack`, the `reports.py` family) that are `.model_dump()`'d or
rendered to markdown, then lost — no run id, no config snapshot, no dataset/split identity, no
persistence, no cross-run comparison, no lineage. As the team reproduces published ER research
(Ditto/Jellyfish/AnyMatch, epic #85) *as clients of langres*, increasingly via agents, a result
must be **reproducible** months later and **comparable** across sessions.

Five-workstream research (`docs/research/20260708_experiment_tracking_observability_analysis.md`)
concluded: **don't build a tracker — add a thin pluggable adapter that wraps langres's existing
seams and reuses its existing Pydantic result models.** langres already has the hard parts (auto
per-judge capture via `LoggingModule`, honest cost via `SpendMonitor` + pinned prices, rich
serializable reports, a `"v":1` JSONL idiom). This PR adds the missing pieces: **run identity +
config/dataset/split capture + backend persistence + LLM-trace correlation + lineage.**

Scope = **Phase 0 (run-store + identity) + Phase 1 (adapter, BOTH MLflow & W&B) + Phase 3
(Langfuse correlation-id).** The `benchmark.py` harness wrap (Stream C) is **deferred** until
eval-readiness lands its `slice_fn` seam — so this PR is **disjoint from eval-readiness code**
(`benchmark.py` untouched) and targets `main` directly.

## The centerpiece — what gets tracked

Two frozen Pydantic models in a **dep-free** `core/runs.py`:

- **`RunContext`** — the recipe. `recipe_id = sha256(canonical_json(RECIPE_FIELDS))` over
  **inputs only** (experiment, resolver config, model, dataset fingerprint, split, seeds) —
  **excluding** git_sha/git_dirty/lockfile/timing, so an idempotent replay on a dirty tree still
  matches. `attempt_id = f"{recipe_id}-{started_at}"` is the record PK.
- **`RunRecord`** — `context` + outcomes (metrics as a reused-model dict, `metric_definition`,
  native `spend_usd`, status/failure, artifacts, timing), one JSONL line. `status="running"` is
  written **first**, so a crashed/torn-down run leaves a *visible* gap.

`RunStore` (JSONL, `fcntl.flock` per append, last-wins-by-attempt_id) is written
**unconditionally** by `capture_run` — trackers are the optional live mirror. Even with zero
trackers you get a replayable record.

## The layer

- **`ExperimentTracker` Protocol** (🤗 Accelerate `GeneralTracker` shape) + `NoOpTracker` (null
  default, zero overhead) + `MultiTracker` (fan-out → MLflow **and** W&B at once) +
  `resolve_tracker(spec)` mirroring langres's `judge="auto"|"string"|MyJudge(...)` idiom.
- **`MlflowTracker`** / **`WandbTracker`** — lazy adapters behind `[project.optional-dependencies]`
  `mlflow` / `wandb`; a missing extra raises a helpful `ImportError` naming the extra.
- **`Resolver.config_dict()`** — public config snapshot (factored from `save()`, byte-identical).
- **LLM correlation** — `LLMJudge.forward` stamps `metadata={langres_attempt_id,left_id,right_id,
  decision_step}` onto the litellm `completion()` **only** when a run is active; `JudgementLog`
  rows gain a nullable `run_id` — the exact three-way join (RunRecord ↔ JudgementLog ↔ Langfuse span).
- **DSPy lineage** — `DSPyJudge.compile()` optionally opens a `capture_run` (an optimization run
  that can parent the eval runs using its compiled program).

**Additive & byte-identical when unused:** omit store/tracker and behavior is unchanged — no files
written, same `MethodResult`. **Import budget preserved:** `import langres` pulls no
mlflow/wandb/ranx/litellm/torch (verified in `tests/test_import_budget.py`, 0.42s).

## Verification (beyond tests)

- ✅ **Import budget** — bare `import langres` leaks no heavy module; result-model refs are
  `TYPE_CHECKING`-only.
- ✅ **Real offline dual-backend e2e** — a zero-spend run mirrored to `["mlflow","wandb"]` +
  `RunStore`; inspected the JSONL `RunRecord` (recipe_id, git dirty flag, resolver_config, seeds
  union, dataset_fingerprint, metrics, spend_usd, `"running"`→terminal transition, `"v":1`).
- ✅ **Idempotent replay** — identical config → identical `recipe_id`; dirty tree flips `git_dirty`
  without changing the id.
- ✅ **No-tracker no-op** — omitting store/tracker is byte-identical.
- ✅ **mypy strict** clean; tracking modules at the `core/**` 95–100% tier (runs 100%, trackers
  100%, mlflow 98%, wandb 100%); full fast suite green.
- ✅ Ships a runnable offline demo (`examples/research/experiment_tracking_demo.py`) + a
  "Persisting & comparing runs" section in `docs/EXPERIMENTS.md`.

## Known fast-follows (non-blocking, tracked)

- **Stream C** (benchmark.py wrap + default-store-on + `run_methods` example) — deferred until
  eval-readiness merges its `slice_fn` seam.
- `DSPyJudge` async `acompletion` path not yet instrumented (sync `completion()` only).
- `git_sha`/`dataset_fingerprint` reachable via `langres.core.runs`, not re-exported from
  `langres.core` (polish).
- If a live tracker's `start_run` throws, the `"running"` line can dangle (the default `NoOpTracker`
  never triggers this).

Plan/contract: `docs/plans/20260708_tracking_observability_plan.md`.
