### PR TITLE
PR-3: EvalReport tearsheet — a $0 self-contained HTML report from persisted judgements

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -85,6 +85,9 @@ jobs:
       - name: Verify the core-only string-judge dedupe() path still works
         run: uv run python examples/quickstart_verbs.py
 
+      - name: Verify the core-only eval tearsheet ($0 EvalReport -> to_html) works
+        run: uv run python examples/quickstart_eval.py
+
   # Full suite INCLUDING the slow embedding/ML tests, plus the 95% coverage gate
   # (inherited from pyproject addopts). Runs weekly + on demand only -- NOT per
   # PR -- so ML regressions and the coverage floor are still enforced on a

--- a/.gitignore
+++ b/.gitignore
@@ -54,6 +54,9 @@ MANIFEST
 pip-log.txt
 pip-delete-this-directory.txt
 
+# Eval tearsheet written by examples/quickstart_eval.py
+tearsheet.html
+
 # Unit test / coverage reports
 htmlcov/
 .tox/

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -49,8 +49,36 @@ earned `confidence`. Builds directly on the eval-honesty groundwork below.
 - **`JudgementLog` persisted `$0` for every cascade row.** `append` / `read` only
   read `provenance["cost_usd"]`, but `CascadeModule` writes `llm_cost_usd`; the
   logged cost is now the first of `("cost_usd", "llm_cost_usd")` present.
+- **`harvest_labeled_pairs` coerced an abstention into a `False` silver label.**
+  A v3 abstention row (`verdict=None`) has no verdict to harvest; it is now
+  **skipped** (unless a human correction supplies a label) rather than seeding
+  training data with a non-match the judge never gave — the label-side twin of
+  never coercing a null score to `0.0`.
+- **`select_for_review("uncertainty")` dropped score-only rows in a mixed log.**
+  Once any row carried a `confidence`, the selector returned only the
+  confidence-bearing rows, silently discarding uncertain score-only rows (a
+  `CascadeJudge` log mixes both). It now folds the score band back in, so no
+  uncertain pair vanishes.
 
 ### Added
+
+- **`EvalReport` — a $0 evaluation tearsheet** (`langres.core.eval_report`, also
+  re-exported from `langres.eval`). `EvalReport.from_log(rows, gold_pairs)` (from
+  persisted `JudgementLog.read()` output) or `EvalReport.from_judgements(...)`
+  (in-process) computes pair precision/recall/F1, the PR and ROC curves +
+  ROC-AUC/AP, a gold-vs-non-gold score histogram, confidence calibration
+  (reliability diagram + Brier + ECE), and the most-confident errors — all at
+  **zero** API cost from already-logged judgements. `to_html()` renders a single
+  self-contained document with inline SVG (`langres.core._svg`): no matplotlib, no
+  external assets, theme-aware. A leaf module — nothing in `reports.py`/`module.py`
+  imports it, and an import-budget test locks that it never pulls a heavy
+  dependency. See `examples/quickstart_eval.py` (fully offline, in CI's
+  core-only job). This is the supported, dependency-free replacement for the
+  dead `plot_*`/`langres[viz]` matplotlib path.
+- **`langres.testing.ScriptedJudge` gained an optional `confidence` provider**
+  (dict or callable) + `confidence_source`, so the test double can model a
+  logprob judge offline (e.g. to populate an `EvalReport` calibration panel with
+  no API calls).
 
 - **`JudgementLog` schema v3.** Rows now carry `decision` / `confidence` /
   `confidence_source` natively; `read()` backfills `decision` from the logged

--- a/examples/quickstart_eval.py
+++ b/examples/quickstart_eval.py
@@ -30,6 +30,10 @@ from langres.core.models import CompanySchema
 from langres.testing import ScriptedJudge
 
 # A toy dataset and the true clustering (what a small labeled sample gives you).
+# The last pair is a deliberately HARD true match -- "IBM" and its full legal
+# name share almost no characters, so a string-similarity judge scores it low and
+# misses it. That one honest error is what gives the tearsheet something to show:
+# a non-trivial ROC/PR curve and a populated "most-confident errors" panel.
 records = [
     {"id": "1", "name": "Acme Corporation"},
     {"id": "2", "name": "Acme Corp"},
@@ -38,8 +42,10 @@ records = [
     {"id": "5", "name": "Initech"},
     {"id": "6", "name": "Initech LLC"},
     {"id": "7", "name": "Unrelated Bakery"},
+    {"id": "8", "name": "IBM"},
+    {"id": "9", "name": "International Business Machines"},
 ]
-gold_clusters = [{"1", "2"}, {"3", "4"}, {"5", "6"}, {"7"}]
+gold_clusters = [{"1", "2"}, {"3", "4"}, {"5", "6"}, {"7"}, {"8", "9"}]
 
 # 1. BLOCK: generate candidate pairs to judge (no judge, no spend yet).
 resolver = Resolver.from_schema(CompanySchema, judge="string")

--- a/examples/quickstart_eval.py
+++ b/examples/quickstart_eval.py
@@ -1,0 +1,81 @@
+"""Quickstart: turn judged pairs into a self-contained eval tearsheet, for free.
+
+The story: judging costs money (LLM calls, embeddings); *analysing* what you
+already judged is free. This example blocks a toy dataset, judges every candidate
+pair, clusters the matches, then builds an ``EvalReport`` and writes a single
+self-contained ``tearsheet.html`` -- pair precision/recall/F1, PR and ROC curves,
+a score histogram, a confidence-calibration diagram, and the most-confident
+errors -- at **zero** extra cost.
+
+Fully offline on purpose: no API key, no network, no torch, no embeddings. The
+judge here is a :class:`~langres.testing.ScriptedJudge` standing in for a real
+one -- it scores each pair by string similarity and reports a confidence, exactly
+the shape an ``LLMJudge(confidence="logprob")`` produces, but with no spend. For a
+real (paid) judge you would wrap the scoring call in
+:func:`~langres.core.benchmark.evaluate` for its default $1 spend cap; the report
+below is identical either way.
+
+Run it:
+    uv run python examples/quickstart_eval.py
+"""
+
+import difflib
+from pathlib import Path
+
+from langres import Resolver
+from langres.core.benchmark import gold_pairs_from_clusters
+from langres.core.clusterer import Clusterer
+from langres.core.eval_report import EvalReport
+from langres.core.models import CompanySchema
+from langres.testing import ScriptedJudge
+
+# A toy dataset and the true clustering (what a small labeled sample gives you).
+records = [
+    {"id": "1", "name": "Acme Corporation"},
+    {"id": "2", "name": "Acme Corp"},
+    {"id": "3", "name": "Globex Inc"},
+    {"id": "4", "name": "Globex Incorporated"},
+    {"id": "5", "name": "Initech"},
+    {"id": "6", "name": "Initech LLC"},
+    {"id": "7", "name": "Unrelated Bakery"},
+]
+gold_clusters = [{"1", "2"}, {"3", "4"}, {"5", "6"}, {"7"}]
+
+# 1. BLOCK: generate candidate pairs to judge (no judge, no spend yet).
+resolver = Resolver.from_schema(CompanySchema, judge="string")
+candidates = resolver.candidates(records)
+
+
+# 2. JUDGE: a mocked judge that scores each pair AND reports a confidence,
+#    standing in for LLMJudge(confidence="logprob") -- deterministic, offline.
+def _similarity(candidate: object) -> float:
+    left, right = candidate.left.name.lower(), candidate.right.name.lower()  # type: ignore[attr-defined]
+    return difflib.SequenceMatcher(None, left, right).ratio()
+
+
+def _credence(candidate: object) -> float:
+    # More confident the further the score is from the 0.5 fence -- a plausible
+    # stand-in for a real judge's self-reported credence.
+    return round(0.5 + abs(_similarity(candidate) - 0.5), 3)
+
+
+judge = ScriptedJudge(
+    _similarity,
+    confidence=_credence,
+    confidence_source="logprob",
+    provenance={"cost_usd": 0.0},  # free judge -> $0 cost track
+)
+judgements = list(judge.forward(iter(candidates)))
+
+# 3. CLUSTER: transitive-closure the predicted matches into entities.
+clusters = Clusterer(threshold=0.6).cluster(judgements)
+print(f"{len(clusters)} cluster(s): {[sorted(c) for c in clusters]}")
+
+# 4. REPORT: grade the judgements against gold and render a $0 tearsheet.
+gold_pairs = gold_pairs_from_clusters(gold_clusters)
+report = EvalReport.from_judgements(judgements, gold_pairs, threshold=0.6)
+print(report.summary)
+
+out_path = Path("tearsheet.html")
+out_path.write_text(report.to_html(title="langres eval tearsheet"), encoding="utf-8")
+print(f"\nWrote {out_path.resolve()} -- open it in a browser (no server needed).")

--- a/src/langres/core/_svg.py
+++ b/src/langres/core/_svg.py
@@ -1,0 +1,380 @@
+"""Pure-stdlib inline-SVG chart primitives for the EvalReport HTML tearsheet.
+
+This module is the *only* place raw SVG strings and data->pixel coordinate math
+live. Callers pass values in **data space**; every scaling step and the SVG
+y-axis flip happen here, so the flip lives in exactly one place and cannot be
+duplicated (or forgotten) by callers.
+
+Design constraints:
+- Pure Python standard library only (``math``, ``html``, ``typing``). No numpy,
+  no matplotlib, no external assets -- an import-budget test enforces this.
+- Output is deterministic: identical inputs produce a byte-identical string
+  (no timestamps, no randomness).
+- Non-finite coordinates (NaN/Infinity) are dropped before emission, so the
+  output never contains a broken numeric attribute.
+- Every caller-supplied string (labels, colors, annotations) is HTML-escaped.
+
+Public API:
+- ``Series``: one plotted series in data coordinates.
+- ``line_chart``: a PR/ROC/reliability line-or-marker chart with an optional
+  chance diagonal and top-right annotations.
+- ``bar_chart``: an overlaid grouped bar chart (e.g. a score histogram split
+  gold vs non-gold).
+"""
+
+from __future__ import annotations
+
+import html
+import math
+from dataclasses import dataclass
+from typing import Literal
+
+# Plot padding (pixels). Left/bottom are generous so tick labels never clip.
+_LEFT_PAD = 44
+_RIGHT_PAD = 12
+_TOP_PAD = 12
+_BOTTOM_PAD = 28
+
+
+@dataclass(frozen=True)
+class Series:
+    """One plotted series in data space.
+
+    Attributes:
+        points: (x, y) pairs in DATA coordinates (not pixels). Non-finite
+            points are dropped at render time.
+        stroke: any CSS color string (html-escaped on output).
+        label: legend label (html-escaped on output). Pass ``""`` to omit the
+            series from the legend.
+        kind: ``"line"`` renders a single ``<polyline>``; ``"markers"`` renders
+            one ``<circle>`` per point.
+    """
+
+    points: list[tuple[float, float]]
+    stroke: str
+    label: str
+    kind: Literal["line", "markers"] = "line"
+
+
+def _scale(value: float, dmin: float, dmax: float, rmin: float, rmax: float) -> float:
+    """Linearly map ``value`` from a data range onto a pixel range.
+
+    Args:
+        value: The data-space value to map.
+        dmin: Minimum of the data range.
+        dmax: Maximum of the data range.
+        rmin: Pixel value that ``dmin`` maps to.
+        rmax: Pixel value that ``dmax`` maps to.
+
+    Returns:
+        The mapped value. When ``dmax == dmin`` (a degenerate range) the range
+        midpoint ``(rmin + rmax) / 2`` is returned instead of dividing by zero.
+        Callers guard non-finite inputs before calling this.
+    """
+    if dmax == dmin:
+        return (rmin + rmax) / 2.0
+    return rmin + (value - dmin) * (rmax - rmin) / (dmax - dmin)
+
+
+def _esc(text: str) -> str:
+    """HTML-escape a caller-supplied string for safe SVG embedding."""
+    return html.escape(text, quote=True)
+
+
+def _fmt(value: float) -> str:
+    """Format a number to at most 2 decimals, trailing zeros stripped."""
+    text = f"{value:.2f}"
+    if "." in text:
+        text = text.rstrip("0").rstrip(".")
+    return "0" if text == "-0" else text
+
+
+def _ticks(dmin: float, dmax: float, n: int) -> list[float]:
+    """Return ``n`` evenly spaced tick values across ``[dmin, dmax]``."""
+    if n < 2:
+        return [float(dmin), float(dmax)]
+    step = (dmax - dmin) / (n - 1)
+    return [dmin + step * i for i in range(n)]
+
+
+def _svg_open(width: int, height: int) -> str:
+    """Open a responsive, theme-neutral ``<svg>`` element."""
+    return (
+        '<svg xmlns="http://www.w3.org/2000/svg" role="img" '
+        f'viewBox="0 0 {width} {height}" width="{width}" height="{height}" '
+        'style="max-width:100%;height:auto">'
+    )
+
+
+def _axes(
+    *,
+    plot_left: float,
+    plot_right: float,
+    plot_top: float,
+    plot_bottom: float,
+    x0: float,
+    x1: float,
+    y0: float,
+    y1: float,
+    x_label: str,
+    y_label: str,
+    n_ticks: int,
+) -> list[str]:
+    """Render the L-shaped axis frame, tick marks, tick labels, and axis titles.
+
+    Uses ``currentColor`` throughout so the frame is legible in both light and
+    dark themes. The y ticks apply the same bottom->top flip as the data.
+    """
+    parts: list[str] = [
+        f'<path d="M {_fmt(plot_left)} {_fmt(plot_top)} '
+        f"L {_fmt(plot_left)} {_fmt(plot_bottom)} "
+        f'L {_fmt(plot_right)} {_fmt(plot_bottom)}" '
+        'fill="none" stroke="currentColor" stroke-opacity="0.6" stroke-width="1"/>'
+    ]
+    for tick in _ticks(x0, x1, n_ticks):
+        px = _scale(tick, x0, x1, plot_left, plot_right)
+        parts.append(
+            f'<line x1="{_fmt(px)}" y1="{_fmt(plot_bottom)}" '
+            f'x2="{_fmt(px)}" y2="{_fmt(plot_bottom + 4)}" '
+            'stroke="currentColor" stroke-opacity="0.6"/>'
+        )
+        parts.append(
+            f'<text x="{_fmt(px)}" y="{_fmt(plot_bottom + 15)}" '
+            'font-size="9" text-anchor="middle" fill="currentColor">'
+            f"{_esc(_fmt(tick))}</text>"
+        )
+    for tick in _ticks(y0, y1, n_ticks):
+        py = _scale(tick, y0, y1, plot_bottom, plot_top)
+        parts.append(
+            f'<line x1="{_fmt(plot_left - 4)}" y1="{_fmt(py)}" '
+            f'x2="{_fmt(plot_left)}" y2="{_fmt(py)}" '
+            'stroke="currentColor" stroke-opacity="0.6"/>'
+        )
+        parts.append(
+            f'<text x="{_fmt(plot_left - 6)}" y="{_fmt(py + 3)}" '
+            'font-size="9" text-anchor="end" fill="currentColor">'
+            f"{_esc(_fmt(tick))}</text>"
+        )
+    if x_label:
+        parts.append(
+            f'<text x="{_fmt((plot_left + plot_right) / 2)}" y="{_fmt(plot_bottom + 26)}" '
+            'font-size="10" text-anchor="middle" fill="currentColor">'
+            f"{_esc(x_label)}</text>"
+        )
+    if y_label:
+        cy = (plot_top + plot_bottom) / 2
+        parts.append(
+            f'<text x="10" y="{_fmt(cy)}" font-size="10" text-anchor="middle" '
+            f'fill="currentColor" transform="rotate(-90 10 {_fmt(cy)})">'
+            f"{_esc(y_label)}</text>"
+        )
+    return parts
+
+
+def _legend(entries: list[tuple[str, str]], x: float, y: float) -> list[str]:
+    """Render a compact top-left legend; entries with an empty label are skipped.
+
+    Args:
+        entries: ``(label, stroke)`` pairs.
+        x: Left edge (pixels) of the plot area.
+        y: Top edge (pixels) of the plot area.
+    """
+    parts: list[str] = []
+    row = 0
+    for label, stroke in entries:
+        if not label:
+            continue
+        ly = y + 12 + row * 14
+        parts.append(
+            f'<line x1="{_fmt(x + 6)}" y1="{_fmt(ly - 3)}" '
+            f'x2="{_fmt(x + 20)}" y2="{_fmt(ly - 3)}" '
+            f'stroke="{_esc(stroke)}" stroke-width="2"/>'
+        )
+        parts.append(
+            f'<text x="{_fmt(x + 24)}" y="{_fmt(ly)}" font-size="9" '
+            f'text-anchor="start" fill="currentColor">{_esc(label)}</text>'
+        )
+        row += 1
+    return parts
+
+
+def line_chart(
+    series: list[Series],
+    *,
+    x_domain: tuple[float, float],
+    y_domain: tuple[float, float],
+    width: int = 340,
+    height: int = 260,
+    x_label: str = "",
+    y_label: str = "",
+    diagonal: bool = False,
+    annotations: list[str] | None = None,
+    n_ticks: int = 5,
+) -> str:
+    """Render a line/marker chart as a self-contained ``<svg>`` string.
+
+    Args:
+        series: Series to plot. ``"line"`` series need >= 2 finite points to
+            emit a ``<polyline>``; ``"markers"`` series emit one ``<circle>``
+            per finite point.
+        x_domain: ``(min, max)`` of the x data range.
+        y_domain: ``(min, max)`` of the y data range. The data max is placed at
+            the TOP of the plot (the SVG y-axis flip happens here).
+        width: SVG width in pixels.
+        height: SVG height in pixels.
+        x_label: X-axis title (html-escaped).
+        y_label: Y-axis title (html-escaped).
+        diagonal: If True, draw a dashed chance line from
+            ``(x_domain[0], y_domain[0])`` to ``(x_domain[1], y_domain[1])``.
+        annotations: Short strings drawn top-right (each html-escaped), e.g.
+            ``"AUC = 0.950"``.
+        n_ticks: Number of ticks per axis.
+
+    Returns:
+        A complete ``<svg ...>...</svg>`` string.
+    """
+    x0, x1 = x_domain
+    y0, y1 = y_domain
+    plot_left = float(_LEFT_PAD)
+    plot_right = float(width - _RIGHT_PAD)
+    plot_top = float(_TOP_PAD)
+    plot_bottom = float(height - _BOTTOM_PAD)
+
+    parts = [_svg_open(width, height)]
+    parts.extend(
+        _axes(
+            plot_left=plot_left,
+            plot_right=plot_right,
+            plot_top=plot_top,
+            plot_bottom=plot_bottom,
+            x0=x0,
+            x1=x1,
+            y0=y0,
+            y1=y1,
+            x_label=x_label,
+            y_label=y_label,
+            n_ticks=n_ticks,
+        )
+    )
+
+    if diagonal:
+        dx1 = _scale(x0, x0, x1, plot_left, plot_right)
+        dy1 = _scale(y0, y0, y1, plot_bottom, plot_top)
+        dx2 = _scale(x1, x0, x1, plot_left, plot_right)
+        dy2 = _scale(y1, y0, y1, plot_bottom, plot_top)
+        parts.append(
+            f'<line x1="{_fmt(dx1)}" y1="{_fmt(dy1)}" '
+            f'x2="{_fmt(dx2)}" y2="{_fmt(dy2)}" '
+            'stroke="currentColor" stroke-opacity="0.4" stroke-dasharray="5,5"/>'
+        )
+
+    for s in series:
+        pixels = [
+            (_scale(x, x0, x1, plot_left, plot_right), _scale(y, y0, y1, plot_bottom, plot_top))
+            for x, y in s.points
+            if math.isfinite(x) and math.isfinite(y)
+        ]
+        stroke = _esc(s.stroke)
+        if s.kind == "line":
+            if len(pixels) >= 2:
+                coords = " ".join(f"{_fmt(px)},{_fmt(py)}" for px, py in pixels)
+                parts.append(
+                    f'<polyline fill="none" stroke="{stroke}" stroke-width="2" points="{coords}"/>'
+                )
+        else:
+            for px, py in pixels:
+                parts.append(f'<circle cx="{_fmt(px)}" cy="{_fmt(py)}" r="3" fill="{stroke}"/>')
+
+    parts.extend(_legend([(s.label, s.stroke) for s in series], plot_left, plot_top))
+
+    for i, note in enumerate(annotations or []):
+        ay = plot_top + 12 + i * 13
+        parts.append(
+            f'<text x="{_fmt(plot_right - 4)}" y="{_fmt(ay)}" font-size="10" '
+            f'text-anchor="end" fill="currentColor">{_esc(note)}</text>'
+        )
+
+    parts.append("</svg>")
+    return "".join(parts)
+
+
+def bar_chart(
+    bin_edges: list[float],
+    series: list[tuple[str, str, list[float]]],
+    *,
+    width: int = 340,
+    height: int = 260,
+    x_label: str = "",
+    y_label: str = "",
+) -> str:
+    """Render an overlaid grouped bar chart as a self-contained ``<svg>`` string.
+
+    One bar group per bin; series are drawn overlaid (semi-transparent) so a
+    two-series split (e.g. a score histogram of gold vs non-gold) reads clearly.
+    Bars are anchored to a zero baseline. Non-finite or non-positive counts
+    emit no ``<rect>`` (the axes still render), so an empty/degenerate histogram
+    renders as bare axes rather than broken attributes.
+
+    Args:
+        bin_edges: ``B + 1`` ascending edges defining ``B`` bins.
+        series: ``(label, stroke, counts)`` tuples, where ``counts`` has length
+            ``B`` (one bar per bin). ``label`` populates the legend.
+        width: SVG width in pixels.
+        height: SVG height in pixels.
+        x_label: X-axis title (html-escaped).
+        y_label: Y-axis title (html-escaped).
+
+    Returns:
+        A complete ``<svg ...>...</svg>`` string.
+    """
+    plot_left = float(_LEFT_PAD)
+    plot_right = float(width - _RIGHT_PAD)
+    plot_top = float(_TOP_PAD)
+    plot_bottom = float(height - _BOTTOM_PAD)
+
+    x0 = bin_edges[0] if bin_edges else 0.0
+    x1 = bin_edges[-1] if bin_edges else 1.0
+
+    finite_counts = [c for _, _, counts in series for c in counts if math.isfinite(c)]
+    y_max = max(finite_counts) if finite_counts else 0.0
+    if y_max <= 0.0:
+        y_max = 1.0  # avoid a degenerate y range; no bars are drawn either way
+
+    parts = [_svg_open(width, height)]
+    parts.extend(
+        _axes(
+            plot_left=plot_left,
+            plot_right=plot_right,
+            plot_top=plot_top,
+            plot_bottom=plot_bottom,
+            x0=x0,
+            x1=x1,
+            y0=0.0,
+            y1=y_max,
+            x_label=x_label,
+            y_label=y_label,
+            n_ticks=5,
+        )
+    )
+
+    n_bins = max(len(bin_edges) - 1, 0)
+    for _label, stroke, counts in series:
+        fill = _esc(stroke)
+        for i in range(min(n_bins, len(counts))):
+            count = counts[i]
+            if not math.isfinite(count) or count <= 0.0:
+                continue
+            left_px = _scale(bin_edges[i], x0, x1, plot_left, plot_right)
+            right_px = _scale(bin_edges[i + 1], x0, x1, plot_left, plot_right)
+            top_px = _scale(count, 0.0, y_max, plot_bottom, plot_top)
+            bar_w = max(right_px - left_px - 1.0, 0.0)
+            bar_h = max(plot_bottom - top_px, 0.0)
+            parts.append(
+                f'<rect x="{_fmt(left_px)}" y="{_fmt(top_px)}" '
+                f'width="{_fmt(bar_w)}" height="{_fmt(bar_h)}" '
+                f'fill="{fill}" fill-opacity="0.55"/>'
+            )
+
+    parts.extend(_legend([(label, stroke) for label, stroke, _ in series], plot_left, plot_top))
+    parts.append("</svg>")
+    return "".join(parts)

--- a/src/langres/core/eval_report.py
+++ b/src/langres/core/eval_report.py
@@ -286,9 +286,19 @@ class EvalReport(BaseModel):
         run's re-judgement supersedes), so every pair is counted exactly once and
         the confusion cells reconcile.
 
+        Raises:
+            ValueError: If ``costs`` is given but its length differs from
+                ``judgements`` -- a misaligned list would silently mis-sum the
+                total spend rather than fail.
+
         Returns:
             A frozen :class:`EvalReport`.
         """
+        if costs is not None and len(costs) != len(judgements):
+            raise ValueError(
+                f"costs must align with judgements: got {len(costs)} costs for "
+                f"{len(judgements)} judgements"
+            )
         # One judgement per pair: a persisted log can carry duplicate rows for the
         # same pair (a resumed run re-judging it). Keep the last -- last write wins,
         # as a re-run supersedes the earlier verdict -- so the set-based tp/fp/fn
@@ -427,9 +437,11 @@ class EvalReport(BaseModel):
         """Build a report from persisted ``JudgementLog.read()`` rows plus gold.
 
         The default mental model: judging already happened and was logged; this
-        recomputes the whole tearsheet at $0. Per-row ``cost_usd`` (falling back
-        to ``llm_cost_usd``, the cascade key) is summed into
-        :attr:`total_cost_usd`.
+        recomputes the whole tearsheet at $0. Per-row ``cost_usd`` is summed into
+        :attr:`total_cost_usd`, falling back to the legacy ``llm_cost_usd`` key for
+        rows not produced by the current ``JudgementLog.append()`` (which resolves
+        cost to a single top-level ``cost_usd``) -- e.g. a hand-built row dict or a
+        pre-normalisation log. This mirrors ``_COST_KEYS``' first-present-wins.
 
         Args:
             rows: Rows as produced by

--- a/src/langres/core/eval_report.py
+++ b/src/langres/core/eval_report.py
@@ -74,6 +74,17 @@ def _num(value: float | None, digits: int = 3) -> str:
     return f"{value:.{digits}f}"
 
 
+def _md_cell(text: str) -> str:
+    """Make a value safe inside a Markdown table cell.
+
+    A record id may contain a ``|`` (the column delimiter) or a newline; either
+    silently corrupts table alignment. Escape the pipe and flatten newlines --
+    the HTML render already escapes ids via :func:`html.escape`, so this keeps
+    the two render paths symmetric.
+    """
+    return str(text).replace("|", "\\|").replace("\n", " ").replace("\r", " ")
+
+
 def _histogram(values: Sequence[float], edges: Sequence[float]) -> list[float]:
     """Count ``values`` into the half-open bins defined by ascending ``edges``.
 
@@ -271,10 +282,19 @@ class EvalReport(BaseModel):
             costs: Optional per-judgement cost (aligned with ``judgements``); the
                 sum becomes :attr:`total_cost_usd`. ``None`` -> ``0.0``.
 
+        Duplicate rows for the same pair are collapsed to the last one (a resumed
+        run's re-judgement supersedes), so every pair is counted exactly once and
+        the confusion cells reconcile.
+
         Returns:
             A frozen :class:`EvalReport`.
         """
-        judged = list(judgements)
+        # One judgement per pair: a persisted log can carry duplicate rows for the
+        # same pair (a resumed run re-judging it). Keep the last -- last write wins,
+        # as a re-run supersedes the earlier verdict -- so the set-based tp/fp/fn
+        # (classify_pairs already dedupes by pair) and the per-judgement
+        # tn/histogram/ROC below count each pair once and the confusion cells reconcile.
+        judged = list({_pair_key(j.left_id, j.right_id): j for j in judgements}.values())
         n_candidates = len(judged)
 
         base = classify_pairs(judged, gold_pairs, threshold)
@@ -312,11 +332,16 @@ class EvalReport(BaseModel):
 
             if predicted is not None and predicted != is_gold:
                 # "how confident in the wrong answer": a self-reported confidence
-                # if present, else distance of the score past the threshold.
+                # if present, else the score's distance past the threshold. The
+                # distance is normalised to [0, 1] (divided by the widest possible
+                # distance) so the two families stay comparable when a log mixes
+                # confidence-bearing and score-only errors -- within one family the
+                # order is unchanged (a monotone rescale).
                 if judgement.confidence is not None:
                     sort_key = judgement.confidence
                 elif judgement.score is not None:
-                    sort_key = abs(judgement.score - threshold)
+                    span = max(threshold, 1.0 - threshold) or 1.0
+                    sort_key = abs(judgement.score - threshold) / span
                 else:
                     sort_key = 0.0
                 errors.append(
@@ -492,8 +517,10 @@ class EvalReport(BaseModel):
             for error in self.top_errors:
                 kind = "match" if error.predicted else "non-match"
                 gold = "match" if error.is_gold else "non-match"
+                left = _md_cell(error.left_id)
+                right = _md_cell(error.right_id)
                 lines.append(
-                    f"| {error.left_id} | {error.right_id} | {kind} | {gold} | "
+                    f"| {left} | {right} | {kind} | {gold} | "
                     f"{_num(error.score)} | {_num(error.confidence)} |"
                 )
         return "\n".join(lines)

--- a/src/langres/core/eval_report.py
+++ b/src/langres/core/eval_report.py
@@ -1,0 +1,683 @@
+"""``EvalReport``: a $0 evaluation tearsheet computed from persisted judgements.
+
+Judging is expensive; *analysing* persisted judgements is free. Once a judge has
+scored a candidate set (paying for LLM calls, embeddings, whatever), every number
+below -- pair precision/recall/F1, the PR and ROC curves, the score distribution,
+the confidence-calibration diagram, the most-confident errors -- is recoverable
+at **zero additional cost** from the logged rows plus the gold pairs. This
+generalises what ``peeters_llm_em_replication.py --report-only`` already does for
+one dataset: recompute the full table from committed JSONL at $0.
+
+Two constructors, both free:
+
+- :meth:`EvalReport.from_log` -- the default mental model. Consumes
+  :meth:`~langres.core.judgement_log.JudgementLog.read` output (plain dicts) and
+  the gold pairs (gold is never in the log). No judge, no candidates, no API.
+- :meth:`EvalReport.from_judgements` -- the in-process path: you already hold the
+  :class:`~langres.core.models.PairwiseJudgement` list, so pass it straight in.
+
+**Layering.** This is a *leaf* module. It imports from ``core.metrics``,
+``core.benchmark``, ``core.models`` and ``core._svg`` -- all import-light -- and
+**nothing in ``reports.py`` / ``module.py`` may import it**, which would reverse
+the dependency arrow and pull SVG/HTML into a bare ``import langres``. A dedicated
+import-budget test locks that this module never drags in a heavy dependency
+(torch/litellm/faiss/sklearn/…): the tearsheet is dependency-free by construction.
+"""
+
+from __future__ import annotations
+
+import html
+import math
+from collections import Counter
+from collections.abc import Mapping, Sequence
+from typing import Any
+
+from pydantic import BaseModel, ConfigDict
+
+from langres.core import _svg
+from langres.core.benchmark import DEFAULT_PAIR_GRID, PairTrack
+from langres.core.metrics import (
+    PairMetrics,
+    ReliabilityBin,
+    average_precision_score,
+    brier_score,
+    classify_pairs,
+    expected_calibration_error,
+    pair_pr_curve,
+    reliability_bins,
+    roc_auc_score,
+)
+from langres.core.models import PairwiseJudgement, predicted_match
+
+# Panel series colors -- explicit (not currentColor) so they render in light AND
+# dark themes. Chosen for contrast against a neutral background either way.
+_COLOR_CURVE = "#4361ee"  # PR / ROC line
+_COLOR_GOLD = "#2a9d8f"  # gold (true-match) distribution
+_COLOR_NONGOLD = "#e76f51"  # non-match distribution
+_COLOR_RELIABILITY = "#4361ee"
+
+
+def _pair_key(left_id: str, right_id: str) -> frozenset[str]:
+    """Order-independent identity of a candidate pair."""
+    return frozenset({left_id, right_id})
+
+
+def _num(value: float | None, digits: int = 3) -> str:
+    """Format a number for display, mapping ``None``/NaN/Inf to ``"n/a"``.
+
+    A blank or ``"n/a"`` cell is the honest render of an undefined metric (a
+    single-class ROC-AUC, calibration with no confidence signal); it must never
+    surface as the literal ``NaN``/``Infinity`` string in the HTML.
+    """
+    if value is None or not math.isfinite(value):
+        return "n/a"
+    return f"{value:.{digits}f}"
+
+
+def _histogram(values: Sequence[float], edges: Sequence[float]) -> list[float]:
+    """Count ``values`` into the half-open bins defined by ascending ``edges``.
+
+    ``len(edges) == B + 1`` yields ``B`` counts. The last bin is closed on the
+    right so a value equal to the final edge (e.g. ``1.0``) is counted, not
+    dropped. Non-finite values are ignored.
+    """
+    n_bins = len(edges) - 1
+    counts = [0.0] * max(n_bins, 0)
+    for value in values:
+        if not math.isfinite(value):
+            continue
+        for b in range(n_bins):
+            lo = edges[b]
+            hi = edges[b + 1]
+            if lo <= value < hi or (b == n_bins - 1 and value == hi):
+                counts[b] += 1.0
+                break
+    return counts
+
+
+def _roc_curve(labels: Sequence[bool], scores: Sequence[float]) -> list[tuple[float, float]]:
+    """ROC-curve points ``(fpr, tpr)`` from ``(0,0)`` to ``(1,1)``.
+
+    Ties are handled by advancing through every equal score before recording a
+    point, so a run of tied scores contributes a single diagonal step rather
+    than a staircase that would misstate the curve. Returns ``[]`` when the
+    labels are single-class (the curve, like AUC, is then undefined).
+    """
+    order = sorted(range(len(scores)), key=lambda i: scores[i], reverse=True)
+    n_pos = sum(1 for label in labels if label)
+    n_neg = len(labels) - n_pos
+    if n_pos == 0 or n_neg == 0:
+        return []
+    points: list[tuple[float, float]] = [(0.0, 0.0)]
+    true_pos = 0
+    false_pos = 0
+    i = 0
+    m = len(order)
+    while i < m:
+        s = scores[order[i]]
+        while i < m and scores[order[i]] == s:
+            if labels[order[i]]:
+                true_pos += 1
+            else:
+                false_pos += 1
+            i += 1
+        points.append((false_pos / n_neg, true_pos / n_pos))
+    return points
+
+
+def _judgement_from_row(row: Mapping[str, Any]) -> PairwiseJudgement:
+    """Rebuild a :class:`PairwiseJudgement` from one ``JudgementLog.read()`` row.
+
+    ``decision`` is read directly (v3 rows carry it; :meth:`JudgementLog.read`
+    backfills it from ``verdict`` for legacy v1/v2 rows), falling back to
+    ``verdict`` only when the ``decision`` key is entirely absent -- so a genuine
+    abstention (``decision`` present and ``None``) stays an abstention and is
+    never coerced to a verdict.
+    """
+    decision = row["decision"] if "decision" in row else row.get("verdict")
+    score = row.get("score")
+    return PairwiseJudgement(
+        left_id=str(row["left_id"]),
+        right_id=str(row["right_id"]),
+        decision=decision,
+        score=None if score is None else float(score),
+        score_type=row.get("score_type", "prob_llm"),
+        confidence=row.get("confidence"),
+        confidence_source=row.get("confidence_source", "none"),
+        decision_step=str(row.get("decision_step", "log")),
+        provenance={},
+    )
+
+
+class EvalError(BaseModel):
+    """One most-confident classification error, for the tearsheet's error table.
+
+    An *error* is a judged pair whose prediction disagrees with gold: a predicted
+    match that is not gold (false positive) or a predicted non-match that is gold
+    (false negative). Abstentions are not errors (no prediction was made). Only
+    *judged* pairs appear -- a gold pair the blocker never surfaced is a false
+    negative in the counts but has no judgement to show here.
+
+    Attributes:
+        left_id: Left entity id.
+        right_id: Right entity id.
+        predicted: The judge's match prediction at the report threshold.
+        is_gold: Whether the pair is a true match.
+        score: The judge's score, if it ranked (else ``None``).
+        confidence: The judge's self-reported confidence, if any (else ``None``).
+    """
+
+    model_config = ConfigDict(frozen=True)
+
+    left_id: str
+    right_id: str
+    predicted: bool
+    is_gold: bool
+    score: float | None
+    confidence: float | None
+
+
+class EvalReport(BaseModel):
+    """A frozen, $0 evaluation tearsheet over a set of judged pairs.
+
+    Every field is derived from the judgements plus the gold pairs -- no judge,
+    no API, no re-run. Build it with :meth:`from_log` (from persisted rows) or
+    :meth:`from_judgements` (in-process), then read :attr:`summary`, call
+    :meth:`to_markdown` / :meth:`to_dict`, or render :meth:`to_html` for a
+    self-contained visual report.
+
+    Attributes:
+        threshold: The match threshold every pair-level number is graded at.
+        n_candidates: Number of judged candidate pairs.
+        n_gold: Number of gold (true-match) pairs.
+        n_ranked: Judgements carrying a usable score (rankers). Deciders that
+            emit only a decision contribute 0 here, so the ROC/PR/histogram
+            panels -- which need a continuous signal -- are empty for a pure
+            binary log.
+        n_abstained: Judgements that neither decided nor scored.
+        tp, fp, fn, tn: Confusion counts at :attr:`threshold`. ``tp``/``fp``/``fn``
+            match :func:`~langres.core.metrics.classify_pairs` exactly (``fn``
+            includes gold pairs the blocker never surfaced); ``tn`` counts judged
+            non-gold pairs the judge explicitly predicted non-match (abstentions
+            are excluded from ``tn`` -- no verdict is not a correct negative).
+        pair: Pair-level precision/recall/F1 at :attr:`threshold` plus the PR
+            curve across :data:`~langres.core.benchmark.DEFAULT_PAIR_GRID`.
+        roc_curve: ``(fpr, tpr)`` points; ``[]`` when the ranking signal is
+            single-class or absent.
+        roc_auc: ROC-AUC of the ranking signal vs gold; ``nan`` when undefined.
+        average_precision: AP of the ranking signal vs gold; ``nan`` when
+            undefined.
+        hist_edges, hist_gold, hist_nongold: Score histogram of the ranking
+            signal split by gold membership (``hist_edges`` has one more entry
+            than each count list).
+        reliability: Per-bin calibration points of ``confidence`` vs the judge's
+            own correctness; empty when no judgement carried a confidence.
+        brier, ece: Calibration scores over the confidence signal; ``None`` when
+            no confidence was present.
+        n_with_confidence: Judged, non-abstained pairs carrying a confidence.
+        confidence_source_counts: Count of judgements per ``confidence_source``.
+        total_cost_usd: Summed logged cost of producing these judgements.
+        top_errors: The most-confident errors, most-confident first.
+    """
+
+    model_config = ConfigDict(frozen=True)
+
+    threshold: float
+    n_candidates: int
+    n_gold: int
+    n_ranked: int
+    n_abstained: int
+    tp: int
+    fp: int
+    fn: int
+    tn: int
+    pair: PairTrack
+    roc_curve: list[tuple[float, float]]
+    roc_auc: float
+    average_precision: float
+    hist_edges: list[float]
+    hist_gold: list[float]
+    hist_nongold: list[float]
+    reliability: list[ReliabilityBin]
+    brier: float | None
+    ece: float | None
+    n_with_confidence: int
+    confidence_source_counts: dict[str, int]
+    total_cost_usd: float
+    top_errors: list[EvalError]
+
+    # ---------------------------------------------------------------- constructors
+    @classmethod
+    def from_judgements(
+        cls,
+        judgements: Sequence[PairwiseJudgement],
+        gold_pairs: set[frozenset[str]],
+        *,
+        threshold: float = 0.5,
+        grid: Sequence[float] = DEFAULT_PAIR_GRID,
+        hist_bins: int = 10,
+        top_n: int = 10,
+        costs: Sequence[float] | None = None,
+    ) -> EvalReport:
+        """Build a report from an in-process judgement list plus gold pairs.
+
+        Args:
+            judgements: The scorer's output (pre-clustering).
+            gold_pairs: True match pairs as order-independent ``frozenset`` pairs.
+            threshold: Match cut every pair-level number is graded at.
+            grid: Threshold grid for the PR curve.
+            hist_bins: Number of score-histogram bins over ``[0, 1]``.
+            top_n: How many most-confident errors to keep.
+            costs: Optional per-judgement cost (aligned with ``judgements``); the
+                sum becomes :attr:`total_cost_usd`. ``None`` -> ``0.0``.
+
+        Returns:
+            A frozen :class:`EvalReport`.
+        """
+        judged = list(judgements)
+        n_candidates = len(judged)
+
+        base = classify_pairs(judged, gold_pairs, threshold)
+        pr_curve: list[PairMetrics] = pair_pr_curve(judged, gold_pairs, grid)
+
+        # tn / abstain: walk once, classifying each judged pair. tp/fp/fn come
+        # from classify_pairs (the tested primitive); tn is the judged non-gold
+        # pairs the judge explicitly said "no" to -- abstentions are neither.
+        tn = 0
+        n_abstained = 0
+        ranked_scores: list[float] = []
+        ranked_labels: list[bool] = []
+        conf_values: list[float] = []
+        conf_outcomes: list[bool] = []
+        errors: list[tuple[float, EvalError]] = []
+        source_counter: Counter[str] = Counter()
+
+        for judgement in judged:
+            source_counter[judgement.confidence_source] += 1
+            is_gold = _pair_key(judgement.left_id, judgement.right_id) in gold_pairs
+            predicted = predicted_match(judgement, threshold)
+
+            if predicted is None:
+                n_abstained += 1
+            elif predicted is False and not is_gold:
+                tn += 1
+
+            if judgement.score is not None:
+                ranked_scores.append(judgement.score)
+                ranked_labels.append(is_gold)
+
+            if judgement.confidence is not None and predicted is not None:
+                conf_values.append(judgement.confidence)
+                conf_outcomes.append(predicted == is_gold)
+
+            if predicted is not None and predicted != is_gold:
+                # "how confident in the wrong answer": a self-reported confidence
+                # if present, else distance of the score past the threshold.
+                if judgement.confidence is not None:
+                    sort_key = judgement.confidence
+                elif judgement.score is not None:
+                    sort_key = abs(judgement.score - threshold)
+                else:
+                    sort_key = 0.0
+                errors.append(
+                    (
+                        sort_key,
+                        EvalError(
+                            left_id=judgement.left_id,
+                            right_id=judgement.right_id,
+                            predicted=predicted,
+                            is_gold=is_gold,
+                            score=judgement.score,
+                            confidence=judgement.confidence,
+                        ),
+                    )
+                )
+
+        roc_auc = _safe_auc(ranked_labels, ranked_scores)
+        avg_precision = _safe_ap(ranked_labels, ranked_scores)
+        roc_curve = _roc_curve(ranked_labels, ranked_scores)
+
+        edges = [i / hist_bins for i in range(hist_bins + 1)]
+        hist_gold = _histogram(
+            [s for s, g in zip(ranked_scores, ranked_labels, strict=True) if g], edges
+        )
+        hist_nongold = _histogram(
+            [s for s, g in zip(ranked_scores, ranked_labels, strict=True) if not g], edges
+        )
+
+        if conf_values:
+            reliability = reliability_bins(conf_values, conf_outcomes)
+            brier: float | None = brier_score(conf_values, conf_outcomes)
+            ece: float | None = expected_calibration_error(conf_values, conf_outcomes)
+        else:
+            reliability = []
+            brier = None
+            ece = None
+
+        errors.sort(key=lambda entry: entry[0], reverse=True)
+        top_errors = [error for _, error in errors[:top_n]]
+
+        return cls(
+            threshold=threshold,
+            n_candidates=n_candidates,
+            n_gold=len(gold_pairs),
+            n_ranked=len(ranked_scores),
+            n_abstained=n_abstained,
+            tp=base.tp,
+            fp=base.fp,
+            fn=base.fn,
+            tn=tn,
+            pair=PairTrack(
+                precision=base.precision,
+                recall=base.recall,
+                f1=base.f1,
+                pr_curve=pr_curve,
+            ),
+            roc_curve=roc_curve,
+            roc_auc=roc_auc,
+            average_precision=avg_precision,
+            hist_edges=edges,
+            hist_gold=hist_gold,
+            hist_nongold=hist_nongold,
+            reliability=reliability,
+            brier=brier,
+            ece=ece,
+            n_with_confidence=len(conf_values),
+            confidence_source_counts=dict(source_counter),
+            total_cost_usd=float(sum(costs)) if costs else 0.0,
+            top_errors=top_errors,
+        )
+
+    @classmethod
+    def from_log(
+        cls,
+        rows: Sequence[Mapping[str, Any]],
+        gold_pairs: set[frozenset[str]],
+        *,
+        threshold: float = 0.5,
+        grid: Sequence[float] = DEFAULT_PAIR_GRID,
+        hist_bins: int = 10,
+        top_n: int = 10,
+    ) -> EvalReport:
+        """Build a report from persisted ``JudgementLog.read()`` rows plus gold.
+
+        The default mental model: judging already happened and was logged; this
+        recomputes the whole tearsheet at $0. Per-row ``cost_usd`` (falling back
+        to ``llm_cost_usd``, the cascade key) is summed into
+        :attr:`total_cost_usd`.
+
+        Args:
+            rows: Rows as produced by
+                :meth:`~langres.core.judgement_log.JudgementLog.read`.
+            gold_pairs: True match pairs (never present in the log).
+            threshold: Match cut every pair-level number is graded at.
+            grid: Threshold grid for the PR curve.
+            hist_bins: Number of score-histogram bins over ``[0, 1]``.
+            top_n: How many most-confident errors to keep.
+
+        Returns:
+            A frozen :class:`EvalReport`.
+        """
+        judgements = [_judgement_from_row(row) for row in rows]
+        costs = [float(row.get("cost_usd") or row.get("llm_cost_usd") or 0.0) for row in rows]
+        return cls.from_judgements(
+            judgements,
+            gold_pairs,
+            threshold=threshold,
+            grid=grid,
+            hist_bins=hist_bins,
+            top_n=top_n,
+            costs=costs,
+        )
+
+    # -------------------------------------------------------------------- summary
+    @property
+    def summary(self) -> str:
+        """A one-line headline of the report's most important numbers."""
+        return (
+            f"{self.n_candidates} pairs @ threshold {self.threshold:g}: "
+            f"P={_num(self.pair.precision)} R={_num(self.pair.recall)} "
+            f"F1={_num(self.pair.f1)} | ROC-AUC={_num(self.roc_auc)} "
+            f"AP={_num(self.average_precision)} | "
+            f"Brier={_num(self.brier)} ECE={_num(self.ece)}"
+        )
+
+    def to_dict(self) -> dict[str, Any]:
+        """The report as a plain dict (``model_dump()``)."""
+        return self.model_dump()
+
+    def to_markdown(self) -> str:
+        """Render the report as a Markdown document."""
+        lines: list[str] = [
+            "# Evaluation report",
+            "",
+            self.summary,
+            "",
+            "## Counts",
+            "",
+            f"- candidates judged: {self.n_candidates}",
+            f"- gold pairs: {self.n_gold}",
+            f"- ranked (with a score): {self.n_ranked}",
+            f"- abstained: {self.n_abstained}",
+            f"- with confidence: {self.n_with_confidence}",
+            f"- total cost: ${self.total_cost_usd:.4f}",
+            "",
+            f"## Confusion @ threshold {self.threshold:g}",
+            "",
+            "| | predicted match | predicted non-match |",
+            "|---|---|---|",
+            f"| **gold match** | {self.tp} (tp) | {self.fn} (fn) |",
+            f"| **gold non-match** | {self.fp} (fp) | {self.tn} (tn) |",
+            "",
+            f"- precision {_num(self.pair.precision)} | "
+            f"recall {_num(self.pair.recall)} | f1 {_num(self.pair.f1)}",
+            f"- ROC-AUC {_num(self.roc_auc)} | average precision {_num(self.average_precision)}",
+        ]
+        if self.reliability:
+            lines += [
+                "",
+                "## Calibration",
+                "",
+                f"- Brier {_num(self.brier)} | ECE {_num(self.ece)} "
+                f"(over {self.n_with_confidence} confidence-bearing judgements)",
+            ]
+        if self.top_errors:
+            lines += [
+                "",
+                "## Most-confident errors",
+                "",
+                "| left | right | predicted | gold | score | confidence |",
+                "|---|---|---|---|---|---|",
+            ]
+            for error in self.top_errors:
+                kind = "match" if error.predicted else "non-match"
+                gold = "match" if error.is_gold else "non-match"
+                lines.append(
+                    f"| {error.left_id} | {error.right_id} | {kind} | {gold} | "
+                    f"{_num(error.score)} | {_num(error.confidence)} |"
+                )
+        return "\n".join(lines)
+
+    # ----------------------------------------------------------------------- html
+    def to_html(self, *, title: str = "Evaluation report") -> str:
+        """Render a single self-contained HTML document (no external assets).
+
+        The whole tearsheet -- styles inline, every chart an inline ``<svg>`` from
+        :mod:`langres.core._svg` -- fits in one string with zero network requests,
+        no CDN, no matplotlib. Themes: neutral ``currentColor`` axes plus a
+        ``prefers-color-scheme`` block, so it reads in light and dark.
+        """
+        panels: list[str] = [self._panel_summary(), self._panel_confusion()]
+        panels.append(self._panel_pr())
+        panels.append(self._panel_roc())
+        panels.append(self._panel_histogram())
+        panels.append(self._panel_reliability())
+        panels.append(self._panel_errors())
+        body = "\n".join(panels)
+        return (
+            "<!doctype html>\n"
+            '<html lang="en">\n<head>\n<meta charset="utf-8">\n'
+            '<meta name="viewport" content="width=device-width, initial-scale=1">\n'
+            f"<title>{html.escape(title)}</title>\n"
+            f"<style>{_CSS}</style>\n</head>\n<body>\n"
+            f"<h1>{html.escape(title)}</h1>\n"
+            f'<p class="summary">{html.escape(self.summary)}</p>\n'
+            f"{body}\n"
+            "</body>\n</html>\n"
+        )
+
+    # ---- panels -----------------------------------------------------------
+    def _panel_summary(self) -> str:
+        rows = [
+            ("candidates judged", str(self.n_candidates)),
+            ("gold pairs", str(self.n_gold)),
+            ("ranked (score)", str(self.n_ranked)),
+            ("abstained", str(self.n_abstained)),
+            ("with confidence", str(self.n_with_confidence)),
+            ("total cost", f"${self.total_cost_usd:.4f}"),
+        ]
+        cells = "".join(
+            f"<tr><th>{html.escape(k)}</th><td>{html.escape(v)}</td></tr>" for k, v in rows
+        )
+        return f'<section><h2>Counts</h2><table class="kv">{cells}</table></section>'
+
+    def _panel_confusion(self) -> str:
+        return (
+            f"<section><h2>Confusion @ threshold {html.escape(f'{self.threshold:g}')}</h2>"
+            '<table class="confusion">'
+            "<tr><th></th><th>predicted match</th><th>predicted non-match</th></tr>"
+            f'<tr><th>gold match</th><td class="tp">{self.tp}</td>'
+            f'<td class="fn">{self.fn}</td></tr>'
+            f'<tr><th>gold non-match</th><td class="fp">{self.fp}</td>'
+            f'<td class="tn">{self.tn}</td></tr>'
+            "</table>"
+            f"<p>precision <b>{_num(self.pair.precision)}</b> &middot; "
+            f"recall <b>{_num(self.pair.recall)}</b> &middot; "
+            f"F1 <b>{_num(self.pair.f1)}</b></p></section>"
+        )
+
+    def _panel_pr(self) -> str:
+        points = [(m.recall, m.precision) for m in (self.pair.pr_curve or [])]
+        svg = _svg.line_chart(
+            [_svg.Series(points=points, stroke=_COLOR_CURVE, label="")],
+            x_domain=(0.0, 1.0),
+            y_domain=(0.0, 1.0),
+            x_label="recall",
+            y_label="precision",
+            annotations=[f"AP = {_num(self.average_precision)}"],
+        )
+        return f"<section><h2>Precision–Recall</h2>{svg}</section>"
+
+    def _panel_roc(self) -> str:
+        svg = _svg.line_chart(
+            [_svg.Series(points=list(self.roc_curve), stroke=_COLOR_CURVE, label="")],
+            x_domain=(0.0, 1.0),
+            y_domain=(0.0, 1.0),
+            x_label="false positive rate",
+            y_label="true positive rate",
+            diagonal=True,
+            annotations=[f"AUC = {_num(self.roc_auc)}"],
+        )
+        note = (
+            ""
+            if self.roc_curve
+            else '<p class="empty">No ranking signal (a pure decider log has no '
+            "continuous score to trace a ROC curve).</p>"
+        )
+        return f"<section><h2>ROC</h2>{svg}{note}</section>"
+
+    def _panel_histogram(self) -> str:
+        svg = _svg.bar_chart(
+            self.hist_edges,
+            [
+                ("gold", _COLOR_GOLD, self.hist_gold),
+                ("non-gold", _COLOR_NONGOLD, self.hist_nongold),
+            ],
+            x_label="score",
+            y_label="count",
+        )
+        return f"<section><h2>Score distribution</h2>{svg}</section>"
+
+    def _panel_reliability(self) -> str:
+        if not self.reliability:
+            return (
+                "<section><h2>Calibration</h2>"
+                '<p class="empty">No confidence signal — run '
+                'LLMJudge(confidence="logprob") to populate this panel.</p></section>'
+            )
+        points = [(b.mean_confidence, b.observed_frequency) for b in self.reliability]
+        svg = _svg.line_chart(
+            [_svg.Series(points=points, stroke=_COLOR_RELIABILITY, label="", kind="markers")],
+            x_domain=(0.0, 1.0),
+            y_domain=(0.0, 1.0),
+            x_label="mean confidence",
+            y_label="observed accuracy",
+            diagonal=True,
+            annotations=[f"Brier = {_num(self.brier)}", f"ECE = {_num(self.ece)}"],
+        )
+        return (
+            f"<section><h2>Calibration</h2>{svg}"
+            f"<p>over {self.n_with_confidence} confidence-bearing judgements</p></section>"
+        )
+
+    def _panel_errors(self) -> str:
+        if not self.top_errors:
+            return "<section><h2>Most-confident errors</h2><p>None.</p></section>"
+        head = (
+            "<tr><th>left</th><th>right</th><th>predicted</th>"
+            "<th>gold</th><th>score</th><th>confidence</th></tr>"
+        )
+        body_rows = []
+        for error in self.top_errors:
+            kind = "match" if error.predicted else "non-match"
+            gold = "match" if error.is_gold else "non-match"
+            body_rows.append(
+                f"<tr><td>{html.escape(error.left_id)}</td>"
+                f"<td>{html.escape(error.right_id)}</td>"
+                f"<td>{kind}</td><td>{gold}</td>"
+                f"<td>{_num(error.score)}</td><td>{_num(error.confidence)}</td></tr>"
+            )
+        return (
+            "<section><h2>Most-confident errors</h2>"
+            f'<table class="errors">{head}{"".join(body_rows)}</table></section>'
+        )
+
+
+def _safe_auc(labels: list[bool], scores: list[float]) -> float:
+    """ROC-AUC that returns ``nan`` (not a raise) on an empty/degenerate input."""
+    if not scores:
+        return float("nan")
+    return roc_auc_score(labels, scores)
+
+
+def _safe_ap(labels: list[bool], scores: list[float]) -> float:
+    """Average precision that returns ``nan`` (not a raise) on empty input."""
+    if not scores:
+        return float("nan")
+    return average_precision_score(labels, scores)
+
+
+# Inline stylesheet: neutral, theme-aware, no external fonts or assets.
+_CSS = """
+:root { color-scheme: light dark; --fg: #1a1a1a; --bg: #ffffff; --muted: #666;
+  --line: #ddd; --tp: #2a9d8f; --fp: #e76f51; --fn: #e9c46a; --tn: #8ecae6; }
+@media (prefers-color-scheme: dark) {
+  :root { --fg: #e6e6e6; --bg: #16181d; --muted: #9aa; --line: #333; } }
+body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif;
+  color: var(--fg); background: var(--bg); margin: 0 auto; max-width: 820px;
+  padding: 24px; line-height: 1.5; }
+h1 { font-size: 1.5rem; margin: 0 0 4px; }
+h2 { font-size: 1.05rem; margin: 0 0 8px; border-bottom: 1px solid var(--line);
+  padding-bottom: 4px; }
+section { margin: 24px 0; }
+.summary { color: var(--muted); font-variant-numeric: tabular-nums; margin: 0 0 8px; }
+.empty { color: var(--muted); font-style: italic; }
+table { border-collapse: collapse; font-variant-numeric: tabular-nums; }
+th, td { padding: 4px 10px; text-align: left; border: 1px solid var(--line); }
+table.kv th { color: var(--muted); font-weight: 500; }
+table.confusion td { text-align: right; font-weight: 600; }
+table.confusion td.tp { color: var(--tp); } table.confusion td.fp { color: var(--fp); }
+table.confusion td.fn { color: var(--fn); } table.confusion td.tn { color: var(--tn); }
+table.errors { width: 100%; font-size: 0.9rem; }
+svg { display: block; margin: 4px 0; }
+""".strip()

--- a/src/langres/core/reports.py
+++ b/src/langres/core/reports.py
@@ -802,6 +802,11 @@ class BlockerEvaluationReport(BaseModel):
     # for a clean `pip install langres`. Fix = add a real [viz] extra
     # (matplotlib + seaborn) or drop these methods; tracked separately, its own
     # blast radius. Do not "fix" by changing the logic here.
+    #
+    # The supported, dependency-free visualization path is
+    # `langres.core.eval_report.EvalReport.to_html()`: it renders a full eval
+    # tearsheet as one self-contained HTML file with inline SVG (no matplotlib,
+    # no external assets). Prefer it over these matplotlib stubs.
     def plot_score_distribution(self, ax=None, **kwargs):  # type: ignore[no-untyped-def]
         """Plot score distribution (delegates to plotting module).
 

--- a/src/langres/eval.py
+++ b/src/langres/eval.py
@@ -33,6 +33,7 @@ if TYPE_CHECKING:
         evaluate,
         gold_pairs_from_clusters,
     )
+    from langres.core.eval_report import EvalReport
     from langres.core.metrics import (
         average_precision_score,
         calculate_bcubed_metrics,
@@ -58,6 +59,7 @@ __all__ = [
     "classify_pairs",
     "DEFAULT_PAIR_GRID",
     "evaluate",
+    "EvalReport",
     "ExternalBenchmarkError",
     "generalized_merge_distance",
     "get_benchmark",
@@ -74,6 +76,7 @@ __all__ = [
 #: real function defined below, not a re-export.
 _LAZY: dict[str, str] = {
     "evaluate": "langres.core.benchmark",
+    "EvalReport": "langres.core.eval_report",
     "DEFAULT_PAIR_GRID": "langres.core.benchmark",
     "gold_pairs_from_clusters": "langres.core.benchmark",
     "list_benchmarks": "langres.data.registry",

--- a/src/langres/testing.py
+++ b/src/langres/testing.py
@@ -95,6 +95,10 @@ class ScriptedJudge(Module[SchemaT]):
         provenance: dict[str, Any] | None = None,
         default_score: float = 0.5,
         abstain: Callable[[ERCandidate[SchemaT]], bool] | None = None,
+        confidence: dict[frozenset[str], float]
+        | Callable[[ERCandidate[SchemaT]], float | None]
+        | None = None,
+        confidence_source: str = "none",
     ) -> None:
         """Build a scripted judge.
 
@@ -122,6 +126,17 @@ class ScriptedJudge(Module[SchemaT]):
                 paths of downstream code (``predicted_match``, ``link``'s
                 ``JudgeAbstainedError``, the review flywheel) are exercisable
                 with no network. Evaluated before ``scores``.
+            confidence: Optional per-pair confidence (credence in [0, 1]),
+                mirroring ``scores`` -- a ``dict`` keyed by the unordered pair or
+                a callable returning a ``float | None``. Lets the double model a
+                logprob judge offline, so the calibration panel of an
+                :class:`~langres.core.eval_report.EvalReport` has a real signal to
+                plot. A callable/dict returning ``None`` for a pair leaves that
+                judgement's ``confidence`` unset. ``None`` (default): no
+                confidence on any judgement.
+            confidence_source: ``PairwiseJudgement.confidence_source`` stamped on
+                a judgement that gets a confidence (e.g. ``"logprob"``). Ignored
+                when ``confidence`` is ``None`` or yields ``None`` for the pair.
         """
         self.scores = scores
         self.score_type = score_type
@@ -130,7 +145,17 @@ class ScriptedJudge(Module[SchemaT]):
         self.provenance: dict[str, Any] = dict(provenance) if provenance is not None else {}
         self.default_score = default_score
         self.abstain = abstain
+        self.confidence = confidence
+        self.confidence_source = confidence_source
         self.seen: list[frozenset[str]] = []
+
+    def _confidence_for(self, candidate: ERCandidate[SchemaT], key: frozenset[str]) -> float | None:
+        """Resolve the scripted confidence for one candidate, or ``None``."""
+        if self.confidence is None:
+            return None
+        if isinstance(self.confidence, dict):
+            return self.confidence.get(key)
+        return self.confidence(candidate)
 
     def forward(self, candidates: Iterator[ERCandidate[SchemaT]]) -> Iterator[PairwiseJudgement]:
         """Yield one scripted :class:`PairwiseJudgement` per candidate, in order.
@@ -158,11 +183,14 @@ class ScriptedJudge(Module[SchemaT]):
                 score = self.scores.get(key, self.default_score)
             else:
                 score = self.scores(candidate)
+            conf = self._confidence_for(candidate, key)
             yield PairwiseJudgement(
                 left_id=candidate.left.id,  # type: ignore[attr-defined]
                 right_id=candidate.right.id,  # type: ignore[attr-defined]
                 score=score,
                 score_type=self.score_type,  # type: ignore[arg-type]
+                confidence=conf,
+                confidence_source=(self.confidence_source if conf is not None else "none"),  # type: ignore[arg-type]
                 decision_step=self.decision_step,
                 reasoning=self.reasoning,
                 provenance=dict(self.provenance),

--- a/tests/core/test_eval_report.py
+++ b/tests/core/test_eval_report.py
@@ -1,0 +1,290 @@
+"""Tests for langres.core.eval_report (the $0 EvalReport tearsheet).
+
+Everything here is zero-spend and dependency-light: hand-built judgements or
+plain log-row dicts, no judge, no model, no network. The rendering tests assert
+by STRUCTURE (svg/section counts, escaping, absence of NaN), never byte equality.
+"""
+
+from __future__ import annotations
+
+import math
+from typing import Any
+
+import pytest
+
+from langres.core.eval_report import EvalError, EvalReport, _histogram, _roc_curve
+from langres.core.models import PairwiseJudgement
+
+
+def _j(
+    left: str,
+    right: str,
+    *,
+    score: float | None = None,
+    decision: bool | None = None,
+    confidence: float | None = None,
+    confidence_source: str = "none",
+) -> PairwiseJudgement:
+    return PairwiseJudgement(
+        left_id=left,
+        right_id=right,
+        score=score,
+        decision=decision,
+        score_type="prob_llm",
+        confidence=confidence,
+        confidence_source=confidence_source,  # type: ignore[arg-type]
+        decision_step="test",
+        provenance={},
+    )
+
+
+_GOLD = {frozenset({"a", "b"}), frozenset({"c", "d"})}
+
+
+# --------------------------------------------------------------------------- #
+# Pure helpers                                                                #
+# --------------------------------------------------------------------------- #
+
+
+def test_histogram_counts_and_closed_right_edge() -> None:
+    edges = [0.0, 0.5, 1.0]
+    # 1.0 must land in the LAST bin (right edge is closed), not be dropped.
+    assert _histogram([0.1, 0.4, 0.6, 1.0], edges) == [2.0, 2.0]
+
+
+def test_histogram_ignores_non_finite() -> None:
+    assert _histogram([0.2, float("nan"), float("inf")], [0.0, 0.5, 1.0]) == [1.0, 0.0]
+
+
+def test_roc_curve_runs_corner_to_corner() -> None:
+    points = _roc_curve([False, False, True, True], [0.1, 0.2, 0.8, 0.9])
+    assert points[0] == (0.0, 0.0)
+    assert points[-1] == (1.0, 1.0)
+
+
+def test_roc_curve_single_class_is_empty() -> None:
+    assert _roc_curve([True, True], [0.1, 0.9]) == []
+
+
+# --------------------------------------------------------------------------- #
+# from_judgements — the arithmetic                                            #
+# --------------------------------------------------------------------------- #
+
+
+def test_confusion_matrix_at_threshold() -> None:
+    """ab=TP (gold, high), ef=FP (non-gold, high), cd=FN (gold, low),
+    gh=TN (non-gold, low)."""
+    judgements = [
+        _j("a", "b", score=0.9),
+        _j("c", "d", score=0.2),
+        _j("e", "f", score=0.8),
+        _j("g", "h", score=0.1),
+    ]
+    report = EvalReport.from_judgements(judgements, _GOLD, threshold=0.5)
+    assert (report.tp, report.fp, report.fn, report.tn) == (1, 1, 1, 1)
+    assert report.n_candidates == 4
+    assert report.n_ranked == 4
+    assert report.n_gold == 2
+
+
+def test_roc_auc_and_average_precision_match_the_primitives() -> None:
+    judgements = [
+        _j("a", "b", score=0.9),
+        _j("c", "d", score=0.2),
+        _j("e", "f", score=0.8),
+        _j("g", "h", score=0.1),
+    ]
+    report = EvalReport.from_judgements(judgements, _GOLD, threshold=0.5)
+    # gold={ab,cd}: scores [0.9,0.2] positive, [0.8,0.1] negative -> AUC 0.75.
+    assert report.roc_auc == pytest.approx(0.75)
+    assert 0.0 <= report.average_precision <= 1.0
+    assert report.roc_curve[0] == (0.0, 0.0)
+
+
+def test_abstention_counts_and_is_excluded_from_tn() -> None:
+    """An abstaining judge (no decision, no score) on a non-gold pair is NOT a
+    correct negative -- it made no prediction. It counts in n_abstained and is
+    absent from tn and from the error list."""
+    judgements = [
+        _j("a", "b", score=0.9),  # TP
+        _j("g", "h"),  # abstain on a non-gold pair
+    ]
+    report = EvalReport.from_judgements(judgements, _GOLD, threshold=0.5)
+    assert report.n_abstained == 1
+    assert report.tn == 0  # the abstention is NOT counted as a correct negative
+    assert all(not (e.left_id == "g" and e.right_id == "h") for e in report.top_errors)
+
+
+def test_decider_only_log_has_no_ranking_panels_and_no_nan_in_html() -> None:
+    """A pure decider (decision set, score None) has no continuous signal: ROC/AP
+    are nan, the ROC curve is empty, yet to_html() renders cleanly with NO literal
+    NaN/Infinity (the silent 'empty chart photographs fine' failure mode)."""
+    judgements = [
+        _j("a", "b", decision=True),
+        _j("c", "d", decision=False),
+        _j("e", "f", decision=True),
+    ]
+    report = EvalReport.from_judgements(judgements, _GOLD, threshold=0.5)
+    assert report.n_ranked == 0
+    assert report.roc_curve == []
+    assert math.isnan(report.roc_auc)
+    assert math.isnan(report.average_precision)
+    out = report.to_html()
+    assert "NaN" not in out and "Infinity" not in out
+    assert "n/a" in out  # the undefined AUC renders as n/a, not a broken number
+
+
+def test_confidence_drives_calibration_panel() -> None:
+    """Judgements carrying a confidence populate reliability/Brier/ECE; the
+    outcome graded is whether the judge's OWN prediction was correct."""
+    judgements = [
+        _j("a", "b", decision=True, confidence=0.9, confidence_source="logprob"),  # correct
+        _j("c", "d", decision=False, confidence=0.6, confidence_source="logprob"),  # wrong (gold)
+        _j(
+            "e", "f", decision=True, confidence=0.55, confidence_source="logprob"
+        ),  # wrong (non-gold)
+    ]
+    report = EvalReport.from_judgements(judgements, _GOLD, threshold=0.5)
+    assert report.n_with_confidence == 3
+    assert report.brier is not None and 0.0 <= report.brier <= 1.0
+    assert report.ece is not None
+    assert len(report.reliability) >= 1
+    assert report.confidence_source_counts["logprob"] == 3
+
+
+def test_no_confidence_leaves_calibration_none() -> None:
+    report = EvalReport.from_judgements([_j("a", "b", score=0.9)], _GOLD, threshold=0.5)
+    assert report.brier is None
+    assert report.ece is None
+    assert report.reliability == []
+    assert report.n_with_confidence == 0
+
+
+def test_top_errors_are_ranked_most_confident_first() -> None:
+    """A blatant false positive (high score, non-gold) outranks a marginal one."""
+    judgements = [
+        _j("a", "b", score=0.99),  # non-gold, very confident FP
+        _j("c", "d", score=0.55),  # non-gold, marginal FP
+    ]
+    gold: set[frozenset[str]] = set()  # nothing is gold -> both are FPs
+    report = EvalReport.from_judgements(judgements, gold, threshold=0.5, top_n=10)
+    assert [(e.left_id, e.right_id) for e in report.top_errors] == [("a", "b"), ("c", "d")]
+    assert report.top_errors[0].predicted is True
+    assert report.top_errors[0].is_gold is False
+
+
+def test_single_class_gold_gives_nan_auc_not_a_raise() -> None:
+    """Every candidate is gold -> AUC undefined. We return nan, never raise (so an
+    all-positive slice degrades to a blank cell, not a crashed report)."""
+    judgements = [_j("a", "b", score=0.9), _j("c", "d", score=0.8)]
+    report = EvalReport.from_judgements(judgements, _GOLD, threshold=0.5)
+    assert math.isnan(report.roc_auc)
+    # AP with no negatives is defined as 1.0 (any ordering is trivially perfect).
+    assert report.average_precision == pytest.approx(1.0)
+
+
+# --------------------------------------------------------------------------- #
+# from_log — the persisted-rows path                                          #
+# --------------------------------------------------------------------------- #
+
+
+def _row(left: str, right: str, **overrides: Any) -> dict[str, Any]:
+    row: dict[str, Any] = {
+        "v": 3,
+        "left_id": left,
+        "right_id": right,
+        "score": None,
+        "verdict": None,
+        "decision": None,
+        "cost_usd": 0.0,
+    }
+    row.update(overrides)
+    return row
+
+
+def test_from_log_reconstructs_and_sums_cost() -> None:
+    rows = [
+        _row("a", "b", score=0.9, decision=True, verdict=True, cost_usd=0.001),
+        _row("e", "f", score=0.8, decision=True, verdict=True, cost_usd=0.002),
+    ]
+    report = EvalReport.from_log(rows, _GOLD, threshold=0.5)
+    assert report.n_candidates == 2
+    assert report.total_cost_usd == pytest.approx(0.003)
+
+
+def test_from_log_falls_back_to_llm_cost_usd_key() -> None:
+    """Cascade rows persist cost under llm_cost_usd, not cost_usd -- sum must
+    still see them (the cost regression this contract also fixed)."""
+    rows = [_row("a", "b", score=0.9, decision=True, verdict=True, cost_usd=0.0, llm_cost_usd=0.05)]
+    report = EvalReport.from_log(rows, _GOLD, threshold=0.5)
+    assert report.total_cost_usd == pytest.approx(0.05)
+
+
+def test_from_log_abstention_row_stays_abstention() -> None:
+    """A v3 abstention row (decision present and None) must NOT be coerced to a
+    verdict -- it stays an abstention in the report's accounting."""
+    rows = [_row("g", "h", score=None, decision=None, verdict=None)]
+    report = EvalReport.from_log(rows, _GOLD, threshold=0.5)
+    assert report.n_abstained == 1
+
+
+# --------------------------------------------------------------------------- #
+# Rendering — structure, escaping, no NaN                                     #
+# --------------------------------------------------------------------------- #
+
+
+def _full_report() -> EvalReport:
+    judgements = [
+        _j("a", "b", score=0.9, confidence=0.8, confidence_source="logprob"),
+        _j("c", "d", score=0.2, confidence=0.4, confidence_source="logprob"),
+        _j("e", "f", score=0.8, confidence=0.7, confidence_source="logprob"),
+        _j("g", "h", score=0.1, confidence=0.9, confidence_source="logprob"),
+    ]
+    return EvalReport.from_judgements(judgements, _GOLD, threshold=0.5)
+
+
+def test_to_html_is_self_contained_and_has_a_chart_per_panel() -> None:
+    out = _full_report().to_html()
+    assert out.startswith("<!doctype html>")
+    # PR, ROC, histogram, reliability = four inline charts, all confidence present.
+    assert out.count("<svg") == 4
+    # self-contained: no external asset references.
+    assert "http://" not in out.replace('xmlns="http://www.w3.org/2000/svg"', "")
+    assert "https://" not in out
+    assert "NaN" not in out and "Infinity" not in out
+
+
+def test_to_html_escapes_ids_in_the_error_table() -> None:
+    judgements = [_j("x&<script>", "b", score=0.99)]  # a hostile id, non-gold -> FP
+    report = EvalReport.from_judgements(judgements, set(), threshold=0.5)
+    out = report.to_html()
+    assert "x&amp;&lt;script&gt;" in out
+    assert "<script>" not in out
+
+
+def test_to_html_reliability_absent_when_no_confidence() -> None:
+    report = EvalReport.from_judgements([_j("a", "b", score=0.9)], _GOLD, threshold=0.5)
+    out = report.to_html()
+    assert "No confidence signal" in out
+    # PR, ROC, histogram render; reliability is a note, so three charts.
+    assert out.count("<svg") == 3
+
+
+def test_to_markdown_and_to_dict_and_summary_smoke() -> None:
+    report = _full_report()
+    md = report.to_markdown()
+    assert md.startswith("# Evaluation report")
+    assert "Confusion" in md
+    assert "NaN" not in md
+    d = report.to_dict()
+    assert d["threshold"] == 0.5
+    assert d["n_candidates"] == 4
+    assert isinstance(report.summary, str) and "ROC-AUC" in report.summary
+
+
+def test_eval_error_is_frozen() -> None:
+    err = EvalError(
+        left_id="a", right_id="b", predicted=True, is_gold=False, score=0.9, confidence=None
+    )
+    with pytest.raises(Exception):  # noqa: B017 - pydantic frozen -> ValidationError
+        err.left_id = "z"  # type: ignore[misc]

--- a/tests/core/test_eval_report.py
+++ b/tests/core/test_eval_report.py
@@ -212,9 +212,14 @@ def test_from_log_reconstructs_and_sums_cost() -> None:
     assert report.total_cost_usd == pytest.approx(0.003)
 
 
-def test_from_log_falls_back_to_llm_cost_usd_key() -> None:
-    """Cascade rows persist cost under llm_cost_usd, not cost_usd -- sum must
-    still see them (the cost regression this contract also fixed)."""
+def test_from_log_falls_back_to_legacy_llm_cost_usd_key() -> None:
+    """`from_log` accepts arbitrary row dicts, not only current `read()` output.
+
+    Current `JudgementLog.append()` normalises cost to a single top-level
+    `cost_usd`, so `read()` rows never carry a top-level `llm_cost_usd`. But a
+    hand-built row (or a pre-normalisation log) may put cost under the legacy
+    `llm_cost_usd` key; the sum must still see it, mirroring `_COST_KEYS`.
+    """
     rows = [_row("a", "b", score=0.9, decision=True, verdict=True, cost_usd=0.0, llm_cost_usd=0.05)]
     report = EvalReport.from_log(rows, _GOLD, threshold=0.5)
     assert report.total_cost_usd == pytest.approx(0.05)
@@ -348,6 +353,13 @@ def test_duplicate_pair_rows_are_collapsed_last_wins_and_not_double_counted() ->
     # (a,b) is a judged gold that IS predicted, so no judged pair falls into fn:
     # the four cells + abstains then account for exactly the judged pairs.
     assert report.tp + report.fp + report.tn + report.n_abstained == report.n_candidates
+
+
+def test_misaligned_costs_raises_rather_than_mis_summing() -> None:
+    """A costs list of the wrong length is a caller bug, not a silent wrong total."""
+    judgements = [_j("a", "b", score=0.9), _j("c", "d", score=0.8)]
+    with pytest.raises(ValueError, match="costs must align"):
+        EvalReport.from_judgements(judgements, _GOLD, threshold=0.5, costs=[0.01])
 
 
 def test_to_markdown_escapes_a_pipe_in_a_record_id() -> None:

--- a/tests/core/test_eval_report.py
+++ b/tests/core/test_eval_report.py
@@ -288,3 +288,75 @@ def test_eval_error_is_frozen() -> None:
     )
     with pytest.raises(Exception):  # noqa: B017 - pydantic frozen -> ValidationError
         err.left_id = "z"  # type: ignore[misc]
+
+
+# --------------------------------------------------------------------------- #
+# Edge cases and robustness (the core contract tier)                          #
+# --------------------------------------------------------------------------- #
+
+
+def test_empty_judgements_render_cleanly() -> None:
+    """No judgements -> every metric is undefined, but nothing raises or leaks NaN."""
+    report = EvalReport.from_judgements([], _GOLD, threshold=0.5)
+
+    assert report.n_candidates == 0
+    assert report.tp == report.fp == report.tn == 0
+    # fn is |gold - predicted|: with nothing predicted, every gold pair is missed.
+    assert report.fn == report.n_gold == 2
+    assert math.isnan(report.roc_auc)
+    assert report.roc_curve == []
+    assert report.brier is None and report.ece is None
+    out = report.to_html()
+    assert "NaN" not in out and "Infinity" not in out
+
+
+def test_all_scores_equal_gives_chance_auc() -> None:
+    """A ranker that scores every pair identically is pure chance: ROC-AUC 0.5."""
+    judgements = [
+        _j("a", "b", score=0.5),  # gold
+        _j("c", "d", score=0.5),  # gold
+        _j("e", "f", score=0.5),  # non-gold
+        _j("g", "h", score=0.5),  # non-gold
+    ]
+    report = EvalReport.from_judgements(judgements, _GOLD, threshold=0.5)
+
+    assert report.roc_auc == pytest.approx(0.5)
+    assert report.roc_curve[0] == (0.0, 0.0)
+    assert report.roc_curve[-1] == (1.0, 1.0)
+
+
+def test_duplicate_pair_rows_are_collapsed_last_wins_and_not_double_counted() -> None:
+    """A log with two rows for one pair counts it once; the later row wins.
+
+    The reviewer's scenario: without dedup a non-gold pair logged both above and
+    below threshold is simultaneously an FP (set-based ``classify_pairs``) and a TN
+    (the per-judgement walk) -- and it inflates ``n_ranked``/histogram/ROC. Dedup
+    (last write wins, as a re-run supersedes) makes the low row the single verdict.
+    """
+    judgements = [
+        _j("e", "f", score=0.9),  # non-gold, high (row 1) -> would be an FP
+        _j("e", "f", score=0.3),  # SAME non-gold pair, re-judged low -> supersedes -> TN
+        _j("a", "b", score=0.9),  # gold, high -> TP
+    ]
+    report = EvalReport.from_judgements(judgements, _GOLD, threshold=0.5)
+
+    assert report.n_candidates == 2  # (e,f) collapsed, plus (a,b)
+    assert report.n_ranked == 2  # not 3 -- the duplicate score is not double-ranked
+    assert report.fp == 0  # last (e,f) row (0.3) wins, so no false positive
+    assert report.tn == 1  # (e,f) counted once as a true negative, not also an FP
+    assert report.tp == 1  # (a,b)
+    # (a,b) is a judged gold that IS predicted, so no judged pair falls into fn:
+    # the four cells + abstains then account for exactly the judged pairs.
+    assert report.tp + report.fp + report.tn + report.n_abstained == report.n_candidates
+
+
+def test_to_markdown_escapes_a_pipe_in_a_record_id() -> None:
+    """A ``|`` in an id must not break the error-table's column alignment."""
+    judgements = [_j("a|b", "c", score=0.99)]  # hostile id, non-gold -> FP
+    report = EvalReport.from_judgements(judgements, set(), threshold=0.5)
+
+    md = report.to_markdown()
+    assert r"a\|b" in md
+    # after removing the escaped pipe, the row has exactly the 6-column borders.
+    error_row = next(line for line in md.splitlines() if r"a\|b" in line)
+    assert error_row.replace(r"\|", "").count("|") == 7

--- a/tests/core/test_svg.py
+++ b/tests/core/test_svg.py
@@ -1,0 +1,189 @@
+"""Tests for the pure-stdlib inline-SVG chart primitives (``langres.core._svg``).
+
+Tested by STRUCTURE (element counts, parsed attributes, escaped substrings),
+never by full-string equality, so cosmetic tweaks don't churn the suite.
+"""
+
+import re
+
+from langres.core._svg import Series, _scale, bar_chart, line_chart
+
+
+def _polyline_points(svg: str) -> list[tuple[float, float]]:
+    """Parse the first ``<polyline points="...">`` into (x, y) float pairs."""
+    match = re.search(r'<polyline[^>]*points="([^"]*)"', svg)
+    assert match is not None, "expected a <polyline> in the output"
+    return [(float(x), float(y)) for x, y in (p.split(",") for p in match.group(1).split())]
+
+
+class TestScale:
+    def test_endpoints(self) -> None:
+        assert _scale(0.0, 0.0, 1.0, 10.0, 20.0) == 10.0
+        assert _scale(1.0, 0.0, 1.0, 10.0, 20.0) == 20.0
+
+    def test_midpoint(self) -> None:
+        assert _scale(0.5, 0.0, 1.0, 0.0, 100.0) == 50.0
+
+    def test_degenerate_range_returns_range_midpoint_no_zerodiv(self) -> None:
+        # dmax == dmin must not raise ZeroDivisionError; returns range midpoint.
+        assert _scale(5.0, 3.0, 3.0, 10.0, 20.0) == 15.0
+
+    def test_y_flip_via_scale(self) -> None:
+        # With the bottom->top pixel range, larger data-y maps to smaller pixel-y.
+        y_top = _scale(1.0, 0.0, 1.0, 232.0, 12.0)
+        y_bottom = _scale(0.0, 0.0, 1.0, 232.0, 12.0)
+        assert y_top < y_bottom
+
+
+class TestLineChartHappyPath:
+    def test_returns_a_single_svg(self) -> None:
+        out = line_chart(
+            [Series([(0.0, 0.0), (1.0, 1.0)], "#f00", "curve")],
+            x_domain=(0.0, 1.0),
+            y_domain=(0.0, 1.0),
+        )
+        assert out.count("<svg") == 1
+        assert out.rstrip().endswith("</svg>")
+        assert 'role="img"' in out
+        assert 'viewBox="0 0 340 260"' in out
+        assert "max-width:100%" in out
+
+    def test_two_point_line_yields_one_polyline_with_two_points(self) -> None:
+        out = line_chart(
+            [Series([(0.0, 0.0), (1.0, 1.0)], "#f00", "curve")],
+            x_domain=(0.0, 1.0),
+            y_domain=(0.0, 1.0),
+        )
+        assert out.count("<polyline") == 1
+        assert len(_polyline_points(out)) == 2
+
+    def test_markers_kind_yields_one_circle_per_point_and_no_polyline(self) -> None:
+        out = line_chart(
+            [Series([(0.0, 0.0), (0.5, 0.5), (1.0, 1.0)], "#00f", "rel", "markers")],
+            x_domain=(0.0, 1.0),
+            y_domain=(0.0, 1.0),
+        )
+        assert out.count("<circle") == 3
+        assert "<polyline" not in out
+
+
+class TestYFlip:
+    def test_data_max_maps_above_data_min(self) -> None:
+        # Two points at the same x, one at y=0 (data min), one at y=1 (data max).
+        out = line_chart(
+            [Series([(0.0, 0.0), (0.0, 1.0)], "#f00", "c")],
+            x_domain=(0.0, 1.0),
+            y_domain=(0.0, 1.0),
+        )
+        pts = _polyline_points(out)
+        (_, y_at_data_min), (_, y_at_data_max) = pts
+        # SVG y grows downward: data y=1 (max) sits at the TOP -> smaller pixel-y.
+        assert y_at_data_max < y_at_data_min
+
+
+class TestNaNGuard:
+    def test_nonfinite_points_are_dropped_and_no_nan_or_infinity_leaks(self) -> None:
+        out = line_chart(
+            [
+                Series(
+                    [
+                        (0.0, 0.0),
+                        (0.5, float("nan")),
+                        (float("inf"), 0.2),
+                        (1.0, 1.0),
+                    ],
+                    "#f00",
+                    "c",
+                )
+            ],
+            x_domain=(0.0, 1.0),
+            y_domain=(0.0, 1.0),
+        )
+        assert "NaN" not in out and "Infinity" not in out
+        # Only the two finite points survive.
+        assert len(_polyline_points(out)) == 2
+
+    def test_all_nonfinite_line_emits_no_polyline_but_svg_still_returns(self) -> None:
+        out = line_chart(
+            [Series([(float("nan"), 0.0), (float("inf"), 1.0)], "#f00", "c")],
+            x_domain=(0.0, 1.0),
+            y_domain=(0.0, 1.0),
+        )
+        assert "<polyline" not in out
+        assert out.count("<svg") == 1
+        assert "NaN" not in out and "Infinity" not in out
+
+    def test_single_finite_point_line_emits_no_polyline(self) -> None:
+        # A "line" needs >= 2 finite points.
+        out = line_chart(
+            [Series([(0.5, 0.5), (float("nan"), 0.2)], "#f00", "c")],
+            x_domain=(0.0, 1.0),
+            y_domain=(0.0, 1.0),
+        )
+        assert "<polyline" not in out
+        assert out.count("<svg") == 1
+
+
+class TestEscaping:
+    def test_axis_label_is_html_escaped_and_does_not_leak_a_tag(self) -> None:
+        out = line_chart(
+            [Series([(0.0, 0.0), (1.0, 1.0)], "#f00", "c")],
+            x_domain=(0.0, 1.0),
+            y_domain=(0.0, 1.0),
+            x_label="a & b <c>",
+        )
+        assert "a &amp; b &lt;c&gt;" in out
+        assert "<c>" not in out
+
+    def test_annotation_appears_escaped(self) -> None:
+        out = line_chart(
+            [Series([(0.0, 0.0), (1.0, 1.0)], "#f00", "c")],
+            x_domain=(0.0, 1.0),
+            y_domain=(0.0, 1.0),
+            annotations=["AUC = 0.950 & <x>"],
+        )
+        assert "AUC = 0.950 &amp; &lt;x&gt;" in out
+        assert "<x>" not in out
+
+
+class TestDiagonal:
+    def test_diagonal_adds_a_dashed_chance_line(self) -> None:
+        kwargs = {"x_domain": (0.0, 1.0), "y_domain": (0.0, 1.0)}
+        base = line_chart([Series([(0.0, 0.0), (1.0, 1.0)], "#f00", "c")], **kwargs)
+        diag = line_chart([Series([(0.0, 0.0), (1.0, 1.0)], "#f00", "c")], diagonal=True, **kwargs)
+        assert "stroke-dasharray" not in base
+        assert "stroke-dasharray" in diag
+        # Chance line runs corner-to-corner: bottom-left (44,232) -> top-right (328,12).
+        assert 'x1="44" y1="232"' in diag
+        assert 'x2="328" y2="12"' in diag
+
+
+class TestBarChart:
+    def test_two_overlaid_series_render_one_rect_per_positive_count(self) -> None:
+        out = bar_chart(
+            [0.0, 0.5, 1.0],
+            [("gold", "#0a0", [3.0, 1.0]), ("non-gold", "#a00", [1.0, 4.0])],
+        )
+        assert out.count("<svg") == 1
+        assert out.count("<rect") == 4  # 2 bins x 2 series, all positive
+        assert "NaN" not in out and "Infinity" not in out
+
+    def test_empty_counts_render_axes_only(self) -> None:
+        out = bar_chart([0.0, 1.0], [("gold", "#0a0", []), ("non-gold", "#a00", [])])
+        assert out.count("<svg") == 1
+        assert "<rect" not in out
+        assert "NaN" not in out and "Infinity" not in out
+
+    def test_zero_counts_draw_no_bars(self) -> None:
+        out = bar_chart([0.0, 0.5, 1.0], [("gold", "#0a0", [0.0, 0.0])])
+        assert "<rect" not in out
+
+    def test_nonfinite_count_is_dropped(self) -> None:
+        out = bar_chart([0.0, 0.5, 1.0], [("gold", "#0a0", [float("nan"), 2.0])])
+        assert "NaN" not in out and "Infinity" not in out
+        assert out.count("<rect") == 1
+
+    def test_series_label_is_escaped_in_legend(self) -> None:
+        out = bar_chart([0.0, 1.0], [("g & <n>", "#0a0", [2.0])])
+        assert "g &amp; &lt;n&gt;" in out
+        assert "<n>" not in out

--- a/tests/test_eval.py
+++ b/tests/test_eval.py
@@ -48,6 +48,7 @@ def test_dir_and_all_list_the_curated_surface() -> None:
     """``dir()`` and ``__all__`` advertise exactly the curated surface."""
     surface = {
         "evaluate",
+        "EvalReport",
         "DEFAULT_PAIR_GRID",
         "list_benchmarks",
         "get_benchmark",

--- a/tests/test_import_budget.py
+++ b/tests/test_import_budget.py
@@ -165,6 +165,49 @@ def test_import_langres_testing_stays_import_light() -> None:
     )
 
 
+# The EvalReport tearsheet (``langres.core.eval_report``) and its SVG backend
+# (``langres.core._svg``) render entirely from stdlib + numpy (a core dep). They
+# must NEVER pull the heavy/optional stack -- that is the permanent guarantee a
+# $0 report can always be built on a bare core-only install (no torch, no
+# matplotlib, no litellm). Same fresh-process subprocess pattern as above.
+_EVAL_REPORT_HEAVY_DEPS = [
+    "torch",
+    "litellm",
+    "faiss",
+    "sentence_transformers",
+    "sklearn",
+    "ranx",
+    "mlflow",
+    "wandb",
+    "matplotlib",
+    "dspy",
+]
+
+_EVAL_REPORT_IMPORT_LIGHT_SCRIPT = (
+    "import sys; import langres.core.eval_report; import langres.core._svg; "
+    "leaked = [m for m in {modules!r} if m in sys.modules]; "
+    "assert not leaked, f'eval_report/_svg leaked heavy modules: {{leaked}}'; "
+    "print('OK')"
+).format(modules=_EVAL_REPORT_HEAVY_DEPS)
+
+
+def test_eval_report_stays_import_light() -> None:
+    """``import langres.core.eval_report`` (+ ``_svg``) must not pull a heavy dep.
+
+    The tearsheet is dependency-free by construction: inline SVG, no matplotlib,
+    no ML stack. This locks it so a future edit can never regress the $0,
+    core-only path.
+    """
+    result = subprocess.run(
+        [sys.executable, "-c", _EVAL_REPORT_IMPORT_LIGHT_SCRIPT],
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode == 0, (
+        f"eval_report import-budget check failed.\nSTDOUT:\n{result.stdout}\nSTDERR:\n{result.stderr}"
+    )
+
+
 # ``langres.data.registry.list_methods`` is a public, import-light discovery API
 # (exported from ``langres.data``): it must return the method NAMES without
 # pulling ``langres.methods`` — which imports VectorBlocker / RandomForestJudge /

--- a/tests/test_testing.py
+++ b/tests/test_testing.py
@@ -243,3 +243,54 @@ class TestScriptedJudgeAbstain:
         [judgement] = list(judge.forward(iter([_pair("a", "b")])))
 
         assert judgement.is_abstain is False
+
+
+class TestScriptedJudgeConfidence:
+    """The optional ``confidence`` provider lets the double model a logprob judge."""
+
+    def test_callable_confidence_and_source_are_stamped(self) -> None:
+        judge = ScriptedJudge(
+            lambda c: 0.9,
+            confidence=lambda c: 0.7,
+            confidence_source="logprob",
+        )
+
+        [judgement] = list(judge.forward(iter([_pair("a", "b")])))
+
+        assert judgement.confidence == 0.7
+        assert judgement.confidence_source == "logprob"
+
+    def test_dict_confidence_is_order_independent(self) -> None:
+        judge = ScriptedJudge(
+            {frozenset({"a", "b"}): 0.9},
+            confidence={frozenset({"a", "b"}): 0.6},
+            confidence_source="logprob",
+        )
+
+        forward = next(iter(judge.forward(iter([_pair("a", "b")]))))
+        reverse = next(iter(judge.forward(iter([_pair("b", "a")]))))
+
+        assert forward.confidence == reverse.confidence == 0.6
+
+    def test_no_confidence_leaves_field_none_and_source_none(self) -> None:
+        judge = ScriptedJudge({frozenset({"a", "b"}): 0.9})
+
+        [judgement] = list(judge.forward(iter([_pair("a", "b")])))
+
+        assert judgement.confidence is None
+        assert judgement.confidence_source == "none"
+
+    def test_confidence_returning_none_leaves_source_none(self) -> None:
+        """A per-pair ``None`` confidence must NOT stamp the source -- an unmapped
+        pair (dict miss) carries no credence, so ``confidence_source`` stays
+        ``"none"`` even though the source kwarg was set."""
+        judge = ScriptedJudge(
+            {frozenset({"a", "b"}): 0.9},
+            confidence={frozenset({"c", "d"}): 0.6},  # only c,d mapped
+            confidence_source="logprob",
+        )
+
+        [judgement] = list(judge.forward(iter([_pair("a", "b")])))
+
+        assert judgement.confidence is None
+        assert judgement.confidence_source == "none"


### PR DESCRIPTION
## PR-3 — the EvalReport tearsheet ($0 evaluation report)

Third and final PR of the judgement-contract series. **Judging costs money; analysing what you already judged is free.** This ships a first-class, self-contained HTML tearsheet computed at **$0** from persisted judgements + gold — the generalisation of what `peeters_llm_em_replication.py --report-only` already does for one experiment.

> **Stacked on `feat/judgement-contract` (#106).** Base is set to that branch so the diff shows only PR-3's own work. Retarget to `main` once #106 merges.

### What's here
- **`core/_svg.py`** (NEW, 380 lines) — pure-stdlib inline-SVG chart primitives (`line_chart`, `bar_chart`). The only place raw SVG lives; the data→pixel y-flip (SVG y grows *downward*) lives here and nowhere else. Non-finite points are dropped (`math.isfinite`); the output can never contain `NaN`/`Infinity`; every text value is `html.escape`d. No matplotlib, no templating engine, no external assets.
- **`core/eval_report.py`** (NEW, 683 lines) — the frozen `EvalReport` model. Two $0 constructors: `from_judgements(judgements, gold_pairs, …)` and `from_log(rows, gold_pairs, …)`. Carries the confusion matrix (with `tn = n_candidates − tp − fp − fn`, since `classify_pairs` has no negative universe), PR + **ROC curve/AUC** + average precision, a gold-vs-non-gold score histogram, reliability bins + Brier + ECE, cost, and the most-confident errors. `to_dict()` / `to_markdown()` / `to_html()` (one self-contained `<!doctype html>` document). **Leaf module:** nothing in `reports.py`/`module.py` imports it, so it never loads on `import langres`.
- **`testing.py`** — `ScriptedJudge` gains a `confidence` provider + `confidence_source`, so the offline double can model a logprob judge.
- **`eval.py`** — `EvalReport` added to the lazy facade.
- **`examples/quickstart_eval.py`** (NEW) — fully offline block → judge → cluster → `EvalReport` → `to_html()`. Zero API calls, zero torch, zero network, zero sklearn. Includes a deliberately hard case (`IBM` vs `International Business Machines`) so the report shows a real ROC/PR curve and a populated errors panel instead of a trivial all-correct grid. Wired into CI's bare-`uv sync` `test-core-only` job.

### Verification
- **Full offline example runs** in CI (`test-core-only`, no extras): `36 pairs @ threshold 0.6: P=1.000 R=0.750 F1=0.857 | ROC-AUC=0.844 AP=0.792 | Brier=0.080 ECE=0.212`.
- **Import-budget lock** (`test_eval_report_stays_import_light`): importing `core.eval_report` + `core._svg` pulls **none** of torch/litellm/faiss/sentence_transformers/sklearn/ranx/mlflow/wandb/matplotlib/dspy into `sys.modules`.
- **Structure-not-bytes tests**: the NaN/Infinity-leak guard, the y-flip assertion (data y=max sits at the top), unescaped-`&` escaping in the error table and axis labels, `≥2`-point polylines, and the `dmax==dmin` ZeroDivision guard. 91 targeted tests pass; ruff / ruff format / mypy --strict clean.
- **Browser visual verification** (Chrome via MCP): all panels render — axes with tick labels, PR curve, ROC from (0,0)→(1,1) with the chance diagonal, the `AUC = 0.844` annotation equal to the numeric `roc_auc`, reliability points (honestly overconfident, matching ECE = 0.212), the IBM miss in the errors table. **Zero console messages** and **zero external network requests** (only the localhost document itself — no CDN fonts, confirming the self-contained property).

https://claude.ai/code/session_01KGKsfNuVYS826hQXpTuebu
