### PR TITLE
docs(plans): LLM-native reframe of the training loop + T4 blocking instruction-transfer experiment

### DIFF
--- a/docs/plans/20260713_training_loop_plan.md
+++ b/docs/plans/20260713_training_loop_plan.md
@@ -3,6 +3,12 @@
 Date: 2026-07-13
 Branch: `docs/training-loop-plan` (plan only — no execution, no training, no paid calls)
 Status: proposed (for David's decision on targets + first-wave budget)
+Amended 2026-07-13 (`docs/training-plan-llm-native`, maintainer feedback): the
+ladder is reframed **LLM-native** — the gap-closing students are prompt-tuned
+and fine-tuned small **LLMs**; Ditto/Magellan-class methods and the RF floor
+are yardstick baselines kept for completeness, not methods to emulate — and a
+new blocking-side experiment (**T4**: instruction transfer to the embedder) is
+added and ranked.
 
 ## Context — why this, why now
 
@@ -45,30 +51,46 @@ hard data — so label-noise handling is a first-class requirement, not a nicety
 
 ### The bet, stated falsifiably
 
-*A small model fine-tuned on labels harvested by a tuned LLM teacher (silver)
-retains ≥90% of the F1 the same model reaches on gold labels, beats its own
-teacher's zero-shot F1, and serves at ~$0 marginal cost per pair (vs the
-teacher's ~$8×10⁻⁵–1.2×10⁻³/pair).* If false, we publish the gap and name why
-(precedent: the honest DBLP-Scholar PC finding).
+*A smaller LLM — first DSPy-prompt-tuned, then QLoRA-fine-tuned, on labels
+harvested by a tuned LLM teacher (silver) — retains ≥90% of the F1 the same
+recipe reaches on gold labels, beats its own teacher's zero-shot F1, and serves
+at ~$0 marginal cost per pair (vs the teacher's ~$8×10⁻⁵–1.2×10⁻³/pair).* If
+false, we publish the gap and name why (precedent: the honest DBLP-Scholar PC
+finding).
+
+**The strategic frame (maintainer, 2026-07-13): the ladder is LLM-native.**
+The "cheaper model" is not a from-scratch classifier. It is, in order: **(a) a
+DSPy prompt-tuned smaller LLM** — teacher model + harvested labels drive the
+prompt optimization of the small LLM — then **(b) a fine-tuned small LM** for
+the task. The point is to *reuse the knowledge already encoded in LLMs and push
+it further*, not to re-train 2018–2020-era architectures. Ditto's published
+band remains the **yardstick**; Ditto/Magellan-class methods and the RF floor
+are **baselines kept for completeness**, not methods to emulate.
 
 ## 1. Candidate replication targets, ranked
 
 Ranking axis: **prove the framework carries training-based methods** ×
 **announcement value**, then cost/risk. Summary first, detail below.
 
-| rank | target | claim to replicate | paid $ | GPU h (est.) | new langres LOC (est.) | headline if it works |
+| rank | target | claim to replicate / test | paid $ | GPU h (est.) | new langres LOC (est.) | headline if it works |
 |---|---|---|---|---|---|---|
-| **T1** | **Silver→student: close the Ditto gap** (#80 Phase 2 + flywheel thesis) | trained student reaches Ditto band; silver-trained variant holds quality at collapsed cost | ~$2–5 (teacher tune + harvest) | ~4–10 | ~500–800 + tests | "An LLM labeled it; a small local model learned it: Ditto-class quality at ~0 $/pair" |
-| **T2** | **AnyMatch recipe** (#83 / #86) | 124M-class tiny LM, curated via hard-positive mining, generalizes zero-shot (mean ~82 F1) | $0 | ~2–6 | ~250–400 + tests (mining seam) | "The data recipe is the lever — replicated through a reusable curation seam" |
-| **T3** | **Jellyfish-style instruct-tune** (#81 Task 2) | Qwen3-1.7B/4B on Jellyfish-Instruct (CC-BY-4.0) vs Jellyfish-13B's 0.813 AG | $0 | ~6–20 | ~50–150 (reuses T1 seams) | "A 1.7B student beats a 13B specialist" (with seen-data asterisk) |
+| **1 — T1** | **Silver→student: close the Ditto gap, LLM-native** (#80 Phase 2 + flywheel thesis) | prompt-tuned → fine-tuned small LLM reaches the Ditto yardstick; silver-trained variant holds quality at collapsed cost | ~$2–5 (teacher tune + harvest) | ~4–10 | ~500–800 + tests | "An LLM labeled it; a smaller LLM learned it: Ditto-class quality at ~0 $/pair" |
+| **2 — T2** | **AnyMatch recipe** (#83 / #86) | 124M-class tiny LM, curated via hard-positive mining, generalizes zero-shot (mean ~82 F1) | $0 | ~2–6 | ~250–400 + tests (mining seam) | "The data recipe is the lever — replicated through a reusable curation seam" |
+| **3 — T4** | **Instruction transfer to blocking** (new; recall side) | matcher-side optimized instructions lift a same-family decoder embedder's blocking recall (PC@k) — an unpublished gap (#86 survey §13) | $0 first rung | ~0–2 (H1); H2 gated | ~0 core (knob exists) + harness | "One small-LLM family, both stages: the matcher's optimized prompt improves the blocker's recall" |
+| **4 — T3** | **Jellyfish-style instruct-tune** (#81 Task 2) | Qwen3-1.7B/4B on Jellyfish-Instruct (CC-BY-4.0) vs Jellyfish-13B's 0.813 AG | $0 | ~6–20 | ~50–150 (reuses T1 seams) | "A 1.7B student beats a 13B specialist" (with seen-data asterisk) |
 | — | Geo/POI conflation (#84) | out of scope this program — new entity type + new blocker, orthogonal to the training loop | — | — | — | — |
 
+**Re-ranked in the LLM-native amendment:** T4 slots third — its first rung is
+pure $0 reuse of existing seams and it tests the "one small-LLM base family for
+both stages" strategic bet; T3 drops to fourth (largest GPU bill, most caveated
+claim). Target labels are stable; the rank column is the order.
+
 GPU-hour figures are **estimates to be verified by the Wave-0 smoke** (epic #85
-rule: tooling maturity is confirmed empirically, never assumed). All three
+rule: tooling maturity is confirmed empirically, never assumed). The training
 targets share one training/eval substrate (Waves 0–1 below), which is why T3
 costs almost no new code once T1 lands.
 
-### T1 — Silver→student: close the Ditto gap (recommended headline target)
+### T1 — Silver→student: close the Ditto gap, LLM-native (recommended headline target)
 
 - **Papers.** Ditto (Li et al., VLDB 2020, arXiv:2004.00584) for the band
   (0.756 AG / 0.893 Abt-Buy, pairwise F1 on the canonical DeepMatcher splits);
@@ -76,9 +98,11 @@ costs almost no new code once T1 lands.
   precedent for LLM-generated EM training data (mixed results — read in full
   before the silver design; flagged unread in the #86 survey).
 - **Exact claims — two rungs, reported separately:**
-  - **Rung A (gold, replication-class):** a student fine-tuned on the *gold*
-    train split reaches the Ditto band on the full test split under the honest
-    protocol. This alone completes #80 Phase 2.
+  - **Rung A (gold, replication-class):** the LLM-native ladder — prompt-tuned,
+    then fine-tuned on the *gold* train split — reaches the Ditto yardstick band
+    on the full test split under the honest protocol. A hosted trained matcher
+    at that band completes #80 Phase 2 (the cross-encoder baseline below is the
+    like-for-like Ditto-method anchor for the record).
   - **Rung B (silver, the economics claim):** the *same recipe* trained only on
     **teacher-harvested silver labels** (teacher never sees test) retains ≥90%
     of Rung A's F1 and beats the teacher's own zero-shot F1 — with the
@@ -89,15 +113,23 @@ costs almost no new code once T1 lands.
   (the M4 lever; the measured Phase-1 profile is high-recall/low-precision, so
   untuned silver would be noise-heavy — the #79 trap). Pro-class teacher is a
   paid ablation, not the default (~$1.1–1.2×10⁻³/pair vs Flash's ~0.8–1.0×10⁻⁴).
-- **Students — two shapes, both planned, one gate to drop either:**
-  - **Cross-encoder** (Ditto-fidelity anchor): `sentence-transformers`
-    `CrossEncoder` (roberta-base-class) — already inside the `[semantic]` extra,
-    trains in well under an hour on the 3070, and implements
-    `SupervisedFitMixin.fit(candidates, labels)` naturally. *(Verify: the
-    pinned sentence-transformers ≥5.x trains cross-encoders via
+- **Students — the LLM-native ladder (the gap-closing candidates), plus one
+  baseline kept for completeness:**
+  - **Rung (a) — DSPy prompt-tuned small LLM:** Qwen3-0.6B→1.7B served locally,
+    signature/instructions optimized against the harvested (or gold) labels.
+    Measured precedents: the M4 lever (precision-tuned signature took a cheap
+    model 0.409 → 0.757 on AG with no compile spend) and Breunig's Qwen3-0.6B
+    60.7% → 82% post-DSPy (epic #85). $0/call once local.
+  - **Rung (b) — QLoRA fine-tuned small LM:** Qwen3-1.7B primary (0.6B smoke,
+    4B stretch), Unsloth on the 3070 per the #85 ladder — pushes past what
+    prompt-tuning alone reaches.
+  - **Baseline (completeness, not the story):** a `sentence-transformers`
+    `CrossEncoder` (roberta-base-class) trained on the same labels — the
+    Ditto/Magellan-method reference point next to the RF floor, and the
+    in-process `SupervisedFitMixin.fit(candidates, labels)` reference
+    implementation. Already inside the `[semantic]` extra; ~1 GPU-h. *(Verify:
+    the pinned sentence-transformers ≥5.x trains cross-encoders via
     `CrossEncoderTrainer`, not the old `.fit()` — API to confirm in Wave 0.)*
-  - **Qwen3-1.7B QLoRA** (forward-looking, the #85 ladder): 0.6B smoke → 1.7B
-    primary → 4B stretch, Unsloth on the 3070.
 - **Cost.** Teacher harvest over train+valid only: ≈ $0.76 (AG) + $0.74 (AB) at
   measured Flash per-pair cost; signature tuning ≈ $1–2 → **$5 cap** is
   comfortable. GPU ≈ 1 h (cross-encoder) + 3–8 h (Qwen ladder).
@@ -143,6 +175,73 @@ costs almost no new code once T1 lands.
 - **Headline earned.** "A 124M-class model near GPT-4 on EM — because of data
   curation, and that curation is now a reusable langres seam."
 
+### T4 — Instruction transfer to blocking: one small-LLM family for both stages (new)
+
+- **The idea (maintainer, 2026-07-13).** Modern embedding models are
+  decoder-LLM-based: **Qwen3-Embedding** (arXiv:2506.05176; Apache-2.0;
+  0.6B/4B/8B; MTEB v2 Eng 70.70/74.60/75.22) is *"built upon the Qwen3
+  foundation models"* (verified from the paper abstract + HF cards, #86 survey
+  §12.3) and is **instruction-aware** — a prepended task instruction steers the
+  embedding space. So use the SAME small-LLM base family (Qwen3-class) for both
+  the DSPy-prompt-tuned matcher (T1 rung a) and the embedder, and test whether
+  matcher-side prompt optimization **transfers** to the embedding side — prompt
+  iteration is normally impossible for embedders (nothing is generated), but a
+  shared base family + instruction-aware embeddings may let it reach blocking
+  recall.
+- **Honest mechanics correction (survey §12.4):** Qwen3-Embedding is a
+  *separately released, contrastively-tuned checkpoint*, not the chat weights
+  doing double duty — "one model" realistically means **one base family, two
+  fine-tunes**. So the experiment splits into two hypotheses:
+  - **H1 — text-level instruction transfer ($0):** does the DSPy-optimized
+    *matching* instruction, reused as the embedding instruction, lift blocking
+    recall on the off-the-shelf Qwen3-Embedding-0.6B? Instruction wording is a
+    measured lever in the literature (E5-mistral: MTEB 64.5 with instructions
+    vs 60.3 without; INSTRUCTOR +3.4%) — but both "optimize an embedder
+    instruction for recall" and "a shared retrieve+match instruction" are
+    **unpublished gaps** (survey §13.4): novel, genuinely unproven.
+  - **H2 — genuinely shared weights (gated):** two LoRA adapters on one Qwen3
+    base (contrastive embedding adapter + matching adapter, PEFT-swapped), or a
+    GritLM-style joint probe — **no published result exists at 0.6–4B/QLoRA
+    scale** (survey §12.2 caveat); a research bet, decided after Waves 1–4.
+- **What's measurable, with what's already built:** Pair Completeness
+  (recall) + Reduction Ratio via `core.metrics.evaluate_blocking`, plus
+  MRR/NDCG via the `[eval]` extra — against the current encoder-baseline
+  `VectorBlocker` at fixed k on registry benchmarks (AG, Abt-Buy,
+  `wdc_computers`). **Zero new architecture for H1:** `VectorBlocker` already
+  persists a `query_prompt` instruction knob in its config
+  (`core/blockers/vector.py`), the embedder `encode()` already takes `prompt=`,
+  and `examples/research/blocking_evaluation_with_instructions.py` /
+  `instruction_embeddings_demo.py` already run Qwen3-family embeddings with
+  instruction prompts.
+- **$0-first steps, in order:** (1) **gating check** (survey §13.0): does
+  off-the-shelf Qwen3-Embedding-0.6B behind `VectorBlocker` even beat the
+  current encoder baseline on PC? The **UniBlocker counter-signal**
+  (arXiv:2404.14831 — encoder backbones deliberately chosen for structured
+  records) is the null hypothesis; if the decoder embedder loses, publish the
+  negative and keep an encoder for blocking. (2) **instruction sweep**: none vs
+  generic vs task-specific vs hand-varied instructions, reported as a
+  *distribution* (wording is high-variance — "One prompt is not enough",
+  arXiv:2605.22544 — never a single cherry-picked prompt). (3) **the transfer
+  probe**: the matcher's DSPy-optimized instruction text as `query_prompt`,
+  once Wave 1/2 produces it. Then, gated: (4) direct optimization of the
+  embedding instruction against recall@k — **not** stock DSPy (MIPROv2 only
+  tunes LM-completion modules; an embedder emits vectors, so
+  `program.predictors()` finds nothing) but the standalone `gepa-ai/gepa`
+  library + a custom adapter (survey §13.4 mechanism note); (5) H2 shared-base
+  variants (GPU, budget gate).
+- **Cost.** H1 entirely $0 (local embeddings, vendored data; steps 1–2 need no
+  GPU beyond embedding throughput). H2: GPU-hours + possibly a small paid gate
+  if GEPA's reflection LM isn't run locally — decided at the Wave-6 gate.
+- **Risk.** Real chance H1 is flat or negative (UniBlocker counter-signal;
+  instruction variance may swamp the transfer effect). Both outcomes are
+  findings: a lift opens "prompt optimization reaches the recall side"; a null
+  kills the shared-instruction story early and cheaply, before H2 spends
+  anything. Evaluate *both* stages either way — the survey's transfer rule:
+  measure PC *and* F1, so capability transfer vs interference is visible.
+- **Headline earned.** "One small-LLM family, both stages: the matcher's
+  optimized prompt improves the blocker's recall" — plus first-mover on an
+  unpublished experiment either way.
+
 ### T3 — Jellyfish-style instruct-tune (defer behind a gate)
 
 - **Paper.** Jellyfish (arXiv:2312.01678, VLDB 2024); training data
@@ -172,12 +271,13 @@ paid gates totaling ≤$10**; everything else is $0 (local GPU + vendored data).
 | wave | content | spend | gate |
 |---|---|---|---|
 | **0 — foundations ($0)** | (a) harvest→fit **id-alignment bridge** (`LabeledPair` id-keyed → positionally-aligned `(candidates, labels)` — the missing glue named in #80); (b) **mining seam v1**: pluggable strategy interface generalized from `select_for_review` + `blocking-derived hard negatives` + `classifier-misclassification` strategies; (c) `COL/VAL` serialization utility; (d) **CrossEncoderJudge scaffold** (fit/forward/save_state/load_state/config) dry-run-trained on `tiny_fixture` in CI (5 steps, CPU); (e) **GPU smoke**: Unsloth + Qwen3-0.6B QLoRA overfits 100 pairs on the 3070 — confirms tooling + calibrates real GPU-h; (f) eval wiring is **already done** (`FixedSplitPairBenchmark` + `evaluate_fixed_split_honest`) — reuse, don't build | $0 | none |
-| **1 — T1 Rung A: gold students ($0)** | Train cross-encoder + Qwen3-0.6B→1.7B on AG/AB **gold train**; evaluate on full test, threshold from train/valid; report next to floor/zero-shot/Ditto rows. Completes #80 Phase 2. | $0 (GPU) | drop the weaker student shape here if one clearly dominates |
+| **1 — T1 Rung A: gold LLM-native ladder ($0)** | DSPy prompt-tune Qwen3-0.6B→1.7B locally against AG/AB **gold train/valid** labels (rung a), then QLoRA fine-tune (rung b); train the cross-encoder baseline alongside for completeness (completes #80 Phase 2); evaluate all on full test, threshold from train/valid; report next to floor / zero-shot / Ditto-yardstick rows | $0 (GPU) | drop a ladder rung here if one clearly dominates |
+| **1b — T4-H1: blocking instruction probes ($0)** | Gating check (Qwen3-Embedding-0.6B via `VectorBlocker.query_prompt` vs the encoder baseline, PC/RR at fixed k); instruction sweep reported as a distribution; the transfer probe runs as soon as Wave 1/2 yields a DSPy-optimized instruction. Existing harness: `blocking_evaluation_with_instructions.py`, `evaluate_blocking` | $0 | if the gating check is negative, publish it and drop T4-H2 |
 | **2 — teacher tune + silver harvest (PAID gate 1)** | Precision-tune the Flash-class teacher's DSPy signature on train/valid (M4 lever, no MIPROv2 compile — it didn't pay at M4); harvest silver over **train+valid only** for AG+AB; run the label-noise rail (below) on the silver set | **≤$5 cap** | ask David; abort criterion: tuned-teacher valid-split F1 must beat its untuned 0.575/0.680, else stop before harvesting |
 | **3 — T1 Rung B: silver students + economics tearsheet ($0)** | Retrain Wave-1 recipes on silver; grade on the same held-out gold test; produce the quality-vs-$/pair table (the `EvalReport` HTML tearsheet from PR #107 is the natural renderer) | $0 (GPU) | none |
 | **4 — T2 AnyMatch folds ($0)** | Mining seam as consumer; 2 leave-one-out headline folds | $0 (GPU) | none |
 | **5 — comparison anchors (PAID gate 2, optional)** | Either a Pro-class-teacher silver ablation on ONE dataset (teacher-quality curve) or a GPT-4o MatchGPT row via the existing Peeters harness (anchors T2's "% of GPT-4" claim) | **≤$5 cap** | ask David; skip if Waves 2–4 already tell the story |
-| **6 — T3 gate** | Decide Jellyfish-style run from Wave 1–4 evidence (#81 Task 0 SOTA review first) | $0 paid | David decision |
+| **6 — T3 / T4-H2 gate** | Decide the Jellyfish-style run (#81 Task 0 SOTA review first) and the T4-H2 shared-base variants (two-adapter Qwen3 base; GEPA embedding-instruction optimization; GritLM-style joint probe) from Wave 1–4 evidence | $0 paid | David decision |
 
 **Label-noise rail (Wave 2/3, from the #86 survey — required, not optional):**
 parse failures are already excluded by the judgement contract (PR #106: `None`/
@@ -193,16 +293,19 @@ ceiling is explained, not mysterious.
 1. **Harvest→fit bridge** (`core/harvest.py` ↔ `SupervisedFitMixin`) — re-block
    + join on `frozenset({left_id, right_id})` → aligned labels. ~60–100 LOC.
    Unblocks *every* trained judge, not just this program.
-2. **A trained-transformer judge** — `CrossEncoderJudge` implementing
-   `SupervisedFitMixin`, `save_state`/`load_state` writing a `safetensors`
-   checkpoint into `state_dir` (the `FAISSIndex` binary-sidecar pattern; no
-   pickle), `config`/`from_config`, wired at **all three judge-dispatch sites**
-   + `@register` + lazy import (torch stays out of bare `import langres`) +
-   `PairwiseJudgement.score_type` `"prob_deep"`. Replaces the dead
-   `GLinkerAdapter` stub as the reference deep judge. Inference dep rides the
-   existing `[semantic]` extra (sentence-transformers/torch already there);
-   **training-only deps (unsloth, trl/peft, optionally autogluon) stay
-   dev-group-only** — never production extras.
+2. **A trained-transformer judge (the baseline seam)** — `CrossEncoderJudge`
+   implementing `SupervisedFitMixin`, `save_state`/`load_state` writing a
+   `safetensors` checkpoint into `state_dir` (the `FAISSIndex` binary-sidecar
+   pattern; no pickle), `config`/`from_config`, wired at **all three
+   judge-dispatch sites** + `@register` + lazy import (torch stays out of bare
+   `import langres`) + `PairwiseJudgement.score_type` `"prob_deep"`. Replaces
+   the dead `GLinkerAdapter` stub as the in-process reference deep judge —
+   under the LLM-native reframe it is the *baseline* trained judge and the
+   `SupervisedFitMixin` reference implementation, while the headline students
+   ride the LLM seams (below). Inference dep rides the existing `[semantic]`
+   extra (sentence-transformers/torch already there); **training-only deps
+   (unsloth, trl/peft, optionally autogluon) stay dev-group-only** — never
+   production extras.
 3. **Local-LLM student serving** — decision, not code: Option A (recommended)
    wrap the fine-tuned checkpoint behind the existing `LLMJudge` via a local
    OpenAI-compatible server (`api_base`) — zero core changes, evaluates through
@@ -216,6 +319,13 @@ ceiling is explained, not mysterious.
 5. **Serialization utility** — one Ditto-style `COL/VAL` textualizer shared by
    trained students, LLM prompts, and the AnyMatch recipe (today each judge
    serializes ad hoc).
+   5b. **Decoder-LLM embedder for blocking (T4) — no new architecture.**
+   `VectorBlocker` already takes a pluggable embedder and already persists a
+   `query_prompt` instruction knob in its config (`core/blockers/vector.py`);
+   the embedder protocol's `encode(texts, prompt=...)` carries the instruction.
+   T4-H1 is therefore harness work, not core work (the research examples
+   already run Qwen3-family embeddings this way). Only T4-H2 would add code: an
+   adapter-swapped shared-base embedder backend, trained dev-side.
 6. **Trained artifacts get an identity** — cross-reference the parallel design
    doc `docs/research/20260713_model_identity_and_hub.md` (branch
    `docs/hub-model-identity`, PR #108): a checkpoint is a first-class artifact
@@ -253,6 +363,12 @@ ceiling is explained, not mysterious.
   reimplementation only; OpenSanctions CC-BY-NC → untouched by this program).
 - Every economics claim carries both sides: teacher $/pair (measured, not
   listed prices) and student $/pair (~$0 marginal; GPU amortization named).
+- **Blocking-side (T4) runs:** report PC + RR (and MRR/NDCG where `[eval]` is
+  present) at fixed k against the encoder baseline; instruction results are
+  reported as a **distribution over instruction variants**, never a single
+  cherry-picked prompt; the UniBlocker counter-signal is the stated null
+  hypothesis, so a negative is a finding; every T4 variant is evaluated on
+  *both* stages (PC and downstream F1) to expose transfer vs interference.
 
 **Success bars:**
 - **T1-A:** honest F1 within the published Ditto spread (≥ ~0.70 AG / ≥ ~0.85
@@ -262,14 +378,21 @@ ceiling is explained, not mysterious.
   the silver noise rate that explains it.
 - **T2:** leave-one-out F1 within ~5 pts of AnyMatch on shared datasets, with
   deviations named ⇒ the curation seam carries a published recipe.
+- **T4-H1:** the transferred (or swept-best) instruction lifts PC@k over both
+  the no-instruction and generic-instruction baselines on ≥2 registry
+  benchmarks at unchanged k/RR ⇒ prompt optimization reaches the recall side.
+  Gating-check failure (decoder embedder ≤ encoder baseline) ⇒ keep the
+  encoder for blocking, publish the negative, drop H2.
 - Any outcome is reported — the honest-but-unflattering result is a finding,
   not a failure (precedent: DBLP-Scholar PC 0.39, the M4 "MIPROv2 didn't help").
 
 ## 5. Recommended first wave (decision requested)
 
-**Recommendation: Wave 0 + Wave 1 now ($0), with Wave 2 pre-approved at a $5
-cap** so the silver harvest starts the moment the gold students exist. That is
-one budget ask: **$5** (second $5 gate deferred until Wave 5 is justified).
+**Recommendation: Wave 0 + Wave 1 + Wave 1b now ($0), with Wave 2 pre-approved
+at a $5 cap** so the silver harvest starts the moment the gold ladder exists.
+Wave 1b (the T4 gating check + instruction sweep) is free, independent, and can
+run on the dev machine in parallel. That is one budget ask: **$5** (second $5
+gate deferred until Wave 5 is justified).
 
 Alternatives, left live:
 - **B — AnyMatch-first (T2 before T1):** $0 all the way to a publishable
@@ -277,9 +400,11 @@ Alternatives, left live:
   delay; the maintainer's framing points at T1, so this is the fallback if the
   Wave-0 GPU smoke surfaces QLoRA tooling friction (T2's 0.6B/GPT-2 student is
   the least demanding).
-- **C — cross-encoder-only T1 (skip the Qwen ladder in Wave 1):** fastest to a
-  Ditto-band number (~1 GPU-h), smallest surface; gives up the small-LM
-  narrative until T3. Right call if 3070 access is the bottleneck.
+- **C — baseline-first T1 (cross-encoder only in Wave 1):** fastest to a
+  Ditto-method-class number (~1 GPU-h), smallest surface — but under the
+  LLM-native reframe it delivers only the yardstick baseline, not the story.
+  Right call only if the 3070 is unavailable (the cross-encoder trains
+  anywhere).
 - **D — teacher-first (run Wave 2 before Wave 1):** proves the silver pipeline
   earlier but spends money before the $0 gold baseline exists to compare
   against — weaker experiment design; not recommended.
@@ -316,3 +441,16 @@ Alternatives, left live:
   silver design — survey flag).
 - Whether the tuned-teacher lift (M4's 0.409→0.757 was on GLM) transfers to
   DeepSeek-Flash — Wave 2's abort criterion exists precisely for this.
+- **T4 facts, provenance:** Qwen3-Embedding "built upon the Qwen3 foundation
+  models", 0.6B/4B/8B, Apache-2.0, instruction-aware — verified from the
+  arXiv:2506.05176 abstract (this amendment) + the #86 survey's HF-card check
+  (2026-07-07). NOT verified: that our pinned sentence-transformers loads
+  Qwen3-Embedding-0.6B on this exact code path (the research examples run a
+  Qwen3-family embedder — confirm it is the same loader in Wave 1b); GEPA
+  custom-adapter glue for direct embedding-instruction optimization (survey
+  mechanism note — stock DSPy cannot do it); GritLM-style joint training at
+  0.6–4B/QLoRA scale (no published result — survey §12.2).
+- **T4-H1's core hypothesis — that matcher-optimized instruction text
+  transfers to embedding recall — is unpublished and unproven**; the survey's
+  "shared identity-core" framing (§13.4) is the thing being tested, not
+  assumed.


### PR DESCRIPTION
Follow-up amendment to the merged training-loop plan (#109), per maintainer feedback.

## 1. LLM-native reframe

The "cheaper model" ladder is now explicitly LLM-native: **(a) a DSPy prompt-tuned smaller LLM** (teacher + harvested labels drive the prompt optimization), then **(b) a QLoRA fine-tuned small LM**. Ditto's published band stays as the **yardstick**; Ditto/Magellan-class methods and the RF floor are **baselines kept for completeness**, not methods to emulate. The strategic point: reuse the knowledge already encoded in LLMs and push it further. T1's students, Wave 1, the falsifiable bet, alternative C, and the framework-delta framing of `CrossEncoderJudge` (now the baseline/`SupervisedFitMixin` reference, not the story) are updated accordingly.

## 2. New experiment — T4: instruction transfer to blocking (recall side)

Ranked 3rd (T3 drops to 4th): use the SAME Qwen3-class base family for the DSPy-prompt-tuned matcher **and** the embedder, and test whether matcher-side optimized instructions transfer to instruction-aware embeddings and lift blocking recall.

- **Verified before writing:** Qwen3-Embedding is "built upon the Qwen3 foundation models" (0.6B/4B/8B, Apache-2.0, instruction-aware) — arXiv:2506.05176 abstract + the #86 survey's HF-card check. Honest mechanics correction included: the published embedding checkpoints are *separately contrastively-tuned*, so "shared weights" is literal only in the gated H2 variants ("one base family, two fine-tunes").
- **H1 ($0, zero new core code):** `VectorBlocker` already persists a `query_prompt` instruction knob and the research examples already run Qwen3-family instruction embeddings — gating check vs the encoder baseline (UniBlocker counter-signal = stated null hypothesis), instruction sweep reported as a distribution, then the transfer probe with the DSPy-optimized matcher instruction. Measured with existing `evaluate_blocking` PC/RR (+ `[eval]` ranking metrics).
- **H2 (gated):** two-adapter shared base / GEPA direct embedding-instruction optimization (stock DSPy cannot — mechanism note) / GritLM-style joint probe — flagged unpublished at 0.6–4B/QLoRA scale.
- New wave 1b ($0), new success bar, protocol rules (distribution reporting, both-stage evaluation), and unverified flags in §8.

Recommended first wave is now **Wave 0 + 1 + 1b ($0) with Wave 2 pre-approved at a $5 cap** — unchanged budget ask.

Refs #85 #80 #81 #83 #86 (amends #109)