### PR TITLE
ci: upload full-suite coverage to Codecov

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -126,4 +126,18 @@ jobs:
         run: uv sync --all-extras
 
       - name: Run full suite incl. slow tests (95% coverage gate)
-        run: uv run pytest -m "not integration"
+        # --cov-report=xml (on top of the pyproject default term/html reports)
+        # emits coverage.xml for the Codecov upload below. This is the ONLY job
+        # that runs the full suite, so it's the only place coverage is honest --
+        # the per-PR `test` job deliberately excludes the slow ML tests, so
+        # uploading its partial numbers would understate real coverage.
+        run: uv run pytest -m "not integration" --cov-report=xml
+
+      - name: Upload coverage to Codecov
+        # Advisory, never a merge gate: fail_ci_if_error stays false so a Codecov
+        # hiccup can't turn this weekly run red. Token is required for uploads.
+        uses: codecov/codecov-action@v5
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          files: ./coverage.xml
+          fail_ci_if_error: false


### PR DESCRIPTION
## What

Wires **Codecov** into the `test-full` job — the one genuinely-missing piece.
Rebased on latest `main`; CodeQL SAST already landed in #114, so this PR is now
**Codecov-only** (1 file, `test.yml`).

- Emits `coverage.xml` (alongside the existing term/html reports) and uploads
  via `codecov/codecov-action@v5` using the `CODECOV_TOKEN` secret.

## Why `test-full` (not per-PR)

`test-full` is the only job that runs the full suite (incl. slow ML tests) — so
it's the only place the coverage number is honest. The per-PR `test` job
excludes those tests (`--cov-fail-under=0`), so uploading its partial numbers
would understate real coverage. Runs weekly + on demand.

Upload is advisory (`fail_ci_if_error: false`) — a Codecov hiccup can't turn the
run red.

## Verification

Since `test-full` is skipped on `pull_request` events, I dispatched the **Test**
workflow on this branch (`workflow_dispatch`) to exercise the upload end-to-end
before merge.

## Note (out of scope)

README's Codecov/other badges still point to `raisesquad/langres` rather than
`fxd24/langres` — left for the canonical-org decision / README pass, not touched
here.