### PR TITLE
fix: resolve __version__ from package metadata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## [Unreleased]
+
+### Fixed
+
+- **`langres.__version__` no longer drifts from the released version.** It was a
+  hardcoded string (still `"0.2.0"` in the published 0.3.0 wheel, while pip
+  metadata correctly said 0.3.0); it now resolves from the installed package
+  metadata (`importlib.metadata`), so pyproject.toml is the single source of
+  truth.
+
 ## [0.3.0] - 2026-07-13
 
 Everything since 0.2.0: the judgement contract (`decision` / abstain / optional

--- a/src/langres/__init__.py
+++ b/src/langres/__init__.py
@@ -28,6 +28,8 @@ which ``derive_threshold`` needs (the ``[trained]`` extra) -- into
 """
 
 import importlib
+from importlib.metadata import PackageNotFoundError
+from importlib.metadata import version as _metadata_version
 from typing import TYPE_CHECKING, Any
 
 from langres.clients.openrouter import BudgetExceeded
@@ -78,7 +80,13 @@ __all__ = [
     "select_for_review",
 ]
 
-__version__ = "0.2.0"
+# Single source of truth is pyproject.toml; resolved from installed metadata so
+# a version bump can never miss this string again. Falls back for source trees
+# imported without installation.
+try:
+    __version__ = _metadata_version("langres")
+except PackageNotFoundError:  # pragma: no cover - only hit on uninstalled source trees
+    __version__ = "0.0.0.dev0"
 
 #: ``name -> owning module`` for root exports resolved on first access (PEP
 #: 562, mirroring ``langres.core.__getattr__``). ``EvalReport`` and


### PR DESCRIPTION
Smoke-testing the published 0.3.0 wheel surfaced `langres.__version__ == "0.2.0"` — a hardcoded string that missed the 0.3.0 bump (pip metadata was correct). Now resolved from `importlib.metadata.version("langres")` with a dev fallback for uninstalled source trees, so pyproject.toml is the single source of truth and a bump can never miss it again.

Verified: `__version__ == 0.3.0` in a synced tree; ruff + mypy strict clean; import-budget and verbs suites pass (111 passed).

## Summary by Sourcery

Resolve the library’s exported __version__ to the installed package metadata so it stays in sync with the released version.

Bug Fixes:
- Prevent langres.__version__ from drifting from the actual released version by deriving it from importlib.metadata with a safe fallback for uninstalled source trees.

Documentation:
- Document the version drift fix and new version resolution behavior in the Unreleased section of the changelog.