### PR TITLE
fix: point langres repo URLs at fxd24 (canonical org)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -5,8 +5,8 @@ KMP_DUPLICATE_LIB_OK=1
 
 # --- LLM teacher / judge (OpenRouter via litellm) -----------------------------
 # OpenRouter is a unified gateway; litellm routes models prefixed "openrouter/".
-# Pull the value from brainsquad's .env (it already has OpenRouter creds):
-#   grep -i openrouter ../brainsquad/.env >> .env
+# Pull the value from a sibling project's .env (if it already has OpenRouter creds):
+#   grep -i openrouter ../<your-other-project>/.env >> .env
 # Not needed for M0.5 (the example uses a fake/recorded LLM); required for the
 # M1 teacher run and the optional live smoke test.
 OPENROUTER_API_KEY=

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -5,7 +5,7 @@ type: software
 authors:
   - family-names: "Graf"
     given-names: "David"
-    email: "david@raisesquad.com"
+    email: "hire@grafdavid.com"
 repository-code: "https://github.com/fxd24/langres"
 url: "https://github.com/fxd24/langres"
 license: Apache-2.0

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # langres
 
-[![Status](https://img.shields.io/badge/status-0.x%20beta-blue.svg)](https://github.com/raisesquad/langres)
-[![Tests](https://github.com/raisesquad/langres/actions/workflows/test.yml/badge.svg)](https://github.com/raisesquad/langres/actions/workflows/test.yml)
-[![codecov](https://codecov.io/gh/raisesquad/langres/branch/main/graph/badge.svg)](https://codecov.io/gh/raisesquad/langres)
+[![Status](https://img.shields.io/badge/status-0.x%20beta-blue.svg)](https://github.com/fxd24/langres)
+[![Tests](https://github.com/fxd24/langres/actions/workflows/test.yml/badge.svg)](https://github.com/fxd24/langres/actions/workflows/test.yml)
+[![codecov](https://codecov.io/gh/fxd24/langres/branch/main/graph/badge.svg)](https://codecov.io/gh/fxd24/langres)
 [![PyPI](https://img.shields.io/pypi/v/langres.svg)](https://pypi.org/project/langres/)
 [![Python](https://img.shields.io/badge/python-3.12+-blue.svg)](https://www.python.org/downloads/)
 [![License](https://img.shields.io/badge/license-Apache--2.0-blue.svg)](#license)
@@ -98,7 +98,7 @@ pip install 'langres[eval]'        # + ranking metrics for blocker evaluation (r
 ```
 
 Or from source with [`uv`](https://docs.astral.sh/uv/):
-`git clone https://github.com/raisesquad/langres.git && cd langres && uv sync`,
+`git clone https://github.com/fxd24/langres.git && cd langres && uv sync`,
 then `uv run python examples/quickstart_verbs.py`.
 
 > **Lean by construction.** A bare `import langres` / `import langres.core`

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -10,7 +10,7 @@ Please report vulnerabilities **privately** — do not open a public issue:
 
 - Preferred: [GitHub private vulnerability reporting](https://github.com/fxd24/langres/security/advisories/new)
   (Security tab → "Report a vulnerability").
-- Or email **david@raisesquad.com** with a description, reproduction steps,
+- Or email **hire@grafdavid.com** with a description, reproduction steps,
   and impact.
 
 You should receive an acknowledgement within a few days. Please allow a

--- a/TODOS.md
+++ b/TODOS.md
@@ -5,8 +5,8 @@ This is the durable home for "we decided not to do this now" so it doesn't only
 live in a planning doc. Each item points to its tracking issue or milestone.
 
 Detail lives in the M4.5/M5 plan, the ROADMAP, and the seam-audit epic
-([#20](https://github.com/raisesquad/langres/issues/20)) with method-delta
-backlog in [#55](https://github.com/raisesquad/langres/issues/55).
+([#20](https://github.com/fxd24/langres/issues/20)) with method-delta
+backlog in [#55](https://github.com/fxd24/langres/issues/55).
 
 ## Flywheel loop follow-ons (deferred from the closed-loop phase, 0.2.0)
 
@@ -46,12 +46,12 @@ backlog in [#55](https://github.com/raisesquad/langres/issues/55).
 ## Method families & extensibility
 
 - **Splink adapter as a Fellegi–Sunter feature-store row** — wrap Splink behind the
-  seam instead of only the native FS-EM judge. ([#55](https://github.com/raisesquad/langres/issues/55))
+  seam instead of only the native FS-EM judge. ([#55](https://github.com/fxd24/langres/issues/55))
 - **Full C1 six-dataset replication portfolio** — only FZ/AG (+ Abt-Buy in M4.5) are
-  in scope now; the rest of the benchmark portfolio is deferred. ([#55](https://github.com/raisesquad/langres/issues/55))
+  in scope now; the rest of the benchmark portfolio is deferred. ([#55](https://github.com/fxd24/langres/issues/55))
 - **Public method-registration API** — a supported, documented way for third parties
   to register a new judge/method (beyond editing `methods.py:_make_module_builder`
-  in-tree). ([#55](https://github.com/raisesquad/langres/issues/55))
+  in-tree). ([#55](https://github.com/fxd24/langres/issues/55))
 
 ## Hardening
 

--- a/TODOS.md
+++ b/TODOS.md
@@ -69,4 +69,4 @@ backlog in [#55](https://github.com/fxd24/langres/issues/55).
 
 - **Hosted demo / notebooks / CLI** — deferred until after the distribution decision.
 - **Human correction UX** — langres owns the `corrections.jsonl` contract + harvest
-  only; the review-queue UI stays brainsquad-side.
+  only; the review-queue UI stays consumer-side.

--- a/docs/ADDING_A_METHOD.md
+++ b/docs/ADDING_A_METHOD.md
@@ -9,7 +9,7 @@ usable, swappable, and tunable by everyone through one seam. This guide walks th
 > **No public plugin API yet.** There is deliberately **no** external/plugin
 > registration entry point today. A new *name-selectable* method must be wired
 > into the in-repo dispatch sites below. A single public method-registration API
-> that collapses them is **deferred to [issue #55](https://github.com/raisesquad/langres/issues/55)**
+> that collapses them is **deferred to [issue #55](https://github.com/fxd24/langres/issues/55)**
 > (see `TODOS.md`). This document is the contract *as it stands* — what a
 > contributor editing the repo does now.
 >

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -22,12 +22,12 @@ Three stacked definitions of "usable", all true at once:
 2. **Training framework** — you `fit` / `optimize` / `distill` a pipeline and it
    produces a **versioned artifact** (extractors + blocking funnel + judge +
    thresholds + compiled prompt).
-3. **Inference** — a consumer (brainsquad) `load`s that artifact and runs it on
+3. **Inference** — a consumer `load`s that artifact and runs it on
    its own infra. *Engine intelligence in langres; data, persistence, visibility
    in the consumer.*
 
-**General by design, proven by one real use case.** brainsquad
-is our first and only real consumer — Person (hard, multilingual), Program/Project
+**General by design, proven by one real use case.** Our first and only
+real consumer — Person (hard, multilingual), Program/Project
 (easy), Geography (external authority), Grant (later). We prove the framework on
 it, while keeping every abstraction entity-agnostic.
 
@@ -84,11 +84,11 @@ raw → [enrich: extractors / GLiNER / (later) web-search] → feature bag
 
 - **Dedup / batch** — resolve a dataset against itself → clusters. (Have the parts.)
 - **Incremental / linking** — probe a *new* record against an existing entity
-  store → matched entity id or "new". (`stream_against`; brainsquad's runtime op.)
+  store → matched entity id or "new". (`stream_against`; the consumer's runtime op.)
 
 ### 2.4 The flagship loop — build a golden label, then grow it over time
 
-The core brainsquad pattern (and the most common real ER loop): we first *see* a
+The core consumer pattern (and the most common real ER loop): we first *see* a
 sparse mention (often just a name — a person extracted from a document, an org
 name), optionally **enrich** it (e.g. add a LinkedIn URL, a registry id, web-search
 content), and mint it as a **golden label**. Then every future appearance of that
@@ -115,21 +115,21 @@ Two properties make this work and must be designed in:
 
 This is **UC2 (Entity Linking) ⊕ UC4 (Master Data Creation), run incrementally** —
 see §2.5. langres provides the *brain* (the linker + the canonicalization rules,
-as a versioned artifact); brainsquad provides the *body* (the persistent golden
-store, the event log, reversibility — exactly its #1051 design).
+as a versioned artifact); the consumer provides the *body* (the persistent golden
+store, the event log, reversibility — exactly its design).
 
 ### 2.5 Use-case coverage — the compass
 
 We track direction against the documented taxonomy in `USE_CASES.md`. Each use
 case must end up either **filled by a milestone** or **deliberately delegated to
-the consumer** (brainsquad owns the stateful "body"; langres owns the "brain").
+the consumer** (which owns the stateful "body"; langres owns the "brain").
 
 | Use case (`USE_CASES.md`) | Where it lands | Status |
 |---|---|---|
 | **UC1 Deduplication** (batch → clusters) | M2 | **shipped** (M2 + `dedupe()` verb) |
 | **UC2 Entity Linking** (link to a target store) | M5 (incremental `assign`) | **shipped** — incremental `assign`; cross-source `stream_against` reserved |
 | **UC10 Fuzzy FK** (special case of UC2) | via M5 | **shipped** via `assign` |
-| **UC4 Master Data Creation** (golden records / survivorship) | M5 — **promoted** (brainsquad needs golden labels *now*, not V1.1) | **shipped** (`Canonicalizer` + enrichment) |
+| **UC4 Master Data Creation** (golden records / survivorship) | M5 — **promoted** (the consumer needs golden labels *now*, not V1.1) | **shipped** (`Canonicalizer` + enrichment) |
 | ⭐ **Flagship: incremental linking + progressive golden-record enrichment** (§2.4) | M5 (= UC2 ⊕ UC4 + Enricher loop) | **shipped** — `assign` ⊕ `Canonicalizer.enrich`, verified end-to-end |
 | **UC9 Negative constraints** (cannot-link) | M6 (constrained clustering) | on path |
 | **Human-in-the-loop** labeling | M1 (bootstrapper labeler — human option) | on path |
@@ -138,12 +138,12 @@ the consumer** (brainsquad owns the stateful "body"; langres owns the "brain").
 | **UC3 Record Linkage** (multi-source) | post-M5, config | deferred (V1.1) |
 | **Enrichment via web-search / Exa** | Enricher plug-in (§2.2) | **deferred, slotted** — out of scope now |
 | **UC8 PPRL** (privacy-preserving) | consumer strips private features *before* langres sees them (§5) | delegated |
-| **UC7 Collective / graph** | langres = pairwise brain; brainsquad builds the graph/network layer on resolved nodes | delegated |
-| **UC5 Streaming** | langres compiles the artifact (brain); brainsquad runs it real-time (body) — matches #1051 | delegated |
-| **UC6 Temporal evolution** | langres emits reversible judgements; brainsquad owns the temporal store + event log (#1051) | delegated |
+| **UC7 Collective / graph** | langres = pairwise brain; the consumer builds the graph/network layer on resolved nodes | delegated |
+| **UC5 Streaming** | langres compiles the artifact (brain); the consumer runs it real-time (body) | delegated |
+| **UC6 Temporal evolution** | langres emits reversible judgements; the consumer owns the temporal store + event log | delegated |
 
 The "delegated" rows are not gaps — they are the **clean brain/body seam** the
-#1051 design already assumes. *Follow-up: once direction is locked, formalize the
+consumer's design already assumes. *Follow-up: once direction is locked, formalize the
 flagship loop (§2.4) as a named use case in `USE_CASES.md` and promote UC4 there.*
 
 ---
@@ -157,10 +157,10 @@ flagship loop (§2.4) as a named use case in `USE_CASES.md` and promote UC4 ther
 | GLiNER / GLiNER2 | Extractor | feature extraction → blocking keys + comparison features |
 | LLM judge (litellm) | Module | strong judge / teacher |
 | **DSPy-distilled judge** | Module | cheap student compiled from the teacher (the differentiator) |
-| **GLinker** (`gliner-linker`, pg_trgm retrieval) | Blocker + Module | candidate — fit for record↔record is **unverified** (trained on mention↔description; see §8), benchmarked as one option in M3 |
+| **GLinker** (`gliner-linker`, pg_trgm retrieval) | Blocker + Module | candidate — fit for record↔record is **unverified** (trained on mention↔description; see §7), benchmarked as one option in M3 |
 | Fellegi-Sunter / logistic | Module | learned weighted comparison |
 
-**Benchmark on two axes:** (a) brainsquad's own Person/Program gold sets
+**Benchmark on two axes:** (a) the consumer's own Person/Program gold sets
 (dogfood + real validity), and (b) standard ER benchmarks (DBLP-ACM, Abt-Buy,
 etc.) for external validity and method sanity-checks.
 
@@ -184,13 +184,13 @@ The bootstrapper is the unlock.
 
 ---
 
-## 5. The artifact (brainsquad integration contract)
+## 5. The artifact (consumer integration contract)
 
 A `Resolver` serialises to a **versioned artifact**: feature extractors +
 blocking funnel config + judge (incl. compiled DSPy prompt / model ref) +
-thresholds + metric provenance. brainsquad `Resolver.load("person_v1")` and calls
+thresholds + metric provenance. The consumer `Resolver.load("person_v1")` and calls
 `.resolve(records)` (batch) or `.link(record)` (incremental). langres owns engine
-intelligence; brainsquad owns persistence, visibility (public/private feature
+intelligence; the consumer owns persistence, visibility (public/private feature
 stripping happens consumer-side before features reach langres), and the cluster
 store.
 
@@ -209,7 +209,7 @@ Build the `Resolver` container (compose Blocker+Comparator+Module+Clusterer;
 
 ### M1 — Person gold set (cold-start, LLM-teacher)
 Bootstrapper: hard-negative mining from the Blocker + LLM-teacher labeler +
-coverage report. Produce the brainsquad **People (board-members) gold set**.
+coverage report. Produce the **People (board-members) gold set**.
 - **Exit:** a Person gold set exists with measured teacher-vs-human agreement on
   a spot-check sample; blocking **Pair-Completeness reported** (target ≥ 0.95).
 
@@ -217,9 +217,9 @@ coverage report. Produce the brainsquad **People (board-members) gold set**.
 feature bag → block → baseline judge → cluster → eval → **artifact**. The shipped
 baseline judge is the zero-spend `WeightedAverageJudge` over the feature bag;
 richer judges (embedding cascade, `gliner-linker`, LLM) are raced in M3. Shipped on
-Fodors-Zagat (Person artifact + brainsquad load-and-run is M5, see below).
+Fodors-Zagat (Person artifact + consumer load-and-run is M5, see below).
 - **Exit (SHIPPED):** **BCubed F1 baseline reported** on held-out gold; the saved
-  artifact runs a brainsquad-style **`.resolve()`** call end-to-end in a fresh
+  artifact runs a consumer-style **`.resolve()`** call end-to-end in a fresh
   process (identical clusters). Measured on Fodors-Zagat (seed=0, threshold 0.8):
   held-out BCubed P/R/F1 = 0.991/0.969/0.980 vs merge-nothing floor 0.932,
   Pair-Completeness 1.0. The M2 consumption contract is `resolve()`-only;
@@ -382,19 +382,7 @@ model/version registry, production/operability guidance, cannot-link clustering.
 
 ---
 
-## 7. Mapping to brainsquad (#1051)
-
-| brainsquad task (#1051) | langres milestone |
-|---|---|
-| Build People gold set (teacher set) | **M1** |
-| Walking skeleton: features → blocking → judge → clusters → persist | **M2** (langres half) |
-| Iterate: multi-filter blocking + DSPy distillation | **M3 + M4 + M6** |
-| Generalise to Program/Project + Geography | **M5** |
-| Versioned model artifact consumed at inference | **M2 artifact, hardened in M6** |
-
----
-
-## 8. Open questions / things to learn
+## 7. Open questions / things to learn
 
 - **Comparator design for heterogeneous features** — how rich to make the
   comparison-level taxonomy; learned vs. LLM-reasoned combiner; how anchors

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -27,7 +27,6 @@ Three stacked definitions of "usable", all true at once:
    in the consumer.*
 
 **General by design, proven by one real use case.** brainsquad
-([raisesquad/brainsquad#1051](https://github.com/raisesquad/brainsquad/issues/1051))
 is our first and only real consumer — Person (hard, multilingual), Program/Project
 (easy), Geography (external authority), Grant (later). We prove the framework on
 it, while keeping every abstraction entity-agnostic.

--- a/docs/research/20260701_er_seam_audit.md
+++ b/docs/research/20260701_er_seam_audit.md
@@ -116,7 +116,7 @@ Prioritized. Each is additive and backward-compatible; the common pairwise/froze
 
 10. **`CollectiveClusterer`** (inverts control: clusterer owns the merge loop, calls back a scorer with mutable `ClusterContext`) for relational/collective ER — a genuinely new stateful primitive, plus relational `FeatureSpec` fields.
 
-11. **Incremental `link(record, existing_anchors) → {matched_id | new} + ClusterDelta`** with stable-ID merge/split, and an optional live-corpus-stats provider on the judge, so brainsquad's living-cluster loop and Senzing-style frequency weighting are expressible without langres owning the store.
+11. **Incremental `link(record, existing_anchors) → {matched_id | new} + ClusterDelta`** with stable-ID merge/split, and an optional live-corpus-stats provider on the judge, so the consumer's living-cluster loop and Senzing-style frequency weighting are expressible without langres owning the store.
 
 **Explicitly out of scope / delegate:** schema-matching/attribute-alignment (Alaska — data integration, upstream of the seam); scale-out blocking execution (SQL/Spark pushdown — delegate to the body); owning GPU training loops for heavy transformers (wrap/delegate, don't reimplement the DL design space).
 
@@ -220,7 +220,7 @@ Sequenced and mapped to milestones, separating cheap high-leverage wins from big
 | S3 | **`DSPyJudge` + MIPROCompiler + gold/metric adapters** (state via SerializableState) | M4 | The M4 cheap-precise-judge target as designed |
 | S4 | **`LabelModelLabeler` (~40-line numpy MeTaL) + LabelingFunction protocol** | M4/M5 | Weak-supervision cold-start, API-free; combine-LFs-with-LLM hypothesis |
 | S5 | **`TrainableEmbeddingProvider.fit()` + SerializableState embedder + `UnionBlocker` + BlockingPy adapter + `ContrastiveEncoderTrainer`** | M5 | DeepBlocker, SC-Block, Sudowoodo blocker, per-feature union |
-| S6 | **Incremental `link(record, anchors) → ClusterDelta`** with stable-ID merge/split | M5 | brainsquad living-cluster loop; production credibility |
+| S6 | **Incremental `link(record, anchors) → ClusterDelta`** with stable-ID merge/split | M5 | the consumer's living-cluster loop; production credibility |
 
 ### Big bets (M5 → M6, only when a real target demands)
 

--- a/docs/research/20260707_data_prep_hard_case_mining_survey.md
+++ b/docs/research/20260707_data_prep_hard_case_mining_survey.md
@@ -2,7 +2,7 @@
 
 **Date:** 2026-07-07
 **Author:** langres research (orchestrated multi-agent survey; primary-source verified)
-**Issues:** Task 0 of [#86](https://github.com/raisesquad/langres/issues/86) (reusable hard-case / informative-pair mining seam) · feeds [#83](https://github.com/raisesquad/langres/issues/83) (AnyMatch) · epic [#85](https://github.com/raisesquad/langres/issues/85)
+**Issues:** Task 0 of [#86](https://github.com/fxd24/langres/issues/86) (reusable hard-case / informative-pair mining seam) · feeds [#83](https://github.com/fxd24/langres/issues/83) (AnyMatch) · epic [#85](https://github.com/fxd24/langres/issues/85)
 **Scope of this doc:** state-of-the-art synthesis **+ langres seam mapping**. It deliberately stops short of a seam interface / API / function design — that is a separate, later step (per the research-only decision on 2026-07-07).
 
 ---
@@ -402,7 +402,7 @@ Encoder models (BERT / sentence-transformers) are no longer the only game; the O
 
 ## 13. Future work
 
-*What the three research threads point to as concrete things to try — direction, not commitment. Kept here as a living note; the data-prep mining directions are tracked in [#86](https://github.com/raisesquad/langres/issues/86), the collective/relational architecture gap in §11.4.*
+*What the three research threads point to as concrete things to try — direction, not commitment. Kept here as a living note; the data-prep mining directions are tracked in [#86](https://github.com/fxd24/langres/issues/86), the collective/relational architecture gap in §11.4.*
 
 **The empirical question threading all of these — does capability *transfer* between the two roles of one model?** The whole bet is that a single decoder can be a *generator* (matching) and a *recall* engine (blocking embeddings) at once. What we don't know — and should measure directly — is the **transfer** between those roles and its *direction*: does fine-tuning / prompt-optimizing the model for matching help, not affect, or *hurt* its embedding/blocking recall — and does contrastive embedding tuning help or hurt matching? GritLM's ablation says *joint* training degrades neither at 7B (§12.2), but transfer under *sequential* or *small-scale QLoRA* tuning is untested. **Practical rule: evaluate every experiment below on *both* stages — recall (Pair Completeness) and matching (F1) — not just the one it targets**, so we can see whether the capability transfers, is neutral, or interferes. These are starting probes; the list is open and expected to grow as results come in.
 

--- a/docs/research/20260709_cost_accounting_design.md
+++ b/docs/research/20260709_cost_accounting_design.md
@@ -157,7 +157,7 @@ they are asked:
 > consumer.* (`ROADMAP.md:25-27`)
 
 Streaming, temporal, and the cluster store are all delegated to the consumer
-(brainsquad) on exactly this basis (ROADMAP §2.3, §5). **Cost falls on the same
+(the consumer) on exactly this basis (ROADMAP §2.3, §5). **Cost falls on the same
 fault line**, and it splits into three, not three-of-a-kind:
 
 - **A paid model invocation is engine-side and is langres's job to meter.** An
@@ -466,7 +466,7 @@ The `Resolver` artifact today is components-only (`ArtifactManifest`,
 + blocking funnel config + judge … + thresholds + **metric provenance**"
 (`ROADMAP.md:190-192`) — the metric-provenance half was never built.
 
-**Why it matters:** the artifact is the brainsquad integration contract
+**Why it matters:** the artifact is the consumer integration contract
 (ROADMAP §5). An artifact that declares what it *is* (its components) but not what
 it *achieves and costs* (held-out F1, `$/1k pairs`, the model + price it was
 measured at) is **not choosable** — a consumer picking `person_v1` vs `person_v2`

--- a/docs/research/20260709_cost_accounting_design.md
+++ b/docs/research/20260709_cost_accounting_design.md
@@ -1,6 +1,6 @@
 # Cost accounting in langres — a design note for the tracking layer
 
-*Design note for [issue #100](https://github.com/raisesquad/langres/issues/100)
+*Design note for [issue #100](https://github.com/fxd24/langres/issues/100)
 ("Cost tracking: comprehensive design"). Scope: how langres should account for
 the cost of an experiment run coherently — what it stores, what it derives, where
 each concern lives, and how `RunRecord` evolves. Documentation only; no code

--- a/docs/research/20260710_dx_audit_examples_we_wish_we_had.md
+++ b/docs/research/20260710_dx_audit_examples_we_wish_we_had.md
@@ -176,7 +176,7 @@ name.** `docs/ROADMAP.md`, the current statement of direction, mentions
 
 `langres.ui` is the one to reject on principle, not just on redundancy. ROADMAP §1:
 *"Engine intelligence in langres; data, persistence, **visibility** in the
-consumer."* A shipped Streamlit app **is** visibility. It belongs to brainsquad, on
+consumer."* A shipped Streamlit app **is** visibility. It belongs to the consumer, on
 the same side of the seam as streaming and temporal support. Shipping it would put
 langres on both sides of its own architectural boundary.
 

--- a/docs/research/20260713_model_identity_and_hub.md
+++ b/docs/research/20260713_model_identity_and_hub.md
@@ -3,7 +3,7 @@
 *Design note for the maintainer's direction question — "think of HF transformers:
 anybody can publish their model, and you can use it easily; today `link`/`dedupe`
 don't tell you which model is used, and the verbs should be tied to the type of
-model one uses" — and for [issue #103](https://github.com/raisesquad/langres/issues/103)
+model one uses" — and for [issue #103](https://github.com/fxd24/langres/issues/103)
 (LLMJudge unreachable by name from the verbs). Scope: what "model identity" and
 "publishing" should mean in langres, mapped honestly onto the seams that exist,
 with staged options. Documentation only; no code changes. Written against `main`

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,10 +6,10 @@ readme = "README.md"
 license = "Apache-2.0"
 license-files = ["LICENSE", "NOTICE"]
 authors = [
-    { name = "David Graf", email = "david@raisesquad.com" }
+    { name = "David Graf", email = "hire@grafdavid.com" }
 ]
 maintainers = [
-    { name = "David Graf", email = "david@raisesquad.com" }
+    { name = "David Graf", email = "hire@grafdavid.com" }
 ]
 requires-python = ">=3.12"
 dependencies = [

--- a/src/langres/core/harvest.py
+++ b/src/langres/core/harvest.py
@@ -11,7 +11,7 @@ and, where applicable, a judge's ``fit()``.
 The division of labor is deliberate: langres owns the **contract**, the
 **harvest**, and the headless + terminal review surfaces (the ``langres review``
 CLI and its CSV round-trip); anything with a rendering loop (a web review UI)
-stays in the downstream application (e.g. brainsquad). :class:`Correction` is the
+stays in the downstream application. :class:`Correction` is the
 stable line schema a review tool writes to ``corrections.jsonl``; :class:`CorrectionLog`
 is the reference reader/writer for that file (mirroring ``JudgementLog`` so the
 two flywheel files are handled the same way); :func:`harvest_labeled_pairs` is
@@ -66,7 +66,7 @@ _CORRECTION_SCHEMA_VERSION = 1
 class Correction(BaseModel):
     """One human verdict-correction for a judged pair: the ``corrections.jsonl`` line.
 
-    This is the stable contract an external review queue (e.g. brainsquad) writes
+    This is the stable contract an external review queue writes
     when a reviewer overrides a judge's verdict. Only ``left_id``/``right_id`` and
     the corrected ``label`` are required; the rest is optional audit context. A
     pair is identified order-independently on harvest (see

--- a/src/langres/core/presets.py
+++ b/src/langres/core/presets.py
@@ -159,7 +159,7 @@ class NoJudgeAvailableError(RuntimeError):
 #: funnels a user onto the LLM-judge path (the keyed path dead-ends without it:
 #: ``dspy`` is imported at dspy_judge.py module level but ships in the extra).
 _INSTALL_LLM_EXTRA = "`uv sync --extra llm` or `pip install 'langres[llm]'`"
-_GETTING_STARTED_URL = "https://github.com/raisesquad/langres/blob/main/docs/GETTING_STARTED.md"
+_GETTING_STARTED_URL = "https://github.com/fxd24/langres/blob/main/docs/GETTING_STARTED.md"
 
 
 def choose_auto_judge(

--- a/tests/data/test_m2_artifact_slow.py
+++ b/tests/data/test_m2_artifact_slow.py
@@ -1,7 +1,7 @@
-"""M2 EXIT — fresh-process artifact identity proof (the brainsquad contract).
+"""M2 EXIT — fresh-process artifact identity proof (the consumer artifact contract).
 
 Proves the second half of the M2 exit criterion: a saved Resolver artifact runs
-a brainsquad-style ``.resolve()`` call end-to-end **in a fresh process** and
+a consumer-style ``.resolve()`` call end-to-end **in a fresh process** and
 yields *identical* clusters to the in-process run. ``resolve()`` is the ONLY M2
 consumption call — ``.link()`` / ``.stream_against()`` are M5 stubs and are never
 touched here.
@@ -77,7 +77,7 @@ def test_m2_artifact_resolve_identity_fresh_process(tmp_path: Path) -> None:
     best_threshold = tune_threshold_on_train(train_records, train_clusters)
     resolver = build_restaurant_resolver(best_threshold)
 
-    # In-process resolve over the held-out test dicts (the brainsquad call shape).
+    # In-process resolve over the held-out test dicts (the consumer call shape).
     test_dicts = [r.model_dump() for r in test_records]
     clusters_a = resolver.resolve(test_dicts)
     assert clusters_a, "expected the baseline to find at least one multi-record cluster"

--- a/tests/data/test_m2_bad_input.py
+++ b/tests/data/test_m2_bad_input.py
@@ -1,6 +1,6 @@
 """M2 bad-input contract — the resolver's documented behavior on degenerate input.
 
-These are the DX-hardening assertions from the Wave 3 review: a brainsquad
+These are the DX-hardening assertions from the Wave 3 review: a downstream
 integrator must know exactly what ``resolve`` does at the edges. They run FAST —
 the resolver here mirrors :func:`build_restaurant_resolver` (same
 ``RestaurantSchema`` + ``Comparator.from_schema`` + ``WeightedAverageJudge`` +


### PR DESCRIPTION
Canonical org is **`fxd24`** (where the repo actually lives). Replaces
`raisesquad/langres` → `fxd24/langres` everywhere it was a repo URL:

- **README** — Status/Tests/**Codecov** badges + the `git clone` command
- **`presets.py`** — the runtime `GETTING_STARTED_URL` shown to users
- **docs/TODOS** — issue links (`.../issues/20`, `#55`, `#86`, …)

Pure string swaps (15×), no logic changes.

**Deliberately left alone:** the `david@raisesquad.com` contact email and the
`raisesquad/brainsquad` cross-repo link (a different repo).

Fixes the Codecov badge flagged in #116.

## Summary by Sourcery

Point all user-facing langres repository and issue URLs at the canonical fxd24 GitHub organization, ensuring badges, clone instructions, runtime help text, and docs links resolve correctly.

Bug Fixes:
- Update README badges and runtime GETTING_STARTED_URL to point at the canonical fxd24/langres repository, fixing broken links including the Codecov badge.

Enhancements:
- Align documentation issue references with the fxd24/langres GitHub repository for consistency with the current project location.

Documentation:
- Refresh README, guides, and research docs to use the canonical fxd24/langres GitHub org in all repo and issue links.