### PR TITLE
docs: zero-context clarity pass (scrub private-repo references, define jargon at first use)

### DIFF
--- a/.claude/dave/workflows/parallel-usage.md
+++ b/.claude/dave/workflows/parallel-usage.md
@@ -8,10 +8,10 @@ Each worktree works on a phase (or milestone) independently. There is no central
 coordinator, no COORDINATION.yaml, no orchestrator branch. Git is the coordinator.
 
 ```
-Worktree A (brainsquad-1):  discuss -> research -> plan -> execute -> review -> verify -> push -> reflect
+Worktree A (worktree-a):  discuss -> research -> plan -> execute -> review -> verify -> push -> reflect
                              Creates branch, does work, creates PR, merges to main.
 
-Worktree B (brainsquad-2):  discuss -> research -> plan -> execute -> review -> verify -> push -> reflect
+Worktree B (worktree-b):  discuss -> research -> plan -> execute -> review -> verify -> push -> reflect
                              Pulls main (sees A's merged work), creates its own branch, works, merges.
 ```
 
@@ -43,13 +43,13 @@ Worktree B (brainsquad-2):  discuss -> research -> plan -> execute -> review -> 
 
 ```bash
 # Worktree 1: Phase 3 (PDF extraction)
-cd brainsquad-1
+cd worktree-a
 git fetch origin && git checkout -B feature/phase-3-pdf origin/main
 # Run Dave workflow: discuss, research, plan, execute, review, verify, push
 # PR merges to main
 
 # Worktree 2: Phase 5 (web search integration) -- independent of Phase 3
-cd brainsquad-2
+cd worktree-b
 git fetch origin && git checkout -B feature/phase-5-web-search origin/main
 # Run Dave workflow in parallel with worktree 1
 # PR merges to main independently
@@ -59,12 +59,12 @@ git fetch origin && git checkout -B feature/phase-5-web-search origin/main
 
 ```bash
 # Worktree 1: Phase 3
-cd brainsquad-1
+cd worktree-a
 git fetch origin && git checkout -B feature/phase-3 origin/main
 # Complete phase 3, merge PR to main
 
 # Worktree 2: Phase 4 (depends on Phase 3)
-cd brainsquad-2
+cd worktree-b
 git fetch origin && git checkout -B feature/phase-4 origin/main  # Now includes Phase 3
 # Phase 4 sees Phase 3's artifacts and code via main
 ```

--- a/.env.example
+++ b/.env.example
@@ -5,8 +5,7 @@ KMP_DUPLICATE_LIB_OK=1
 
 # --- LLM teacher / judge (OpenRouter via litellm) -----------------------------
 # OpenRouter is a unified gateway; litellm routes models prefixed "openrouter/".
-# Pull the value from brainsquad's .env (it already has OpenRouter creds):
-#   grep -i openrouter ../brainsquad/.env >> .env
+# Get a key at https://openrouter.ai/keys and paste it below.
 # Not needed for M0.5 (the example uses a fake/recorded LLM); required for the
 # M1 teacher run and the optional live smoke test.
 OPENROUTER_API_KEY=

--- a/README.md
+++ b/README.md
@@ -8,11 +8,13 @@
 [![License](https://img.shields.io/badge/license-Apache--2.0-blue.svg)](#license)
 [![Ruff](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/astral-sh/ruff/main/assets/badge/v2.json)](https://github.com/astral-sh/ruff)
 
-**langres** is a composable entity resolution (ER) framework for Python: the same
-matching "brain" (a swappable **judge**) behind one seam, tunable with zero
-labeled data. Its thesis is to be the place where any ER method — string
-similarity, embeddings, an LLM judge, a trained classifier — is implemented
-**once** and stays usable/swappable/tunable by anyone.
+**langres** is a composable entity resolution (ER) framework for Python: it
+finds records that refer to the same real-world entity. The matching "brain" —
+a swappable **judge**, the component that scores whether two records match —
+sits behind one interface and is tunable with zero labeled data. Its thesis is
+to be the place where any ER method — string similarity, embeddings, an LLM
+judge, a trained classifier — is implemented **once** and stays
+usable/swappable/tunable by anyone.
 
 ---
 
@@ -20,9 +22,12 @@ similarity, embeddings, an LLM judge, a trained classifier — is implemented
 
 langres closes a loop most ER tools leave open — and the loop is **LLM-native**
 end to end. A frontier LLM gets you far out of the box with just a prompt and
-bootstraps *silver* labels; a human reviews only the uncertain margin; the
-harvested labels then buy the **same judgement cheaper** — the production
-pattern is prompt-tuning a *smaller* LLM with DSPy (`DSPyJudge`), with
+bootstraps *silver* labels (machine-generated, not yet human-verified); a human
+reviews only the **uncertain margin** — the candidate pairs whose scores fall
+closest to the decision threshold, i.e. the ones the judge is least sure about
+and the only ones worth human eyes; the harvested labels then buy the **same
+judgement cheaper** — the production pattern is prompt-tuning a *smaller* LLM
+with DSPy (`DSPyJudge`), with
 fine-tuning a small LM as the roadmap's next rung — and a **cascade** runs the
 cheap judge everywhere, escalating only the still-uncertain pairs back to the
 frontier. The point is reusing the knowledge already encoded in LLMs and
@@ -45,14 +50,18 @@ pushing it further.
 ```
 
 Every stage is shipped API, not roadmap: `dedupe(records, log=…)` (the signal
-inlet), `select_for_review` + `ReviewQueue` + the `langres review` / CSV
-round-trip CLI, `harvest_labeled_pairs` → `derive_threshold_from_pairs`,
-DSPy prompt-tuned judges (`DSPyJudge` — a precision-tuned signature let a
+inlet), `select_for_review` + `ReviewQueue` + the `langres review` CLI with its
+CSV round-trip (`langres export-csv` writes the uncertain pairs to a `.csv`
+file you label in any spreadsheet; `langres import-csv` reads the answers
+back), `harvest_labeled_pairs` → `derive_threshold_from_pairs`,
+DSPy prompt-tuned judges (`DSPyJudge` — a precision-tuned prompt signature let a
 cheap model **beat an uncompiled frontier model at lower cost** on our paid
 benchmark), `CascadeJudge`, and `Resolver.save`/`load` for the whole fitted
-pipeline. Classical students (`RandomForestJudge.fit`) ship too, as honest
+pipeline. Classical *students* (cheap judges trained on the harvested labels —
+`RandomForestJudge.fit`) ship too, as honest
 baselines and **$0 plumbing**. Run the loop's core offline for free — dedupe →
-log → review → harvest → tuned threshold → tearsheet:
+log → review → harvest → tuned threshold → tearsheet (a one-page HTML quality
+report):
 
 ```bash
 uv run python examples/flywheel_min.py
@@ -60,8 +69,9 @@ uv run python examples/flywheel_min.py
 
 The full student-and-cascade lifecycle runs at $0 in
 [`examples/flywheel_closed_loop.py`](examples/flywheel_closed_loop.py).
-Blocking gets the modern treatment too: `VectorBlocker` recalls candidates
-with LLM-based embedders.
+Blocking — the cheap pre-filter that decides which record pairs are worth
+judging at all — gets the modern treatment too: `VectorBlocker` recalls
+candidates with LLM-based embedders.
 [**docs/GETTING_STARTED.md**](docs/GETTING_STARTED.md) walks the lifecycle step
 by step, with a runnable snippet inline at every stage.
 
@@ -203,7 +213,7 @@ custom pipelines. See [docs/DX_RESOLVER.md](docs/DX_RESOLVER.md) and
 | Pairwise **link verdict** (`link`) | ✅ shipped |
 | String / embedding / zero-shot-LLM judges; fail-fast, spend-capped `"auto"` | ✅ shipped |
 | Schema-driven `Resolver` with `save`/`load` (no pickle) | ✅ shipped |
-| **The flywheel loop**: judgement log, review queue + `langres` CLI, silver/gold harvest, threshold calibration | ✅ shipped |
+| **The flywheel loop**: judgement log, review queue + `langres` CLI, silver/gold label harvest, threshold calibration | ✅ shipped |
 | DSPy prompt-tuned judges (`DSPyJudge`) — tune a smaller, cheaper LLM on harvested labels | ✅ shipped |
 | Classical/probabilistic baseline judges (`RandomForestJudge`, `FellegiSunterJudge`), `CascadeJudge`, set-wise `SelectJudge` | ✅ shipped |
 | Blocking algebra (`KeyBlocker`, `CompositeBlocker` union/intersection/difference) | ✅ shipped |
@@ -250,7 +260,7 @@ real per-call cost in provenance, and every verb runs under a spend cap.
 
 The Peeters, Steiner & Bizer LLM entity-matching study
 ([arXiv 2310.11244](https://arxiv.org/abs/2310.11244), EDBT 2025) is replicated
-behind the langres seam. The **offline replay** parses the authors' archived
+inside langres. The **offline replay** parses the authors' archived
 model answers through langres' own prompt renderer, parser, and metrics and
 **reproduces the published F1 exactly**, at $0, with a byte-exact prompt
 round-trip. **Live re-runs** of two GPT-4o-family cells over all 1,206 Abt-Buy

--- a/TODOS.md
+++ b/TODOS.md
@@ -69,4 +69,4 @@ backlog in [#55](https://github.com/raisesquad/langres/issues/55).
 
 - **Hosted demo / notebooks / CLI** — deferred until after the distribution decision.
 - **Human correction UX** — langres owns the `corrections.jsonl` contract + harvest
-  only; the review-queue UI stays brainsquad-side.
+  only; the review-queue UI stays in the consuming application.

--- a/docs/GETTING_STARTED.md
+++ b/docs/GETTING_STARTED.md
@@ -6,12 +6,16 @@ Every step below carries a short runnable snippet **inline**; the links point
 *down* to the mechanics (they are for depth, never for the code you need to get
 moving).
 
-langres closes a loop most ER tools leave open: a frontier LLM bootstraps
-*silver* labels with just a prompt, a human reviews only the uncertain margin,
-those labels tune a **cheaper judge** — in production a DSPy prompt-tuned
-smaller LLM, in this page's $0 demo a classical student — and a **cascade**
-runs the cheap judge everywhere while escalating only the still-uncertain
-pairs back to the frontier.
+langres closes a loop most entity-resolution (ER) tools leave open: a frontier
+LLM acts as the first **judge** (the component that scores whether two records
+match) and bootstraps *silver* labels — machine-generated, not yet
+human-verified — with just a prompt; a human reviews only the **uncertain
+margin**: the candidate pairs whose scores fall closest to the decision
+threshold, the ones the judge is least sure about and the only ones a human
+needs to look at. Those labels tune a **cheaper judge** — in production a DSPy
+prompt-tuned smaller LLM, in this page's $0 demo a classical *student* model
+trained on them — and a **cascade** runs the cheap judge everywhere while
+escalating only the still-uncertain pairs back to the frontier.
 
 ```
    ┌────────────────────────────────────────────────────────────────────┐
@@ -31,8 +35,8 @@ pairs back to the frontier.
 
 **Its runnable twin is [`examples/flywheel_min.py`](https://github.com/fxd24/langres/blob/main/examples/flywheel_min.py)** —
 the core of the loop (steps 1–4: log → review the margin → CSV round-trip →
-harvest → data-driven threshold → re-run → tearsheet) in ~90 lines, offline at
-**$0**. Run it while you read:
+harvest → data-driven threshold → re-run → tearsheet, a one-page HTML quality
+report) in ~90 lines, offline at **$0**. Run it while you read:
 
 ```bash
 uv run python examples/flywheel_min.py
@@ -41,7 +45,8 @@ uv run python examples/flywheel_min.py
 The **full** seven steps — including the trained student and the cascade —
 run at $0 in [`examples/flywheel_closed_loop.py`](https://github.com/fxd24/langres/blob/main/examples/flywheel_closed_loop.py),
 a deeper fixture-driven harness that drives the `langres.core` primitives
-directly, bypassing the verbs and the CLI.
+directly, bypassing the verbs (`dedupe` / `link`, the one-call entry points)
+and the CLI.
 
 ---
 
@@ -133,8 +138,9 @@ covers all seven.
 
 ### 1. Day 1 — dedupe with the LLM, under a cap
 
-Start with the teacher. `dedupe(records)` (default `judge="auto"`) blocks,
-scores every candidate pair with the LLM, and clusters — spend-capped:
+Start with the teacher. `dedupe(records)` (default `judge="auto"`) blocks
+(pre-selects the record pairs worth comparing), scores every candidate pair
+with the LLM, and clusters — spend-capped:
 
 ```python
 result = dedupe(records)                    # judge="auto", $1 cap by default
@@ -177,7 +183,9 @@ print(f"{len(items)} pairs to review. Next:  uv run langres review queue.jsonl")
 ```
 
 Then a human answers the queue. The **primary review path is the CSV
-round-trip** — export the queue to a spreadsheet, label it, import it back:
+round-trip** — `langres export-csv` writes the queued pairs to a plain `.csv`
+file you can open in any spreadsheet; fill the `label` column with `y`/`n`,
+and `langres import-csv` reads the answers back:
 
 ```bash
 uv run langres export-csv queue.jsonl to_label.csv   # fill the 'label' column (y/n)
@@ -235,7 +243,7 @@ student_threshold = derive_threshold(student_scores, heldout_labels)
 > cheaper LLM.** This step's `RandomForestJudge` is Magellan-style supervised
 > matching, shipped as an honest baseline and free plumbing for the loop. The
 > LLM-native pattern is to spend the same harvested labels on **prompt-tuning a
-> smaller LLM** (`DSPyJudge`): a precision-tuned DSPy signature let a cheap
+> smaller LLM** (`DSPyJudge`): a precision-tuned DSPy prompt signature let a cheap
 > model beat an uncompiled frontier model at lower cost (see `docs/ROADMAP.md`;
 > automatic MIPROv2 *compilation* was measured and cut — the signature is the
 > lever). Fine-tuning a small LM on these labels is the roadmap's next rung.

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -22,15 +22,14 @@ Three stacked definitions of "usable", all true at once:
 2. **Training framework** — you `fit` / `optimize` / `distill` a pipeline and it
    produces a **versioned artifact** (extractors + blocking funnel + judge +
    thresholds + compiled prompt).
-3. **Inference** — a consumer (brainsquad) `load`s that artifact and runs it on
+3. **Inference** — a consumer application `load`s that artifact and runs it on
    its own infra. *Engine intelligence in langres; data, persistence, visibility
    in the consumer.*
 
-**General by design, proven by one real use case.** brainsquad
-([raisesquad/brainsquad#1051](https://github.com/raisesquad/brainsquad/issues/1051))
-is our first and only real consumer — Person (hard, multilingual), Program/Project
-(easy), Geography (external authority), Grant (later). We prove the framework on
-it, while keeping every abstraction entity-agnostic.
+**General by design, proven by one real use case.** A private downstream data
+product is our first and only real consumer — Person (hard, multilingual),
+Program/Project (easy), Geography (external authority), Grant (later). We prove
+the framework on it, while keeping every abstraction entity-agnostic.
 
 ---
 
@@ -85,11 +84,11 @@ raw → [enrich: extractors / GLiNER / (later) web-search] → feature bag
 
 - **Dedup / batch** — resolve a dataset against itself → clusters. (Have the parts.)
 - **Incremental / linking** — probe a *new* record against an existing entity
-  store → matched entity id or "new". (`stream_against`; brainsquad's runtime op.)
+  store → matched entity id or "new". (`stream_against`; the consumer's runtime op.)
 
 ### 2.4 The flagship loop — build a golden label, then grow it over time
 
-The core brainsquad pattern (and the most common real ER loop): we first *see* a
+The consumer's core pattern (and the most common real ER loop): we first *see* a
 sparse mention (often just a name — a person extracted from a document, an org
 name), optionally **enrich** it (e.g. add a LinkedIn URL, a registry id, web-search
 content), and mint it as a **golden label**. Then every future appearance of that
@@ -116,21 +115,21 @@ Two properties make this work and must be designed in:
 
 This is **UC2 (Entity Linking) ⊕ UC4 (Master Data Creation), run incrementally** —
 see §2.5. langres provides the *brain* (the linker + the canonicalization rules,
-as a versioned artifact); brainsquad provides the *body* (the persistent golden
-store, the event log, reversibility — exactly its #1051 design).
+as a versioned artifact); the consumer provides the *body* (the persistent golden
+store, the event log, reversibility).
 
 ### 2.5 Use-case coverage — the compass
 
 We track direction against the documented taxonomy in `USE_CASES.md`. Each use
 case must end up either **filled by a milestone** or **deliberately delegated to
-the consumer** (brainsquad owns the stateful "body"; langres owns the "brain").
+the consumer** (the consumer owns the stateful "body"; langres owns the "brain").
 
 | Use case (`USE_CASES.md`) | Where it lands | Status |
 |---|---|---|
 | **UC1 Deduplication** (batch → clusters) | M2 | **shipped** (M2 + `dedupe()` verb) |
 | **UC2 Entity Linking** (link to a target store) | M5 (incremental `assign`) | **shipped** — incremental `assign`; cross-source `stream_against` reserved |
 | **UC10 Fuzzy FK** (special case of UC2) | via M5 | **shipped** via `assign` |
-| **UC4 Master Data Creation** (golden records / survivorship) | M5 — **promoted** (brainsquad needs golden labels *now*, not V1.1) | **shipped** (`Canonicalizer` + enrichment) |
+| **UC4 Master Data Creation** (golden records / survivorship) | M5 — **promoted** (the consumer needs golden labels *now*, not V1.1) | **shipped** (`Canonicalizer` + enrichment) |
 | ⭐ **Flagship: incremental linking + progressive golden-record enrichment** (§2.4) | M5 (= UC2 ⊕ UC4 + Enricher loop) | **shipped** — `assign` ⊕ `Canonicalizer.enrich`, verified end-to-end |
 | **UC9 Negative constraints** (cannot-link) | M6 (constrained clustering) | on path |
 | **Human-in-the-loop** labeling | M1 (bootstrapper labeler — human option) | on path |
@@ -139,12 +138,12 @@ the consumer** (brainsquad owns the stateful "body"; langres owns the "brain").
 | **UC3 Record Linkage** (multi-source) | post-M5, config | deferred (V1.1) |
 | **Enrichment via web-search / Exa** | Enricher plug-in (§2.2) | **deferred, slotted** — out of scope now |
 | **UC8 PPRL** (privacy-preserving) | consumer strips private features *before* langres sees them (§5) | delegated |
-| **UC7 Collective / graph** | langres = pairwise brain; brainsquad builds the graph/network layer on resolved nodes | delegated |
-| **UC5 Streaming** | langres compiles the artifact (brain); brainsquad runs it real-time (body) — matches #1051 | delegated |
-| **UC6 Temporal evolution** | langres emits reversible judgements; brainsquad owns the temporal store + event log (#1051) | delegated |
+| **UC7 Collective / graph** | langres = pairwise brain; the consumer builds the graph/network layer on resolved nodes | delegated |
+| **UC5 Streaming** | langres compiles the artifact (brain); the consumer runs it real-time (body) | delegated |
+| **UC6 Temporal evolution** | langres emits reversible judgements; the consumer owns the temporal store + event log | delegated |
 
 The "delegated" rows are not gaps — they are the **clean brain/body seam** the
-#1051 design already assumes. *Follow-up: once direction is locked, formalize the
+consumer's design already assumes. *Follow-up: once direction is locked, formalize the
 flagship loop (§2.4) as a named use case in `USE_CASES.md` and promote UC4 there.*
 
 ---
@@ -161,7 +160,7 @@ flagship loop (§2.4) as a named use case in `USE_CASES.md` and promote UC4 ther
 | **GLinker** (`gliner-linker`, pg_trgm retrieval) | Blocker + Module | candidate — fit for record↔record is **unverified** (trained on mention↔description; see §8), benchmarked as one option in M3 |
 | Fellegi-Sunter / logistic | Module | learned weighted comparison |
 
-**Benchmark on two axes:** (a) brainsquad's own Person/Program gold sets
+**Benchmark on two axes:** (a) the consumer's own Person/Program gold sets
 (dogfood + real validity), and (b) standard ER benchmarks (DBLP-ACM, Abt-Buy,
 etc.) for external validity and method sanity-checks.
 
@@ -185,13 +184,13 @@ The bootstrapper is the unlock.
 
 ---
 
-## 5. The artifact (brainsquad integration contract)
+## 5. The artifact (the consumer integration contract)
 
 A `Resolver` serialises to a **versioned artifact**: feature extractors +
 blocking funnel config + judge (incl. compiled DSPy prompt / model ref) +
-thresholds + metric provenance. brainsquad `Resolver.load("person_v1")` and calls
+thresholds + metric provenance. The consumer runs `Resolver.load("person_v1")` and calls
 `.resolve(records)` (batch) or `.link(record)` (incremental). langres owns engine
-intelligence; brainsquad owns persistence, visibility (public/private feature
+intelligence; the consumer owns persistence, visibility (public/private feature
 stripping happens consumer-side before features reach langres), and the cluster
 store.
 
@@ -210,7 +209,7 @@ Build the `Resolver` container (compose Blocker+Comparator+Module+Clusterer;
 
 ### M1 — Person gold set (cold-start, LLM-teacher)
 Bootstrapper: hard-negative mining from the Blocker + LLM-teacher labeler +
-coverage report. Produce the brainsquad **People (board-members) gold set**.
+coverage report. Produce the consumer's **People (board-members) gold set**.
 - **Exit:** a Person gold set exists with measured teacher-vs-human agreement on
   a spot-check sample; blocking **Pair-Completeness reported** (target ≥ 0.95).
 
@@ -218,9 +217,9 @@ coverage report. Produce the brainsquad **People (board-members) gold set**.
 feature bag → block → baseline judge → cluster → eval → **artifact**. The shipped
 baseline judge is the zero-spend `WeightedAverageJudge` over the feature bag;
 richer judges (embedding cascade, `gliner-linker`, LLM) are raced in M3. Shipped on
-Fodors-Zagat (Person artifact + brainsquad load-and-run is M5, see below).
+Fodors-Zagat (Person artifact + consumer load-and-run is M5, see below).
 - **Exit (SHIPPED):** **BCubed F1 baseline reported** on held-out gold; the saved
-  artifact runs a brainsquad-style **`.resolve()`** call end-to-end in a fresh
+  artifact runs a consumer-style **`.resolve()`** call end-to-end in a fresh
   process (identical clusters). Measured on Fodors-Zagat (seed=0, threshold 0.8):
   held-out BCubed P/R/F1 = 0.991/0.969/0.980 vs merge-nothing floor 0.932,
   Pair-Completeness 1.0. The M2 consumption contract is `resolve()`-only;
@@ -383,9 +382,9 @@ model/version registry, production/operability guidance, cannot-link clustering.
 
 ---
 
-## 7. Mapping to brainsquad (#1051)
+## 7. Mapping to the first production consumer
 
-| brainsquad task (#1051) | langres milestone |
+| Consumer task | langres milestone |
 |---|---|
 | Build People gold set (teacher set) | **M1** |
 | Walking skeleton: features → blocking → judge → clusters → persist | **M2** (langres half) |

--- a/docs/index.md
+++ b/docs/index.md
@@ -5,8 +5,9 @@
 langres resolves records that refer to the same real-world entity — deduplicating
 one dataset or linking two — through a layered API: two user-facing **verbs**
 (`langres.link` / `langres.dedupe`) over a declarative **`Resolver`** over
-low-level **`langres.core`** primitives (blockers, judges, clusterers) that you
-can swap, tune, and evaluate independently.
+low-level **`langres.core`** primitives — blockers (pick candidate pairs),
+judges (score whether a pair matches), clusterers (group the matches) — that
+you can swap, tune, and evaluate independently.
 
 ```python
 import langres
@@ -23,7 +24,7 @@ pip install "langres @ git+https://github.com/fxd24/langres"
 ## Where to go next
 
 - **[Getting Started](GETTING_STARTED.md)** — install, first dedupe, and the
-  review/harvest/calibrate flywheel.
+  review → harvest → calibrate improvement loop.
 - **[Tutorial: Your Own CSV](TUTORIAL_YOUR_OWN_CSV.md)** — end-to-end walkthrough
   on your own data.
 - **[Technical Overview](TECHNICAL_OVERVIEW.md)** — architecture, data contracts,

--- a/docs/research/20260701_er_seam_audit.md
+++ b/docs/research/20260701_er_seam_audit.md
@@ -116,7 +116,7 @@ Prioritized. Each is additive and backward-compatible; the common pairwise/froze
 
 10. **`CollectiveClusterer`** (inverts control: clusterer owns the merge loop, calls back a scorer with mutable `ClusterContext`) for relational/collective ER — a genuinely new stateful primitive, plus relational `FeatureSpec` fields.
 
-11. **Incremental `link(record, existing_anchors) → {matched_id | new} + ClusterDelta`** with stable-ID merge/split, and an optional live-corpus-stats provider on the judge, so brainsquad's living-cluster loop and Senzing-style frequency weighting are expressible without langres owning the store.
+11. **Incremental `link(record, existing_anchors) → {matched_id | new} + ClusterDelta`** with stable-ID merge/split, and an optional live-corpus-stats provider on the judge, so the consumer's living-cluster loop and Senzing-style frequency weighting are expressible without langres owning the store.
 
 **Explicitly out of scope / delegate:** schema-matching/attribute-alignment (Alaska — data integration, upstream of the seam); scale-out blocking execution (SQL/Spark pushdown — delegate to the body); owning GPU training loops for heavy transformers (wrap/delegate, don't reimplement the DL design space).
 
@@ -220,7 +220,7 @@ Sequenced and mapped to milestones, separating cheap high-leverage wins from big
 | S3 | **`DSPyJudge` + MIPROCompiler + gold/metric adapters** (state via SerializableState) | M4 | The M4 cheap-precise-judge target as designed |
 | S4 | **`LabelModelLabeler` (~40-line numpy MeTaL) + LabelingFunction protocol** | M4/M5 | Weak-supervision cold-start, API-free; combine-LFs-with-LLM hypothesis |
 | S5 | **`TrainableEmbeddingProvider.fit()` + SerializableState embedder + `UnionBlocker` + BlockingPy adapter + `ContrastiveEncoderTrainer`** | M5 | DeepBlocker, SC-Block, Sudowoodo blocker, per-feature union |
-| S6 | **Incremental `link(record, anchors) → ClusterDelta`** with stable-ID merge/split | M5 | brainsquad living-cluster loop; production credibility |
+| S6 | **Incremental `link(record, anchors) → ClusterDelta`** with stable-ID merge/split | M5 | the consumer's living-cluster loop; production credibility |
 
 ### Big bets (M5 → M6, only when a real target demands)
 

--- a/docs/research/20260709_cost_accounting_design.md
+++ b/docs/research/20260709_cost_accounting_design.md
@@ -157,7 +157,7 @@ they are asked:
 > consumer.* (`ROADMAP.md:25-27`)
 
 Streaming, temporal, and the cluster store are all delegated to the consumer
-(brainsquad) on exactly this basis (ROADMAP §2.3, §5). **Cost falls on the same
+on exactly this basis (ROADMAP §2.3, §5). **Cost falls on the same
 fault line**, and it splits into three, not three-of-a-kind:
 
 - **A paid model invocation is engine-side and is langres's job to meter.** An
@@ -466,7 +466,7 @@ The `Resolver` artifact today is components-only (`ArtifactManifest`,
 + blocking funnel config + judge … + thresholds + **metric provenance**"
 (`ROADMAP.md:190-192`) — the metric-provenance half was never built.
 
-**Why it matters:** the artifact is the brainsquad integration contract
+**Why it matters:** the artifact is the consumer integration contract
 (ROADMAP §5). An artifact that declares what it *is* (its components) but not what
 it *achieves and costs* (held-out F1, `$/1k pairs`, the model + price it was
 measured at) is **not choosable** — a consumer picking `person_v1` vs `person_v2`

--- a/docs/research/20260710_dx_audit_examples_we_wish_we_had.md
+++ b/docs/research/20260710_dx_audit_examples_we_wish_we_had.md
@@ -176,7 +176,7 @@ name.** `docs/ROADMAP.md`, the current statement of direction, mentions
 
 `langres.ui` is the one to reject on principle, not just on redundancy. ROADMAP §1:
 *"Engine intelligence in langres; data, persistence, **visibility** in the
-consumer."* A shipped Streamlit app **is** visibility. It belongs to brainsquad, on
+consumer."* A shipped Streamlit app **is** visibility. It belongs to the consumer, on
 the same side of the seam as streaming and temporal support. Shipping it would put
 langres on both sides of its own architectural boundary.
 

--- a/src/langres/core/harvest.py
+++ b/src/langres/core/harvest.py
@@ -11,7 +11,7 @@ and, where applicable, a judge's ``fit()``.
 The division of labor is deliberate: langres owns the **contract**, the
 **harvest**, and the headless + terminal review surfaces (the ``langres review``
 CLI and its CSV round-trip); anything with a rendering loop (a web review UI)
-stays in the downstream application (e.g. brainsquad). :class:`Correction` is the
+stays in the downstream application. :class:`Correction` is the
 stable line schema a review tool writes to ``corrections.jsonl``; :class:`CorrectionLog`
 is the reference reader/writer for that file (mirroring ``JudgementLog`` so the
 two flywheel files are handled the same way); :func:`harvest_labeled_pairs` is
@@ -66,7 +66,7 @@ _CORRECTION_SCHEMA_VERSION = 1
 class Correction(BaseModel):
     """One human verdict-correction for a judged pair: the ``corrections.jsonl`` line.
 
-    This is the stable contract an external review queue (e.g. brainsquad) writes
+    This is the stable contract an external review queue writes
     when a reviewer overrides a judge's verdict. Only ``left_id``/``right_id`` and
     the corrected ``label`` are required; the rest is optional audit context. A
     pair is identified order-independently on harvest (see

--- a/tests/data/test_m2_artifact_slow.py
+++ b/tests/data/test_m2_artifact_slow.py
@@ -1,7 +1,7 @@
-"""M2 EXIT — fresh-process artifact identity proof (the brainsquad contract).
+"""M2 EXIT — fresh-process artifact identity proof (the consumer contract).
 
 Proves the second half of the M2 exit criterion: a saved Resolver artifact runs
-a brainsquad-style ``.resolve()`` call end-to-end **in a fresh process** and
+a consumer-style ``.resolve()`` call end-to-end **in a fresh process** and
 yields *identical* clusters to the in-process run. ``resolve()`` is the ONLY M2
 consumption call — ``.link()`` / ``.stream_against()`` are M5 stubs and are never
 touched here.
@@ -77,7 +77,7 @@ def test_m2_artifact_resolve_identity_fresh_process(tmp_path: Path) -> None:
     best_threshold = tune_threshold_on_train(train_records, train_clusters)
     resolver = build_restaurant_resolver(best_threshold)
 
-    # In-process resolve over the held-out test dicts (the brainsquad call shape).
+    # In-process resolve over the held-out test dicts (the consumer call shape).
     test_dicts = [r.model_dump() for r in test_records]
     clusters_a = resolver.resolve(test_dicts)
     assert clusters_a, "expected the baseline to find at least one multi-record cluster"

--- a/tests/data/test_m2_bad_input.py
+++ b/tests/data/test_m2_bad_input.py
@@ -1,6 +1,6 @@
 """M2 bad-input contract — the resolver's documented behavior on degenerate input.
 
-These are the DX-hardening assertions from the Wave 3 review: a brainsquad
+These are the DX-hardening assertions from the Wave 3 review: a downstream
 integrator must know exactly what ``resolve`` does at the edges. They run FAST —
 the resolver here mirrors :func:`build_restaurant_resolver` (same
 ``RestaurantSchema`` + ``Comparator.from_schema`` + ``WeightedAverageJudge`` +


### PR DESCRIPTION
## What

A zero-context clarity pass on the public docs — docs/comments only, no behavior changes. Addresses the maintainer feedback that parts of the README/docs assume context a first-time reader doesn't have.

### 1. Scrub every reference to the private downstream repo

A public repo must not name or link a private one. Every mention (docs/ROADMAP.md incl. the private issue link, TODOS.md, .env.example, docs/research/*, src/langres/core/harvest.py docstrings, tests/data/test_m2_*.py docstrings/comments, .claude/dave/workflows/parallel-usage.md example worktree names) is replaced with a neutral phrase that keeps the meaning: "the consumer" / "a private downstream data product" / "the consuming application". Verified with a whole-repo grep: zero matches remain.

### 2. Define "margin" at first use

README + GETTING_STARTED now define the **uncertain margin** where it first appears: the candidate pairs whose scores fall closest to the decision threshold — the ones the judge is least sure about, and the only ones a human needs to look at. Later uses stay bare.

### 3. Clarify the CSV round-trip

Both docs now say it plainly at first mention: `langres export-csv` writes the uncertain pairs to a literal `.csv` file you open in any spreadsheet, you fill the `label` column (y/n), `langres import-csv` reads it back.

### 4. Gloss remaining jargon at first use

- entity resolution itself, "judge", "silver labels", "blocking", "tearsheet", "student", "the verbs", DSPy "prompt signature"
- first-use "seam" replaced with plain "interface"; `docs/index.md` now says what blockers/judges/clusterers each do

## Verification

- `grep -ri brainsquad` (excl. `.venv`/`.git`): no matches
- `uv run --group docs mkdocs build --strict`: passes
- `pytest tests/data/test_m2_artifact_slow.py tests/data/test_m2_bad_input.py --collect-only`: 3 tests collected (docstring edits don't affect collection)

https://claude.ai/code/session_0174WFUBZyvPhM5wHssLAmjq

## Summary by Sourcery

Clarify public documentation and terminology while removing private downstream-repo references, without changing runtime behavior.

Enhancements:
- Standardize terminology around the external consumer application in roadmap, research notes, core docstrings, and example workflows in place of private repo names.
- Improve conceptual explanations in README, Getting Started, and index docs by defining key ER concepts (judge, uncertain margin, silver labels, blocking, tearsheet, students) at first use and clarifying the entity-resolution pipeline roles.
- Document the CSV review round-trip more explicitly, including how `langres export-csv` / `import-csv` integrate with spreadsheet-based labeling.

Documentation:
- Refine user-facing docs (README, GETTING_STARTED, ROADMAP, index, and research docs) to be self-contained, zero-context friendly, and free of private repository references.

Tests:
- Update test module docstrings and comments to use the new generic consumer terminology while preserving existing test behavior.

Chores:
- Adjust internal workflow and configuration examples (worktree names, .env.example references) to avoid mentioning private downstream repositories.