### PR TITLE
docs: fix stale index.md (PyPI install, 0.x beta status)

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -15,10 +15,10 @@ import langres
 clusters = langres.dedupe(records)  # judge="auto" picks the best available judge
 ```
 
-Install from source (PyPI release pending):
+Install from PyPI:
 
 ```bash
-pip install "langres @ git+https://github.com/fxd24/langres"
+pip install langres
 ```
 
 ## Where to go next
@@ -38,6 +38,7 @@ pip install "langres @ git+https://github.com/fxd24/langres"
 
 ## Project status
 
-langres is in early development (pre-alpha). The verbs / `Resolver` / `core`
-contracts are stable enough to build on, but expect breaking changes between
-releases — see the [Roadmap](ROADMAP.md) and [Changelog](CHANGELOG.md).
+langres is a 0.x beta, [released on PyPI](https://pypi.org/project/langres/)
+under Apache-2.0. The verbs / `Resolver` / `core` contracts are stable enough
+to build on, but expect breaking changes between 0.x releases — see the
+[Roadmap](ROADMAP.md) and [Changelog](CHANGELOG.md).


### PR DESCRIPTION
The docs-site landing page still said "Install from source (PyPI release pending)" and "pre-alpha" — contradicting the README and the live 0.3.0 PyPI release. Flagged by the zero-context clarity pass (#119) as out of its scope.

## Summary by Sourcery

Update docs landing page to reflect the current 0.x beta status and PyPI availability of langres.

Documentation:
- Update installation instructions to recommend installing langres directly from PyPI instead of from source.
- Refresh project status text to describe langres as a 0.x beta released on PyPI under Apache-2.0 and to clarify expected breaking changes within 0.x releases.