### PR TITLE
fix: point repo URLs at fxd24 + update contact email

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -5,7 +5,7 @@ type: software
 authors:
   - family-names: "Graf"
     given-names: "David"
-    email: "david@raisesquad.com"
+    email: "hire@grafdavid.com"
 repository-code: "https://github.com/fxd24/langres"
 url: "https://github.com/fxd24/langres"
 license: Apache-2.0

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # langres
 
-[![Status](https://img.shields.io/badge/status-0.x%20beta-blue.svg)](https://github.com/raisesquad/langres)
-[![Tests](https://github.com/raisesquad/langres/actions/workflows/test.yml/badge.svg)](https://github.com/raisesquad/langres/actions/workflows/test.yml)
-[![codecov](https://codecov.io/gh/raisesquad/langres/branch/main/graph/badge.svg)](https://codecov.io/gh/raisesquad/langres)
+[![Status](https://img.shields.io/badge/status-0.x%20beta-blue.svg)](https://github.com/fxd24/langres)
+[![Tests](https://github.com/fxd24/langres/actions/workflows/test.yml/badge.svg)](https://github.com/fxd24/langres/actions/workflows/test.yml)
+[![codecov](https://codecov.io/gh/fxd24/langres/branch/main/graph/badge.svg)](https://codecov.io/gh/fxd24/langres)
 [![PyPI](https://img.shields.io/pypi/v/langres.svg)](https://pypi.org/project/langres/)
 [![Python](https://img.shields.io/badge/python-3.12+-blue.svg)](https://www.python.org/downloads/)
 [![License](https://img.shields.io/badge/license-Apache--2.0-blue.svg)](#license)
@@ -108,7 +108,7 @@ pip install 'langres[eval]'        # + ranking metrics for blocker evaluation (r
 ```
 
 Or from source with [`uv`](https://docs.astral.sh/uv/):
-`git clone https://github.com/raisesquad/langres.git && cd langres && uv sync`,
+`git clone https://github.com/fxd24/langres.git && cd langres && uv sync`,
 then `uv run python examples/quickstart_verbs.py`.
 
 > **Lean by construction.** A bare `import langres` / `import langres.core`

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -10,7 +10,7 @@ Please report vulnerabilities **privately** — do not open a public issue:
 
 - Preferred: [GitHub private vulnerability reporting](https://github.com/fxd24/langres/security/advisories/new)
   (Security tab → "Report a vulnerability").
-- Or email **david@raisesquad.com** with a description, reproduction steps,
+- Or email **hire@grafdavid.com** with a description, reproduction steps,
   and impact.
 
 You should receive an acknowledgement within a few days. Please allow a

--- a/TODOS.md
+++ b/TODOS.md
@@ -5,8 +5,8 @@ This is the durable home for "we decided not to do this now" so it doesn't only
 live in a planning doc. Each item points to its tracking issue or milestone.
 
 Detail lives in the M4.5/M5 plan, the ROADMAP, and the seam-audit epic
-([#20](https://github.com/raisesquad/langres/issues/20)) with method-delta
-backlog in [#55](https://github.com/raisesquad/langres/issues/55).
+([#20](https://github.com/fxd24/langres/issues/20)) with method-delta
+backlog in [#55](https://github.com/fxd24/langres/issues/55).
 
 ## Flywheel loop follow-ons (deferred from the closed-loop phase, 0.2.0)
 
@@ -46,12 +46,12 @@ backlog in [#55](https://github.com/raisesquad/langres/issues/55).
 ## Method families & extensibility
 
 - **Splink adapter as a Fellegi–Sunter feature-store row** — wrap Splink behind the
-  seam instead of only the native FS-EM judge. ([#55](https://github.com/raisesquad/langres/issues/55))
+  seam instead of only the native FS-EM judge. ([#55](https://github.com/fxd24/langres/issues/55))
 - **Full C1 six-dataset replication portfolio** — only FZ/AG (+ Abt-Buy in M4.5) are
-  in scope now; the rest of the benchmark portfolio is deferred. ([#55](https://github.com/raisesquad/langres/issues/55))
+  in scope now; the rest of the benchmark portfolio is deferred. ([#55](https://github.com/fxd24/langres/issues/55))
 - **Public method-registration API** — a supported, documented way for third parties
   to register a new judge/method (beyond editing `methods.py:_make_module_builder`
-  in-tree). ([#55](https://github.com/raisesquad/langres/issues/55))
+  in-tree). ([#55](https://github.com/fxd24/langres/issues/55))
 
 ## Hardening
 

--- a/docs/ADDING_A_METHOD.md
+++ b/docs/ADDING_A_METHOD.md
@@ -9,7 +9,7 @@ usable, swappable, and tunable by everyone through one seam. This guide walks th
 > **No public plugin API yet.** There is deliberately **no** external/plugin
 > registration entry point today. A new *name-selectable* method must be wired
 > into the in-repo dispatch sites below. A single public method-registration API
-> that collapses them is **deferred to [issue #55](https://github.com/raisesquad/langres/issues/55)**
+> that collapses them is **deferred to [issue #55](https://github.com/fxd24/langres/issues/55)**
 > (see `TODOS.md`). This document is the contract *as it stands* — what a
 > contributor editing the repo does now.
 >

--- a/docs/research/20260707_data_prep_hard_case_mining_survey.md
+++ b/docs/research/20260707_data_prep_hard_case_mining_survey.md
@@ -2,7 +2,7 @@
 
 **Date:** 2026-07-07
 **Author:** langres research (orchestrated multi-agent survey; primary-source verified)
-**Issues:** Task 0 of [#86](https://github.com/raisesquad/langres/issues/86) (reusable hard-case / informative-pair mining seam) · feeds [#83](https://github.com/raisesquad/langres/issues/83) (AnyMatch) · epic [#85](https://github.com/raisesquad/langres/issues/85)
+**Issues:** Task 0 of [#86](https://github.com/fxd24/langres/issues/86) (reusable hard-case / informative-pair mining seam) · feeds [#83](https://github.com/fxd24/langres/issues/83) (AnyMatch) · epic [#85](https://github.com/fxd24/langres/issues/85)
 **Scope of this doc:** state-of-the-art synthesis **+ langres seam mapping**. It deliberately stops short of a seam interface / API / function design — that is a separate, later step (per the research-only decision on 2026-07-07).
 
 ---
@@ -402,7 +402,7 @@ Encoder models (BERT / sentence-transformers) are no longer the only game; the O
 
 ## 13. Future work
 
-*What the three research threads point to as concrete things to try — direction, not commitment. Kept here as a living note; the data-prep mining directions are tracked in [#86](https://github.com/raisesquad/langres/issues/86), the collective/relational architecture gap in §11.4.*
+*What the three research threads point to as concrete things to try — direction, not commitment. Kept here as a living note; the data-prep mining directions are tracked in [#86](https://github.com/fxd24/langres/issues/86), the collective/relational architecture gap in §11.4.*
 
 **The empirical question threading all of these — does capability *transfer* between the two roles of one model?** The whole bet is that a single decoder can be a *generator* (matching) and a *recall* engine (blocking embeddings) at once. What we don't know — and should measure directly — is the **transfer** between those roles and its *direction*: does fine-tuning / prompt-optimizing the model for matching help, not affect, or *hurt* its embedding/blocking recall — and does contrastive embedding tuning help or hurt matching? GritLM's ablation says *joint* training degrades neither at 7B (§12.2), but transfer under *sequential* or *small-scale QLoRA* tuning is untested. **Practical rule: evaluate every experiment below on *both* stages — recall (Pair Completeness) and matching (F1) — not just the one it targets**, so we can see whether the capability transfers, is neutral, or interferes. These are starting probes; the list is open and expected to grow as results come in.
 

--- a/docs/research/20260709_cost_accounting_design.md
+++ b/docs/research/20260709_cost_accounting_design.md
@@ -1,6 +1,6 @@
 # Cost accounting in langres — a design note for the tracking layer
 
-*Design note for [issue #100](https://github.com/raisesquad/langres/issues/100)
+*Design note for [issue #100](https://github.com/fxd24/langres/issues/100)
 ("Cost tracking: comprehensive design"). Scope: how langres should account for
 the cost of an experiment run coherently — what it stores, what it derives, where
 each concern lives, and how `RunRecord` evolves. Documentation only; no code

--- a/docs/research/20260713_model_identity_and_hub.md
+++ b/docs/research/20260713_model_identity_and_hub.md
@@ -3,7 +3,7 @@
 *Design note for the maintainer's direction question — "think of HF transformers:
 anybody can publish their model, and you can use it easily; today `link`/`dedupe`
 don't tell you which model is used, and the verbs should be tied to the type of
-model one uses" — and for [issue #103](https://github.com/raisesquad/langres/issues/103)
+model one uses" — and for [issue #103](https://github.com/fxd24/langres/issues/103)
 (LLMJudge unreachable by name from the verbs). Scope: what "model identity" and
 "publishing" should mean in langres, mapped honestly onto the seams that exist,
 with staged options. Documentation only; no code changes. Written against `main`

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,10 +6,10 @@ readme = "README.md"
 license = "Apache-2.0"
 license-files = ["LICENSE", "NOTICE"]
 authors = [
-    { name = "David Graf", email = "david@raisesquad.com" }
+    { name = "David Graf", email = "hire@grafdavid.com" }
 ]
 maintainers = [
-    { name = "David Graf", email = "david@raisesquad.com" }
+    { name = "David Graf", email = "hire@grafdavid.com" }
 ]
 requires-python = ">=3.12"
 dependencies = [

--- a/src/langres/core/presets.py
+++ b/src/langres/core/presets.py
@@ -159,7 +159,7 @@ class NoJudgeAvailableError(RuntimeError):
 #: funnels a user onto the LLM-judge path (the keyed path dead-ends without it:
 #: ``dspy`` is imported at dspy_judge.py module level but ships in the extra).
 _INSTALL_LLM_EXTRA = "`uv sync --extra llm` or `pip install 'langres[llm]'`"
-_GETTING_STARTED_URL = "https://github.com/raisesquad/langres/blob/main/docs/GETTING_STARTED.md"
+_GETTING_STARTED_URL = "https://github.com/fxd24/langres/blob/main/docs/GETTING_STARTED.md"
 
 
 def choose_auto_judge(


### PR DESCRIPTION
Two corrections that #119's de-identification pass left unaddressed:

- **`raisesquad/langres` → `fxd24/langres`** — badges, README `git clone`, the
  runtime `GETTING_STARTED_URL` in `presets.py`, and issue links in TODOS/docs.
  The repo lives at `github.com/fxd24/langres`, so these were broken/misleading
  (Codecov badge included).
- **Contact email `david@raisesquad.com` → `hire@grafdavid.com`** — CITATION.cff,
  SECURITY.md, pyproject.toml.

Rebased clean on latest `main`. Supersedes the org/email part of #118 (whose
brainsquad scrub is redundant with #119 and is being closed).

## Summary by Sourcery

Update repository links and contact email to reflect the current GitHub org and maintainer details.

Bug Fixes:
- Correct all remaining GitHub URLs from raisesquad/langres to fxd24/langres in README badges, docs, issue references, and runtime presets.
- Update maintainer contact email from david@raisesquad.com to hire@grafdavid.com in project metadata and security reporting guidance.

Documentation:
- Refresh documentation references (README, TODOS, research notes, contributor guides) to point at the new GitHub repository location.