### PR TITLE
feat: align_pairs + per-role fit protocols + FitReport (PR-B, training-surface epic)

### DIFF
--- a/docs/TECHNICAL_OVERVIEW.md
+++ b/docs/TECHNICAL_OVERVIEW.md
@@ -672,31 +672,68 @@ amortization happens through the runner yet. Extending the runner (or adding
 a group-aware variant) to pre-flight and price whole groups atomically is
 deferred to the branch that lands the first concrete `GroupwiseMatcher`.
 
-### Fit hooks (`langres.core.fit`)
+### Fit-hook contract (`langres.core.fit`)
 
-Two runtime-checkable, structural `Protocol`s — **not** abstract methods on
-`Matcher` (that would break every existing, non-learnable module):
+Runtime-checkable, structural `Protocol`s — **not** abstract methods on any base
+class (that would break every existing, non-learnable component). A component
+opts in by implementing the method with the matching name — no subclassing. The
+taxonomy spans the **three trainable pipeline roles**, each with its own
+signature:
 
-- `SupervisedFitMixin.fit(candidates: Iterator[ERCandidate[SchemaT]], labels: Sequence[bool]) -> None`
-- `UnsupervisedFitMixin.fit_unlabeled(candidates: Iterator[ERCandidate[SchemaT]]) -> None`
+- **Matcher** —
+  `SupervisedFitMixin.fit(candidates: Iterator[ERCandidate[SchemaT]], labels: Sequence[bool]) -> None`
+  and `UnsupervisedFitMixin.fit_unlabeled(candidates: Iterator[ERCandidate[SchemaT]]) -> None`.
+  `FellegiSunterMatcher` (unsupervised EM over `ComparisonVector`) and
+  `RandomForestMatcher` (supervised, `[trained]`) are the concrete implementers.
+- **Blocker** — `BlockerFitMixin.fit_blocker(records: Sequence[Any], pairs: Sequence[tuple[str, str]]) -> None`
+  (learn a high-recall blocking key/index from known match pairs). Contract-only
+  for now — the concrete `TrainableVectorBlocker` is a later PR.
+- **Calibrator** — `CalibratorFitMixin.fit_calibrator(scores: Sequence[float], labels: Sequence[bool]) -> None`
+  (learn a score→probability map). Contract-only for now — the concrete
+  Platt/isotonic impl is a later PR.
 
-A module opts in by implementing the method with the matching name — no
-subclassing required. `Resolver.fit(data, labels=None)` detects this with
-`isinstance(module, SupervisedFitMixin)` / `isinstance(module, UnsupervisedFitMixin)`:
+`Resolver.fit(data, labels=None, *, pairs=None, split=None, seed=0)` consumes the
+**matcher** mixins, detected with `isinstance(module, SupervisedFitMixin)` /
+`isinstance(module, UnsupervisedFitMixin)`:
 
-- Matcher implements `SupervisedFitMixin`: `labels` is required; omitting it
+- Matcher implements `SupervisedFitMixin`: supervision comes from either
+  pre-aligned `labels` **or** id-keyed `pairs` (see below); passing neither
   **raises** (a genuinely trainable module silently not being trained is the
-  exact footgun this hook exists to prevent).
+  exact footgun this hook exists to prevent), and passing both raises.
 - Matcher implements `UnsupervisedFitMixin`: `fit_unlabeled` is called
-  unconditionally; passing `labels` to it raises (they would otherwise be
-  silently ignored).
+  unconditionally; passing `labels`/`pairs` to it raises.
 - Matcher implements **neither** hook (e.g. `WeightedAverageMatcher`): `fit()`
   is a no-op returning `self` — the original sklearn-style symmetry is
-  preserved for non-learnable pipelines — unless `labels` was passed, which
-  raises rather than silently discarding them.
+  preserved for non-learnable pipelines — unless `labels`/`pairs` was passed,
+  which raises rather than silently discarding them.
 
-`FellegiSunterMatcher` (unsupervised EM over `ComparisonVector`) and
-`RandomForestMatcher` (supervised, `[trained]`) are the concrete implementers.
+Every non-raising path sets `resolver.fit_report_` (an sklearn
+trailing-underscore digest, `langres.core.fit_report.FitReport`) and returns
+`self`, so `resolver.fit(...).resolve(...)` still chains.
+
+### `align_pairs` + coverage + `FitReport`
+
+`langres.core.harvest.align_pairs(candidates, labels, *, split=None, seed=0) ->
+AlignedPairs` is the id-join bridge for supervised fit: it joins id-keyed labels
+(a `corrections.jsonl` path, or a `Sequence` of `LabeledPair`/`Correction` —
+`PairLabel` is a thin alias of `LabeledPair`, not a forked schema) to the blocked
+candidates order-independently, and returns a named result with:
+
+- `.train` / `.valid` — positionally-aligned `(candidates, labels)` splits for
+  `SupervisedFitMixin.fit`. The split is **entity-disjoint** (union-find over the
+  labeled pairs, whole components assigned to one side) — a row-random split
+  would leak an entity across train/valid and inflate held-out metrics. A single
+  all-connected component keeps `valid` empty rather than emptying `train`.
+- `.coverage` — a `GoldCoverage` guardrail (reusing `metrics.evaluate_blocking`)
+  surfacing `gold_coverage` (fraction of labeled positives that survived
+  blocking) and the `dropped_positives` id-pairs blocking never proposed.
+
+`Resolver.fit(..., pairs=...)` runs `align_pairs` internally, trains on `.train`,
+and — when a `split` was given — scores held-out pair P/R/F1 on `.valid` via
+`metrics.classify_pairs`, all captured in the `FitReport` (`.to_markdown()` for a
+digest). `FitReport` is import-light (Pydantic + `harvest`/`metrics` only, no
+sklearn/torch) and references the enclosing `RunRecord`'s `attempt_id` via
+`run_ref` for lineage rather than duplicating it.
 
 ## 9. Blocking Algebra + Merge-Resistant Clustering (W1.3)
 

--- a/src/langres/core/fit.py
+++ b/src/langres/core/fit.py
@@ -1,26 +1,34 @@
-"""Fit-hook contracts: how a Matcher opts into being trainable (W1.0, E6).
+"""Fit-hook contracts: how a pipeline role opts into being trainable (W1.0, E6).
 
-Two runtime-checkable, structural `Protocol`s -- **not** abstract methods on
-the base ``Matcher``. Adding an abstract ``fit``/``fit_unlabeled`` to ``Matcher``
-would break every existing, non-learnable module (``WeightedAverageMatcher``,
-``LLMMatcher``, ...), which is not the goal here: most judges stay heuristic or
-zero-shot and never need a fit hook. Instead, a module *opts in* structurally
-by implementing the method with the matching name and signature; callers (the
-Resolver) detect this with ``isinstance(module, SupervisedFitMixin)`` /
-``isinstance(module, UnsupervisedFitMixin)``.
+Runtime-checkable, structural `Protocol`s -- **not** abstract methods on any
+base class. Adding an abstract ``fit`` to ``Matcher`` would break every
+existing, non-learnable matcher (``WeightedAverageMatcher``, ``LLMMatcher``,
+...), which is not the goal here: most components stay heuristic or zero-shot
+and never need a fit hook. Instead, a component *opts in* structurally by
+implementing the method with the matching name and signature; callers (the
+Resolver) detect this with ``isinstance(component, <Mixin>)``.
 
-- ``SupervisedFitMixin``: for judges that learn from labeled pairs (e.g. a
-  future ``RandomForestMatcher`` fitting an sklearn RandomForest over
-  ``ComparisonVector.similarities``).
-- ``UnsupervisedFitMixin``: for judges that learn without labels (e.g. a
-  future ``FellegiSunterMatcher`` fitting m/u probabilities via EM).
+Three pipeline roles can be trained, each with its own fit signature:
 
-See ``Resolver.fit()`` for how these are consumed, and
+- **Matcher** -- ``SupervisedFitMixin`` (``fit(candidates, labels)``, e.g. a
+  ``RandomForestMatcher`` fitting an sklearn forest over
+  ``ComparisonVector.similarities``) and ``UnsupervisedFitMixin``
+  (``fit_unlabeled(candidates)``, e.g. a ``FellegiSunterMatcher`` fitting m/u
+  probabilities via EM).
+- **Blocker** -- ``BlockerFitMixin`` (``fit_blocker(records, pairs)``: learn a
+  high-recall blocking key/index from known match pairs). Contract-only here;
+  the concrete ``TrainableVectorBlocker`` is a later PR -- this makes learned
+  blocking *expressible* in the role taxonomy.
+- **Calibrator** -- ``CalibratorFitMixin`` (``fit_calibrator(scores, labels)``:
+  learn a score->probability map). Contract-only here; the concrete
+  Platt/isotonic impl is a later PR.
+
+See ``Resolver.fit()`` for how the matcher mixins are consumed, and
 docs/TECHNICAL_OVERVIEW.md ("Fit-hook contract") for the full picture.
 """
 
 from collections.abc import Iterator, Sequence
-from typing import Protocol, TypeVar, runtime_checkable
+from typing import Any, Protocol, TypeVar, runtime_checkable
 
 from pydantic import BaseModel
 
@@ -67,5 +75,50 @@ class UnsupervisedFitMixin(Protocol[SchemaT]):
         Args:
             candidates: The blocked (and, if a comparator is configured,
                 comparison-attached) candidate stream to learn from.
+        """
+        ...  # pragma: no cover — Protocol method body, never executed
+
+
+@runtime_checkable
+class BlockerFitMixin(Protocol):
+    """A Blocker that learns its blocking scheme from known match pairs.
+
+    Implement ``fit_blocker(records, pairs)`` to opt in; no subclassing required
+    (structural typing via ``isinstance()``, enabled by ``@runtime_checkable``).
+    Contract-only for now -- the concrete ``TrainableVectorBlocker`` is a later
+    PR; this makes learned blocking *expressible* in the role taxonomy without
+    shipping an impl.
+    """
+
+    def fit_blocker(self, records: Sequence[Any], pairs: Sequence[tuple[str, str]]) -> None:
+        """Fit the blocker's parameters from records + known match pairs.
+
+        Args:
+            records: The raw records to index (same shape ``Blocker.stream``
+                accepts).
+            pairs: Known ``(left_id, right_id)`` match pairs -- the recall target
+                the learned blocking key/index must keep.
+        """
+        ...  # pragma: no cover — Protocol method body, never executed
+
+
+@runtime_checkable
+class CalibratorFitMixin(Protocol):
+    """A calibrator that learns a score->probability map from scores + labels.
+
+    Implement ``fit_calibrator(scores, labels)`` to opt in; no subclassing
+    required (structural typing via ``isinstance()``). Contract-only for now --
+    the concrete Platt/isotonic impl is a later PR; this makes score calibration
+    *expressible* as its own fit role, distinct from a matcher's
+    ``fit(candidates, labels)``.
+    """
+
+    def fit_calibrator(self, scores: Sequence[float], labels: Sequence[bool]) -> None:
+        """Fit the calibrator's parameters from scores + gold labels.
+
+        Args:
+            scores: The matcher scores to calibrate, positionally aligned with
+                ``labels``.
+            labels: Gold match/non-match labels for each score.
         """
         ...  # pragma: no cover — Protocol method body, never executed

--- a/src/langres/core/fit_report.py
+++ b/src/langres/core/fit_report.py
@@ -164,7 +164,13 @@ class FitReport(BaseModel):
 
         lines.append("## Held-out pair metrics (valid split)")
         if self.metrics is None:
-            lines.append("- No split was given (no held-out evaluation).")
+            if self.split is not None:
+                lines.append(
+                    "- The requested split produced no held-out pairs (all labeled "
+                    "entities are connected -- no entity-disjoint valid is possible)."
+                )
+            else:
+                lines.append("- No split was given (no held-out evaluation).")
         else:
             m = self.metrics
             lines += [

--- a/src/langres/core/fit_report.py
+++ b/src/langres/core/fit_report.py
@@ -1,0 +1,187 @@
+"""FitReport: the human-facing digest of one ``Resolver.fit()`` call (W1.x).
+
+``bootstrap/report.py:BootstrapReport`` is the template: a plain Pydantic model
+composed of the sub-stat models it needs, a ``@classmethod build(...)``, and a
+``to_markdown()`` digest. FitReport answers "what just trained, on how much
+data, and how well does it hold out?" for a single ``fit()``:
+
+- **what trained** -- the component + fit role (``trainable``), and whether a
+  fit hook actually ran (``trained``) -- an honest no-op is not a silent success;
+- **on how much** -- train/valid sizes and the split provenance;
+- **did blocking keep the positives** -- the
+  :class:`~langres.core.harvest.GoldCoverage` from
+  :func:`~langres.core.harvest.align_pairs`;
+- **how well does it hold out** -- pair P/R/F1 on the entity-disjoint ``valid``
+  split (from :func:`~langres.core.metrics.classify_pairs`), when a split was
+  given.
+
+Import-light on purpose (Pydantic + the two light leaves
+:mod:`langres.core.harvest`/:mod:`langres.core.metrics` only): it must NEVER
+pull sklearn/torch, so a report built right after a heavy fit stays cheap to
+import, dump, and render (locked by ``tests/test_import_budget.py``). Lineage is
+*referenced*, not duplicated: ``run_ref`` carries the enclosing
+:class:`~langres.core.runs.RunRecord`'s ``attempt_id`` (the machine record),
+while this model is the human-facing digest.
+"""
+
+from __future__ import annotations
+
+from pydantic import BaseModel
+
+from langres.core.harvest import GoldCoverage
+from langres.core.metrics import PairMetrics
+
+
+class FitReport(BaseModel):
+    """Digest of one ``Resolver.fit()`` call. Build with :meth:`build`.
+
+    Attributes:
+        trainable: What trained -- ``"<Matcher> (<FitRole>)"`` (e.g.
+            ``"RandomForestMatcher (SupervisedFitMixin)"``), or the matcher name
+            tagged ``"(no fit hook)"`` for the no-op case. ``None`` is reserved
+            for a genuinely empty pipeline.
+        trained: Whether a fit hook actually ran (``False`` for the no-op case).
+        n_train: Aligned training pairs the fit consumed.
+        n_valid: Held-out validation pairs (``0`` when no split was given).
+        split: The held-out fraction requested, or ``None`` for no split.
+        seed: Seed for the entity-disjoint split.
+        entity_disjoint: Whether a split was applied entity-disjointly (``True``
+            iff ``split`` is not ``None`` -- the only split algorithm).
+        coverage: Blocking coverage of the labeled positives, or ``None`` when
+            fit was given pre-aligned labels (no id-join, so no coverage) or
+            nothing trained.
+        threshold: The clusterer decision threshold in force, or ``None``.
+        metrics: Held-out pair P/R/F1 on ``valid``, or ``None`` when no split.
+        cost: Tokens/$ or GPU-seconds when a paid/GPU fit ran (filled by later
+            PRs), else ``None``.
+        run_ref: The enclosing run's ``attempt_id`` (lineage reference to the
+            machine :class:`~langres.core.runs.RunRecord`), or ``None``.
+    """
+
+    trainable: str | None
+    trained: bool
+    n_train: int
+    n_valid: int
+    split: float | None
+    seed: int
+    entity_disjoint: bool
+    coverage: GoldCoverage | None
+    threshold: float | None = None
+    metrics: PairMetrics | None = None
+    cost: float | None = None
+    run_ref: str | None = None
+
+    @classmethod
+    def build(
+        cls,
+        *,
+        trainable: str | None,
+        trained: bool,
+        n_train: int,
+        n_valid: int = 0,
+        split: float | None = None,
+        seed: int = 0,
+        coverage: GoldCoverage | None = None,
+        threshold: float | None = None,
+        metrics: PairMetrics | None = None,
+        cost: float | None = None,
+        run_ref: str | None = None,
+    ) -> FitReport:
+        """Assemble a FitReport from the artefacts of one ``fit()`` call.
+
+        ``entity_disjoint`` is derived (``split is not None``) rather than passed:
+        the entity-disjoint union-find split is the only algorithm, so a split
+        always implies it.
+        """
+        return cls(
+            trainable=trainable,
+            trained=trained,
+            n_train=n_train,
+            n_valid=n_valid,
+            split=split,
+            seed=seed,
+            entity_disjoint=split is not None,
+            coverage=coverage,
+            threshold=threshold,
+            metrics=metrics,
+            cost=cost,
+            run_ref=run_ref,
+        )
+
+    @classmethod
+    def nothing_trainable(cls, matcher_name: str) -> FitReport:
+        """A minimal report for the no-op branch: nothing in the pipeline trained.
+
+        Names the matcher so the digest is still informative ("this pipeline had
+        nothing to train") rather than an anonymous empty report.
+        """
+        return cls.build(trainable=f"{matcher_name} (no fit hook)", trained=False, n_train=0)
+
+    def to_markdown(self) -> str:
+        """Render a human-readable Markdown digest of the report.
+
+        The model itself is the source of truth and is JSON-serializable; this is
+        for quick eyeballing after a ``fit()``.
+        """
+        lines: list[str] = ["# Fit Report", ""]
+
+        split_line = f"- Split: {self.split if self.split is not None else 'none'}"
+        if self.entity_disjoint:
+            split_line += f" (entity-disjoint, seed={self.seed})"
+        lines += [
+            "## What trained",
+            f"- Trainable: {self.trainable if self.trainable is not None else 'nothing'}",
+            f"- Trained: {self.trained}",
+            f"- Train pairs: {self.n_train}",
+            f"- Valid pairs: {self.n_valid}",
+            split_line,
+        ]
+        if self.threshold is not None:
+            lines.append(f"- Threshold: {self.threshold:.4f}")
+        if self.cost is not None:
+            lines.append(f"- Cost: {self.cost}")
+        if self.run_ref is not None:
+            lines.append(f"- Run: {self.run_ref}")
+        lines.append("")
+
+        lines.append("## Gold coverage (labeled positives kept by blocking)")
+        if self.coverage is None:
+            lines.append("- Not computed (fit received pre-aligned labels or nothing trained).")
+        else:
+            c = self.coverage
+            lines += [
+                f"- Gold coverage: {c.gold_coverage:.4f}",
+                f"- Positive labels: {c.n_positive_labels}",
+                f"- Dropped positives: {len(c.dropped_positives)}",
+                f"- Labeled pairs: {c.n_labeled} (aligned to candidates: {c.n_aligned})",
+            ]
+            if c.dropped_positives:
+                preview = ", ".join(f"({a}, {b})" for a, b in c.dropped_positives[:5])
+                extra = len(c.dropped_positives) - 5
+                more = f", +{extra} more" if extra > 0 else ""
+                lines.append(f"  - Dropped: {preview}{more}")
+        lines.append("")
+
+        lines.append("## Held-out pair metrics (valid split)")
+        if self.metrics is None:
+            lines.append("- No split was given (no held-out evaluation).")
+        else:
+            m = self.metrics
+            lines += [
+                f"- Precision: {m.precision:.4f}",
+                f"- Recall: {m.recall:.4f}",
+                f"- F1: {m.f1:.4f}",
+                f"- TP/FP/FN: {m.tp}/{m.fp}/{m.fn} @ threshold {m.threshold:.4f}",
+            ]
+        lines.append("")
+
+        return "\n".join(lines)
+
+    def render(self) -> str:
+        """Render the report as Markdown.
+
+        Provided alongside :meth:`to_markdown` so callers expecting either the
+        generic ``render()`` name or the format-specific one get the same output
+        (mirrors ``BootstrapReport``).
+        """
+        return self.to_markdown()

--- a/src/langres/core/harvest.py
+++ b/src/langres/core/harvest.py
@@ -37,23 +37,35 @@ from __future__ import annotations
 
 import json
 import logging
+import random
 import warnings
-from collections.abc import Mapping, Sequence
+from collections.abc import Iterable, Mapping, Sequence
+from dataclasses import dataclass
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, Literal
+from typing import TYPE_CHECKING, Any, Generic, Literal, TypeVar
 
 from pydantic import BaseModel
 
 if TYPE_CHECKING:
     from langres.core.calibration import ThresholdMethod
+    from langres.core.models import ERCandidate
 
 __all__ = [
+    "AlignedPairs",
+    "AlignedSplit",
     "Correction",
     "CorrectionLog",
+    "GoldCoverage",
     "LabeledPair",
+    "PairLabel",
+    "align_pairs",
     "derive_threshold_from_pairs",
     "harvest_labeled_pairs",
 ]
+
+#: Schema type variable for the entity schema an ``ERCandidate`` carries. Defined
+#: locally to keep this module import-light (no ``models`` import at runtime).
+SchemaT = TypeVar("SchemaT", bound=BaseModel)
 
 logger = logging.getLogger(__name__)
 
@@ -340,3 +352,272 @@ def derive_threshold_from_pairs(
         method=method,
         percentile=percentile,
     )
+
+
+# ---------------------------------------------------------------------------
+# align_pairs: the id-join bridge from labeled pairs to fit-ready candidates
+# ---------------------------------------------------------------------------
+
+#: Public spelling of the pair-label record. :class:`LabeledPair` already IS the
+#: pair-label schema (a score + a label + provenance), so ``PairLabel`` is a
+#: thin alias rather than a forked, duplicated model -- callers/docs may prefer
+#: the ``PairLabel`` name without a second class to keep in sync.
+PairLabel = LabeledPair
+
+
+class GoldCoverage(BaseModel):
+    """How many labeled *positive* pairs survived blocking (the honest-numbers guardrail).
+
+    A positive label whose pair the blocker never proposed is silently
+    unrecoverable downstream -- no matcher can match a pair it never sees. This
+    model makes that leak visible instead of letting held-out metrics quietly
+    absorb it.
+
+    Attributes:
+        gold_coverage: Fraction of labeled positive pairs that appeared among the
+            candidates -- blocking pair-completeness restricted to the labeled
+            positives (from :func:`~langres.core.metrics.evaluate_blocking`, not
+            reimplemented). ``1.0`` when there are no positive labels (nothing to
+            miss).
+        dropped_positives: The lexicographically-ordered ``(left_id, right_id)``
+            id-pairs of positive labels with no matching candidate -- the pairs
+            blocking dropped. ``len(dropped_positives)`` is the dropped count.
+        n_labeled: Distinct labeled pairs after order-independent de-duplication.
+        n_aligned: Labeled pairs that matched a candidate (the fit-set size).
+        n_positive_labels: Positive labels among ``n_labeled`` (the coverage
+            denominator).
+    """
+
+    gold_coverage: float
+    dropped_positives: list[tuple[str, str]]
+    n_labeled: int
+    n_aligned: int
+    n_positive_labels: int
+
+
+@dataclass(frozen=True)
+class AlignedSplit(Generic[SchemaT]):
+    """One split's positionally-aligned candidates and their boolean labels.
+
+    ``candidates[i]`` and ``labels[i]`` describe the same pair, ready to hand to
+    :meth:`SupervisedFitMixin.fit(candidates, labels)
+    <langres.core.fit.SupervisedFitMixin>`.
+    """
+
+    candidates: list[ERCandidate[SchemaT]]
+    labels: list[bool]
+
+
+@dataclass(frozen=True)
+class AlignedPairs(Generic[SchemaT]):
+    """Result of :func:`align_pairs`: fit-ready train/valid splits + coverage.
+
+    A small named result (not a bare 4-tuple) so downstream code reads
+    ``aligned.train.candidates`` / ``aligned.coverage.gold_coverage`` instead of
+    positional unpacking.
+
+    Attributes:
+        train: The training split (all labeled candidates when ``split is None``).
+        valid: The held-out split (empty when ``split is None``); entity-disjoint
+            from ``train`` so no entity id appears in both.
+        coverage: The :class:`GoldCoverage` guardrail for the whole label set.
+    """
+
+    train: AlignedSplit[SchemaT]
+    valid: AlignedSplit[SchemaT]
+    coverage: GoldCoverage
+
+    @property
+    def labels(self) -> list[bool]:
+        """The training split's labels -- convenience for the common no-split case."""
+        return self.train.labels
+
+
+class _UnionFind:
+    """Minimal union-find over string ids for the entity-disjoint split."""
+
+    def __init__(self) -> None:
+        self._parent: dict[str, str] = {}
+
+    def find(self, x: str) -> str:
+        """Root of ``x``'s component, with path compression."""
+        self._parent.setdefault(x, x)
+        root = x
+        while self._parent[root] != root:
+            root = self._parent[root]
+        node = x
+        while self._parent[node] != root:
+            self._parent[node], node = root, self._parent[node]
+        return root
+
+    def union(self, a: str, b: str) -> None:
+        """Merge the components of ``a`` and ``b``."""
+        self._parent[self.find(a)] = self.find(b)
+
+
+def _labels_to_map(
+    labels: str | Path | Sequence[LabeledPair] | Sequence[Correction],
+) -> dict[frozenset[str], bool]:
+    """Normalize any labels input to ``{frozenset({left_id, right_id}): label}``.
+
+    A ``corrections.jsonl`` path is read via :class:`CorrectionLog`. Pairs are
+    keyed order-independently (mirroring :func:`harvest_labeled_pairs`), and a
+    later label for the same pair wins (last-write-wins) -- so duplicate and
+    conflicting labels collapse deterministically to the last one seen.
+    """
+    resolved: Sequence[LabeledPair] | Sequence[Correction]
+    if isinstance(labels, (str, Path)):
+        resolved = CorrectionLog(labels).read()
+    else:
+        resolved = labels
+    label_map: dict[frozenset[str], bool] = {}
+    for item in resolved:
+        label_map[frozenset({str(item.left_id), str(item.right_id)})] = bool(item.label)
+    return label_map
+
+
+def _candidate_key(candidate: ERCandidate[Any]) -> frozenset[str]:
+    """Order-independent id key for a candidate (mirrors the label key)."""
+    return frozenset({str(candidate.left.id), str(candidate.right.id)})
+
+
+def _gold_coverage(
+    candidates: list[ERCandidate[Any]],
+    label_map: dict[frozenset[str], bool],
+    candidate_keys: set[frozenset[str]],
+) -> GoldCoverage:
+    """Build the :class:`GoldCoverage` guardrail, reusing ``evaluate_blocking``."""
+    positive_keys = {key for key, label in label_map.items() if label and len(key) == 2}
+
+    dropped: list[tuple[str, str]] = []
+    for key in positive_keys - candidate_keys:
+        ordered = sorted(key)
+        dropped.append((ordered[0], ordered[1]))
+    dropped.sort()
+
+    if positive_keys:
+        # Reuse evaluate_blocking (do NOT reimplement pair-completeness): each
+        # positive pair is its own 2-id cluster, so candidate_recall is exactly
+        # the fraction of labeled positive pairs captured by blocking -- with no
+        # transitive closure fabricating pairs that were never labeled.
+        from langres.core.metrics import evaluate_blocking
+
+        gold_clusters = [set(key) for key in positive_keys]
+        gold_coverage = evaluate_blocking(candidates, gold_clusters).candidate_recall
+    else:
+        gold_coverage = 1.0  # No positives -> nothing to miss.
+
+    return GoldCoverage(
+        gold_coverage=gold_coverage,
+        dropped_positives=dropped,
+        n_labeled=len(label_map),
+        n_aligned=sum(1 for key in label_map if key in candidate_keys),
+        n_positive_labels=len(positive_keys),
+    )
+
+
+def _entity_disjoint_split(
+    aligned: list[tuple[ERCandidate[Any], bool]],
+    *,
+    split: float | None,
+    seed: int,
+) -> tuple[list[int], list[int]]:
+    """Partition aligned indices into ``(train, valid)`` with NO entity in both.
+
+    Groups aligned pairs into connected entity-components (union-find over the
+    two ids each pair touches), then assigns whole components to valid -- in a
+    seed-shuffled order -- until about ``split`` of the pairs are held out. A
+    row-random split would leak an entity across the boundary and inflate
+    held-out metrics; assigning whole components cannot. Indices within each
+    returned split keep their original candidate order.
+    """
+    n = len(aligned)
+    if split is None or n == 0:
+        return list(range(n)), []
+
+    uf = _UnionFind()
+    for candidate, _ in aligned:
+        uf.union(str(candidate.left.id), str(candidate.right.id))
+
+    components: dict[str, list[int]] = {}
+    for index, (candidate, _) in enumerate(aligned):
+        components.setdefault(uf.find(str(candidate.left.id)), []).append(index)
+
+    # Deterministic base order (by smallest member index), then a seeded shuffle
+    # so the split is reproducible but not coupled to component discovery order.
+    component_lists = sorted(components.values(), key=min)
+    random.Random(seed).shuffle(component_lists)
+
+    target_valid = round(split * n)
+    valid_set: set[int] = set()
+    for members in component_lists:
+        if len(valid_set) >= target_valid:
+            break
+        valid_set.update(members)
+
+    train_indices = [i for i in range(n) if i not in valid_set]
+    valid_indices = [i for i in range(n) if i in valid_set]
+    return train_indices, valid_indices
+
+
+def align_pairs(
+    candidates: Iterable[ERCandidate[SchemaT]],
+    labels: str | Path | Sequence[LabeledPair] | Sequence[Correction],
+    *,
+    split: float | None = None,
+    seed: int = 0,
+) -> AlignedPairs[SchemaT]:
+    """Join labeled pairs to blocked candidates, split entity-disjointly, report coverage.
+
+    The id-join bridge between the two halves of a supervised fit: raw labels
+    (by id, in any left/right order) on one side, the blocker's candidate stream
+    on the other. Each candidate whose ``{left_id, right_id}`` matches a label is
+    emitted with that label, positionally aligned for
+    :meth:`SupervisedFitMixin.fit <langres.core.fit.SupervisedFitMixin>`.
+
+    Args:
+        candidates: The blocked (and, if a comparator is configured,
+            comparison-attached) candidate stream to align labels onto. Consumed
+            once and materialized.
+        labels: A ``corrections.jsonl`` path (``str``/``Path``), or an in-memory
+            ``Sequence`` of :class:`LabeledPair`/:class:`Correction`. Pairs are
+            keyed order-independently; a later label for the same pair wins.
+        split: ``None`` (default) puts every labeled candidate in ``train`` and
+            leaves ``valid`` empty. Otherwise the held-out fraction
+            (``0 < split < 1``): whole entity-components are assigned to ``valid``
+            until about ``split`` of the labeled pairs are held out.
+        seed: Seed for the deterministic component shuffle.
+
+    Returns:
+        An :class:`AlignedPairs` with ``train``/``valid`` splits and a
+        :class:`GoldCoverage` guardrail.
+
+    Raises:
+        ValueError: If ``split`` is given but not in the open interval ``(0, 1)``.
+    """
+    if split is not None and not 0.0 < split < 1.0:
+        raise ValueError(f"split must be in the open interval (0, 1) or None; got {split!r}")
+
+    label_map = _labels_to_map(labels)
+    materialized = list(candidates)
+
+    aligned: list[tuple[ERCandidate[SchemaT], bool]] = []
+    candidate_keys: set[frozenset[str]] = set()
+    for candidate in materialized:
+        key = _candidate_key(candidate)
+        candidate_keys.add(key)
+        if key in label_map:
+            aligned.append((candidate, label_map[key]))
+
+    coverage = _gold_coverage(materialized, label_map, candidate_keys)
+
+    train_indices, valid_indices = _entity_disjoint_split(aligned, split=split, seed=seed)
+    train = AlignedSplit(
+        candidates=[aligned[i][0] for i in train_indices],
+        labels=[aligned[i][1] for i in train_indices],
+    )
+    valid = AlignedSplit(
+        candidates=[aligned[i][0] for i in valid_indices],
+        labels=[aligned[i][1] for i in valid_indices],
+    )
+    return AlignedPairs(train=train, valid=valid, coverage=coverage)

--- a/src/langres/core/harvest.py
+++ b/src/langres/core/harvest.py
@@ -553,6 +553,12 @@ def _entity_disjoint_split(
     for members in component_lists:
         if len(valid_set) >= target_valid:
             break
+        # Never empty train: skip a component that would swallow EVERY pair. A
+        # single all-connected component cannot be split entity-disjointly, so
+        # the honest outcome is an empty valid (train keeps everything), not an
+        # empty train. With >1 component this still fills valid toward target.
+        if len(valid_set) + len(members) >= n:
+            continue
         valid_set.update(members)
 
     train_indices = [i for i in range(n) if i not in valid_set]

--- a/src/langres/core/resolver.py
+++ b/src/langres/core/resolver.py
@@ -47,10 +47,14 @@ from langres.core.blockers.composite import CompositeBlocker
 from langres.core.clusterer import Clusterer
 from langres.core.comparator import Comparator
 from langres.core.fit import SupervisedFitMixin, UnsupervisedFitMixin
+from langres.core.fit_report import FitReport
+from langres.core.harvest import Correction, LabeledPair, align_pairs
 from langres.core.matchers.weighted_average import WeightedAverageMatcher
+from langres.core.metrics import PairMetrics, classify_pairs
 from langres.core.models import ERCandidate, PairwiseJudgement
 from langres.core.matcher import Matcher
 from langres.core.registry import get_component
+from langres.core.runs import current_run
 from langres.core.serialization import (
     ARTIFACT_VERSION,
     ArtifactManifest,
@@ -334,6 +338,9 @@ class Resolver:
         self.comparator = comparator
         self.module = matcher
         self.clusterer = clusterer
+        # Set by fit(); the sklearn trailing-underscore "produced by fit" digest.
+        # None until fit() runs (never serialized -- it is a fit-time artifact).
+        self.fit_report_: FitReport | None = None
         # Set by build_anchor_store(); the incremental-assign state assign() uses.
         # Quoted: AnchorStore is a TYPE_CHECKING-only import (avoids an import cycle).
         self._anchor_store: "AnchorStore | None" = None
@@ -452,69 +459,173 @@ class Resolver:
     # Running the pipeline
     # ------------------------------------------------------------------
 
-    def fit(self, data: list[Any], labels: Sequence[bool] | None = None) -> Self:
+    def fit(
+        self,
+        data: list[Any],
+        labels: Sequence[bool] | None = None,
+        *,
+        pairs: str | Path | Sequence[LabeledPair] | Sequence[Correction] | None = None,
+        split: float | None = None,
+        seed: int = 0,
+    ) -> Self:
         """Fit the module when it supports a fit hook; sklearn-style no-op otherwise.
 
-        Delegates to the module's fit hook when it implements one of the two
-        runtime-checkable Protocols in :mod:`langres.core.fit` (W1.0, E6):
+        Every non-raising path sets :attr:`fit_report_` (an sklearn
+        trailing-underscore, produced-by-fit digest) and returns ``self`` so
+        ``resolver.fit(...).resolve(...)`` still chains. Delegates to the module's
+        fit hook when it implements one of the runtime-checkable Protocols in
+        :mod:`langres.core.fit` (W1.0, E6):
 
         - :class:`~langres.core.fit.UnsupervisedFitMixin`
-          (``fit_unlabeled(candidates)``): called unconditionally with the
-          blocked (and, if a comparator is configured, comparison-attached)
-          candidate stream. ``labels`` is not used by this path.
-        - :class:`~langres.core.fit.SupervisedFitMixin`
-          (``fit(candidates, labels)``): called with ``labels`` when given;
-          **raises** rather than silently skipping training when ``labels``
-          is omitted -- a genuinely trainable module that never gets
-          trained is exactly the silent-no-op footgun this hook exists to
-          prevent.
+          (``fit_unlabeled(candidates)``): called with the blocked (and, if a
+          comparator is configured, comparison-attached) candidate stream.
+          ``labels``/``pairs`` are not used by this path (passing either raises).
+        - :class:`~langres.core.fit.SupervisedFitMixin` (``fit(candidates,
+          labels)``): trained from either pre-aligned ``labels`` or id-keyed
+          ``pairs`` (see below); **raises** rather than silently skipping when
+          neither is given -- a genuinely trainable module that never gets trained
+          is exactly the silent-no-op footgun this hook exists to prevent.
 
-        When the module implements **neither** hook, this is a no-op that
-        returns ``self`` -- unchanged sklearn-style symmetry so callers can
-        write ``resolver.fit(data).resolve(data)`` for non-learnable
-        pipelines (e.g. ``WeightedAverageMatcher``) without branching -- UNLESS
-        ``labels`` was passed, in which case it raises rather than silently
-        discarding them.
+        Two ways to supply supervision for a ``SupervisedFitMixin`` matcher:
+
+        - ``labels``: a ``Sequence[bool]`` the caller has *already* positionally
+          aligned with the blocked candidates (the pre-existing contract). No
+          id-join happens, so the report carries no ``coverage``.
+        - ``pairs``: id-keyed labels (a ``corrections.jsonl`` path, or a
+          ``Sequence`` of :class:`~langres.core.harvest.LabeledPair` /
+          :class:`~langres.core.harvest.Correction`) that
+          :func:`~langres.core.harvest.align_pairs` joins to the candidates for
+          you -- with an optional entity-disjoint ``split`` for held-out metrics
+          and a :class:`~langres.core.harvest.GoldCoverage` guardrail. Pass at
+          most one of ``labels``/``pairs``.
+
+        When the module implements **neither** hook, this is a no-op that returns
+        ``self`` (unchanged sklearn-style symmetry for non-learnable pipelines
+        like ``WeightedAverageMatcher``) with a minimal ``fit_report_`` -- UNLESS
+        ``labels``/``pairs`` was passed, in which case it raises rather than
+        silently discarding them.
 
         Args:
             data: Raw records (dicts) in a stable list order, same shape as
                 ``resolve()``/``predict()`` accept.
-            labels: Gold match/non-match labels, positionally aligned with the
-                blocked candidates. Required (and only used) when the module
-                implements ``SupervisedFitMixin``.
+            labels: Gold labels pre-aligned with the blocked candidates. Only for
+                a ``SupervisedFitMixin`` module; mutually exclusive with ``pairs``.
+            pairs: Id-keyed labels ``align_pairs`` joins to the candidates. Only
+                for a ``SupervisedFitMixin`` module; mutually exclusive with
+                ``labels``.
+            split: Held-out fraction for the entity-disjoint ``pairs`` split
+                (``None`` = train on everything; only meaningful with ``pairs``).
+            seed: Seed for the entity-disjoint split.
 
         Returns:
             ``self``, so ``resolver.fit(data).resolve(data)`` chains.
 
         Raises:
-            ValueError: If the module implements ``SupervisedFitMixin`` and
-                ``labels`` is omitted, or if ``labels`` is given but the
-                module implements neither fit hook.
+            ValueError: If both ``labels`` and ``pairs`` are given; if the module
+                implements ``SupervisedFitMixin`` and neither is given; or if
+                ``labels``/``pairs`` is given to a module that cannot use them.
         """
+        if labels is not None and pairs is not None:
+            raise ValueError(
+                "pass either labels= (a Sequence[bool] pre-aligned with the blocked "
+                "candidates) or pairs= (id-keyed labels align_pairs() joins for you), "
+                "not both."
+            )
+        if pairs is not None:
+            self.fit_report_ = self._fit_from_pairs(data, pairs, split=split, seed=seed)
+            return self
+
+        matcher_name = type(self.module).__name__
         if isinstance(self.module, SupervisedFitMixin):
             if labels is None:
                 raise ValueError(
-                    f"{type(self.module).__name__} requires labeled data: pass "
+                    f"{matcher_name} requires labeled data: pass "
                     "labels=<Sequence[bool] aligned with the blocked candidates> "
-                    "to fit()."
+                    "(or pairs=<id-keyed labels>) to fit()."
                 )
             self.module.fit(self._candidates(data), labels)
+            self.fit_report_ = FitReport.build(
+                trainable=f"{matcher_name} (SupervisedFitMixin)",
+                trained=True,
+                n_train=len(labels),
+                threshold=self.clusterer.threshold,
+                run_ref=current_run.get(),
+            )
             return self
         if isinstance(self.module, UnsupervisedFitMixin):
             if labels is not None:
                 raise ValueError(
-                    f"{type(self.module).__name__} does not support fit(labels=...): "
+                    f"{matcher_name} does not support fit(labels=...): "
                     "it implements UnsupervisedFitMixin, which trains without labels "
                     "(fit_unlabeled) -- drop the labels= argument."
                 )
-            self.module.fit_unlabeled(self._candidates(data))
+            candidates = self.candidates(data)
+            self.module.fit_unlabeled(iter(candidates))
+            self.fit_report_ = FitReport.build(
+                trainable=f"{matcher_name} (UnsupervisedFitMixin)",
+                trained=True,
+                n_train=len(candidates),
+                run_ref=current_run.get(),
+            )
             return self
         if labels is not None:
             raise ValueError(
-                f"{type(self.module).__name__} does not support fit(labels=...): "
+                f"{matcher_name} does not support fit(labels=...): "
                 "it implements neither SupervisedFitMixin nor UnsupervisedFitMixin."
             )
+        self.fit_report_ = FitReport.nothing_trainable(matcher_name)
         return self
+
+    def _fit_from_pairs(
+        self,
+        data: list[Any],
+        pairs: str | Path | Sequence[LabeledPair] | Sequence[Correction],
+        *,
+        split: float | None,
+        seed: int,
+    ) -> FitReport:
+        """Fit a ``SupervisedFitMixin`` matcher from id-keyed labels via ``align_pairs``.
+
+        Runs the id-join + entity-disjoint split + coverage in one place, trains
+        on the train split, and evaluates held-out pair P/R/F1 on the valid split
+        (when a split was given, via :func:`~langres.core.metrics.classify_pairs`
+        at the clusterer's threshold). Returns the assembled :class:`FitReport`.
+        """
+        matcher_name = type(self.module).__name__
+        if not isinstance(self.module, SupervisedFitMixin):
+            raise ValueError(
+                f"{matcher_name} does not support fit(pairs=...): pairs= supplies "
+                "labeled pairs for a SupervisedFitMixin matcher, and this matcher "
+                "implements no supervised fit hook. Use fit() with no labels for an "
+                "unsupervised/non-learnable matcher."
+            )
+        aligned = align_pairs(self.candidates(data), pairs, split=split, seed=seed)
+        self.module.fit(iter(aligned.train.candidates), aligned.train.labels)
+
+        metrics: PairMetrics | None = None
+        if aligned.valid.candidates:
+            judgements = list(self.module.forward(iter(aligned.valid.candidates)))
+            gold_pairs = {
+                frozenset({str(c.left.id), str(c.right.id)})
+                for c, label in zip(
+                    aligned.valid.candidates, aligned.valid.labels, strict=True
+                )
+                if label
+            }
+            metrics = classify_pairs(judgements, gold_pairs, self.clusterer.threshold)
+
+        return FitReport.build(
+            trainable=f"{matcher_name} (SupervisedFitMixin)",
+            trained=True,
+            n_train=len(aligned.train.labels),
+            n_valid=len(aligned.valid.labels),
+            split=split,
+            seed=seed,
+            coverage=aligned.coverage,
+            threshold=self.clusterer.threshold,
+            metrics=metrics,
+            run_ref=current_run.get(),
+        )
 
     def _candidates(self, records: list[Any]) -> Iterator[ERCandidate[Any]]:
         """Block records into candidates, attaching comparisons if configured.

--- a/src/langres/core/resolver.py
+++ b/src/langres/core/resolver.py
@@ -607,9 +607,7 @@ class Resolver:
             judgements = list(self.module.forward(iter(aligned.valid.candidates)))
             gold_pairs = {
                 frozenset({str(c.left.id), str(c.right.id)})
-                for c, label in zip(
-                    aligned.valid.candidates, aligned.valid.labels, strict=True
-                )
+                for c, label in zip(aligned.valid.candidates, aligned.valid.labels, strict=True)
                 if label
             }
             metrics = classify_pairs(judgements, gold_pairs, self.clusterer.threshold)

--- a/tests/core/test_align_pairs.py
+++ b/tests/core/test_align_pairs.py
@@ -25,8 +25,9 @@ from langres.core.harvest import (
 from langres.core.models import CompanySchema, ERCandidate
 
 
-def _cand(left_id: str, right_id: str, *, left_name: str | None = None,
-          right_name: str | None = None) -> ERCandidate[CompanySchema]:
+def _cand(
+    left_id: str, right_id: str, *, left_name: str | None = None, right_name: str | None = None
+) -> ERCandidate[CompanySchema]:
     """A minimal candidate keyed by (left_id, right_id)."""
     return ERCandidate(
         left=CompanySchema(id=left_id, name=left_name or left_id),
@@ -36,7 +37,9 @@ def _cand(left_id: str, right_id: str, *, left_name: str | None = None,
 
 
 def _labeled(left_id: str, right_id: str, label: bool) -> LabeledPair:
-    return LabeledPair(left_id=left_id, right_id=right_id, score=None, label=label, source="correction")
+    return LabeledPair(
+        left_id=left_id, right_id=right_id, score=None, label=label, source="correction"
+    )
 
 
 # ---------------------------------------------------------------------------

--- a/tests/core/test_align_pairs.py
+++ b/tests/core/test_align_pairs.py
@@ -196,6 +196,18 @@ def test_split_is_deterministic_for_a_fixed_seed() -> None:
     assert [c.left.id for c in a1.valid.candidates] == [c.left.id for c in a2.valid.candidates]
 
 
+def test_single_connected_component_cannot_split_keeps_train_nonempty() -> None:
+    """All labeled entities connected -> valid empty, train keeps everything (never empties train)."""
+    # (a,b),(b,c),(c,d) chain everything into one component.
+    candidates = [_cand("a", "b"), _cand("b", "c"), _cand("c", "d")]
+    labels = [_labeled("a", "b", True), _labeled("b", "c", False), _labeled("c", "d", True)]
+
+    aligned = align_pairs(candidates, labels, split=0.5, seed=0)
+
+    assert len(aligned.train.candidates) == 3  # everything stays in train
+    assert aligned.valid.candidates == []  # no entity-disjoint valid is possible
+
+
 def test_split_none_gives_empty_valid_and_all_train() -> None:
     candidates = [_cand("a", "b"), _cand("c", "d")]
     labels = [_labeled("a", "b", True), _labeled("c", "d", False)]

--- a/tests/core/test_align_pairs.py
+++ b/tests/core/test_align_pairs.py
@@ -1,0 +1,270 @@
+"""Tests for align_pairs: the id-join bridge (W1.x, PR-B correctness gate).
+
+align_pairs joins id-keyed labels to blocked candidates, emits
+positionally-aligned (candidates, labels) for SupervisedFitMixin.fit, splits
+entity-disjointly (NOT row-random -- a row-random split leaks entities across
+train/valid and inflates held-out metrics), and reports a GoldCoverage
+guardrail surfacing blocker-dropped positives.
+
+These are pure, dependency-light unit tests: candidates are constructed
+directly (no blocker/comparator needed), so nothing here pulls sklearn/torch.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from langres.core.harvest import (
+    AlignedPairs,
+    Correction,
+    CorrectionLog,
+    GoldCoverage,
+    LabeledPair,
+    align_pairs,
+)
+from langres.core.models import CompanySchema, ERCandidate
+
+
+def _cand(left_id: str, right_id: str, *, left_name: str | None = None,
+          right_name: str | None = None) -> ERCandidate[CompanySchema]:
+    """A minimal candidate keyed by (left_id, right_id)."""
+    return ERCandidate(
+        left=CompanySchema(id=left_id, name=left_name or left_id),
+        right=CompanySchema(id=right_id, name=right_name or right_id),
+        blocker_name="test",
+    )
+
+
+def _labeled(left_id: str, right_id: str, label: bool) -> LabeledPair:
+    return LabeledPair(left_id=left_id, right_id=right_id, score=None, label=label, source="correction")
+
+
+# ---------------------------------------------------------------------------
+# Gold coverage: blocker-dropped positives are surfaced, not silently lost.
+# ---------------------------------------------------------------------------
+
+
+def test_blocker_miss_drops_coverage_below_one_and_names_the_pair() -> None:
+    """A positive label whose pair the blocker never proposed -> coverage < 1.0."""
+    candidates = [_cand("a", "b"), _cand("c", "d")]
+    labels = [_labeled("a", "b", True), _labeled("x", "y", True)]  # (x,y) has no candidate
+
+    aligned = align_pairs(candidates, labels)
+
+    assert isinstance(aligned, AlignedPairs)
+    assert isinstance(aligned.coverage, GoldCoverage)
+    assert aligned.coverage.gold_coverage == pytest.approx(0.5)  # 1 of 2 positives kept
+    assert aligned.coverage.dropped_positives == [("x", "y")]
+    assert aligned.coverage.n_positive_labels == 2
+
+
+def test_full_coverage_when_every_positive_has_a_candidate() -> None:
+    candidates = [_cand("a", "b"), _cand("c", "d")]
+    labels = [_labeled("a", "b", True), _labeled("c", "d", True)]
+
+    aligned = align_pairs(candidates, labels)
+
+    assert aligned.coverage.gold_coverage == pytest.approx(1.0)
+    assert aligned.coverage.dropped_positives == []
+
+
+def test_coverage_is_one_when_there_are_no_positive_labels() -> None:
+    """No positives -> nothing to miss -> coverage 1.0 (not 0.0 from an empty ratio)."""
+    candidates = [_cand("a", "b")]
+    labels = [_labeled("a", "b", False)]
+
+    aligned = align_pairs(candidates, labels)
+
+    assert aligned.coverage.gold_coverage == pytest.approx(1.0)
+    assert aligned.coverage.n_positive_labels == 0
+
+
+def test_negative_labels_do_not_count_toward_coverage() -> None:
+    """A dropped *negative* label is not a coverage miss (only positives matter)."""
+    candidates = [_cand("a", "b")]
+    labels = [_labeled("a", "b", True), _labeled("x", "y", False)]  # (x,y) negative, no candidate
+
+    aligned = align_pairs(candidates, labels)
+
+    assert aligned.coverage.gold_coverage == pytest.approx(1.0)
+    assert aligned.coverage.dropped_positives == []
+    assert aligned.coverage.n_labeled == 2  # both labels counted for the total
+
+
+# ---------------------------------------------------------------------------
+# Order-independent id-join + duplicate / conflicting labels.
+# ---------------------------------------------------------------------------
+
+
+def test_id_join_is_order_independent() -> None:
+    """A candidate (a,b) matches a label keyed (b,a) -- unordered frozenset join."""
+    candidates = [_cand("a", "b")]
+    labels = [_labeled("b", "a", True)]
+
+    aligned = align_pairs(candidates, labels)
+
+    assert len(aligned.train.candidates) == 1
+    assert aligned.train.labels == [True]
+    assert aligned.coverage.n_aligned == 1
+
+
+def test_duplicate_label_for_same_pair_is_deduplicated() -> None:
+    candidates = [_cand("a", "b")]
+    labels = [_labeled("a", "b", True), _labeled("a", "b", True)]
+
+    aligned = align_pairs(candidates, labels)
+
+    assert aligned.coverage.n_labeled == 1
+    assert aligned.train.labels == [True]
+
+
+def test_conflicting_label_is_last_write_wins() -> None:
+    """Same pair labeled both ways (order flipped) -> deterministic last-write-wins."""
+    candidates = [_cand("a", "b")]
+    labels = [_labeled("a", "b", True), _labeled("b", "a", False)]  # last one (False) wins
+
+    aligned = align_pairs(candidates, labels)
+
+    assert aligned.coverage.n_labeled == 1
+    assert aligned.train.labels == [False]
+
+
+def test_self_referential_label_does_not_crash_and_matches_nothing() -> None:
+    """A degenerate (a,a) label is harmless: it can never match a real candidate."""
+    candidates = [_cand("a", "b")]
+    labels = [_labeled("a", "a", True), _labeled("a", "b", True)]
+
+    aligned = align_pairs(candidates, labels)
+
+    assert aligned.train.labels == [True]  # only (a,b) aligns
+    assert aligned.coverage.dropped_positives == []  # (a,a) is not a real positive pair
+
+
+# ---------------------------------------------------------------------------
+# Entity-disjoint split (NOT row-random).
+# ---------------------------------------------------------------------------
+
+
+def _two_component_setup() -> tuple[list[ERCandidate[CompanySchema]], list[LabeledPair]]:
+    # Component 1: {a,b,c} via pairs (a,b),(b,c). Component 2: {d,e,f} via (d,e),(e,f).
+    candidates = [_cand("a", "b"), _cand("b", "c"), _cand("d", "e"), _cand("e", "f")]
+    labels = [
+        _labeled("a", "b", True),
+        _labeled("b", "c", False),
+        _labeled("d", "e", True),
+        _labeled("e", "f", False),
+    ]
+    return candidates, labels
+
+
+@pytest.mark.parametrize("seed", [0, 1, 2, 7, 42])
+def test_split_is_entity_disjoint_no_id_in_both_train_and_valid(seed: int) -> None:
+    """The subtle trap: no entity id may appear in both train and valid."""
+    candidates, labels = _two_component_setup()
+
+    aligned = align_pairs(candidates, labels, split=0.5, seed=seed)
+
+    train_ids = {c.left.id for c in aligned.train.candidates} | {
+        c.right.id for c in aligned.train.candidates
+    }
+    valid_ids = {c.left.id for c in aligned.valid.candidates} | {
+        c.right.id for c in aligned.valid.candidates
+    }
+    assert train_ids and valid_ids  # both non-empty for this 2-component, 0.5 split
+    assert train_ids.isdisjoint(valid_ids)
+    # Every aligned pair lands in exactly one split.
+    assert len(aligned.train.candidates) + len(aligned.valid.candidates) == len(candidates)
+
+
+def test_split_keeps_whole_components_together() -> None:
+    """A whole entity-component goes to one side (the mechanism behind disjointness)."""
+    candidates, labels = _two_component_setup()
+
+    aligned = align_pairs(candidates, labels, split=0.5, seed=0)
+
+    # Each split holds a whole 3-id component -> exactly 2 aligned pairs each.
+    assert len(aligned.train.candidates) == 2
+    assert len(aligned.valid.candidates) == 2
+
+
+def test_split_is_deterministic_for_a_fixed_seed() -> None:
+    candidates, labels = _two_component_setup()
+
+    a1 = align_pairs(candidates, labels, split=0.5, seed=3)
+    a2 = align_pairs(candidates, labels, split=0.5, seed=3)
+
+    assert [c.left.id for c in a1.valid.candidates] == [c.left.id for c in a2.valid.candidates]
+
+
+def test_split_none_gives_empty_valid_and_all_train() -> None:
+    candidates = [_cand("a", "b"), _cand("c", "d")]
+    labels = [_labeled("a", "b", True), _labeled("c", "d", False)]
+
+    aligned = align_pairs(candidates, labels)  # split defaults to None
+
+    assert aligned.valid.candidates == []
+    assert aligned.valid.labels == []
+    assert len(aligned.train.candidates) == 2
+    assert aligned.labels == aligned.train.labels  # .labels convenience == train labels
+
+
+@pytest.mark.parametrize("bad_split", [0.0, 1.0, -0.1, 1.5])
+def test_split_out_of_range_raises(bad_split: float) -> None:
+    candidates = [_cand("a", "b")]
+    labels = [_labeled("a", "b", True)]
+
+    with pytest.raises(ValueError, match="split must be in the open interval"):
+        align_pairs(candidates, labels, split=bad_split)
+
+
+# ---------------------------------------------------------------------------
+# Path-vs-in-memory equivalence + Correction input.
+# ---------------------------------------------------------------------------
+
+
+def test_path_and_in_memory_labels_give_identical_alignment(tmp_path) -> None:
+    """A corrections.jsonl path and the equivalent in-memory Corrections align identically."""
+    candidates = [_cand("a", "b"), _cand("c", "d"), _cand("e", "f")]
+    corrections = [
+        Correction(left_id="a", right_id="b", label=True),
+        Correction(left_id="d", right_id="c", label=False),  # order flipped on purpose
+        Correction(left_id="e", right_id="f", label=True),
+    ]
+
+    path = tmp_path / "corrections.jsonl"
+    log = CorrectionLog(path)
+    for c in corrections:
+        log.append(c)
+
+    from_path = align_pairs(candidates, path, split=0.5, seed=1)
+    from_memory = align_pairs(candidates, corrections, split=0.5, seed=1)
+
+    assert [c.left.id for c in from_path.train.candidates] == [
+        c.left.id for c in from_memory.train.candidates
+    ]
+    assert from_path.train.labels == from_memory.train.labels
+    assert [c.left.id for c in from_path.valid.candidates] == [
+        c.left.id for c in from_memory.valid.candidates
+    ]
+    assert from_path.coverage.model_dump() == from_memory.coverage.model_dump()
+
+
+def test_correction_input_is_accepted_like_labeled_pair() -> None:
+    candidates = [_cand("a", "b")]
+    corrections = [Correction(left_id="a", right_id="b", label=True)]
+
+    aligned = align_pairs(candidates, corrections)
+
+    assert aligned.train.labels == [True]
+    assert aligned.coverage.n_aligned == 1
+
+
+def test_unlabeled_candidates_are_dropped_from_the_fit_set() -> None:
+    """Candidates with no matching label are not part of the training set."""
+    candidates = [_cand("a", "b"), _cand("c", "d")]  # (c,d) is unlabeled
+    labels = [_labeled("a", "b", True)]
+
+    aligned = align_pairs(candidates, labels)
+
+    assert len(aligned.train.candidates) == 1
+    assert aligned.train.candidates[0].left.id == "a"

--- a/tests/core/test_fit_report.py
+++ b/tests/core/test_fit_report.py
@@ -55,9 +55,7 @@ class _FakeSupervised(Matcher[CompanySchema]):
     ) -> ScoreInspectionReport:
         raise NotImplementedError
 
-    def fit(
-        self, candidates: Iterator[ERCandidate[CompanySchema]], labels: Sequence[bool]
-    ) -> None:
+    def fit(self, candidates: Iterator[ERCandidate[CompanySchema]], labels: Sequence[bool]) -> None:
         self.fit_calls.append((len(list(candidates)), list(labels)))
 
 

--- a/tests/core/test_fit_report.py
+++ b/tests/core/test_fit_report.py
@@ -152,24 +152,35 @@ def test_supervised_labels_path_sets_report_without_coverage() -> None:
 def test_pairs_path_sets_coverage_and_heldout_metrics() -> None:
     module = _FakeSupervised()
     resolver = _resolver(module)
-    # Label the two true-match pairs positive and one cross pair negative.
+    # Two DISJOINT entity-components (no cross pair to bridge them), so an
+    # entity-disjoint split can hold one whole component out as valid.
+    records = [
+        {"id": "a1", "name": "Acme"},
+        {"id": "a2", "name": "Acme"},
+        {"id": "a3", "name": "Aardvark"},
+        {"id": "b1", "name": "Beta"},
+        {"id": "b2", "name": "Beta"},
+        {"id": "b3", "name": "Bumble"},
+    ]
     pairs = [
         LabeledPair(left_id="a1", right_id="a2", score=None, label=True, source="correction"),
+        LabeledPair(left_id="a1", right_id="a3", score=None, label=False, source="correction"),
         LabeledPair(left_id="b1", right_id="b2", score=None, label=True, source="correction"),
-        LabeledPair(left_id="a1", right_id="b1", score=None, label=False, source="correction"),
+        LabeledPair(left_id="b1", right_id="b3", score=None, label=False, source="correction"),
     ]
 
-    resolver.fit(RECORDS, pairs=pairs, split=0.5, seed=0)
+    resolver.fit(records, pairs=pairs, split=0.5, seed=0)
 
     report = resolver.fit_report_
     assert report is not None
     assert report.trained is True
     assert report.trainable == "_FakeSupervised (SupervisedFitMixin)"
     assert report.entity_disjoint is True
-    assert report.n_train + report.n_valid == 3  # all three labeled pairs aligned
+    assert report.n_train + report.n_valid == 4  # all four labeled pairs aligned
+    assert report.n_train > 0 and report.n_valid > 0  # split held one component out
     assert isinstance(report.coverage, GoldCoverage)
     assert report.coverage.gold_coverage == pytest.approx(1.0)  # AllPairs keeps every pair
-    # A split was given, so held-out pair metrics exist.
+    # A split was given and a valid component exists, so held-out pair metrics exist.
     assert report.metrics is not None
     assert "Held-out pair metrics" in report.to_markdown()
     # The matcher was actually trained on the train split (label count == n_train).

--- a/tests/core/test_fit_report.py
+++ b/tests/core/test_fit_report.py
@@ -1,0 +1,240 @@
+"""Tests for FitReport + Resolver.fit() wiring (W1.x, PR-B).
+
+Every non-raising Resolver.fit() path must set self.fit_report_ (the sklearn
+trailing-underscore digest) and still return self. Covers the no-op branch, the
+pre-aligned labels= branch, and the id-keyed pairs= branch (coverage + held-out
+metrics), plus the import-light guarantee for the fit_report leaf.
+
+Uses a lightweight fake SupervisedFitMixin matcher so these stay fast and pull
+no sklearn/torch; the real RandomForestMatcher path is exercised by the PR-B
+runtime smoke.
+"""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+from collections.abc import Iterator, Sequence
+
+import pytest
+
+from langres.core.blockers.all_pairs import AllPairsBlocker
+from langres.core.clusterer import Clusterer
+from langres.core.fit_report import FitReport
+from langres.core.harvest import GoldCoverage, LabeledPair
+from langres.core.matcher import Matcher
+from langres.core.models import CompanySchema, ERCandidate, PairwiseJudgement
+from langres.core.reports import ScoreInspectionReport
+from langres.core.resolver import Resolver
+
+
+class _FakeSupervised(Matcher[CompanySchema]):
+    """A SupervisedFitMixin matcher: scores 1.0 when the two names are equal.
+
+    Deterministic and dependency-free, so held-out metrics are predictable.
+    """
+
+    def __init__(self) -> None:
+        self.fit_calls: list[tuple[int, list[bool]]] = []
+
+    def forward(
+        self, candidates: Iterator[ERCandidate[CompanySchema]]
+    ) -> Iterator[PairwiseJudgement]:
+        for c in candidates:
+            yield PairwiseJudgement(
+                left_id=c.left.id,
+                right_id=c.right.id,
+                score=1.0 if c.left.name == c.right.name else 0.0,
+                score_type="heuristic",
+                decision_step="fake",
+                provenance={},
+            )
+
+    def inspect_scores(
+        self, judgements: list[PairwiseJudgement], sample_size: int = 10
+    ) -> ScoreInspectionReport:
+        raise NotImplementedError
+
+    def fit(
+        self, candidates: Iterator[ERCandidate[CompanySchema]], labels: Sequence[bool]
+    ) -> None:
+        self.fit_calls.append((len(list(candidates)), list(labels)))
+
+
+class _NoHook(Matcher[CompanySchema]):
+    """Implements neither fit hook (non-learnable)."""
+
+    def forward(
+        self, candidates: Iterator[ERCandidate[CompanySchema]]
+    ) -> Iterator[PairwiseJudgement]:
+        yield from ()
+
+    def inspect_scores(
+        self, judgements: list[PairwiseJudgement], sample_size: int = 10
+    ) -> ScoreInspectionReport:
+        raise NotImplementedError
+
+
+# Two matching pairs (same name) + one non-match, across two entity-components.
+RECORDS = [
+    {"id": "a1", "name": "Acme"},
+    {"id": "a2", "name": "Acme"},
+    {"id": "b1", "name": "Beta"},
+    {"id": "b2", "name": "Beta"},
+    {"id": "c1", "name": "Gamma"},
+]
+
+
+def _resolver(module: Matcher[CompanySchema], *, threshold: float = 0.5) -> Resolver:
+    return Resolver(
+        blocker=AllPairsBlocker(schema=CompanySchema),
+        comparator=None,
+        matcher=module,
+        clusterer=Clusterer(threshold=threshold),
+    )
+
+
+# ---------------------------------------------------------------------------
+# FitReport model basics.
+# ---------------------------------------------------------------------------
+
+
+def test_nothing_trainable_report_names_the_matcher_and_marks_untrained() -> None:
+    report = FitReport.nothing_trainable("WeightedAverageMatcher")
+
+    assert report.trained is False
+    assert report.trainable == "WeightedAverageMatcher (no fit hook)"
+    assert report.coverage is None
+    assert "Fit Report" in report.to_markdown()
+    assert report.render() == report.to_markdown()
+
+
+def test_build_derives_entity_disjoint_from_split() -> None:
+    with_split = FitReport.build(trainable="X", trained=True, n_train=1, split=0.3)
+    no_split = FitReport.build(trainable="X", trained=True, n_train=1)
+
+    assert with_split.entity_disjoint is True
+    assert no_split.entity_disjoint is False
+
+
+# ---------------------------------------------------------------------------
+# Resolver.fit() sets fit_report_ on every non-raising path.
+# ---------------------------------------------------------------------------
+
+
+def test_noop_fit_sets_minimal_report_and_chains() -> None:
+    resolver = _resolver(_NoHook())
+
+    result = resolver.fit(RECORDS)
+
+    assert result is resolver
+    assert resolver.fit_report_ is not None
+    assert resolver.fit_report_.trained is False
+    # Still chains into resolve() (sklearn-style symmetry).
+    assert isinstance(resolver.resolve(RECORDS), list)
+
+
+def test_supervised_labels_path_sets_report_without_coverage() -> None:
+    module = _FakeSupervised()
+    resolver = _resolver(module)
+    labels = [True, False, True, False, False, True, False, False, False, False]
+
+    resolver.fit(RECORDS, labels=labels)
+
+    report = resolver.fit_report_
+    assert report is not None
+    assert report.trained is True
+    assert report.trainable == "_FakeSupervised (SupervisedFitMixin)"
+    assert report.n_train == len(labels)
+    assert report.coverage is None  # pre-aligned labels -> no id-join, no coverage
+    assert report.metrics is None
+    assert report.threshold == pytest.approx(0.5)
+
+
+def test_pairs_path_sets_coverage_and_heldout_metrics() -> None:
+    module = _FakeSupervised()
+    resolver = _resolver(module)
+    # Label the two true-match pairs positive and one cross pair negative.
+    pairs = [
+        LabeledPair(left_id="a1", right_id="a2", score=None, label=True, source="correction"),
+        LabeledPair(left_id="b1", right_id="b2", score=None, label=True, source="correction"),
+        LabeledPair(left_id="a1", right_id="b1", score=None, label=False, source="correction"),
+    ]
+
+    resolver.fit(RECORDS, pairs=pairs, split=0.5, seed=0)
+
+    report = resolver.fit_report_
+    assert report is not None
+    assert report.trained is True
+    assert report.trainable == "_FakeSupervised (SupervisedFitMixin)"
+    assert report.entity_disjoint is True
+    assert report.n_train + report.n_valid == 3  # all three labeled pairs aligned
+    assert isinstance(report.coverage, GoldCoverage)
+    assert report.coverage.gold_coverage == pytest.approx(1.0)  # AllPairs keeps every pair
+    # A split was given, so held-out pair metrics exist.
+    assert report.metrics is not None
+    assert "Held-out pair metrics" in report.to_markdown()
+    # The matcher was actually trained on the train split (label count == n_train).
+    assert module.fit_calls
+    assert len(module.fit_calls[0][1]) == report.n_train
+
+
+def test_pairs_path_surfaces_blocker_dropped_positive() -> None:
+    """A positive label for a pair with no candidate (unknown id) -> coverage < 1.0."""
+    module = _FakeSupervised()
+    resolver = _resolver(module)
+    pairs = [
+        LabeledPair(left_id="a1", right_id="a2", score=None, label=True, source="correction"),
+        LabeledPair(left_id="a1", right_id="ghost", score=None, label=True, source="correction"),
+    ]
+
+    resolver.fit(RECORDS, pairs=pairs)
+
+    report = resolver.fit_report_
+    assert report is not None
+    assert report.coverage is not None
+    assert report.coverage.gold_coverage == pytest.approx(0.5)
+    assert ("a1", "ghost") in report.coverage.dropped_positives
+
+
+# ---------------------------------------------------------------------------
+# Raise contracts around labels=/pairs=.
+# ---------------------------------------------------------------------------
+
+
+def test_both_labels_and_pairs_raises() -> None:
+    resolver = _resolver(_FakeSupervised())
+    with pytest.raises(ValueError, match="not both"):
+        resolver.fit(RECORDS, labels=[True], pairs=[])
+
+
+def test_pairs_given_to_non_supervised_matcher_raises() -> None:
+    resolver = _resolver(_NoHook())
+    pairs = [LabeledPair(left_id="a1", right_id="a2", score=None, label=True, source="correction")]
+    with pytest.raises(ValueError, match="does not support fit\\(pairs="):
+        resolver.fit(RECORDS, pairs=pairs)
+
+
+def test_supervised_without_labels_or_pairs_still_raises() -> None:
+    resolver = _resolver(_FakeSupervised())
+    with pytest.raises(ValueError, match="requires labeled data"):
+        resolver.fit(RECORDS)
+
+
+# ---------------------------------------------------------------------------
+# Import-light guarantee for the fit_report leaf.
+# ---------------------------------------------------------------------------
+
+
+def test_fit_report_module_stays_import_light() -> None:
+    """importing langres.core.fit_report must not pull sklearn/torch/litellm."""
+    script = (
+        "import sys; import langres.core.fit_report; "
+        "leaked = [m for m in ['sklearn', 'torch', 'litellm', 'faiss'] if m in sys.modules]; "
+        "assert not leaked, f'fit_report leaked heavy modules: {leaked}'; "
+        "print('OK')"
+    )
+    result = subprocess.run([sys.executable, "-c", script], capture_output=True, text=True)
+    assert result.returncode == 0, (
+        f"fit_report import-budget check failed.\nSTDOUT:\n{result.stdout}\nSTDERR:\n{result.stderr}"
+    )


### PR DESCRIPTION
## PR-B — align_pairs + per-role fit protocols + gold-coverage + FitReport (training-surface epic)

The correctness gate for the training surface: the labeled-pairs→candidates bridge, the fit-hook contracts generalized beyond matcher-only, and honest fit reporting. Merges into `feat/training-surface`.

### Delivered
- **`align_pairs`** (`core/harvest.py`) → named `AlignedPairs` (`.train/.valid/.labels/.coverage`): order-independent frozenset id-join, **entity-disjoint union-find split** (a row-random split leaks — tested that no id appears in both train & valid across seeds), `GoldCoverage` reusing `core.metrics.evaluate_blocking` and surfacing `dropped_positives` (blocker-missed positive labels).
- **Per-role fit protocols** (`core/fit.py`): added `BlockerFitMixin` (`fit_blocker(records, pairs)`) and `CalibratorFitMixin` (`fit_calibrator(scores, labels)`) as runtime-checkable Protocols (contract-only; impls land in later PRs). Matcher mixins untouched.
- **`FitReport`** (new import-light leaf `core/fit_report.py`, `BootstrapReport`-shaped): `build()`/`nothing_trainable()` + `to_markdown()`; `Resolver.fit()` sets `self.fit_report_` on every non-raising path and still returns `self`. Lineage via `run_ref` → `RunRecord` (no duplication).
- **`Resolver.fit(records, pairs=..., split=..., seed=...)`** id-keyed bridge running `align_pairs` internally — this is the brief's DoD (`resolver.fit(records, pairs="corrections.jsonl")`). The existing `labels=` path + all raise contracts are preserved byte-for-byte.
- `PairLabel = LabeledPair` thin alias (no forked schema). Docs: `TECHNICAL_OVERVIEW.md` "Fit-hook contract" rewritten for the 3-role split.

### Verified (local, sandbox off)
- `pytest -m "not integration and not slow"` → **2807 passed, 4 skipped**, coverage 98.61%.
- mypy clean on changed sources; ruff check + format clean; `mkdocs build --strict` clean.
- `tests/test_import_budget.py` green (fit_report.py stays sklearn/torch-free).
- Runtime smoke: real `RandomForestMatcher` fit on the entity-disjoint train split → held-out valid F1=1.0, gold_coverage=1.0, `.resolve()` chains, `FitReport.to_markdown()` renders.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Introduce align_pairs as the bridge from labeled pairs to candidates with entity-disjoint splitting and coverage reporting, extend the fit-hook contract and Resolver.fit to support per-role protocols and id-keyed supervision, and add a FitReport model plus tests and documentation updates for the new training surface.

New Features:
- Add align_pairs and related AlignedPairs/AlignedSplit/GoldCoverage types to join labeled pairs to candidates, perform entity-disjoint train/valid splits, and surface blocking coverage.
- Extend Resolver.fit to accept id-keyed labeled pairs with configurable entity-disjoint splitting, compute held-out pair metrics, and expose a FitReport digest of each fit call.
- Introduce BlockerFitMixin and CalibratorFitMixin protocols to express trainable blocker and calibrator roles alongside existing matcher fit mixins.
- Add the FitReport model to capture fit configuration, coverage, and evaluation metrics in an import-light, markdown-renderable report.

Enhancements:
- Refine the fit-hook contract documentation to cover matcher, blocker, and calibrator roles and to describe Resolver.fit semantics for labels and pairs inputs.

Documentation:
- Update TECHNICAL_OVERVIEW to describe the extended fit-hook contract, align_pairs and coverage, and how FitReport summarizes Resolver.fit runs.

Tests:
- Add unit tests for align_pairs covering coverage calculation, order-independent id-joining, entity-disjoint splitting behavior, and input variants.
- Add tests for FitReport construction, Resolver.fit wiring for no-op, supervised labels, and pairs-based fits, error handling around labels/pairs, and the import-budget guarantee for the fit_report module.