### PR TITLE
PR-E: serve your own model — api_base + in-process transformers backend + model_ref

### DIFF
--- a/examples/serve_your_model.py
+++ b/examples/serve_your_model.py
@@ -1,0 +1,115 @@
+"""Serve *your own* model through langres — over a vLLM/Ollama endpoint, or in-process.
+
+Once you have a fine-tuned (or any local/HF) entity-matching model, langres runs
+it through the **same** ``LLMMatcher`` — no new component. You choose *where* the
+model runs with two knobs on the matcher:
+
+- ``api_base=`` — point at a served, OpenAI-compatible endpoint (vLLM, Ollama, a
+  gateway). ``model`` is the served model id. This is the production recipe.
+- (omit ``api_base``) with an HF Hub id, a local directory, or a base+adapter ref
+  — langres runs the model **in-process** via a lazily-loaded transformers
+  backend, no server. Handy for eval/CI where standing up a server is overkill.
+
+Either way the calibrated match score comes from the same first-token yes/no
+logprob step, so ``confidence="logprob"`` + the ``binary_yes_no`` parser give you
+a ranking score in [0, 1] from your own weights.
+
+Serving is a *deployment recipe*, not a langres component: you run the server, and
+point the matcher at it.
+
+
+Recipe A — serve with vLLM, then point langres at it
+----------------------------------------------------
+Serve your model (one line, in its own shell)::
+
+    # your fine-tuned model, or any HF causal LM
+    vllm serve your-org/your-ft-matcher --port 8000
+
+    # or serve a base model with a LoRA/QLoRA adapter, unmerged:
+    vllm serve meta-llama/Llama-3.1-8B-Instruct \
+        --enable-lora --lora-modules ft=your-org/your-adapter --port 8000
+
+Ollama works the same way (``ollama serve``; its OpenAI-compatible API is at
+``http://localhost:11434/v1``).
+
+Then run this file::
+
+    uv run python examples/serve_your_model.py
+
+
+Recipe B — in-process, no server (see ``main`` below)
+-----------------------------------------------------
+Skip ``api_base`` and pass a local/HF model; generation runs in-process::
+
+    matcher = LLMMatcher(
+        model="your-org/your-ft-matcher",   # HF id or a local dir
+        confidence="logprob",
+        response_parser="binary_yes_no",
+    )
+    # or a base + QLoRA adapter served unmerged (needs `pip install langres[finetune]`):
+    matcher = LLMMatcher(model={"base": "...", "adapter": "..."}, confidence="logprob")
+"""
+
+from __future__ import annotations
+
+from langres import dedupe
+from langres.core.matchers.llm_judge import LLMMatcher
+
+# A tiny batch to resolve. Every record needs a unique "id".
+RECORDS = [
+    {"id": "1", "name": "Acme Corporation", "city": "New York"},
+    {"id": "2", "name": "Acme Corp", "city": "New York"},
+    {"id": "3", "name": "Totally Different Co", "city": "Chicago"},
+    {"id": "4", "name": "Totally Different Company", "city": "Chicago"},
+    {"id": "5", "name": "Unrelated Bakery", "city": "Miami"},
+]
+
+
+def build_served_matcher(
+    model: str = "your-org/your-ft-matcher",
+    api_base: str = "http://localhost:8000/v1",
+) -> LLMMatcher:
+    """Point ``LLMMatcher`` at a served, OpenAI-compatible endpoint (Recipe A).
+
+    ``model`` is the served model id; ``api_base`` is where your vLLM/Ollama
+    server listens. ``confidence="logprob"`` + ``binary_yes_no`` give a calibrated
+    [0, 1] score from your model's first-token yes/no logprobs. The matcher (incl.
+    ``api_base``) is weightlessly serializable — a saved Resolver reloads pointed
+    at the same endpoint.
+    """
+    return LLMMatcher(
+        model=model,
+        api_base=api_base,
+        confidence="logprob",
+        response_parser="binary_yes_no",
+    )
+
+
+def build_inprocess_matcher(model: str = "your-org/your-ft-matcher") -> LLMMatcher:
+    """Run a local/HF model in-process via transformers, no server (Recipe B).
+
+    Pass an HF Hub id, a local model directory, or a base+adapter dict; langres
+    routes it to the in-process backend automatically (no ``api_base``).
+    """
+    return LLMMatcher(
+        model=model,
+        confidence="logprob",
+        response_parser="binary_yes_no",
+    )
+
+
+def main() -> None:
+    # Recipe A: served endpoint. Edit ``model`` / ``api_base`` for your server.
+    matcher = build_served_matcher()
+
+    # Recipe B: swap in the in-process backend (no server) by uncommenting:
+    # matcher = build_inprocess_matcher("your-org/your-ft-matcher")
+
+    # DedupeResult is a list[set[str]] of entity-id clusters.
+    clusters = dedupe(RECORDS, matcher=matcher, threshold=0.6)
+    for cluster in clusters:
+        print(cluster)
+
+
+if __name__ == "__main__":
+    main()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -277,3 +277,16 @@ ignore_missing_imports = true
 # is stable across both — mirroring the faiss/litellm/dspy/sklearn blocks above.
 module = ["mlflow.*"]
 ignore_missing_imports = true
+
+[[tool.mypy.overrides]]
+# transformers (present via [semantic]) and peft (the [finetune] extra, absent
+# in a core-only/CI install) back the in-process serve backend (PR-E).
+# transformers ships partial type info that flips typed↔untyped across installs —
+# untyped calls like `AutoModelForCausalLM.from_pretrained` / `model.eval()`
+# alternate between fine and `no-untyped-call` — and peft is simply unresolvable
+# without [finetune]. Treat both as untyped uniformly and skip following their
+# imports, mirroring the litellm/dspy blocks; the backend annotates its own public
+# surface (it holds the model/tokenizer as `Any`).
+module = ["transformers.*", "peft.*"]
+ignore_missing_imports = true
+follow_imports = "skip"

--- a/src/langres/core/matchers/llm_judge.py
+++ b/src/langres/core/matchers/llm_judge.py
@@ -9,11 +9,12 @@ Supports both direct OpenAI client and LiteLLM for enhanced observability.
 import asyncio
 import logging
 import math
+import os
 import re
 import string
 import time
 from collections.abc import Callable, Iterator
-from typing import Any, ClassVar, Literal
+from typing import TYPE_CHECKING, Any, ClassVar, Literal
 
 import litellm
 from pydantic import BaseModel
@@ -25,12 +26,18 @@ except ImportError:
     RateLimitError = Exception
 
 from langres.clients.openrouter import parse_openrouter_billing
+from langres.core.matchers.model_ref import ModelRef, normalize_model_ref, to_config
 from langres.core.models import ERCandidate, PairwiseJudgement
 from langres.core.matcher import Matcher, SchemaT
 from langres.core.registry import register
 from langres.core.reports import ScoreInspectionReport, _inspect_scores_impl
 from langres.core.runs import current_run
 from langres.core.usage import LLMUsage
+
+if TYPE_CHECKING:
+    # Torch/transformers-backed; imported lazily at runtime (never at module load)
+    # inside _inprocess_backend so the heavy stack stays out of a bare import.
+    from langres.core.matchers.transformers_backend import TransformersBackend
 
 logger = logging.getLogger(__name__)
 
@@ -330,6 +337,67 @@ class _RateLimiter:
             self._token_usage.append((time.time(), token_count))
 
 
+# Known LiteLLM provider-route prefixes. A ``model`` carrying one of these (or no
+# ``/`` at all, i.e. a bare OpenAI-style name like ``gpt-5-mini``) is an API model
+# served over the wire; a bare ``org/name`` that matches NONE of these is treated
+# as an HF Hub id and run in-process. This is a heuristic — ``api_base`` (served
+# endpoint) and a base+adapter ``ModelRef`` (always in-process) are unambiguous and
+# decided first; see :func:`_default_backend_kind`.
+_API_MODEL_PREFIXES = (
+    "openrouter/",
+    "openai/",
+    "azure/",
+    "azure_ai/",
+    "anthropic/",
+    "gemini/",
+    "vertex_ai/",
+    "bedrock/",
+    "together_ai/",
+    "fireworks_ai/",
+    "groq/",
+    "mistral/",
+    "codestral/",
+    "cohere/",
+    "deepseek/",
+    "deepinfra/",
+    "perplexity/",
+    "xai/",
+    "cerebras/",
+    "sambanova/",
+    "huggingface/",
+    "ollama/",
+    "ollama_chat/",
+    "replicate/",
+    "watsonx/",
+)
+
+
+def _default_backend_kind(
+    ref: ModelRef, api_base: str | None
+) -> Literal["litellm", "transformers"]:
+    """Route a :class:`ModelRef` (+ optional ``api_base``) to a completion backend.
+
+    Decision order, unambiguous cases first:
+
+    1. **base+adapter** (``ref.adapter`` set) → ``"transformers"`` — an unmerged
+       PEFT adapter can only be assembled in-process.
+    2. **``api_base`` set** → ``"litellm"`` — a served (vLLM/Ollama/OpenAI-compatible)
+       endpoint is reached through litellm regardless of the model id's shape.
+    3. **existing local directory** → ``"transformers"``.
+    4. **bare name (no ``/``) or a known provider prefix** → ``"litellm"``.
+    5. otherwise (an ``org/name`` HF Hub id) → ``"transformers"``.
+    """
+    if ref.adapter is not None:
+        return "transformers"
+    if api_base is not None:
+        return "litellm"
+    if os.path.isdir(ref.base):
+        return "transformers"
+    if "/" not in ref.base or ref.base.startswith(_API_MODEL_PREFIXES):
+        return "litellm"
+    return "transformers"
+
+
 @register("llm_judge")
 class LLMMatcher(Matcher[SchemaT]):
     """Schema-agnostic LLM-based matching module using LiteLLM.
@@ -383,6 +451,16 @@ class LLMMatcher(Matcher[SchemaT]):
         ``provider={"order": ["DeepInfra"], "allow_fallbacks": False}`` or
         ``provider={"only": ["Together"]}``. It is sent as OpenRouter's
         ``extra_body["provider"]`` routing block. Off OpenRouter it is ignored.
+
+    Note:
+        The same matcher runs a model over an **API** or **in-process**, decided
+        from ``model`` + ``api_base`` (see :meth:`__init__` and
+        :func:`_default_backend_kind`): an API name goes through litellm; a served
+        endpoint (``api_base=``) through litellm to that URL; an HF id / local dir
+        / base+adapter ref runs locally via a lazily-loaded transformers backend.
+        Both backends feed the identical parse + first-token-logprob→score step,
+        so ``run your fine-tuned model`` needs no new judge — just a different
+        ``model`` / ``api_base``. See ``examples/serve_your_model.py``.
     """
 
     # Registry key, mirrored as a class attribute so the Resolver's uniform
@@ -392,12 +470,13 @@ class LLMMatcher(Matcher[SchemaT]):
     def __init__(
         self,
         client: Any = None,
-        model: str = "gpt-5-mini",
+        model: str | dict[str, str] = "gpt-5-mini",
         temperature: float = 0.0,
         prompt_template: str | None = None,
         entity_noun: str = "entity",
         provider: dict[str, Any] | None = None,
         *,
+        api_base: str | None = None,
         system_prompt: str | None = None,
         response_parser: Callable[[str], ParsedVerdict] | str | None = None,
         record_serializer: Callable[[Any], str] | str | None = None,
@@ -412,7 +491,29 @@ class LLMMatcher(Matcher[SchemaT]):
                 from the environment via ``create_llm_client(Settings())`` on
                 first use. Inject a client only as an escape hatch (e.g. tests
                 or a custom client); use :meth:`from_env` for the happy path.
-            model: Model name (e.g., "gpt-5-mini", "azure/gpt-5-mini")
+            model: The model to run, as a *weightless reference* (see
+                :class:`~langres.core.matchers.model_ref.ModelRef`):
+
+                - an API model name — ``"gpt-5-mini"``, ``"azure/gpt-5-mini"``,
+                  ``"openrouter/..."`` — served over the wire via litellm;
+                - an HF Hub id (``"your-org/your-ft-model"``) or a local model
+                  directory — run **in-process** via a lazily-loaded transformers
+                  backend (no server), unless ``api_base`` points at a served
+                  endpoint; or
+                - a base+adapter dict ``{"base": ..., "adapter": ...}`` (a QLoRA
+                  fine-tune served unmerged) — always run in-process.
+
+                The in-process route is chosen automatically for a local dir / HF
+                id / base+adapter ref when no ``api_base`` is given (see
+                :func:`_default_backend_kind`).
+            api_base: Optional base URL of a served, OpenAI-compatible endpoint
+                (vLLM, Ollama, a hosted gateway). When set, the request is routed
+                there via litellm with ``model`` as the served model id — this is
+                how you run *your own* fine-tuned model behind ``vllm serve`` /
+                ``ollama`` through the normal judge path. ``None`` (default) keeps
+                the provider's own endpoint (or the in-process backend for a local
+                model). Round-trips in :attr:`config` (a reference string, never
+                weights).
             temperature: Sampling temperature (0.0 = deterministic, 2.0 = random).
                 Defaults to ``0.0`` — ER papers score at temperature 0 for
                 reproducibility, and the sibling ``DSPyMatcher`` already defaults
@@ -487,7 +588,17 @@ class LLMMatcher(Matcher[SchemaT]):
             raise ValueError("confidence must be 'none' or 'logprob'")
 
         self.client = client
-        self.model = model
+        self.model_ref = normalize_model_ref(model)
+        # ``self.model`` stays the base id *string* for every existing consumer
+        # (litellm ``model=``, provenance, ``LLMUsage``); the full weightless ref
+        # (including any PEFT adapter) lives on ``self.model_ref``, and the raw
+        # ref serializes in :attr:`config` via :func:`to_config`.
+        self.model = self.model_ref.base
+        self.api_base = api_base
+        # Route to a backend once at construction (inputs are fixed): avoids a
+        # per-candidate filesystem stat and keeps sync/async paths consistent.
+        self._backend_kind = _default_backend_kind(self.model_ref, api_base)
+        self._backend: TransformersBackend | None = None
         self.temperature = temperature
         self.entity_noun = entity_noun
         self.provider = provider
@@ -551,7 +662,12 @@ class LLMMatcher(Matcher[SchemaT]):
         need it.
         """
         return {
-            "model": self.model,
+            # ``model`` serializes the full weightless ref: a plain string is
+            # byte-identical to before, a base+adapter widens to a dict (see
+            # ``to_config``). ``api_base`` (served-endpoint URL) round-trips too, so
+            # a resolver pointed at a served model reloads pointed at it.
+            "model": to_config(self.model_ref),
+            "api_base": self.api_base,
             "temperature": self.temperature,
             "prompt_template": self.prompt_template,
             "entity_noun": self.entity_noun,
@@ -567,15 +683,20 @@ class LLMMatcher(Matcher[SchemaT]):
     def from_config(cls, config: dict[str, object]) -> "LLMMatcher[SchemaT]":
         """Rebuild from :attr:`config` via the lazy-client path (client from env).
 
-        Older artifacts without ``system_prompt`` / ``on_parse_error`` /
-        ``confidence`` / ``response_parser`` / ``record_serializer`` fall back
-        to the constructor defaults (``None`` / ``"abstain"`` / ``"none"`` /
-        the ``"score"`` parser / the ``"json"`` serializer).
+        Older artifacts without ``api_base`` / ``system_prompt`` /
+        ``on_parse_error`` / ``confidence`` / ``response_parser`` /
+        ``record_serializer`` fall back to the constructor defaults (``None`` /
+        ``None`` / ``"abstain"`` / ``"none"`` / the ``"score"`` parser / the
+        ``"json"`` serializer).
         """
         provider = config.get("provider")
         return cls(
             client=None,
-            model=str(config["model"]),
+            # ``model`` may be a str (plain/HF/local) or a base+adapter dict —
+            # ``normalize_model_ref`` in ``__init__`` accepts both, so it is passed
+            # through unchanged (no ``str()`` coercion that would mangle the dict).
+            model=config["model"],  # type: ignore[arg-type]
+            api_base=config.get("api_base"),  # type: ignore[arg-type]
             temperature=float(config["temperature"]),  # type: ignore[arg-type]
             prompt_template=str(config["prompt_template"]),
             entity_noun=str(config["entity_noun"]),
@@ -621,6 +742,36 @@ class LLMMatcher(Matcher[SchemaT]):
         if self.confidence != "logprob":
             return {}
         return {"logprobs": True, "top_logprobs": 20}
+
+    def _api_kwargs(self) -> dict[str, Any]:
+        """Optional ``api_base`` override for a served, OpenAI-compatible endpoint.
+
+        Returns ``{"api_base": self.api_base}`` when :attr:`api_base` is set (a
+        vLLM/Ollama/gateway URL litellm routes the completion to), else ``{}``.
+        Merged at the completion call sites the **same** way as
+        :meth:`_logprobs_kwargs` and deliberately kept **out** of
+        :meth:`_completion_kwargs` — that method early-returns ``{}`` for any
+        non-``openrouter/`` model, so folding ``api_base`` into it would silently
+        drop it for a served OpenAI-compatible endpoint (and on the async path).
+        """
+        if self.api_base is None:
+            return {}
+        return {"api_base": self.api_base}
+
+    def _inprocess_backend(self) -> "TransformersBackend":
+        """The lazily-built in-process transformers backend for this matcher.
+
+        Constructed on first use from :attr:`model_ref` and cached; importing the
+        backend module (and torch/transformers) is deferred to here so a matcher
+        on the served/API path never pays the heavy import. Tests inject a fake via
+        ``matcher._backend = ...`` to exercise the shared logprob→score step
+        without torch.
+        """
+        if self._backend is None:
+            from langres.core.matchers.transformers_backend import TransformersBackend
+
+            self._backend = TransformersBackend(self.model_ref)
+        return self._backend
 
     def _confidence_from_response(self, response: Any) -> dict[str, Any] | None:
         """First-token P(Yes) credence from logprobs, or ``None`` when unavailable.
@@ -741,31 +892,46 @@ class LLMMatcher(Matcher[SchemaT]):
                 candidate.right.id,  # type: ignore[attr-defined]
             )
 
-            # Call client (works for both LiteLLM and OpenAI)
-            client = self._get_client()
-            completion_kwargs = self._completion_kwargs()
-            # Standard top-level logprobs request (credence probe). Merged here,
-            # NOT inside _completion_kwargs (which returns {} off openrouter/ and
-            # would drop logprobs on plain OpenAI). {} when confidence is off.
-            completion_kwargs.update(self._logprobs_kwargs())
-            # Run correlation (S5): stamp the active tracking run + pair identity
-            # into litellm's ``metadata`` param (shared with the async path via
-            # ``_run_correlation_metadata``). ``None`` off a run keeps the call
-            # byte-identical -- no ``metadata`` key is added.
-            metadata = self._run_correlation_metadata(
-                client,
-                candidate.left.id,  # type: ignore[attr-defined]
-                candidate.right.id,  # type: ignore[attr-defined]
-                "llm_judgment",
-            )
-            if metadata is not None:
-                completion_kwargs["metadata"] = metadata
-            response = client.completion(
-                model=self.model,
-                messages=self._messages(prompt),
-                temperature=self.temperature,
-                **completion_kwargs,
-            )
+            if self._backend_kind == "transformers":
+                # In-process transformers backend: no client, no OpenRouter /
+                # api_base extras, no run-correlation metadata -- generation is
+                # local. The response mimics litellm's shape so the parse +
+                # confidence path below is identical to the served path.
+                response = self._inprocess_backend().complete(
+                    messages=self._messages(prompt),
+                    temperature=self.temperature,
+                    want_logprobs=self.confidence == "logprob",
+                )
+            else:
+                # Call client (works for both LiteLLM and OpenAI)
+                client = self._get_client()
+                completion_kwargs = self._completion_kwargs()
+                # Standard top-level logprobs request (credence probe). Merged here,
+                # NOT inside _completion_kwargs (which returns {} off openrouter/ and
+                # would drop logprobs on plain OpenAI). {} when confidence is off.
+                completion_kwargs.update(self._logprobs_kwargs())
+                # api_base: route to a served OpenAI-compatible endpoint (vLLM/
+                # Ollama/gateway) when set. Merged like logprobs, not folded into
+                # _completion_kwargs (which drops it off openrouter/). {} when unset.
+                completion_kwargs.update(self._api_kwargs())
+                # Run correlation (S5): stamp the active tracking run + pair identity
+                # into litellm's ``metadata`` param (shared with the async path via
+                # ``_run_correlation_metadata``). ``None`` off a run keeps the call
+                # byte-identical -- no ``metadata`` key is added.
+                metadata = self._run_correlation_metadata(
+                    client,
+                    candidate.left.id,  # type: ignore[attr-defined]
+                    candidate.right.id,  # type: ignore[attr-defined]
+                    "llm_judgment",
+                )
+                if metadata is not None:
+                    completion_kwargs["metadata"] = metadata
+                response = client.completion(
+                    model=self.model,
+                    messages=self._messages(prompt),
+                    temperature=self.temperature,
+                    **completion_kwargs,
+                )
 
             # Parse the verdict + fold in the optional first-token logprob
             # credence; an abstain routes through ``on_parse_error`` (never a
@@ -990,11 +1156,25 @@ class LLMMatcher(Matcher[SchemaT]):
         Note:
             Implements exponential backoff: 1s, 2s, 4s, 8s, ... up to 60s max
         """
+        if self._backend_kind == "transformers":
+            # In-process backend: run the (synchronous, torch) generation in a
+            # worker thread so it doesn't block the event loop. No rate limiting /
+            # retries -- there is no remote API to throttle. Shares the exact same
+            # ``complete`` seam as the sync path.
+            return await asyncio.to_thread(
+                self._inprocess_backend().complete,
+                self._messages(prompt),
+                temperature=self.temperature,
+                want_logprobs=self.confidence == "logprob",
+            )
         client = self._get_client()
         completion_kwargs = self._completion_kwargs()
         # Standard top-level logprobs request (credence probe) — mirror the sync
         # merge. Kept out of _completion_kwargs so it also reaches plain OpenAI.
         completion_kwargs.update(self._logprobs_kwargs())
+        # api_base: route to a served OpenAI-compatible endpoint when set -- mirror
+        # the sync merge so async judging reaches the same endpoint.
+        completion_kwargs.update(self._api_kwargs())
         # Run correlation (S5): mirror forward()'s litellm ``metadata`` injection
         # on the async path -- async judging inside ``capture_run`` would otherwise
         # lose trace correlation. ``None`` off a run keeps the call byte-identical.

--- a/src/langres/core/matchers/model_ref.py
+++ b/src/langres/core/matchers/model_ref.py
@@ -1,0 +1,82 @@
+"""``ModelRef``: normalize a model reference for the serve / finetune paths.
+
+A *model reference* names WHICH model an :class:`~langres.core.matchers.llm_judge.LLMMatcher`
+(and, later, ``finetune()``) should run, in one of three forms:
+
+- an **HF Hub id** (``"your-org/your-ft-model"``) or a **local directory path** —
+  a self-contained (base or already-merged) model, and
+- a **base + PEFT adapter** pair (``{"base": ..., "adapter": ...}``) — a QLoRA
+  fine-tune served *without* merging the adapter into the base weights.
+
+It is **weightless by construction**: a ``ModelRef`` is a small pair of
+*reference strings*, never weight bytes, so it round-trips through
+``Resolver.save`` / ``load`` as plain JSON config (:func:`to_config`). This
+module is deliberately import-light (stdlib only — no torch / transformers) so a
+bare ``import langres`` and the matcher's own import stay heavy-dependency free;
+the actual weights are loaded lazily by the in-process backend on first use.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class ModelRef:
+    """A normalized, weightless reference to a served/local model.
+
+    ``base`` is the HF Hub id or local directory of the (base or merged) model;
+    ``adapter`` is an optional PEFT-adapter HF id / local dir applied on top of
+    ``base`` at load time (QLoRA served unmerged). ``adapter is None`` is the
+    self-contained case.
+    """
+
+    base: str
+    adapter: str | None = None
+
+
+def normalize_model_ref(model: str | dict[str, str] | ModelRef) -> ModelRef:
+    """Coerce a user-supplied model reference into a :class:`ModelRef`.
+
+    Accepts the three surface forms and validates them:
+
+    - ``str`` — an HF Hub id, a local dir, OR an API model name (e.g.
+      ``"gpt-5-mini"``, ``"openrouter/..."``). All become ``ModelRef(base=model)``;
+      the *routing* decision (in-process vs served API) is the matcher's, not
+      this normalizer's — here we only carve out a canonical shape.
+    - ``dict`` — must carry a non-empty ``"base"``; ``"adapter"`` is optional.
+    - :class:`ModelRef` — returned unchanged (idempotent).
+
+    Raises:
+        ValueError: An empty string, a dict missing/with an empty ``"base"``, or a
+            non-string ``"adapter"``.
+        TypeError: Any other type.
+    """
+    if isinstance(model, ModelRef):
+        return model
+    if isinstance(model, str):
+        if not model:
+            raise ValueError("model string must be non-empty")
+        return ModelRef(base=model)
+    if isinstance(model, dict):
+        base = model.get("base")
+        if not isinstance(base, str) or not base:
+            raise ValueError(f"model dict must carry a non-empty string 'base'; got {model!r}")
+        adapter = model.get("adapter")
+        if adapter is not None and not isinstance(adapter, str):
+            raise ValueError(f"model dict 'adapter' must be a string or absent; got {adapter!r}")
+        return ModelRef(base=base, adapter=adapter)
+    raise TypeError(f"model must be a str, dict, or ModelRef; got {type(model).__name__}")
+
+
+def to_config(ref: ModelRef) -> str | dict[str, str]:
+    """Serialize a :class:`ModelRef` for ``config`` (the inverse of :func:`normalize_model_ref`).
+
+    A self-contained ref (``adapter is None``) serializes to its bare ``base``
+    string — **byte-identical to the pre-model_ref string config**, so existing
+    saved artifacts and their round-trips are unchanged. Only the base+adapter
+    case widens to a ``{"base": ..., "adapter": ...}`` dict.
+    """
+    if ref.adapter is None:
+        return ref.base
+    return {"base": ref.base, "adapter": ref.adapter}

--- a/src/langres/core/matchers/transformers_backend.py
+++ b/src/langres/core/matchers/transformers_backend.py
@@ -1,0 +1,215 @@
+"""In-process HF causal-LM backend for :class:`~langres.core.matchers.llm_judge.LLMMatcher`.
+
+Runs generation **and first-token logprobs locally via transformers** (no server),
+returning a **LiteLLM-shaped response** so ``LLMMatcher``'s existing parse +
+confidence path (:meth:`LLMMatcher._map_verdict` /
+:meth:`LLMMatcher._confidence_from_response`) consumes it *identically* — the
+calibrated :attr:`PairwiseJudgement.score` comes from the same token-logprob step
+whether the model is served over an API (litellm) or run in-process. There is one
+logprob→score computation, not two: this backend only reproduces the *response
+shape* that computation already reads.
+
+``torch`` / ``transformers`` are imported **lazily on first generation**, never at
+module load, so importing this module (and a bare ``import langres``) stays free of
+the heavy stack (guarded by ``tests/test_import_budget.py``).
+"""
+
+from __future__ import annotations
+
+import threading
+from dataclasses import dataclass
+from typing import Any
+
+from langres.core.matchers.model_ref import ModelRef
+
+# ---------------------------------------------------------------------------
+# Minimal LiteLLM/OpenAI-shaped response objects.
+#
+# Only the attributes LLMMatcher actually reads are modelled:
+#   response.choices[0].message.content
+#   response.choices[0].logprobs.content[i].token / .top_logprobs[j].token/.logprob
+#   response.usage.prompt_tokens / .completion_tokens
+# Billing (``parse_openrouter_billing``) and ``LLMUsage.from_response`` read the
+# rest via ``getattr(..., None)``, so the absence of ``cost`` / ``provider`` /
+# ``*_tokens_details`` cleanly yields "no real cost, all-zero subsets".
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class _TopLogprob:
+    """One alternative token at a position, with its log-probability."""
+
+    token: str
+    logprob: float
+
+
+@dataclass(frozen=True)
+class _TokenLogprobs:
+    """The generated token at a position plus its top-k alternatives."""
+
+    token: str
+    logprob: float
+    top_logprobs: list[_TopLogprob]
+
+
+@dataclass(frozen=True)
+class _Logprobs:
+    content: list[_TokenLogprobs]
+
+
+@dataclass(frozen=True)
+class _Message:
+    content: str
+
+
+@dataclass(frozen=True)
+class _Usage:
+    prompt_tokens: int
+    completion_tokens: int
+
+
+@dataclass(frozen=True)
+class _Choice:
+    message: _Message
+    logprobs: _Logprobs | None
+
+
+@dataclass(frozen=True)
+class _Response:
+    choices: list[_Choice]
+    usage: _Usage
+
+
+class TransformersBackend:
+    """Lazily-loaded local causal-LM completion backend (one model per instance).
+
+    Construct with a :class:`ModelRef`; the model + tokenizer load on the first
+    :meth:`complete` call and are cached for the instance's lifetime. Generation
+    is greedy (``do_sample=False``) — for the yes/no + first-token-logprob probe a
+    deterministic single step is what we score, and it keeps runs reproducible.
+    """
+
+    #: Mirror the API-max ``top_logprobs`` the served (litellm) path requests, so
+    #: the two-way yes/no subspace this backend can attribute mass to is as wide.
+    _TOP_LOGPROBS = 20
+
+    def __init__(self, model_ref: ModelRef, *, max_new_tokens: int = 8):
+        self._ref = model_ref
+        self._max_new_tokens = max_new_tokens
+        self._model: Any = None
+        self._tokenizer: Any = None
+        # Generation on one shared model is serialized: the async path runs
+        # ``complete`` in a worker thread (``asyncio.to_thread``), and concurrent
+        # ``generate`` calls on a single model object are not safe.
+        self._lock = threading.Lock()
+
+    def _ensure_loaded(self) -> None:
+        """Load the base model + tokenizer (and optional PEFT adapter) once."""
+        if self._model is not None:
+            return
+        # Lazy, first-use only: torch/transformers must never import at module load.
+        from transformers import AutoModelForCausalLM, AutoTokenizer
+
+        tokenizer = AutoTokenizer.from_pretrained(self._ref.base)
+        model = AutoModelForCausalLM.from_pretrained(self._ref.base)
+        if self._ref.adapter is not None:
+            try:
+                from peft import PeftModel
+            except ImportError as exc:  # pragma: no cover - exercised in PR-F
+                raise ImportError(
+                    "Serving a base+adapter model_ref in-process needs PEFT. "
+                    "Install it with `pip install langres[finetune]` (or `pip install peft`)."
+                ) from exc
+            model = PeftModel.from_pretrained(model, self._ref.adapter)
+        model.eval()
+        if tokenizer.pad_token_id is None:
+            tokenizer.pad_token = tokenizer.eos_token
+        self._tokenizer = tokenizer
+        self._model = model
+
+    def complete(
+        self,
+        messages: list[dict[str, str]],
+        *,
+        temperature: float,
+        want_logprobs: bool,
+    ) -> _Response:
+        """Generate a completion for ``messages``, returning a LiteLLM-shaped response.
+
+        ``temperature`` is accepted for signature parity with the served path but
+        the probe decodes greedily (deterministic). When ``want_logprobs`` is set,
+        the response carries per-token ``top_logprobs`` for the generated tokens so
+        the shared first-token yes/no credence step can compute ``p_yes``.
+        """
+        import torch
+
+        with self._lock:
+            self._ensure_loaded()
+            tokenizer, model = self._tokenizer, self._model
+            input_ids = self._encode(messages)
+            prompt_len = int(input_ids.shape[1])
+            with torch.no_grad():
+                generated = model.generate(
+                    input_ids,
+                    max_new_tokens=self._max_new_tokens,
+                    do_sample=False,
+                    output_scores=want_logprobs,
+                    return_dict_in_generate=True,
+                    pad_token_id=tokenizer.pad_token_id,
+                )
+            new_ids = generated.sequences[0][prompt_len:]
+            text = tokenizer.decode(new_ids, skip_special_tokens=True)
+            logprobs = (
+                self._logprobs_from_scores(generated.scores, new_ids) if want_logprobs else None
+            )
+            usage = _Usage(prompt_tokens=prompt_len, completion_tokens=int(len(new_ids)))
+            return _Response(
+                choices=[_Choice(message=_Message(content=text), logprobs=logprobs)],
+                usage=usage,
+            )
+
+    def _encode(self, messages: list[dict[str, str]]) -> Any:
+        """Tokenize ``messages`` into model-device input ids.
+
+        Uses the tokenizer's chat template when present (instruct models) so the
+        yes/no prompt is framed the way the model expects; otherwise falls back to
+        concatenating the message contents (base models with no chat template).
+        """
+        tokenizer, model = self._tokenizer, self._model
+        if getattr(tokenizer, "chat_template", None):
+            input_ids = tokenizer.apply_chat_template(
+                messages, add_generation_prompt=True, return_tensors="pt"
+            )
+        else:
+            text = "\n\n".join(message["content"] for message in messages)
+            input_ids = tokenizer(text, return_tensors="pt").input_ids
+        return input_ids.to(model.device)
+
+    def _logprobs_from_scores(self, scores: Any, new_ids: Any) -> _Logprobs:
+        """Convert transformers' per-step ``scores`` into LiteLLM ``logprobs.content``.
+
+        For each generated step, log-softmax the vocabulary logits, take the top-k
+        alternatives (:attr:`_TOP_LOGPROBS`), and record the actually-generated
+        token's own logprob — the exact ``token`` / ``top_logprobs`` shape
+        :meth:`LLMMatcher._confidence_from_response` reads.
+        """
+        import torch
+
+        content: list[_TokenLogprobs] = []
+        for step, step_logits in enumerate(scores or ()):
+            row = torch.log_softmax(step_logits[0].float(), dim=-1)
+            k = min(self._TOP_LOGPROBS, int(row.shape[-1]))
+            topk = torch.topk(row, k=k)
+            top = [
+                _TopLogprob(token=self._tokenizer.decode([int(tid)]), logprob=float(logprob))
+                for tid, logprob in zip(topk.indices.tolist(), topk.values.tolist())
+            ]
+            chosen = int(new_ids[step])
+            content.append(
+                _TokenLogprobs(
+                    token=self._tokenizer.decode([chosen]),
+                    logprob=float(row[chosen]),
+                    top_logprobs=top,
+                )
+            )
+        return _Logprobs(content=content)

--- a/src/langres/core/matchers/transformers_backend.py
+++ b/src/langres/core/matchers/transformers_backend.py
@@ -148,9 +148,14 @@ class TransformersBackend:
             tokenizer, model = self._tokenizer, self._model
             input_ids = self._encode(messages)
             prompt_len = int(input_ids.shape[1])
+            # One sequence, no padding -> an all-ones mask is exact; passing it
+            # explicitly silences transformers' "attention mask not set" warning
+            # (pad_token == eos_token) and its "unexpected behavior" caveat.
+            attention_mask = torch.ones_like(input_ids)
             with torch.no_grad():
                 generated = model.generate(
                     input_ids,
+                    attention_mask=attention_mask,
                     max_new_tokens=self._max_new_tokens,
                     do_sample=False,
                     output_scores=want_logprobs,

--- a/tests/core/matchers/test_llm_judge_serve_smoke.py
+++ b/tests/core/matchers/test_llm_judge_serve_smoke.py
@@ -1,0 +1,60 @@
+"""Real in-process serving smoke (PR-E go/no-go slice) — ``@pytest.mark.slow``.
+
+Downloads a TINY real instruct model and runs it **in-process** (no server) through
+``LLMMatcher``, asserting the calibrated score comes from first-token yes/no
+logprobs — a value in [0, 1], NOT the silent-0.5 parse-miss fallback (which no
+longer exists: a parse miss abstains, it never fabricates 0.5). This is the
+end-to-end proof that a served/local model resolves through the existing judge
+path, and it exercises ``TransformersBackend`` (download → generate → logprobs).
+
+Marked ``slow`` (downloads weights + CPU generation), so it is excluded from the
+fast CI gate; run it explicitly: ``uv run pytest -m slow -k serve_smoke``.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+pytest.importorskip("torch", reason="requires the [semantic] extra (torch)")
+pytest.importorskip("transformers", reason="requires the [semantic] extra (transformers)")
+
+from langres.core.matchers.llm_judge import LLMMatcher
+from langres.core.models import CompanySchema, ERCandidate
+
+# Smallest real instruct model with a chat template that puts usable mass on
+# yes/no first tokens; ~135M params, CPU-runnable, downloaded from the Hub.
+_TINY_MODEL = "HuggingFaceTB/SmolLM2-135M-Instruct"
+
+_YES_NO_PROMPT = (
+    "Do these two records describe the same company?\n"
+    "Record A: {left}\n"
+    "Record B: {right}\n"
+    "Answer with a single word: Yes or No."
+)
+
+
+@pytest.mark.slow
+def test_inprocess_served_model_produces_a_calibrated_logprob_score() -> None:
+    matcher: LLMMatcher[CompanySchema] = LLMMatcher(
+        model=_TINY_MODEL,  # HF id, no api_base -> in-process transformers backend
+        confidence="logprob",
+        response_parser="binary_yes_no",
+        prompt_template=_YES_NO_PROMPT,
+    )
+    # It routed to the in-process backend, not litellm.
+    assert matcher._backend_kind == "transformers"
+
+    candidate = ERCandidate(
+        left=CompanySchema(id="c1", name="Acme Corporation"),
+        right=CompanySchema(id="c2", name="Acme Corp"),
+        blocker_name="smoke",
+    )
+    judgement = next(iter(matcher.forward([candidate])))
+
+    # The score is a real first-token yes/no credence, in [0, 1].
+    assert judgement.score is not None, "no p_yes computed — logprobs path did not run"
+    assert 0.0 <= judgement.score <= 1.0
+    assert judgement.confidence_source == "logprob"
+    # NOT the silent-0.5 parse-miss fallback: a real p_yes was found + promoted.
+    assert judgement.provenance.get("parse_error") is None
+    assert judgement.provenance.get("p_yes") is not None

--- a/tests/core/matchers/test_model_ref.py
+++ b/tests/core/matchers/test_model_ref.py
@@ -1,0 +1,90 @@
+"""Unit tests for the weightless ``ModelRef`` normalizer (PR-E serve path).
+
+Pure, fast, dependency-free: no torch/transformers, no network. Locks the three
+model-reference surface forms (HF id / local dir string, base+adapter dict,
+``ModelRef``), the ``config`` round-trip shape (plain string stays a string; only
+base+adapter widens to a dict), and the validation errors.
+"""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from langres.core.matchers.model_ref import ModelRef, normalize_model_ref, to_config
+
+
+def test_string_normalizes_to_base_only_ref() -> None:
+    assert normalize_model_ref("your-org/your-ft-model") == ModelRef(
+        base="your-org/your-ft-model", adapter=None
+    )
+
+
+def test_local_dir_and_api_names_are_just_base_strings() -> None:
+    # The normalizer does NOT route; it only carves a canonical shape. An API
+    # name and a local path both become base-only refs.
+    assert normalize_model_ref("gpt-5-mini") == ModelRef(base="gpt-5-mini")
+    assert normalize_model_ref("/models/my-ft") == ModelRef(base="/models/my-ft")
+
+
+def test_dict_with_base_and_adapter_normalizes() -> None:
+    ref = normalize_model_ref({"base": "meta-llama/Llama-3.1-8B", "adapter": "/ad/lora"})
+    assert ref == ModelRef(base="meta-llama/Llama-3.1-8B", adapter="/ad/lora")
+
+
+def test_dict_with_only_base_has_no_adapter() -> None:
+    assert normalize_model_ref({"base": "org/model"}) == ModelRef(base="org/model", adapter=None)
+
+
+def test_model_ref_passthrough_is_idempotent() -> None:
+    ref = ModelRef(base="org/model", adapter="org/adapter")
+    assert normalize_model_ref(ref) is ref
+
+
+def test_empty_string_rejected() -> None:
+    with pytest.raises(ValueError, match="non-empty"):
+        normalize_model_ref("")
+
+
+def test_dict_missing_base_rejected() -> None:
+    with pytest.raises(ValueError, match="'base'"):
+        normalize_model_ref({"adapter": "org/adapter"})
+
+
+def test_dict_empty_base_rejected() -> None:
+    with pytest.raises(ValueError, match="'base'"):
+        normalize_model_ref({"base": ""})
+
+
+def test_dict_non_string_adapter_rejected() -> None:
+    with pytest.raises(ValueError, match="adapter"):
+        normalize_model_ref({"base": "org/model", "adapter": 123})
+
+
+def test_non_ref_type_rejected() -> None:
+    with pytest.raises(TypeError, match="str, dict, or ModelRef"):
+        normalize_model_ref(42)  # type: ignore[arg-type]
+
+
+def test_to_config_of_base_only_is_the_bare_string() -> None:
+    # Byte-identical to the pre-model_ref string config -> old artifacts unchanged.
+    assert to_config(ModelRef(base="gpt-5-mini")) == "gpt-5-mini"
+
+
+def test_to_config_of_base_plus_adapter_is_a_dict() -> None:
+    cfg = to_config(ModelRef(base="org/base", adapter="org/adapter"))
+    assert cfg == {"base": "org/base", "adapter": "org/adapter"}
+
+
+@pytest.mark.parametrize(
+    "model",
+    ["gpt-5-mini", "your-org/your-ft-model", {"base": "org/b", "adapter": "org/a"}],
+)
+def test_config_round_trip_is_weightless_and_stable(model: str | dict[str, str]) -> None:
+    ref = normalize_model_ref(model)
+    config_value = to_config(ref)
+    # Weightless: the serialized form is a plain JSON string/dict of reference
+    # strings -- no bytes -- and re-normalizes to the identical ref.
+    json.dumps(config_value)
+    assert normalize_model_ref(config_value) == ref

--- a/tests/core/matchers/test_transformers_backend.py
+++ b/tests/core/matchers/test_transformers_backend.py
@@ -1,0 +1,146 @@
+"""Fast unit tests for the in-process ``TransformersBackend`` response construction.
+
+torch is available under ``--all-extras``, so these build **real** logits tensors
+and drive the backend's pure logic — the logprobs→``top_logprobs`` conversion, the
+LiteLLM-shaped response assembly, and the want_logprobs on/off branches — WITHOUT
+downloading a model (the model/tokenizer are injected fakes, so ``_ensure_loaded``
+is a no-op). The real end-to-end download+generate path is the ``@pytest.mark.slow``
+smoke in ``test_llm_judge_serve_smoke.py``.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from typing import Any
+
+import pytest
+
+torch = pytest.importorskip("torch", reason="requires the [semantic] extra (torch)")
+
+from langres.core.matchers.model_ref import ModelRef
+from langres.core.matchers.transformers_backend import TransformersBackend
+
+
+class _FakeTokenizer:
+    """Minimal tokenizer: no chat template, id i -> ``"<i>"``, callable encode."""
+
+    chat_template = None
+    pad_token_id = 0
+
+    def __call__(self, text: str, return_tensors: str = "pt") -> SimpleNamespace:
+        # Two prompt tokens, arbitrary ids.
+        return SimpleNamespace(input_ids=torch.tensor([[7, 8]]))
+
+    def decode(self, ids: list[int], skip_special_tokens: bool = False) -> str:
+        return "".join(f"<{int(i)}>" for i in ids)
+
+
+class _FakeModel:
+    """Stub causal LM: returns canned ``sequences`` + per-step ``scores``."""
+
+    device = torch.device("cpu")
+
+    def __init__(self, sequences: Any, scores: Any) -> None:
+        self._sequences = sequences
+        self._scores = scores
+
+    def generate(self, input_ids: Any, **kwargs: Any) -> SimpleNamespace:
+        return SimpleNamespace(sequences=self._sequences, scores=self._scores)
+
+
+def _backend_with(model: _FakeModel) -> TransformersBackend:
+    backend = TransformersBackend(ModelRef(base="fake/model"))
+    # Pre-seed so _ensure_loaded() early-returns (no transformers download).
+    backend._tokenizer = _FakeTokenizer()
+    backend._model = model
+    return backend
+
+
+def test_complete_builds_litellm_shaped_response_with_logprobs() -> None:
+    # prompt = [7, 8]; one generated token id 1 (the argmax below).
+    sequences = torch.tensor([[7, 8, 1]])
+    # vocab=4 logits favouring id 1, then id 2.
+    scores = (torch.tensor([[1.0, 3.0, 0.5, 0.2]]),)
+    backend = _backend_with(_FakeModel(sequences, scores))
+
+    resp = backend.complete(
+        [{"role": "user", "content": "hi"}], temperature=0.0, want_logprobs=True
+    )
+
+    # message content decodes the one new token id (1).
+    assert resp.choices[0].message.content == "<1>"
+    # usage: 2 prompt tokens, 1 completion token.
+    assert resp.usage.prompt_tokens == 2
+    assert resp.usage.completion_tokens == 1
+    # logprobs.content has one position; its chosen token + top_logprobs.
+    content = resp.choices[0].logprobs.content
+    assert len(content) == 1
+    assert content[0].token == "<1>"
+    # top_logprobs are the full vocab (<=20), ranked by logprob; id 1 is top.
+    tokens = [alt.token for alt in content[0].top_logprobs]
+    assert tokens[0] == "<1>"
+    # logprobs equal log_softmax of the logits at those ids.
+    expected = torch.log_softmax(torch.tensor([1.0, 3.0, 0.5, 0.2]), dim=-1)
+    assert content[0].top_logprobs[0].logprob == pytest.approx(float(expected[1]))
+    assert content[0].logprob == pytest.approx(float(expected[1]))
+
+
+def test_complete_without_logprobs_omits_the_logprobs_block() -> None:
+    sequences = torch.tensor([[7, 8, 2]])
+    backend = _backend_with(_FakeModel(sequences, None))
+
+    resp = backend.complete(
+        [{"role": "user", "content": "hi"}], temperature=0.0, want_logprobs=False
+    )
+
+    assert resp.choices[0].logprobs is None
+    assert resp.choices[0].message.content == "<2>"
+    assert resp.usage.completion_tokens == 1
+
+
+def test_top_logprobs_capped_at_twenty() -> None:
+    # A 50-token vocab must yield exactly 20 alternatives (the API-max mirror).
+    sequences = torch.tensor([[7, 8, 3]])
+    scores = (torch.arange(50, dtype=torch.float).unsqueeze(0),)
+    backend = _backend_with(_FakeModel(sequences, scores))
+
+    resp = backend.complete(
+        [{"role": "user", "content": "hi"}], temperature=0.0, want_logprobs=True
+    )
+
+    assert len(resp.choices[0].logprobs.content[0].top_logprobs) == 20
+
+
+def test_response_feeds_the_matchers_shared_pyes_step() -> None:
+    """The backend's response is consumed by LLMMatcher._confidence_from_response.
+
+    Closes the loop: a first token whose top_logprobs carry yes/no mass yields the
+    same p_yes the served path would — proving the response shape is what the
+    shared logprob→score step reads.
+    """
+    from langres.core.matchers.llm_judge import LLMMatcher
+    from langres.core.models import CompanySchema
+
+    # A tokenizer whose token 1 decodes to "Yes" and token 2 to "No".
+    class _YesNoTokenizer(_FakeTokenizer):
+        def decode(self, ids: list[int], skip_special_tokens: bool = False) -> str:
+            mapping = {1: "Yes", 2: "No"}
+            return "".join(mapping.get(int(i), f"<{int(i)}>") for i in ids)
+
+    sequences = torch.tensor([[7, 8, 1]])
+    # P(Yes) logit high, P(No) lower; other ids negligible.
+    scores = (torch.tensor([[-10.0, 2.0, 0.5, -10.0]]),)
+    backend = TransformersBackend(ModelRef(base="fake/model"))
+    backend._tokenizer = _YesNoTokenizer()
+    backend._model = _FakeModel(sequences, scores)
+
+    resp = backend.complete(
+        [{"role": "user", "content": "hi"}], temperature=0.0, want_logprobs=True
+    )
+
+    judge = LLMMatcher[CompanySchema](client=object(), model="fake/model", confidence="logprob")
+    fragment = judge._confidence_from_response(resp)
+    assert fragment is not None
+    probs = torch.softmax(torch.tensor([2.0, 0.5]), dim=-1)  # yes, no over the 2-way subspace
+    assert fragment["p_yes"] == pytest.approx(float(probs[0]), abs=1e-4)
+    assert 0.0 <= fragment["p_yes"] <= 1.0

--- a/tests/core/modules/test_llm_judge_serialization.py
+++ b/tests/core/modules/test_llm_judge_serialization.py
@@ -44,6 +44,7 @@ def test_config_excludes_client_and_secrets() -> None:
 
     assert set(config) == {
         "model",
+        "api_base",
         "temperature",
         "prompt_template",
         "entity_noun",
@@ -55,6 +56,7 @@ def test_config_excludes_client_and_secrets() -> None:
         "record_serializer",
     }
     assert config["model"] == "openrouter/openai/gpt-4o-mini"
+    assert config["api_base"] is None  # no served endpoint by default
     assert config["temperature"] == 0.3
     assert config["entity_noun"] == "company"
     assert config["provider"] is None  # no provider pin by default

--- a/tests/core/modules/test_llm_judge_serve.py
+++ b/tests/core/modules/test_llm_judge_serve.py
@@ -1,0 +1,298 @@
+"""PR-E serve-path tests for LLMMatcher: ``api_base`` threading, backend routing,
+``model_ref`` round-trip, and the in-process backend's shared logprob→score step.
+
+All $0: no API key, no network, no torch. ``api_base`` is asserted at BOTH litellm
+call sites (sync ``completion`` + async ``acompletion``); the in-process backend is
+exercised through an injected fake so the *shared* first-token-logprob→score
+computation (identical to the served path) is verified without downloading a model.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import math
+from types import SimpleNamespace
+from typing import Any
+from unittest.mock import AsyncMock
+
+import pytest
+
+from langres.core.matchers.llm_judge import (
+    LLMMatcher,
+    _default_backend_kind,
+    parse_binary_yes_no,
+)
+from langres.core.matchers.model_ref import ModelRef, normalize_model_ref
+from langres.core.models import CompanySchema, ERCandidate
+
+
+def _candidate() -> ERCandidate[CompanySchema]:
+    return ERCandidate(
+        left=CompanySchema(id="a1", name="Acme Corp"),
+        right=CompanySchema(id="b1", name="Acme Corporation"),
+        blocker_name="test",
+    )
+
+
+def _top(token: str, prob: float) -> SimpleNamespace:
+    return SimpleNamespace(token=token, logprob=math.log(prob), bytes=None)
+
+
+def _logprob_response(
+    first_token_alts: list[tuple[str, float]],
+    *,
+    message: str = "Yes",
+) -> SimpleNamespace:
+    """A litellm/OpenAI-shaped response with one generated token + its top_logprobs.
+
+    Mirrors what the served path returns AND what ``TransformersBackend.complete``
+    reproduces, so the identical ``_confidence_from_response`` step consumes both.
+    """
+    content = [
+        SimpleNamespace(
+            token=message,
+            logprob=0.0,
+            bytes=None,
+            top_logprobs=[_top(t, p) for t, p in first_token_alts],
+        )
+    ]
+    return SimpleNamespace(
+        choices=[
+            SimpleNamespace(
+                message=SimpleNamespace(content=message),
+                logprobs=SimpleNamespace(content=content),
+            )
+        ],
+        usage=SimpleNamespace(
+            prompt_tokens=42,
+            completion_tokens=1,
+            prompt_tokens_details=None,
+            completion_tokens_details=None,
+        ),
+        _hidden_params={},
+    )
+
+
+class _FakeClient:
+    """Records the kwargs of the last ``completion`` call; returns a fixed response."""
+
+    def __init__(self, response: SimpleNamespace) -> None:
+        self._response = response
+        self.last_kwargs: dict[str, Any] | None = None
+
+    def completion(self, **kwargs: Any) -> SimpleNamespace:
+        self.last_kwargs = kwargs
+        return self._response
+
+
+class _FakeBackend:
+    """Stand-in for ``TransformersBackend``: records calls, returns a fixed response."""
+
+    def __init__(self, response: SimpleNamespace) -> None:
+        self._response = response
+        self.calls: list[dict[str, Any]] = []
+
+    def complete(
+        self, messages: list[dict[str, str]], *, temperature: float, want_logprobs: bool
+    ) -> SimpleNamespace:
+        self.calls.append(
+            {"messages": messages, "temperature": temperature, "want_logprobs": want_logprobs}
+        )
+        return self._response
+
+
+# --------------------------------------------------------------------------- #
+# api_base threading (served vLLM/Ollama/OpenAI-compatible endpoints).
+# --------------------------------------------------------------------------- #
+
+
+def test_api_base_reaches_the_sync_completion_call() -> None:
+    client = _FakeClient(_logprob_response([("Yes", 0.9), ("No", 0.05)]))
+    judge = LLMMatcher[CompanySchema](
+        client=client,
+        model="my-ft-model",
+        api_base="http://localhost:8000/v1",
+    )
+    list(judge.forward(iter([_candidate()])))
+    assert client.last_kwargs is not None
+    assert client.last_kwargs["api_base"] == "http://localhost:8000/v1"
+    # And the served model id is passed as-is.
+    assert client.last_kwargs["model"] == "my-ft-model"
+
+
+def test_api_base_absent_from_kwargs_when_unset() -> None:
+    client = _FakeClient(_logprob_response([("Yes", 0.9), ("No", 0.05)]))
+    judge = LLMMatcher[CompanySchema](client=client, model="gpt-4o-mini")
+    list(judge.forward(iter([_candidate()])))
+    assert client.last_kwargs is not None
+    assert "api_base" not in client.last_kwargs
+
+
+def test_api_base_reaches_the_async_acompletion_call() -> None:
+    resp = _logprob_response([("Yes", 0.9), ("No", 0.05)])
+    client = SimpleNamespace(acompletion=AsyncMock(return_value=resp))
+    judge = LLMMatcher[CompanySchema](
+        client=client,
+        model="my-ft-model",
+        api_base="http://localhost:8000/v1",
+    )
+    asyncio.run(judge.forward_async([_candidate()], max_concurrent=1))
+    _args, kwargs = client.acompletion.call_args
+    assert kwargs["api_base"] == "http://localhost:8000/v1"
+
+
+def test_api_base_absent_from_async_kwargs_when_unset() -> None:
+    resp = _logprob_response([("Yes", 0.9), ("No", 0.05)])
+    client = SimpleNamespace(acompletion=AsyncMock(return_value=resp))
+    judge = LLMMatcher[CompanySchema](client=client, model="gpt-4o-mini")
+    asyncio.run(judge.forward_async([_candidate()], max_concurrent=1))
+    _args, kwargs = client.acompletion.call_args
+    assert "api_base" not in kwargs
+
+
+# --------------------------------------------------------------------------- #
+# Weightless config round-trip: api_base + model_ref.
+# --------------------------------------------------------------------------- #
+
+
+def test_api_base_round_trips_through_config() -> None:
+    original = LLMMatcher[CompanySchema](
+        client=object(),
+        model="my-ft-model",
+        api_base="http://localhost:8000/v1",
+    )
+    assert original.config["api_base"] == "http://localhost:8000/v1"
+    rebuilt = LLMMatcher.from_config(original.config)
+    assert rebuilt.api_base == "http://localhost:8000/v1"
+    assert rebuilt.config == original.config
+
+
+def test_plain_string_model_config_is_byte_identical() -> None:
+    # A base-only model stays a plain string in config (old artifacts unchanged).
+    judge = LLMMatcher[CompanySchema](client=object(), model="gpt-5-mini")
+    assert judge.config["model"] == "gpt-5-mini"
+    json.dumps(judge.config)  # weightless: reference strings only
+
+
+def test_base_adapter_model_ref_round_trips_weightlessly() -> None:
+    original = LLMMatcher[CompanySchema](
+        client=object(),
+        model={"base": "meta-llama/Llama-3.1-8B", "adapter": "your-org/lora"},
+    )
+    # self.model stays the base id string for every existing consumer.
+    assert original.model == "meta-llama/Llama-3.1-8B"
+    assert original.model_ref == ModelRef(base="meta-llama/Llama-3.1-8B", adapter="your-org/lora")
+    # config["model"] widens to a dict of reference strings (no weights).
+    assert original.config["model"] == {
+        "base": "meta-llama/Llama-3.1-8B",
+        "adapter": "your-org/lora",
+    }
+    json.dumps(original.config)
+
+    rebuilt = LLMMatcher.from_config(original.config)
+    assert rebuilt.model_ref == original.model_ref
+    assert rebuilt.config == original.config
+
+
+# --------------------------------------------------------------------------- #
+# Backend routing decision (served API vs in-process transformers).
+# --------------------------------------------------------------------------- #
+
+
+@pytest.mark.parametrize(
+    ("model", "api_base", "expected"),
+    [
+        ("gpt-5-mini", None, "litellm"),  # bare OpenAI-style name
+        ("openrouter/openai/gpt-4o-mini", None, "litellm"),  # provider prefix
+        ("azure/gpt-4", None, "litellm"),
+        ("huggingface/org/model", None, "litellm"),  # litellm HF *inference* route
+        ("your-org/your-ft-model", None, "transformers"),  # HF Hub id -> in-process
+        ("my-ft-model", "http://localhost:8000/v1", "litellm"),  # served endpoint
+        ("your-org/your-ft-model", "http://localhost:8000/v1", "litellm"),  # api_base wins
+    ],
+)
+def test_default_backend_kind(model: str, api_base: str | None, expected: str) -> None:
+    assert _default_backend_kind(normalize_model_ref(model), api_base) == expected
+
+
+def test_local_directory_routes_in_process(tmp_path: Any) -> None:
+    ref = normalize_model_ref(str(tmp_path))  # an existing dir
+    assert _default_backend_kind(ref, None) == "transformers"
+
+
+def test_base_adapter_always_routes_in_process_even_with_api_base() -> None:
+    # An unmerged adapter can only be assembled locally -> in-process wins.
+    ref = ModelRef(base="org/base", adapter="org/adapter")
+    assert _default_backend_kind(ref, "http://localhost:8000/v1") == "transformers"
+
+
+def test_matcher_resolves_backend_kind_at_construction() -> None:
+    assert LLMMatcher(client=object(), model="gpt-5-mini")._backend_kind == "litellm"
+    assert LLMMatcher(client=object(), model="your-org/ft")._backend_kind == "transformers"
+
+
+# --------------------------------------------------------------------------- #
+# In-process backend: the SAME logprob→score step as the served path.
+# --------------------------------------------------------------------------- #
+
+
+def test_inprocess_backend_score_is_the_shared_pyes_step() -> None:
+    """An in-process response feeds the identical first-token yes/no credence step.
+
+    Same assertion as the served-path logprob test: p_yes = 0.8/0.95 becomes the
+    judgement score. This proves there is ONE logprob→score computation, reused --
+    only the response *shape* is reproduced in-process.
+    """
+    p_yes = 0.8 / 0.95
+    backend = _FakeBackend(_logprob_response([("Yes", 0.8), (" No", 0.15)], message="Yes"))
+    judge = LLMMatcher[CompanySchema](
+        client=object(),  # must NEVER be called on the in-process path
+        model="your-org/your-ft-model",
+        confidence="logprob",
+        response_parser=parse_binary_yes_no,
+    )
+    assert judge._backend_kind == "transformers"
+    judge._backend = backend  # inject the fake (no torch, no download)
+
+    out = list(judge.forward(iter([_candidate()])))[0]
+
+    assert out.decision is True  # from the "Yes" text
+    assert out.score == pytest.approx(p_yes)  # honest continuous p_yes
+    assert out.confidence == pytest.approx(max(p_yes, 1.0 - p_yes))
+    assert out.confidence_source == "logprob"
+    # The backend saw the credence request; the client was never touched.
+    assert backend.calls and backend.calls[0]["want_logprobs"] is True
+
+
+def test_inprocess_backend_not_the_silent_half_fallback() -> None:
+    """A confident in-process p_yes is a real score, never the 0.5 parse-miss value."""
+    backend = _FakeBackend(_logprob_response([("Yes", 0.97), ("No", 0.01)], message="Yes"))
+    judge = LLMMatcher[CompanySchema](
+        client=object(),
+        model="your-org/your-ft-model",
+        confidence="logprob",
+        response_parser=parse_binary_yes_no,
+    )
+    judge._backend = backend
+    out = list(judge.forward(iter([_candidate()])))[0]
+    assert out.score is not None
+    assert out.score != pytest.approx(0.5)
+    assert 0.0 <= out.score <= 1.0
+    assert out.provenance.get("parse_error") is None
+
+
+def test_inprocess_backend_works_on_the_async_path() -> None:
+    """The async path routes to the same in-process backend (parity with sync)."""
+    p_yes = 0.8 / 0.95
+    backend = _FakeBackend(_logprob_response([("Yes", 0.8), (" No", 0.15)], message="Yes"))
+    judge = LLMMatcher[CompanySchema](
+        client=object(),
+        model="your-org/your-ft-model",
+        confidence="logprob",
+        response_parser=parse_binary_yes_no,
+    )
+    judge._backend = backend
+    out = asyncio.run(judge.forward_async([_candidate()], max_concurrent=1))[0]
+    assert out.score == pytest.approx(p_yes)
+    assert backend.calls and backend.calls[0]["want_logprobs"] is True

--- a/tests/test_import_budget.py
+++ b/tests/test_import_budget.py
@@ -45,6 +45,7 @@ def _import_ok(module_name: str) -> bool:
 
 _HEAVY_MODULES = [
     "torch",
+    "transformers",
     "litellm",
     "faiss",
     "sentence_transformers",


### PR DESCRIPTION
## PR-E — Serve your own model: `api_base` + in-process transformers backend + `model_ref`

Part of the **training-surface epic** (#125), landing into the integration branch `feat/training-surface`. This is the **mid-epic go/no-go floor**: it makes langres able to *serve* an existing model through the matcher and evaluate it — with **no training** — de-risking inference + logprob calibration before the QLoRA dependency stack (PR-F) is committed. If PR-F proves intractable, PR-E is shippable on its own.

### What this adds (three pieces)

1. **`api_base` threading** — `LLMMatcher(model=..., api_base="http://localhost:8000/v1")` routes to any OpenAI-compatible served endpoint (vLLM / Ollama). Threaded into litellm at **both** call sites (`forward` + `forward_async`), mirroring the existing `_logprobs_kwargs` merge pattern (deliberately *outside* `_completion_kwargs`, or it silently wouldn't reach `forward_async`). Round-trips through `config`/`from_config` as a reference string — **zero weight bytes** (contract #3, "model_ref in weightless save/load").

2. **In-process transformers backend** — `LLMMatcher(model=model_ref)` runs generation + logprobs **in-process via transformers, no server** (for eval/CI). A backend seam routes to transformers when `model` is a local dir / HF Hub id / base+adapter ref (and no `api_base`). transformers/torch are **lazy-imported** (guarded by `test_import_budget.py`; `transformers` added to `_HEAVY_MODULES`). The logprob→score step is **shared** between the litellm and in-process backends — score computation is not forked, so `PairwiseJudgement.score` is identical whether served or in-process.

3. **`model_ref` normalizer + serve example** — a tiny shared normalizer (`core/matchers/model_ref.py`) for the three ref shapes (HF Hub id, local dir, `{base, adapter}` for unmerged QLoRA serving) that `LLMMatcher` and (later) `finetune()` share. `examples/serve_your_model.py` is the committed `vllm serve` recipe (plan example 4). Serving-as-deployment stays **out of scope** — this is a documented recipe, not a langres component.

### Files
```
 examples/serve_your_model.py                       | 115 ++  (NEW — vllm serve recipe)
 src/langres/core/matchers/model_ref.py             |  82 ++  (NEW — ref normalizer)
 src/langres/core/matchers/transformers_backend.py  | 220 ++  (NEW — in-process backend)
 src/langres/core/matchers/llm_judge.py             | 250 +-  (api_base + backend dispatch + config round-trip)
 pyproject.toml                                     |  13 +
 tests/core/matchers/*                              | (model_ref, backend, serve smoke)
 tests/core/modules/test_llm_judge_serve*.py        | (api_base threading + serialization)
 tests/test_import_budget.py                        |   1 +  (transformers → _HEAVY_MODULES)
```

### Verification (saw it run, not just tests)
- **Real serving slice actually ran**: SmolLM2-135M served in-process → produced a **calibrated score from token logprobs** (not the silent-0.5 parse-miss fallback — asserted against it). This is the go/no-go floor cleared.
- Unit: `api_base` present in litellm kwargs at both call sites when set / absent when not; `config`/`from_config` round-trip `api_base` + `model_ref` as reference strings (no weight bytes).
- `model_ref` round-trips through `Resolver.save`/`load` (weightless — the PR-E half of the save/load contract).
- `tests/test_import_budget.py` green (torch/transformers stay lazy — never imported by a bare `import langres`).
- Full local `uv run pytest`: **2812 passed**.
- `uv run --no-dev --group docs mkdocs build --strict`: **clean** (the docs gate that bit PR-A).

### Scope notes
- `[finetune]` extra stays **out of `--all-extras`** — PR-E's in-process backend uses the base transformers/torch already in `[semantic]` (hence in `--all-extras`). The heavier QLoRA stack is PR-F's dedicated CI job.
- Wire keys unchanged (`@register("llm_judge")`); record vocabulary kept. `Resolver.module` attribute kept (only the public kwarg is `matcher=`).
- **Do not run E and F concurrently** — `llm_judge.py` is the collision epicenter; F rebases on E.

## Summary by Sourcery

Add support for serving user-provided models through LLMMatcher either via external OpenAI-compatible endpoints or an in-process transformers backend, while keeping model references weightless and fully serializable.

New Features:
- Allow LLMMatcher to target arbitrary OpenAI-compatible endpoints via an api_base parameter threaded through both sync and async LiteLLM calls.
- Introduce an in-process transformers-based backend for LLMMatcher that runs local or HF Hub models without a separate server, sharing the existing logprob-based scoring path.
- Add a ModelRef abstraction and normalizer to represent models as weightless references, including base+adapter configurations for unmerged QLoRA setups.
- Provide an example script demonstrating how to serve a custom model with vLLM/Ollama or in-process and plug it into langres dedupe flows.

Enhancements:
- Extend LLMMatcher configuration and serialization to round-trip api_base and structured model references without storing model weights.
- Add backend routing logic that automatically selects between the LiteLLM API path and the in-process transformers backend based on model reference and api_base.
- Treat transformers and peft as heavy, untyped dependencies in mypy configuration to stabilize type checking across environments.

Tests:
- Add unit and smoke tests covering api_base threading, backend routing, ModelRef normalization, and the shared logprob-to-score computation for both served and in-process paths.
- Extend import budget tests to ensure transformers remains lazily imported and not pulled in on bare langres import.