### PR TITLE
PR-M: the method= object seam on Resolver.fit (no concrete methods)

### DIFF
--- a/src/langres/core/methods_api.py
+++ b/src/langres/core/methods_api.py
@@ -1,0 +1,60 @@
+"""The ``method=`` object seam: a training strategy as a first-class object.
+
+``Resolver.fit(..., method=...)`` takes a :class:`Method` -- a small,
+declarative object that names *how* to train (its ``kind``) and *what it costs*
+(its :meth:`Method.describe`), and routes to the matching fit path. This extends
+the blessed "a strategy is a meta-object you pass" pattern: one ``method=``
+argument replaces a growing pile of per-strategy keyword flags, and each concrete
+strategy (prompt-optimize, fine-tune, calibrate) is its own subclass declaring a
+distinct ``kind``. It is deliberately *not* the rejected ``TrainingRecipe`` noun
+-- a ``Method`` is a value passed at the call site, not a config document.
+
+The base is import-light by construction -- Pydantic only, no torch/litellm/
+scikit-learn -- so ``import langres`` never pays for a training backend it may
+never use (locked by ``tests/test_import_budget.py``). Concrete methods land in
+later PRs (MIPRO prompt-optimization, QLoRA fine-tune, Platt calibration) and
+pull their heavy dependencies lazily in their own modules.
+
+.. note::
+   This is intentionally **not** :mod:`langres.methods` -- that module is the
+   benchmark-method registry (``_make_module_builder``), an unrelated concept
+   that happens to share the word "method". :class:`Method` here is the
+   training-strategy object :meth:`langres.core.resolver.Resolver.fit` dispatches
+   on via ``.kind``.
+"""
+
+from typing import ClassVar
+
+from pydantic import BaseModel
+
+__all__ = ["Method"]
+
+
+class Method(BaseModel):
+    """A training strategy passed to ``Resolver.fit(method=...)``.
+
+    A ``Method`` carries the two things the fit call site needs: a ``kind`` that
+    selects the fit path (the Resolver dispatches on it), and a
+    :meth:`describe` one-liner that renders "what + cost" for
+    ``Resolver.describe()`` and the ``FitReport``. Concrete subclasses declare a
+    distinct ``kind`` and add their own Pydantic-validated configuration fields;
+    this base only fixes the contract the Resolver dispatches against.
+
+    ``kind`` is a ``ClassVar`` -- an identity of the strategy *type*, not a
+    per-instance field -- so it never becomes serialized config and every
+    instance of a subclass shares it. Subclasses set it (e.g.
+    ``kind = "finetune"``); the base leaves it unset because it is not meant to
+    be instantiated on its own.
+    """
+
+    kind: ClassVar[str]
+
+    def describe(self) -> str:
+        """Return a one-line "what this method does + what it costs" summary.
+
+        Rendered at the fit call site by ``Resolver.describe()`` and the
+        ``FitReport`` so a caller sees the chosen strategy and its cost profile
+        without running it. The base returns the bare ``kind``; subclasses
+        override with their specifics (e.g. ``"fine-tune (QLoRA, ~GPU-seconds)"``).
+        """
+        return self.kind

--- a/src/langres/core/resolver.py
+++ b/src/langres/core/resolver.py
@@ -83,19 +83,6 @@ _MANIFEST_FILENAME = "resolver.json"
 #: constructor argument.
 _FromSchemaJudge = Literal["string", "embedding", "zero_shot_llm", "prompt_llm"]
 
-#: ``method=`` dispatch table: maps a :class:`~langres.core.methods_api.Method`'s
-#: ``kind`` to the PR that implements its fit path. The dispatch in
-#: :meth:`Resolver.fit` is REAL today (``method.kind`` selects the branch here);
-#: only the per-kind training body is stubbed until each concrete ``Method``
-#: lands -- prompt-optimize (MIPRO) in PR-C, fine-tune (QLoRA) in PR-F, calibrate
-#: (Platt/isotonic) in PR-D. An unrecognized kind falls through to a distinct
-#: "no Method implements it yet" error.
-_METHOD_KIND_PENDING_PR: dict[str, str] = {
-    "prompt": "PR-C",
-    "finetune": "PR-F",
-    "calibrate": "PR-D",
-}
-
 
 def _build_module_for_judge(
     judge: "_FromSchemaJudge | Matcher[Any]",
@@ -533,11 +520,13 @@ class Resolver:
             seed: Seed for the entity-disjoint split.
             method: An optional :class:`~langres.core.methods_api.Method` naming
                 *how* to train (prompt-optimize / fine-tune / calibrate). When
-                given, ``fit`` dispatches on ``method.kind`` to the matching fit
-                path instead of the isinstance-on-the-module default above; when
-                ``None`` (the default), behavior is exactly the module-hook path
-                described here. The concrete per-kind fit paths land in later PRs
-                (see :data:`_METHOD_KIND_PENDING_PR`).
+                given, ``fit`` dispatches on ``method.kind`` to a per-kind handler
+                (``_fit_prompt`` / ``_fit_finetune`` / ``_fit_calibrate``) instead
+                of the isinstance-on-the-module default above; when ``None`` (the
+                default), behavior is exactly the module-hook path described here.
+                Those handlers are thin stubs today -- the concrete per-kind fit
+                paths land in later PRs (prompt in PR-C, finetune in PR-F,
+                calibrate in PR-D).
 
         Returns:
             ``self``, so ``resolver.fit(data).resolve(data)`` chains.
@@ -552,20 +541,27 @@ class Resolver:
         """
         if method is not None:
             # The ``method=`` object seam: a Method names *how* to train and
-            # dispatches on its ``kind`` to the matching fit path. The dispatch
-            # is real today; the per-kind training bodies are stubbed until each
-            # concrete Method lands (see _METHOD_KIND_PENDING_PR). Guarded by
-            # ``is not None`` so the ``method=None`` default leaves every existing
-            # fit path below byte-for-byte unchanged.
-            pending_pr = _METHOD_KIND_PENDING_PR.get(method.kind)
-            if pending_pr is not None:
-                raise NotImplementedError(
-                    f"method kind {method.kind!r} dispatch is wired but its fit path "
-                    f"lands in {pending_pr} ({method.describe()})."
+            # routes to its own per-kind handler below, so the concrete
+            # strategies that fill these in later touch DISJOINT methods instead
+            # of one shared branch. Each handler is a thin stub today, raising a
+            # clear NotImplementedError naming its PR. Guarded by ``is not None``
+            # so the ``method=None`` default leaves every existing fit path below
+            # byte-for-byte unchanged.
+            if method.kind == "prompt":
+                return self._fit_prompt(
+                    data, labels=labels, pairs=pairs, split=split, seed=seed, method=method
+                )
+            if method.kind == "finetune":
+                return self._fit_finetune(
+                    data, labels=labels, pairs=pairs, split=split, seed=seed, method=method
+                )
+            if method.kind == "calibrate":
+                return self._fit_calibrate(
+                    data, labels=labels, pairs=pairs, split=split, seed=seed, method=method
                 )
             raise NotImplementedError(
-                f"method kind {method.kind!r} has no fit path: no langres Method "
-                f"implements it yet ({method.describe()})."
+                f"method kind {method.kind!r} is not recognized: no langres Method "
+                f"implements it ({method.describe()})."
             )
         if labels is not None and pairs is not None:
             raise ValueError(
@@ -617,6 +613,79 @@ class Resolver:
             )
         self.fit_report_ = FitReport.nothing_trainable(matcher_name)
         return self
+
+    # ------------------------------------------------------------------
+    # ``method=`` per-kind fit handlers (the object seam)
+    #
+    # Each ``Method.kind`` routes to its OWN handler so the concrete strategies
+    # land in disjoint methods -- prompt-optimize in PR-C, fine-tune in PR-F,
+    # calibrate in PR-D -- rather than colliding on one shared branch. Every
+    # handler takes the full fit context (data + supervision + split/seed + the
+    # Method itself) so its PR fills in only the body, not the call site. Until
+    # then each is a thin stub raising a clear, PR-naming NotImplementedError.
+    # ------------------------------------------------------------------
+
+    def _fit_prompt(
+        self,
+        data: list[Any],
+        *,
+        labels: Sequence[bool] | None,
+        pairs: str | Path | Sequence[LabeledPair] | Sequence[Correction] | None,
+        split: float | None,
+        seed: int,
+        method: Method,
+    ) -> Self:
+        """Fit via prompt-optimization (``method.kind == "prompt"``) -- STUB.
+
+        Wired into ``fit``'s ``method=`` dispatch; the concrete
+        DSPy-compile-under-fit body lands in PR-C. Until then this raises with
+        that pointer.
+        """
+        raise NotImplementedError(
+            f"method kind 'prompt' dispatch is wired but its fit path lands in "
+            f"PR-C ({method.describe()})."
+        )
+
+    def _fit_finetune(
+        self,
+        data: list[Any],
+        *,
+        labels: Sequence[bool] | None,
+        pairs: str | Path | Sequence[LabeledPair] | Sequence[Correction] | None,
+        split: float | None,
+        seed: int,
+        method: Method,
+    ) -> Self:
+        """Fit via fine-tuning (``method.kind == "finetune"``) -- STUB.
+
+        Wired into ``fit``'s ``method=`` dispatch; the concrete QLoRA fine-tune
+        body (with GPU-seconds cost) lands in PR-F. Until then this raises with
+        that pointer.
+        """
+        raise NotImplementedError(
+            f"method kind 'finetune' dispatch is wired but its fit path lands in "
+            f"PR-F ({method.describe()})."
+        )
+
+    def _fit_calibrate(
+        self,
+        data: list[Any],
+        *,
+        labels: Sequence[bool] | None,
+        pairs: str | Path | Sequence[LabeledPair] | Sequence[Correction] | None,
+        split: float | None,
+        seed: int,
+        method: Method,
+    ) -> Self:
+        """Fit via score calibration (``method.kind == "calibrate"``) -- STUB.
+
+        Wired into ``fit``'s ``method=`` dispatch; the concrete Platt/isotonic
+        calibration body lands in PR-D. Until then this raises with that pointer.
+        """
+        raise NotImplementedError(
+            f"method kind 'calibrate' dispatch is wired but its fit path lands in "
+            f"PR-D ({method.describe()})."
+        )
 
     def _fit_from_pairs(
         self,

--- a/src/langres/core/resolver.py
+++ b/src/langres/core/resolver.py
@@ -49,6 +49,7 @@ from langres.core.comparator import Comparator
 from langres.core.fit import SupervisedFitMixin, UnsupervisedFitMixin
 from langres.core.fit_report import FitReport
 from langres.core.harvest import Correction, LabeledPair, align_pairs
+from langres.core.methods_api import Method
 from langres.core.matchers.weighted_average import WeightedAverageMatcher
 from langres.core.metrics import PairMetrics, classify_pairs
 from langres.core.models import ERCandidate, PairwiseJudgement
@@ -81,6 +82,19 @@ _MANIFEST_FILENAME = "resolver.json"
 #: ``langres.core.presets.choose_auto_judge``); this stays a plain, explicit
 #: constructor argument.
 _FromSchemaJudge = Literal["string", "embedding", "zero_shot_llm", "prompt_llm"]
+
+#: ``method=`` dispatch table: maps a :class:`~langres.core.methods_api.Method`'s
+#: ``kind`` to the PR that implements its fit path. The dispatch in
+#: :meth:`Resolver.fit` is REAL today (``method.kind`` selects the branch here);
+#: only the per-kind training body is stubbed until each concrete ``Method``
+#: lands -- prompt-optimize (MIPRO) in PR-C, fine-tune (QLoRA) in PR-F, calibrate
+#: (Platt/isotonic) in PR-D. An unrecognized kind falls through to a distinct
+#: "no Method implements it yet" error.
+_METHOD_KIND_PENDING_PR: dict[str, str] = {
+    "prompt": "PR-C",
+    "finetune": "PR-F",
+    "calibrate": "PR-D",
+}
 
 
 def _build_module_for_judge(
@@ -467,6 +481,7 @@ class Resolver:
         pairs: str | Path | Sequence[LabeledPair] | Sequence[Correction] | None = None,
         split: float | None = None,
         seed: int = 0,
+        method: Method | None = None,
     ) -> Self:
         """Fit the module when it supports a fit hook; sklearn-style no-op otherwise.
 
@@ -516,6 +531,13 @@ class Resolver:
             split: Held-out fraction for the entity-disjoint ``pairs`` split
                 (``None`` = train on everything; only meaningful with ``pairs``).
             seed: Seed for the entity-disjoint split.
+            method: An optional :class:`~langres.core.methods_api.Method` naming
+                *how* to train (prompt-optimize / fine-tune / calibrate). When
+                given, ``fit`` dispatches on ``method.kind`` to the matching fit
+                path instead of the isinstance-on-the-module default above; when
+                ``None`` (the default), behavior is exactly the module-hook path
+                described here. The concrete per-kind fit paths land in later PRs
+                (see :data:`_METHOD_KIND_PENDING_PR`).
 
         Returns:
             ``self``, so ``resolver.fit(data).resolve(data)`` chains.
@@ -524,7 +546,27 @@ class Resolver:
             ValueError: If both ``labels`` and ``pairs`` are given; if the module
                 implements ``SupervisedFitMixin`` and neither is given; or if
                 ``labels``/``pairs`` is given to a module that cannot use them.
+            NotImplementedError: If ``method`` is given but its ``kind``'s fit
+                path is not implemented yet (the seam is wired ahead of the
+                concrete methods; the error names the PR that will land it).
         """
+        if method is not None:
+            # The ``method=`` object seam: a Method names *how* to train and
+            # dispatches on its ``kind`` to the matching fit path. The dispatch
+            # is real today; the per-kind training bodies are stubbed until each
+            # concrete Method lands (see _METHOD_KIND_PENDING_PR). Guarded by
+            # ``is not None`` so the ``method=None`` default leaves every existing
+            # fit path below byte-for-byte unchanged.
+            pending_pr = _METHOD_KIND_PENDING_PR.get(method.kind)
+            if pending_pr is not None:
+                raise NotImplementedError(
+                    f"method kind {method.kind!r} dispatch is wired but its fit path "
+                    f"lands in {pending_pr} ({method.describe()})."
+                )
+            raise NotImplementedError(
+                f"method kind {method.kind!r} has no fit path: no langres Method "
+                f"implements it yet ({method.describe()})."
+            )
         if labels is not None and pairs is not None:
             raise ValueError(
                 "pass either labels= (a Sequence[bool] pre-aligned with the blocked "

--- a/tests/core/test_resolver_fit_method.py
+++ b/tests/core/test_resolver_fit_method.py
@@ -1,0 +1,155 @@
+"""Tests for the ``method=`` object seam on ``Resolver.fit`` (PR-M).
+
+``fit(..., method=<Method>)`` dispatches on ``method.kind`` to the matching fit
+path *before* the module-hook isinstance chain. The concrete per-kind training
+bodies land in later PRs (MIPRO/PR-C, QLoRA/PR-F, Platt/PR-D), so every wired
+kind currently raises a clear ``NotImplementedError`` naming that PR -- but the
+dispatch + param plumbing is real, which is what these tests lock:
+
+- distinct ``kind`` values route to distinct branches (distinct error text);
+- an unrecognized ``kind`` falls through to a "no Method implements it" error;
+- ``method=None`` preserves today's exact module-hook behavior (no-op here);
+- ``Method`` carries ``kind`` as a ClassVar (identity, not serialized config)
+  and a ``describe()`` "what + cost" one-liner.
+"""
+
+from collections.abc import Iterator
+from typing import ClassVar
+
+import pytest
+
+from langres.core.blockers.all_pairs import AllPairsBlocker
+from langres.core.clusterer import Clusterer
+from langres.core.matcher import Matcher
+from langres.core.methods_api import Method
+from langres.core.models import CompanySchema, ERCandidate, PairwiseJudgement
+from langres.core.reports import ScoreInspectionReport
+from langres.core.resolver import Resolver
+
+
+class _NoHookModule(Matcher[CompanySchema]):
+    """Implements neither fit hook -- the ``method=None`` no-op baseline."""
+
+    def forward(
+        self, candidates: Iterator[ERCandidate[CompanySchema]]
+    ) -> Iterator[PairwiseJudgement]:
+        yield from ()
+
+    def inspect_scores(
+        self, judgements: list[PairwiseJudgement], sample_size: int = 10
+    ) -> ScoreInspectionReport:
+        raise NotImplementedError
+
+
+class _PromptMethod(Method):
+    """Fake prompt-optimize strategy (kind wired to PR-C)."""
+
+    kind: ClassVar[str] = "prompt"
+
+
+class _FinetuneMethod(Method):
+    """Fake fine-tune strategy (kind wired to PR-F) with a custom describe()."""
+
+    kind: ClassVar[str] = "finetune"
+
+    def describe(self) -> str:
+        return "fine-tune (QLoRA, ~GPU-seconds)"
+
+
+class _CalibrateMethod(Method):
+    """Fake calibrate strategy (kind wired to PR-D)."""
+
+    kind: ClassVar[str] = "calibrate"
+
+
+class _UnknownMethod(Method):
+    """A kind no concrete Method implements -- the fall-through branch."""
+
+    kind: ClassVar[str] = "bogus"
+
+
+RECORDS = [
+    {"id": "a", "name": "Acme Corp"},
+    {"id": "b", "name": "Acme Corporation"},
+    {"id": "c", "name": "Beta Inc"},
+]
+
+
+def _resolver() -> Resolver:
+    return Resolver(
+        blocker=AllPairsBlocker(schema=CompanySchema),
+        comparator=None,
+        matcher=_NoHookModule(),
+        clusterer=Clusterer(threshold=0.5),
+    )
+
+
+# --- dispatch: kind routes to its branch, all stubbed for now ---------------
+
+
+def test_finetune_kind_routes_to_pr_f_stub() -> None:
+    """A ``kind="finetune"`` method routes to the wired-but-stubbed PR-F branch."""
+    with pytest.raises(NotImplementedError, match=r"method kind 'finetune'.*lands in PR-F"):
+        _resolver().fit(RECORDS, method=_FinetuneMethod())
+
+
+def test_prompt_kind_routes_to_pr_c_stub() -> None:
+    """A ``kind="prompt"`` method routes to a *different* branch (PR-C) -- proves routing."""
+    with pytest.raises(NotImplementedError, match=r"method kind 'prompt'.*lands in PR-C"):
+        _resolver().fit(RECORDS, method=_PromptMethod())
+
+
+def test_calibrate_kind_routes_to_pr_d_stub() -> None:
+    """A ``kind="calibrate"`` method routes to the PR-D branch."""
+    with pytest.raises(NotImplementedError, match=r"method kind 'calibrate'.*lands in PR-D"):
+        _resolver().fit(RECORDS, method=_CalibrateMethod())
+
+
+def test_unknown_kind_falls_through_to_no_impl_error() -> None:
+    """A kind no concrete Method implements raises the distinct fall-through error."""
+    with pytest.raises(NotImplementedError, match=r"method kind 'bogus' has no fit path"):
+        _resolver().fit(RECORDS, method=_UnknownMethod())
+
+
+def test_error_carries_the_describe_string() -> None:
+    """The dispatch surfaces ``method.describe()`` at the call site (kind + cost)."""
+    with pytest.raises(NotImplementedError, match=r"fine-tune \(QLoRA, ~GPU-seconds\)"):
+        _resolver().fit(RECORDS, method=_FinetuneMethod())
+
+
+# --- backward compatibility: method=None is byte-for-byte today's behavior --
+
+
+def test_method_none_preserves_noop_behavior() -> None:
+    """``method=None`` on a no-hook module stays the existing no-op that returns self."""
+    resolver = _resolver()
+
+    result = resolver.fit(RECORDS, method=None)
+
+    assert result is resolver
+
+
+def test_method_default_is_none() -> None:
+    """Omitting ``method`` entirely is identical to the module-hook path (no-op here)."""
+    resolver = _resolver()
+
+    assert resolver.fit(RECORDS) is resolver
+
+
+# --- Method contract: describe() + kind is a ClassVar, not a field ----------
+
+
+def test_describe_defaults_to_kind() -> None:
+    """The base ``describe()`` returns the bare ``kind`` when not overridden."""
+    assert _PromptMethod().describe() == "prompt"
+
+
+def test_describe_can_be_overridden() -> None:
+    """A subclass overriding ``describe()`` returns its own 'what + cost' string."""
+    assert _FinetuneMethod().describe() == "fine-tune (QLoRA, ~GPU-seconds)"
+
+
+def test_kind_is_classvar_not_a_model_field() -> None:
+    """``kind`` is strategy-type identity, so it must not become a serialized field."""
+    assert "kind" not in _PromptMethod.model_fields
+    assert _PromptMethod.kind == "prompt"

--- a/tests/core/test_resolver_fit_method.py
+++ b/tests/core/test_resolver_fit_method.py
@@ -107,7 +107,7 @@ def test_calibrate_kind_routes_to_pr_d_stub() -> None:
 
 def test_unknown_kind_falls_through_to_no_impl_error() -> None:
     """A kind no concrete Method implements raises the distinct fall-through error."""
-    with pytest.raises(NotImplementedError, match=r"method kind 'bogus' has no fit path"):
+    with pytest.raises(NotImplementedError, match=r"method kind 'bogus' is not recognized"):
         _resolver().fit(RECORDS, method=_UnknownMethod())
 
 


### PR DESCRIPTION
## PR-M — the `method=` object seam on `Resolver.fit`

Part of the **training-surface epic** (#125), into the integration branch `feat/training-surface`. This is the **seam only**: a `Method` base object + `method=` keyword-only param + per-kind dispatch on `fit()`. **No concrete methods** — `QLoRA`/`MIPRO`/`Platt` arrive in PR-F/PR-C/PR-D. Proves a `method=` object flows to the right fit path and carries kind + cost + config at the call site (extends the blessed "search is a meta-object" pattern; NOT the rejected `TrainingRecipe`).

### What this adds (3 files, +257)
- **NEW `src/langres/core/methods_api.py`** — `Method` Pydantic base, import-light (typing + pydantic only). `kind: ClassVar[str]` (each subclass declares its kind) + `describe() -> str` (the call-site "what + cost" one-liner rendered by PR-C's `describe()` and PR-B's `FitReport`). Separate `__all__`; kept deliberately distinct from `langres/methods.py` (the benchmark-method registry — a different concept; noted in the module docstring to avoid reviewer confusion).
- **`src/langres/core/resolver.py`** — imports `Method`; adds `method: Method | None = None` keyword-only param after `seed`; dispatch at the **top of the fit body** (before the labels/pairs check), guarded by `if method is not None:` so **`method=None` is byte-for-byte today's behavior** (every existing `fit` test stays green). A module constant `_METHOD_KIND_PENDING_PR = {"prompt": "PR-C", "finetune": "PR-F", "calibrate": "PR-D"}` maps each not-yet-implemented kind to the PR that will land it.
- **NEW `tests/core/test_resolver_fit_method.py`** — 11 tests: per-kind routing (distinct branch/message), unknown-kind fall-through, `method=None` no-op returns self, `describe()` default + override, `kind` is a `ClassVar` not a field.

### Dispatch behavior
- Wired-but-stubbed kind → clear `NotImplementedError`, e.g. `method kind 'finetune' dispatch is wired but its fit path lands in PR-F (fine-tune (QLoRA, ~GPU-seconds)).`
- Unrecognized kind → `method kind 'bogus' has no fit path: no langres Method implements it yet (bogus).`
- **Downstream contract:** PR-C/D/F each drop their kind out of `_METHOD_KIND_PENDING_PR` and replace their `raise` with the real per-kind fit path. (Recommended: replace the branch with `return self._fit_<kind>(...)` and implement the body as a separate method, so the three PRs edit disjoint bodies.)

### Verification (all seen green)
- 11/11 method-seam tests pass; existing `test_resolver_fit_hooks` / `test_fit_mixins` / `test_fit_report` all green → `method=None` path unchanged.
- `uv run pytest tests/test_import_budget.py` → 35 passed, 4 skipped (methods_api stays import-light).
- `uv run --all-extras pytest -m "not integration and not slow"` → **2856 passed**, 4 skipped, 105 deselected; coverage 98.44% (methods_api.py 100%, resolver.py 99%).
- `uv run --no-dev --group docs mkdocs build --strict` → **clean** (the docs gate that bit PR-A; resolver autodoc renders the new `method:` param and matched the signature).
- ruff format + ruff check + mypy → clean on changed files.

## Summary by Sourcery

Introduce a pluggable training strategy object passed via a new `method=` parameter on `Resolver.fit`, with dispatch wired by method kind but concrete implementations still stubbed.

New Features:
- Add a `Method` Pydantic base class representing a training strategy, with a `kind` identifier and overridable `describe()` summary.
- Extend `Resolver.fit` with an optional `method` parameter that dispatches on `Method.kind` to select a training path while preserving existing behavior when omitted.

Tests:
- Add resolver fit tests covering per-kind method dispatch, unknown kind handling, error messaging, `describe()` behavior, and backward compatibility when `method` is `None`.