### PR TITLE
PR-C: prompt-optimize fit path (_fit_prompt) + Resolver.describe() + DSPy-compile-under-fit

### DIFF
--- a/docs/TECHNICAL_OVERVIEW.md
+++ b/docs/TECHNICAL_OVERVIEW.md
@@ -735,6 +735,33 @@ digest). `FitReport` is import-light (Pydantic + `harvest`/`metrics` only, no
 sklearn/torch) and references the enclosing `RunRecord`'s `attempt_id` via
 `run_ref` for lineage rather than duplicating it.
 
+### Training strategies: the `method=` seam + `describe()`
+
+Beyond the module-hook default above, `Resolver.fit(..., method=<Method>)` takes
+a `langres.core.methods_api.Method` — a declarative object naming *how* to train
+— and dispatches on `method.kind` to a per-kind handler *before* the
+isinstance-on-the-module chain (`method=None` leaves that default byte-for-byte
+unchanged):
+
+- **prompt-optimize** (`kind="prompt"`, implemented) — `Bootstrap()` /
+  `MIPRO(auto=..., budget_usd=...)` from `langres.core.methods_prompt` compile a
+  `DSPyMatcher`'s prompt from labeled pairs (the optimizer's `BootstrapFewShot` /
+  `MIPROv2`). Supervision comes from `pairs=` (reusing `align_pairs` + the
+  entity-disjoint split, whose `valid` fold feeds `MIPROv2`'s valset) or
+  pre-aligned `labels=`. The `FitReport` names the demos learned, teacher model,
+  and declared budget. Requires a `DSPyMatcher` (else a clear error); DSPy stays
+  lazy-imported, so `Bootstrap()`/`MIPRO()` construct without pulling `dspy`.
+  `budget_usd` threads through the existing `SpendMonitor` seam (DSPy-compile
+  spend capture is deferred to #100, so it observes `$0` today).
+- **fine-tune** (`kind="finetune"`) / **calibrate** (`kind="calibrate"`) — wired
+  stubs raising a clear NotImplementedError naming their PR.
+
+`Resolver.describe()` is the pre-fit honesty device: a per-component string
+tagging each pipeline role **TRAINABLE** (implements a `langres.core.fit`
+Protocol, or is a prompt-compilable `DSPyMatcher`) or **frozen**. A pure string
+builder — it never trains, imports a backend, or mutates state — so it is safe to
+call on a fresh Resolver to see what a `fit()` would (and would not) tune.
+
 ## 9. Blocking Algebra + Merge-Resistant Clustering (W1.3)
 
 ### KeyBlocker (`langres.core.blockers.key`)

--- a/src/langres/core/matchers/dspy_judge.py
+++ b/src/langres/core/matchers/dspy_judge.py
@@ -204,6 +204,17 @@ class DSPyMatcher(Matcher[SchemaT]):
         return self._compiled
 
     @property
+    def n_demos(self) -> int:
+        """Total bootstrapped few-shot demos across the program's predictors.
+
+        ``0`` before :meth:`compile` (a bare ``ChainOfThought`` carries none);
+        the count the ``FitReport`` surfaces after a prompt-optimize fit as "what
+        the compile learned". Mirrors the demo-count probe :meth:`load_state`
+        uses to infer compilation on markerless artifacts.
+        """
+        return sum(len(predictor.demos) for _, predictor in self._program.named_predictors())
+
+    @property
     def config(self) -> dict[str, object]:
         """Pure, serializable construction config (never the LM, program, or secrets)."""
         return {
@@ -233,6 +244,36 @@ class DSPyMatcher(Matcher[SchemaT]):
     def _render_entity(self, entity: SchemaT) -> str:
         """Render an entity for the prompt (LLMMatcher's JSON convention)."""
         return entity.model_dump_json(indent=2)
+
+    def examples_from_candidates(
+        self, candidates: Sequence[ERCandidate[SchemaT]], labels: Sequence[bool]
+    ) -> list[dspy.Example]:
+        """Build a :meth:`compile` trainset from labeled candidates.
+
+        Each pair becomes a ``dspy.Example`` whose ``left`` / ``right`` inputs are
+        rendered *exactly* as :meth:`forward` renders them (via
+        :meth:`_render_entity`), so the demos the optimizer learns reflect what the
+        program sees at inference; ``match`` carries the gold label. This is the
+        candidate->``dspy.Example`` bridge ``Resolver.fit(method=<prompt>)`` uses
+        to feed :meth:`compile`, keeping the rendering convention owned by the
+        matcher rather than duplicated at the call site.
+
+        Args:
+            candidates: Blocked candidate pairs to train on, positionally aligned
+                with ``labels`` (e.g. ``align_pairs(...).train.candidates``).
+            labels: Gold match/non-match labels for each candidate.
+
+        Returns:
+            One ``dspy.Example`` per candidate, inputs marked ``left`` / ``right``.
+        """
+        return [
+            dspy.Example(
+                left=self._render_entity(candidate.left),
+                right=self._render_entity(candidate.right),
+                match=bool(label),
+            ).with_inputs("left", "right")
+            for candidate, label in zip(candidates, labels, strict=True)
+        ]
 
     def forward(self, candidates: Iterator[ERCandidate[SchemaT]]) -> Iterator[PairwiseJudgement]:
         """Score each candidate pair with the DSPy program, yielding PairwiseJudgements.
@@ -324,6 +365,7 @@ class DSPyMatcher(Matcher[SchemaT]):
         valset: Sequence[dspy.Example] | None = None,
         *,
         optimizer: str = "bootstrap",
+        auto: str = "light",
         tracker: ExperimentTracker | None = None,
         store: str | Path | RunStore | None = None,
         parent_run_id: str | None = None,
@@ -345,8 +387,11 @@ class DSPyMatcher(Matcher[SchemaT]):
                 gold ``match``) the optimizer tunes against.
             valset: Optional validation set (used by ``mipro``).
             optimizer: ``"bootstrap"`` (``BootstrapFewShot`` — deterministic under
-                ``DummyLM``, the zero-spend path) or ``"mipro"`` (``MIPROv2
-                auto="light"`` — the paid path, exercised only by the example).
+                ``DummyLM``, the zero-spend path) or ``"mipro"`` (``MIPROv2`` —
+                the paid path, exercised only by the example).
+            auto: ``MIPROv2``'s search-budget preset (``"light"`` / ``"medium"`` /
+                ``"heavy"``); ignored by ``"bootstrap"``. Threaded from the
+                ``MIPRO`` method's ``auto`` field by ``Resolver.fit``.
             tracker: Experiment tracker for the compile run (``None`` — the
                 default — resolves to a no-op via ``resolve_tracker``).
             store: Where to persist the compile :class:`RunRecord` (default: none).
@@ -393,7 +438,7 @@ class DSPyMatcher(Matcher[SchemaT]):
                     # Exercised only by the paid example (MIPROv2 proposes+evaluates
                     # instructions via real LM calls; it is not deterministic under
                     # DummyLM, so it is kept out of the zero-spend unit suite).
-                    self._program = dspy.MIPROv2(metric=_pair_metric, auto="light").compile(
+                    self._program = dspy.MIPROv2(metric=_pair_metric, auto=auto).compile(
                         self._program,
                         trainset=list(trainset),
                         valset=list(valset) if valset is not None else None,

--- a/src/langres/core/methods_prompt.py
+++ b/src/langres/core/methods_prompt.py
@@ -1,0 +1,115 @@
+"""Prompt-optimization :class:`~langres.core.methods_api.Method` s (``kind == "prompt"``).
+
+The concrete strategies :meth:`Resolver.fit(method=...) <langres.core.resolver.Resolver.fit>`
+dispatches to when the module is a compilable
+:class:`~langres.core.matchers.dspy_judge.DSPyMatcher`: tune the prompt from
+labeled pairs by **compiling** the DSPy program against a gold set. Each strategy
+maps to one DSPy optimizer:
+
+- :class:`Bootstrap` -> ``BootstrapFewShot`` (deterministic under ``DummyLM`` --
+  the zero-spend path the CI suite exercises);
+- :class:`MIPRO` -> ``MIPROv2`` (proposes+evaluates instructions via real LM
+  calls -- the paid path, exercised only by the example / a ``slow`` test).
+
+Import-light by construction (Pydantic only -- no ``dspy``/``litellm``): a
+``Method`` is a *value* the caller constructs at the fit call site, so
+constructing ``MIPRO(budget_usd=5.0)`` must never pull a training backend into
+``sys.modules`` (locked by ``tests/test_import_budget.py``). The heavy ``dspy``
+import stays lazy inside
+:mod:`langres.core.matchers.dspy_judge`, reached only when
+:meth:`~langres.core.resolver.Resolver.fit` actually compiles.
+
+.. note::
+   The ``metric`` DSPy compiles against is fixed to the built-in match-decision
+   metric (``dspy_judge._pair_metric``); a user-selectable metric would be dead
+   config today, so these methods deliberately omit a ``metric`` knob.
+"""
+
+from typing import Any, ClassVar, Literal
+
+from langres.core.methods_api import Method
+
+__all__ = ["Bootstrap", "MIPRO", "PromptMethod"]
+
+
+class PromptMethod(Method):
+    """Base for the prompt-optimization strategies (``kind == "prompt"``).
+
+    Fixes the contract :meth:`~langres.core.resolver.Resolver._fit_prompt` reads:
+    an :attr:`optimizer` naming the DSPy optimizer to run, an optional
+    :attr:`budget_usd` cap, and a :meth:`compile_kwargs` hook mapping the
+    method's config onto ``DSPyMatcher.compile``'s arguments. Like
+    :attr:`~langres.core.methods_api.Method.kind`, :attr:`optimizer` is a
+    ``ClassVar`` -- strategy-type identity, not serialized config -- so the base
+    declares it and each concrete subclass sets it.
+
+    Attributes:
+        budget_usd: Spend cap for the compile, enforced through the existing
+            :class:`~langres.clients.openrouter.SpendMonitor` seam. ``None`` (the
+            default) means uncapped. Surfaced in :meth:`describe` and the
+            ``FitReport`` so a caller sees the budget the fit ran under.
+    """
+
+    kind: ClassVar[str] = "prompt"
+    #: The ``DSPyMatcher.compile`` optimizer this strategy runs ("bootstrap" /
+    #: "mipro"). Set by concrete subclasses; unset on the base (never instantiated).
+    optimizer: ClassVar[str]
+
+    budget_usd: float | None = None
+
+    def compile_kwargs(self) -> dict[str, Any]:
+        """Return the method's config as ``DSPyMatcher.compile`` keyword arguments.
+
+        The base maps nothing (``BootstrapFewShot`` takes no extra config here);
+        subclasses override to thread their knobs (e.g. ``MIPROv2``'s ``auto``
+        level). The ``optimizer`` itself is passed separately, not via this dict.
+        """
+        return {}
+
+
+def _with_budget(base: str, budget_usd: float | None) -> str:
+    """Append ``", budget $<n>"`` to a describe() string when a budget is set."""
+    return base if budget_usd is None else f"{base}, budget ${budget_usd:g}"
+
+
+class Bootstrap(PromptMethod):
+    """Prompt-optimize by bootstrapping few-shot demos (``BootstrapFewShot``).
+
+    The zero-spend optimizer: it selects demonstrations that reproduce the gold
+    match decision, deterministic under a ``DummyLM`` -- so a
+    ``resolver.fit(pairs=..., method=Bootstrap())`` on a ``DummyLM``-backed
+    ``DSPyMatcher`` compiles at ``$0`` (the path the unit suite locks).
+    """
+
+    optimizer: ClassVar[str] = "bootstrap"
+
+    def describe(self) -> str:
+        """One-liner: ``"prompt-optimize (BootstrapFewShot[, budget $N])"``."""
+        return _with_budget("prompt-optimize (BootstrapFewShot)", self.budget_usd)
+
+
+class MIPRO(PromptMethod):
+    """Prompt-optimize by proposing+evaluating instructions (``MIPROv2``).
+
+    The paid optimizer: ``MIPROv2`` drafts candidate instructions and scores them
+    with real LM calls, so it is non-deterministic and kept out of the zero-spend
+    unit suite (exercised only by the example / a ``slow`` test). Pair it with a
+    :attr:`budget_usd` cap.
+
+    Attributes:
+        auto: ``MIPROv2``'s search-budget preset (``"light"`` / ``"medium"`` /
+            ``"heavy"``) -- more compute for a better prompt. Threaded onto
+            ``compile`` via :meth:`compile_kwargs`.
+    """
+
+    optimizer: ClassVar[str] = "mipro"
+
+    auto: Literal["light", "medium", "heavy"] = "light"
+
+    def compile_kwargs(self) -> dict[str, Any]:
+        """Thread the ``auto`` search-budget preset onto ``DSPyMatcher.compile``."""
+        return {"auto": self.auto}
+
+    def describe(self) -> str:
+        """One-liner: ``"prompt-optimize (MIPROv2, auto=<level>[, budget $N])"``."""
+        return _with_budget(f"prompt-optimize (MIPROv2, auto={self.auto})", self.budget_usd)

--- a/src/langres/core/resolver.py
+++ b/src/langres/core/resolver.py
@@ -700,16 +700,122 @@ class Resolver:
         seed: int,
         method: Method,
     ) -> Self:
-        """Fit via prompt-optimization (``method.kind == "prompt"``) -- STUB.
+        """Fit via prompt-optimization (``method.kind == "prompt"``).
 
-        Wired into ``fit``'s ``method=`` dispatch; the concrete
-        DSPy-compile-under-fit body lands in PR-C. Until then this raises with
-        that pointer.
+        Tunes a compilable :class:`~langres.core.matchers.dspy_judge.DSPyMatcher`'s
+        prompt from labeled pairs by compiling its DSPy program against a gold set
+        -- the optimizer named by ``method.optimizer`` (``BootstrapFewShot`` for
+        :class:`~langres.core.methods_prompt.Bootstrap`, ``MIPROv2`` for
+        :class:`~langres.core.methods_prompt.MIPRO`). Supervision comes from either
+        id-keyed ``pairs`` (joined via :func:`~langres.core.harvest.align_pairs`,
+        whose optional entity-disjoint ``split`` yields the ``valid`` fold
+        ``MIPROv2`` uses as its valset) or pre-aligned ``labels``. Sets
+        :attr:`fit_report_` naming the demos learned + teacher model + declared
+        budget, and returns ``self`` so ``resolver.fit(...).resolve(...)`` chains.
+
+        The budget seam: ``method.budget_usd`` caps the compile via the existing
+        :class:`~langres.clients.openrouter.SpendMonitor`. DSPy-compile spend
+        capture is deferred to issue #100 -- today the compile records ``$0`` (the
+        ``DummyLM`` CI path is genuinely free; the paid ``MIPROv2`` path stays
+        uncosted until #100 wires real spend through this same guard).
+
+        Raises:
+            ValueError: If the module is not a ``DSPyMatcher``
+                (prompt-optimization needs a compilable scorer); if both
+                ``labels`` and ``pairs`` are given, or neither.
         """
-        raise NotImplementedError(
-            f"method kind 'prompt' dispatch is wired but its fit path lands in "
-            f"PR-C ({method.describe()})."
+        # Lazy imports: keep ``dspy`` (and litellm-adjacent client code) out of a
+        # bare ``import langres`` -- they load only when a prompt-optimize fit runs.
+        from langres.clients.openrouter import SpendMonitor
+        from langres.core.matchers.dspy_judge import DSPyMatcher
+
+        matcher_name = type(self.module).__name__
+        if not isinstance(self.module, DSPyMatcher):
+            raise ValueError(
+                f"method.kind='prompt' prompt-optimization needs a DSPyMatcher in "
+                f"the module slot (a compilable DSPy scorer), but this Resolver's "
+                f"matcher is {matcher_name}. Build it with matcher=DSPyMatcher(...) "
+                f"to prompt-optimize, or drop method= to use {matcher_name}'s own "
+                f"fit path."
+            )
+        if self.module.compiled:
+            raise ValueError(
+                "this DSPyMatcher is already compiled -- prompt-optimization "
+                "compiles a fresh program once per matcher instance and DSPy "
+                "cannot recompile in place. Build a new DSPyMatcher(...) for "
+                "another prompt-optimize round."
+            )
+        if labels is not None and pairs is not None:
+            raise ValueError(
+                "pass either labels= (pre-aligned with the blocked candidates) or "
+                "pairs= (id-keyed labels align_pairs() joins), not both."
+            )
+        optimizer = getattr(method, "optimizer", None)
+        if optimizer is None:
+            raise ValueError(
+                f"method.kind='prompt' needs a PromptMethod exposing .optimizer "
+                f"(e.g. Bootstrap()/MIPRO()); got {type(method).__name__} "
+                f"({method.describe()})."
+            )
+
+        # Assemble labeled candidates (train + optional valid), reusing the same
+        # id-join + entity-disjoint split as the SupervisedFitMixin pairs path.
+        coverage = None
+        valid_candidates: Sequence[ERCandidate[Any]] = []
+        valid_labels: Sequence[bool] = []
+        if pairs is not None:
+            aligned = align_pairs(self.candidates(data), pairs, split=split, seed=seed)
+            train_candidates: Sequence[ERCandidate[Any]] = aligned.train.candidates
+            train_labels: Sequence[bool] = aligned.train.labels
+            valid_candidates = aligned.valid.candidates
+            valid_labels = aligned.valid.labels
+            coverage = aligned.coverage
+        elif labels is not None:
+            train_candidates = self.candidates(data)
+            train_labels = labels
+        else:
+            raise ValueError(
+                f"prompt-optimization ({method.describe()}) needs gold labels to "
+                "tune the prompt from: pass pairs=<id-keyed labels> or "
+                "labels=<pre-aligned with the blocked candidates>."
+            )
+
+        trainset = self.module.examples_from_candidates(train_candidates, train_labels)
+        valset = (
+            self.module.examples_from_candidates(valid_candidates, valid_labels)
+            if valid_candidates
+            else None
         )
+
+        budget_usd = getattr(method, "budget_usd", None)
+        monitor = SpendMonitor(budget_usd=budget_usd) if budget_usd is not None else None
+        compile_kwargs = method.compile_kwargs() if hasattr(method, "compile_kwargs") else {}
+        self.module.compile(trainset, valset, optimizer=optimizer, **compile_kwargs)
+
+        # See the docstring's budget note: DSPy-compile spend is not yet captured
+        # (#100), so the monitor observes $0 today. The seam is wired so real
+        # spend flows through this cap once #100 lands.
+        spend_usd = 0.0
+        if monitor is not None:
+            monitor.add(spend_usd)
+            monitor.check()
+
+        self.fit_report_ = FitReport.build(
+            trainable=(
+                f"{matcher_name} ({method.describe()}; "
+                f"teacher={self.module.model}, demos={self.module.n_demos})"
+            ),
+            trained=True,
+            n_train=len(train_labels),
+            n_valid=len(valid_labels),
+            split=split,
+            seed=seed,
+            coverage=coverage,
+            threshold=self.clusterer.threshold,
+            cost=spend_usd if monitor is not None else None,
+            run_ref=current_run.get(),
+        )
+        return self
 
     def _fit_finetune(
         self,

--- a/src/langres/core/resolver.py
+++ b/src/langres/core/resolver.py
@@ -46,7 +46,12 @@ from langres.core.blocker import Blocker
 from langres.core.blockers.composite import CompositeBlocker
 from langres.core.clusterer import Clusterer
 from langres.core.comparator import Comparator
-from langres.core.fit import SupervisedFitMixin, UnsupervisedFitMixin
+from langres.core.fit import (
+    BlockerFitMixin,
+    CalibratorFitMixin,
+    SupervisedFitMixin,
+    UnsupervisedFitMixin,
+)
 from langres.core.fit_report import FitReport
 from langres.core.harvest import Correction, LabeledPair, align_pairs
 from langres.core.methods_api import Method
@@ -304,6 +309,19 @@ def _rebuild_component(spec: ComponentSpec, state_dir: Path | None = None) -> An
     return component
 
 
+def _is_prompt_compilable(module: object) -> bool:
+    """Whether ``module`` is a prompt-optimizable (DSPy-style) matcher.
+
+    Structural, import-light check (no ``dspy`` import): a compilable scorer
+    exposes a ``compile(trainset, ...)`` method and a ``compiled`` flag -- the
+    :class:`~langres.core.matchers.dspy_judge.DSPyMatcher` shape. Used by
+    :meth:`Resolver.describe` to tag the matcher TRAINABLE and mirrors the
+    matcher the ``method.kind == "prompt"`` fit path requires, without pulling
+    ``dspy`` into a bare ``import langres``.
+    """
+    return callable(getattr(module, "compile", None)) and hasattr(module, "compiled")
+
+
 class Resolver:
     """Composable entity-resolution pipeline: blocker -> compare -> score -> cluster.
 
@@ -459,6 +477,53 @@ class Resolver:
     # ------------------------------------------------------------------
     # Running the pipeline
     # ------------------------------------------------------------------
+
+    def describe(self) -> str:
+        """Return a per-component "what would train vs what is frozen" digest.
+
+        The honesty device the caller reads *before* ``fit``: one line per
+        pipeline role naming the component and tagging it ``TRAINABLE`` (a fit
+        hook or a prompt-compile would tune it) or ``frozen`` (nothing to train).
+        A role is TRAINABLE when it implements the matching fit Protocol from
+        :mod:`langres.core.fit` -- a :class:`~langres.core.fit.BlockerFitMixin`
+        blocker, a :class:`~langres.core.fit.SupervisedFitMixin`/
+        :class:`~langres.core.fit.UnsupervisedFitMixin` matcher (or a
+        prompt-compilable :class:`~langres.core.matchers.dspy_judge.DSPyMatcher`,
+        tuned by ``fit(method="prompt")``), or a
+        :class:`~langres.core.fit.CalibratorFitMixin` calibrator. The clusterer is
+        always frozen (a decision threshold, not a learned parameter).
+
+        Pure string builder: it reads slots and reports, never trains, imports a
+        backend, or mutates anything -- safe to call on a fresh Resolver. Example::
+
+            blocker:    AllPairsBlocker         — frozen
+            matcher:    DSPyMatcher             — TRAINABLE
+            calibrator: <none>                  — frozen
+            clusterer:  threshold=0.5           — frozen
+
+        Returns:
+            A newline-joined, column-aligned digest (no trailing newline).
+        """
+        calibrator = getattr(self, "calibrator", None)
+        matcher_trainable = isinstance(
+            self.module, (SupervisedFitMixin, UnsupervisedFitMixin)
+        ) or _is_prompt_compilable(self.module)
+        rows: list[tuple[str, str, bool]] = [
+            ("blocker", type(self.blocker).__name__, isinstance(self.blocker, BlockerFitMixin)),
+            ("matcher", type(self.module).__name__, matcher_trainable),
+            (
+                "calibrator",
+                "<none>" if calibrator is None else type(calibrator).__name__,
+                calibrator is not None and isinstance(calibrator, CalibratorFitMixin),
+            ),
+            ("clusterer", f"threshold={self.clusterer.threshold:g}", False),
+        ]
+        label_w = max(len(label) for label, _, _ in rows) + 1  # +1 for the trailing ":"
+        desc_w = max(len(desc) for _, desc, _ in rows)
+        return "\n".join(
+            f"{label + ':':<{label_w}} {desc:<{desc_w}} — {'TRAINABLE' if trainable else 'frozen'}"
+            for label, desc, trainable in rows
+        )
 
     def fit(
         self,

--- a/src/langres/core/resolver.py
+++ b/src/langres/core/resolver.py
@@ -589,9 +589,11 @@ class Resolver:
                 (``_fit_prompt`` / ``_fit_finetune`` / ``_fit_calibrate``) instead
                 of the isinstance-on-the-module default above; when ``None`` (the
                 default), behavior is exactly the module-hook path described here.
-                Those handlers are thin stubs today -- the concrete per-kind fit
-                paths land in later PRs (prompt in PR-C, finetune in PR-F,
-                calibrate in PR-D).
+                Prompt-optimization is implemented (:class:`~langres.core.methods_prompt.Bootstrap`
+                / :class:`~langres.core.methods_prompt.MIPRO` compile a
+                ``DSPyMatcher``'s prompt -- see :meth:`_fit_prompt`); the
+                fine-tune (PR-F) and calibrate (PR-D) handlers are still stubs
+                that raise a clear NotImplementedError naming their PR.
 
         Returns:
             ``self``, so ``resolver.fit(data).resolve(data)`` chains.
@@ -686,8 +688,9 @@ class Resolver:
     # land in disjoint methods -- prompt-optimize in PR-C, fine-tune in PR-F,
     # calibrate in PR-D -- rather than colliding on one shared branch. Every
     # handler takes the full fit context (data + supervision + split/seed + the
-    # Method itself) so its PR fills in only the body, not the call site. Until
-    # then each is a thin stub raising a clear, PR-naming NotImplementedError.
+    # Method itself) so its PR fills in only the body, not the call site.
+    # ``_fit_prompt`` is implemented; ``_fit_finetune`` / ``_fit_calibrate``
+    # remain thin stubs raising a clear, PR-naming NotImplementedError.
     # ------------------------------------------------------------------
 
     def _fit_prompt(

--- a/tests/core/test_resolver_fit_method.py
+++ b/tests/core/test_resolver_fit_method.py
@@ -93,9 +93,14 @@ def test_finetune_kind_routes_to_pr_f_stub() -> None:
         _resolver().fit(RECORDS, method=_FinetuneMethod())
 
 
-def test_prompt_kind_routes_to_pr_c_stub() -> None:
-    """A ``kind="prompt"`` method routes to a *different* branch (PR-C) -- proves routing."""
-    with pytest.raises(NotImplementedError, match=r"method kind 'prompt'.*lands in PR-C"):
+def test_prompt_kind_routes_to_pr_c_prompt_fit() -> None:
+    """A ``kind="prompt"`` method routes to the real PR-C ``_fit_prompt`` branch.
+
+    ``_fit_prompt`` requires a compilable DSPyMatcher; the no-hook module here is
+    not one, so it raises that clear error -- which *proves routing* (a different
+    branch than finetune/calibrate) without a paid DSPy compile.
+    """
+    with pytest.raises(ValueError, match=r"prompt-optimization needs a DSPyMatcher"):
         _resolver().fit(RECORDS, method=_PromptMethod())
 
 

--- a/tests/core/test_resolver_fit_prompt.py
+++ b/tests/core/test_resolver_fit_prompt.py
@@ -1,0 +1,232 @@
+"""Tests for the prompt-optimize fit path + ``Resolver.describe()`` (PR-C).
+
+Two seams land here on top of the PR-M ``method=`` dispatch:
+
+- **``fit(method=Bootstrap()/MIPRO())``** compiles a ``DSPyMatcher``'s prompt
+  from labeled pairs (the ``method.kind == "prompt"`` branch, now real). Every
+  test runs at ``$0`` with DSPy's ``DummyLM`` on the deterministic
+  ``BootstrapFewShot`` optimizer -- never a paid ``MIPROv2`` compile.
+- **``Resolver.describe()``** -- the pre-fit "what trains vs what is frozen"
+  digest, a pure string builder (no training, no backend import).
+
+The concrete ``MIPRO``/``Bootstrap`` :class:`Method` objects are unit-tested
+here too (kind, optimizer identity, budget-aware ``describe()``, compile-arg
+mapping).
+"""
+
+from collections.abc import Iterator
+
+import pytest
+from dspy.utils.dummies import DummyLM
+
+from langres.core.harvest import LabeledPair
+from langres.core.matcher import Matcher
+from langres.core.matchers.dspy_judge import DSPyMatcher
+from langres.core.methods_api import Method
+from langres.core.methods_prompt import MIPRO, Bootstrap, PromptMethod
+from langres.core.models import CompanySchema, ERCandidate, PairwiseJudgement
+from langres.core.reports import ScoreInspectionReport
+from langres.core.resolver import Resolver
+
+RECORDS = [
+    {"id": "a", "name": "Acme Corp"},
+    {"id": "b", "name": "Acme Corporation"},
+    {"id": "c", "name": "Beta Inc"},
+    {"id": "d", "name": "Beta Incorporated"},
+]
+
+# Two positives (a~b, c~d) + one negative (a!c): enough for BootstrapFewShot to
+# select demos that reproduce the labeled match decision.
+PAIRS = [
+    LabeledPair(left_id="a", right_id="b", score=None, label=True, source="correction"),
+    LabeledPair(left_id="c", right_id="d", score=None, label=True, source="correction"),
+    LabeledPair(left_id="a", right_id="c", score=None, label=False, source="correction"),
+]
+
+_ANSWER = {"reasoning": "same", "match": "True", "match_probability": "0.9"}
+
+
+def _dspy_resolver() -> tuple[Resolver, DSPyMatcher]:
+    """A Resolver whose matcher is a ``DummyLM``-backed (zero-spend) DSPyMatcher."""
+    matcher: DSPyMatcher[CompanySchema] = DSPyMatcher(
+        lm=DummyLM([_ANSWER] * 40), entity_noun="company"
+    )
+    resolver = Resolver.from_schema(CompanySchema, matcher=matcher)
+    return resolver, matcher
+
+
+# --- Method objects: kind, optimizer identity, describe(), compile-arg map ---
+
+
+def test_prompt_methods_share_kind_prompt() -> None:
+    """Both concrete prompt methods route through the ``kind == "prompt"`` branch."""
+    assert Bootstrap.kind == "prompt"
+    assert MIPRO.kind == "prompt"
+    assert issubclass(Bootstrap, PromptMethod) and issubclass(MIPRO, Method)
+
+
+def test_optimizer_is_classvar_not_a_field() -> None:
+    """``optimizer`` is strategy-type identity, not serialized per-instance config."""
+    assert Bootstrap.optimizer == "bootstrap"
+    assert MIPRO.optimizer == "mipro"
+    assert "optimizer" not in MIPRO.model_fields
+    assert "kind" not in MIPRO.model_fields
+
+
+def test_budget_usd_is_a_field_and_defaults_none() -> None:
+    """``budget_usd`` IS serialized config (unlike kind/optimizer) and defaults off."""
+    assert "budget_usd" in Bootstrap.model_fields
+    assert Bootstrap().budget_usd is None
+    assert MIPRO(budget_usd=5.0).budget_usd == 5.0
+
+
+def test_describe_renders_optimizer_and_budget() -> None:
+    """``describe()`` names the optimizer and appends the budget only when set."""
+    assert Bootstrap().describe() == "prompt-optimize (BootstrapFewShot)"
+    assert Bootstrap(budget_usd=5.0).describe() == "prompt-optimize (BootstrapFewShot), budget $5"
+    assert MIPRO().describe() == "prompt-optimize (MIPROv2, auto=light)"
+    assert MIPRO(auto="heavy", budget_usd=2.5).describe() == (
+        "prompt-optimize (MIPROv2, auto=heavy), budget $2.5"
+    )
+
+
+def test_compile_kwargs_maps_auto_for_mipro_only() -> None:
+    """MIPRO threads its ``auto`` preset onto compile; Bootstrap adds nothing."""
+    assert Bootstrap().compile_kwargs() == {}
+    assert MIPRO(auto="medium").compile_kwargs() == {"auto": "medium"}
+
+
+# --- fit(method=Bootstrap()): the zero-spend compile-under-fit happy path ------
+
+
+def test_fit_prompt_compiles_and_sets_report() -> None:
+    """``fit(pairs, method=Bootstrap())`` compiles the DSPy program and reports it."""
+    resolver, matcher = _dspy_resolver()
+    assert matcher.compiled is False
+
+    out = resolver.fit(RECORDS, pairs=PAIRS, method=Bootstrap(budget_usd=5.0))
+
+    assert out is resolver  # chains
+    assert matcher.compiled is True
+    report = resolver.fit_report_
+    assert report is not None
+    assert report.trained is True
+    assert report.n_train == len(PAIRS)
+    # The descriptor names the method, teacher model, and demos learned.
+    assert "prompt-optimize (BootstrapFewShot)" in report.trainable
+    assert f"teacher={matcher.model}" in report.trainable
+    assert f"demos={matcher.n_demos}" in report.trainable
+    # Zero-spend under DummyLM: a declared budget reports $0 observed (see #100).
+    assert report.cost == 0.0
+
+
+def test_fit_prompt_reports_gold_coverage_from_pairs() -> None:
+    """The pairs id-join is reused, so blocking coverage lands in the report."""
+    resolver, _ = _dspy_resolver()
+    resolver.fit(RECORDS, pairs=PAIRS, method=Bootstrap())
+    coverage = resolver.fit_report_.coverage
+    assert coverage is not None
+    assert coverage.gold_coverage == 1.0  # both positives survive AllPairs blocking
+
+
+def test_fit_prompt_no_budget_leaves_cost_unset() -> None:
+    """Without a budget there is no SpendMonitor, so cost stays ``None`` (unmeasured)."""
+    resolver, _ = _dspy_resolver()
+    resolver.fit(RECORDS, pairs=PAIRS, method=Bootstrap())
+    assert resolver.fit_report_.cost is None
+
+
+def test_fit_prompt_accepts_prealigned_labels() -> None:
+    """Pre-aligned ``labels`` feed the trainset directly (no id-join, no coverage)."""
+    resolver, matcher = _dspy_resolver()
+    candidates = resolver.candidates(RECORDS)
+    labels = [True] * len(candidates)
+
+    resolver.fit(RECORDS, labels=labels, method=Bootstrap())
+
+    assert matcher.compiled is True
+    assert resolver.fit_report_.n_train == len(candidates)
+    assert resolver.fit_report_.coverage is None
+
+
+# --- fit(method=...) error contracts -----------------------------------------
+
+
+def test_prompt_method_on_non_dspy_matcher_raises() -> None:
+    """A prompt method needs a compilable DSPyMatcher; a string matcher is rejected."""
+    resolver = Resolver.from_schema(CompanySchema, matcher="string")
+    with pytest.raises(ValueError, match=r"prompt-optimization needs a DSPyMatcher"):
+        resolver.fit(RECORDS, pairs=PAIRS, method=MIPRO(budget_usd=5.0))
+
+
+def test_refitting_compiled_matcher_raises_clear_error() -> None:
+    """DSPy cannot recompile in place -- the second fit gets a clear langres error."""
+    resolver, _ = _dspy_resolver()
+    resolver.fit(RECORDS, pairs=PAIRS, method=Bootstrap())
+    with pytest.raises(ValueError, match=r"already compiled"):
+        resolver.fit(RECORDS, pairs=PAIRS, method=Bootstrap())
+
+
+def test_prompt_fit_rejects_both_labels_and_pairs() -> None:
+    """Supervision is one of labels/pairs, not both -- mirrors the module-hook path."""
+    resolver, _ = _dspy_resolver()
+    with pytest.raises(ValueError, match=r"either labels= .* or pairs="):
+        resolver.fit(RECORDS, labels=[True], pairs=PAIRS, method=Bootstrap())
+
+
+def test_prompt_fit_requires_supervision() -> None:
+    """Prompt-optimization has nothing to tune from without gold labels."""
+    resolver, _ = _dspy_resolver()
+    with pytest.raises(ValueError, match=r"needs gold labels"):
+        resolver.fit(RECORDS, method=Bootstrap())
+
+
+# --- Resolver.describe(): the pre-fit trainable/frozen honesty device ---------
+
+
+class _FitHookMatcher(Matcher[CompanySchema]):
+    """A structural ``SupervisedFitMixin`` matcher (has ``fit(candidates, labels)``)."""
+
+    def fit(self, candidates: Iterator[ERCandidate[CompanySchema]], labels: list[bool]) -> None:
+        pass
+
+    def forward(
+        self, candidates: Iterator[ERCandidate[CompanySchema]]
+    ) -> Iterator[PairwiseJudgement]:
+        yield from ()
+
+    def inspect_scores(
+        self, judgements: list[PairwiseJudgement], sample_size: int = 10
+    ) -> ScoreInspectionReport:
+        raise NotImplementedError
+
+
+def test_describe_tags_frozen_string_pipeline() -> None:
+    """A non-learnable string pipeline: every role frozen, clusterer named by threshold."""
+    resolver = Resolver.from_schema(CompanySchema, matcher="string", threshold=0.5)
+    text = resolver.describe()
+    lines = text.splitlines()
+    assert len(lines) == 4  # blocker / matcher / calibrator / clusterer
+    assert text.count("frozen") == 4
+    assert "TRAINABLE" not in text
+    assert any(line.startswith("matcher:") and "frozen" in line for line in lines)
+    assert any(line.startswith("clusterer:") and "threshold=0.5" in line for line in lines)
+
+
+def test_describe_tags_dspy_matcher_trainable_before_fit() -> None:
+    """A compilable DSPyMatcher reads TRAINABLE even before fit -- the point of describe()."""
+    resolver, _ = _dspy_resolver()
+    matcher_line = next(
+        line for line in resolver.describe().splitlines() if line.startswith("matcher:")
+    )
+    assert "DSPyMatcher" in matcher_line
+    assert "TRAINABLE" in matcher_line
+
+
+def test_describe_tags_supervised_fit_matcher_trainable() -> None:
+    """A ``SupervisedFitMixin`` matcher is TRAINABLE (structural Protocol detection)."""
+    resolver = Resolver.from_schema(CompanySchema, matcher=_FitHookMatcher())
+    matcher_line = next(
+        line for line in resolver.describe().splitlines() if line.startswith("matcher:")
+    )
+    assert "TRAINABLE" in matcher_line


### PR DESCRIPTION
## PR-C — prompt-optimize fit path (`_fit_prompt`) + `Resolver.describe()` + DSPy-compile-under-fit

Part of the **training-surface epic** (#125), into `feat/training-surface`. Fills the `method.kind == "prompt"` seam PR-M stubbed: `resolver.fit(records, pairs, method=MIPRO(...))` now compiles a `DSPyMatcher` under `fit`, and `Resolver.describe()` gives the honesty-device digest (what's trainable vs frozen). Disjoint from PR-F/PR-D (fills only `_fit_prompt`; `_fit_finetune`/`_fit_calibrate` untouched).

### What this adds (6 files, +617/-19)
- **NEW `src/langres/core/methods_prompt.py`** — import-light `PromptMethod` base + `Bootstrap`/`MIPRO` (`kind="prompt"`), carrying `budget_usd`, an `optimizer` ClassVar, and a `compile_kwargs()` hook. Own module → disjoint from PR-F/PR-D's method objects.
- **`src/langres/core/resolver.py`** — fills `_fit_prompt` (align_pairs→trainset or pre-aligned labels → `DSPyMatcher.compile` → `fit_report_`); new `Resolver.describe()`; `_is_prompt_compilable` helper.
- **`src/langres/core/matchers/dspy_judge.py`** — `examples_from_candidates()` (renders identically to `forward()`) + `n_demos` property; `compile()` now threads `auto` (from MIPRO; bootstrap unchanged).
- **`docs/TECHNICAL_OVERVIEW.md`** — "Training strategies: the `method=` seam + `describe()`" subsection.
- **tests** — `test_resolver_fit_prompt.py` (NEW, 15 tests) + updated the prompt-routing test in `test_resolver_fit_method.py`.

### `describe()` sample (DummyLM DSPyMatcher, before fit)
```
blocker:    AllPairsBlocker — frozen
matcher:    DSPyMatcher     — TRAINABLE
calibrator: <none>          — frozen
clusterer:  threshold=0.7   — frozen
```
`FitReport.trainable` sample: `DSPyMatcher (prompt-optimize (BootstrapFewShot), budget $5; teacher=openrouter/openai/gpt-4o-mini, demos=3)`.

### Three deliberate design decisions (accepted by team-lead)
1. **Dropped MIPRO's `metric` field** — `compile`'s metric is hardcoded to `_pair_metric`; a `metric=` knob that can't change compile behavior is dead config + a silent-ignore footgun (simplicity-first). Easy to add later behind a real metric registry.
2. **`budget_usd` is honest-but-inert today** — DSPy-compile spend capture is deferred to #100 (pre-existing: `compile()` already records $0), so the monitor observes $0. The cap seam is wired so real spend flows through once #100 lands; budget is surfaced in `describe()`/the report regardless.
3. **Re-fitting an already-compiled DSPyMatcher raises a clear langres error** instead of DSPy's cryptic `AssertionError: Student must be uncompiled`. Re-enterable prompt rounds need a fresh DSPyMatcher (out of scope; flagged for the flywheel).

### Deferred to the integration PR
Did **not** surface `MIPRO`/`Bootstrap`/`Method`/`FitReport` in `langres.core.__init__` — kept the direct-module-import convention. Public-namespace surfacing is best done uniformly in the `feat/training-surface → main` PR.

### Verification (all green)
- `fit(pairs, method=Bootstrap())` on a DummyLM DSPyMatcher compiles **zero-spend**, sets `fit_report_`; non-DSPy module + MIPRO raises a clear `ValueError`.
- `describe()` returns the per-component digest, works before fit.
- finetune/calibrate/bogus still raise their PR-M stubs (no regression).
- `uv run --all-extras pytest -m "not integration and not slow"` → **2872 passed, 4 skipped**, 98.44% cov. `test_import_budget` → 35 passed (dspy stays lazy).
- `uv run --no-dev --group docs mkdocs build --strict` → exit 0. ruff + mypy strict clean on all 3 src files.

## Summary by Sourcery

Implement prompt-optimization training for DSPy-based matchers and add a pre-fit training digest for resolver pipelines.

New Features:
- Add prompt Method types (Bootstrap and MIPRO) for kind="prompt" training strategies with budget-aware descriptions and compile configuration.
- Implement Resolver._fit_prompt to compile a DSPyMatcher from labeled pairs or pre-aligned labels, producing a FitReport and chaining resolve.
- Introduce Resolver.describe() to report which pipeline components are trainable versus frozen.
- Extend DSPyMatcher with example-building from candidates and a demos-count property for reporting and state inspection.

Enhancements:
- Update DSPyMatcher.compile to accept a configurable MIPRO auto search-budget preset instead of hardcoding it.
- Clarify Resolver.fit documentation around method-based prompt/fine-tune/calibrate dispatch and current implementation status.

Documentation:
- Expand the technical overview with a section describing method-based training strategies and the Resolver.describe() honesty device.

Tests:
- Add a dedicated test suite for the prompt fit path and Resolver.describe(), covering happy paths, error contracts, and method object behavior.
- Adjust method-routing tests to assert that kind="prompt" dispatches to the implemented prompt branch and its error semantics.