### PR TITLE
PR-F: finetune() + QLoRA method + [finetune] extra + GPU-seconds cost (go/no-go F1 0.667→0.927)

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -29,7 +29,10 @@ jobs:
         # symbols that W0.4 made lazy (still statically type-checked via
         # TYPE_CHECKING imports) -- a core-only `uv sync` wouldn't have
         # torch/faiss/litellm/scikit-learn installed for it to check against.
-        run: uv sync --all-extras
+        # --no-extra finetune: peft/trl/bitsandbytes are treated as untyped
+        # (pyproject mypy override) and core.finetune imports them lazily, so the
+        # type check needs neither installed -- keep the heavy/Linux-only deps out.
+        run: uv sync --all-extras --no-extra finetune
 
       - name: Run ruff check
         run: uv run ruff check .

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -31,7 +31,10 @@ jobs:
       - name: Install dependencies
         # --all-extras: scan the [semantic]/[llm] extras' dependencies (torch,
         # litellm, faiss, ...) too, not just the core-only dependency set.
-        run: uv sync --all-extras
+        # --no-extra finetune: keep the heavy/Linux-only QLoRA stack
+        # (peft/trl/bitsandbytes) out of every normal job (it has its own
+        # `test-finetune` job). pip-audit/guarddog here are advisory anyway.
+        run: uv sync --all-extras --no-extra finetune
 
       # pip-audit and guarddog are ADVISORY signals, not merge gates. The hard
       # supply-chain controls are the exclude-newer 7-day quarantine (pyproject)

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -45,10 +45,14 @@ jobs:
         # LLMJudge/RandomForestJudge/etc. (the [semantic]/[llm]/[trained] extras), which
         # W0.4 made optional at runtime but which CI still needs installed to
         # run those tests.
-        run: uv sync --all-extras
+        # --no-extra finetune: the QLoRA training stack (peft/trl/bitsandbytes) is
+        # heavy + Linux/CUDA-fragile and is covered by the dedicated `test-finetune`
+        # job below -- core.finetune imports it lazily, so the fast suite exercises
+        # the finetune orchestration with a fake trainer, no training stack needed.
+        run: uv sync --all-extras --no-extra finetune
 
       - name: Run fast unit tests (excludes slow ML tests)
-        run: uv run pytest -m "not integration and not slow" --cov-fail-under=0
+        run: uv run pytest -m "not integration and not slow and not finetune" --cov-fail-under=0
 
   test-core-only:
     if: github.event_name == 'pull_request'
@@ -123,7 +127,10 @@ jobs:
           enable-cache: true
 
       - name: Install dependencies
-        run: uv sync --all-extras
+        # --no-extra finetune: same rationale as the `test` job -- the QLoRA
+        # training stack is covered by `test-finetune`; core.finetune's lazy
+        # imports keep the full suite green without peft/trl/bitsandbytes here.
+        run: uv sync --all-extras --no-extra finetune
 
       - name: Run full suite incl. slow tests (95% coverage gate)
         # --cov-report=xml (on top of the pyproject default term/html reports)
@@ -131,7 +138,7 @@ jobs:
         # that runs the full suite, so it's the only place coverage is honest --
         # the per-PR `test` job deliberately excludes the slow ML tests, so
         # uploading its partial numbers would understate real coverage.
-        run: uv run pytest -m "not integration" --cov-report=xml
+        run: uv run pytest -m "not integration and not finetune" --cov-report=xml
 
       - name: Upload coverage to Codecov
         # Advisory, never a merge gate: fail_ci_if_error stays false so a Codecov
@@ -141,3 +148,34 @@ jobs:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: ./coverage.xml
           fail_ci_if_error: false
+
+  # The [finetune] extra's OWN job: install the QLoRA training stack (peft/trl/
+  # bitsandbytes) that every other job deliberately excludes (`--no-extra
+  # finetune`) and run the `finetune`-marked tests -- the CPU dry-run that actually
+  # imports peft/trl and trains a tiny LoRA (no GPU). Kept NON-BLOCKING
+  # (`continue-on-error: true`) so a fragile/heavy/Linux-only training dep can
+  # never red-CI the whole training-surface epic; once the QLoRA path is proven
+  # stable this can be promoted to a required check. The real GPU QLoRA train is
+  # `@pytest.mark.slow` + local-only (needs CUDA + bitsandbytes 4-bit), excluded here.
+  test-finetune:
+    if: github.event_name == 'pull_request' || github.event_name == 'workflow_dispatch'
+    runs-on: ubuntu-latest
+    continue-on-error: true
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+
+      - name: Install uv and set the python version
+        uses: astral-sh/setup-uv@v7
+        with:
+          version: "0.11.24"
+          python-version: "3.13"
+          enable-cache: true
+
+      - name: Install dependencies (incl. the [finetune] training stack)
+        run: uv sync --all-extras
+
+      - name: Run finetune tests (CPU dry-run; real GPU train is slow + local-only)
+        run: uv run pytest -m "finetune and not slow" --cov-fail-under=0

--- a/docs/TECHNICAL_OVERVIEW.md
+++ b/docs/TECHNICAL_OVERVIEW.md
@@ -309,9 +309,11 @@ a **blocker's** hyperparameters (e.g. embedding model, `k_neighbors`) to maximiz
 a metric you compute in an objective function.
 
 > There is **no** general `Optimizer` that "compiles"/"finetunes" a whole
-> pipeline — no `compile()`, no `finetune()`, no PyTorch training loop. A general
-> `Optimizer` over full pipelines is roadmap (`docs/ROADMAP.md`), not
-> implemented. DSPy prompt optimization exists separately, inside `DSPyMatcher`
+> *pipeline* — no `compile()`, no pipeline-level training loop; a general
+> `Optimizer` over full pipelines is roadmap (`docs/ROADMAP.md`), not implemented.
+> *Component*-level training does exist, though: `langres.finetune()` QLoRA-fine-tunes
+> a single small-LM matcher (a real peft/trl training loop, `[finetune]` extra) into
+> a servable `model_ref`, and DSPy prompt optimization lives inside `DSPyMatcher`
 > (`[llm]` extra).
 
 **Constructor:**

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -299,14 +299,17 @@ module = ["mlflow.*"]
 ignore_missing_imports = true
 
 [[tool.mypy.overrides]]
-# transformers (present via [semantic]) and peft (the [finetune] extra, absent
-# in a core-only/CI install) back the in-process serve backend (PR-E).
-# transformers ships partial type info that flips typed↔untyped across installs —
-# untyped calls like `AutoModelForCausalLM.from_pretrained` / `model.eval()`
-# alternate between fine and `no-untyped-call` — and peft is simply unresolvable
-# without [finetune]. Treat both as untyped uniformly and skip following their
-# imports, mirroring the litellm/dspy blocks; the backend annotates its own public
-# surface (it holds the model/tokenizer as `Any`).
-module = ["transformers.*", "peft.*", "trl.*", "bitsandbytes.*"]
+# transformers (present via [semantic]) backs the in-process serve backend (PR-E);
+# peft/trl/datasets (the [finetune] extra, absent in a core-only/CI-lint install)
+# back QLoRA training (PR-F). transformers ships partial type info that flips
+# typed↔untyped across installs — untyped calls like
+# `AutoModelForCausalLM.from_pretrained` / `model.eval()` alternate between fine
+# and `no-untyped-call` — and peft/trl/datasets are simply unresolvable without
+# [finetune]. Treat them as untyped uniformly and skip following their imports,
+# mirroring the litellm/dspy blocks; the backend/trainer annotate their own public
+# surface (they hold the model/tokenizer as `Any`). (bitsandbytes is a runtime dep
+# of the extra but never imported by name — its config comes via
+# `transformers.BitsAndBytesConfig` — so it needs no override.)
+module = ["transformers.*", "peft.*", "trl.*", "datasets.*"]
 ignore_missing_imports = true
 follow_imports = "skip"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -87,6 +87,25 @@ trained = [
 eval = [
     "ranx>=0.3.21",
 ]
+# The fine-tune stack -- QLoRA training in core.finetune (peft LoRA adapters +
+# trl SFT). Kept OUT of every normal CI job (they run
+# `uv sync --all-extras --no-extra finetune`); one dedicated `test-finetune` job
+# installs it. peft/trl/bitsandbytes import lazily inside core.finetune (never at
+# module load -- locked by tests/test_import_budget.py). This extra adds only the
+# training-specific deps; it complements `[semantic]` (torch/transformers, used to
+# load + serve the model) and `[llm]` (LLMMatcher serving) -- the full train+serve
+# install is `pip install 'langres[semantic,llm,finetune]'`.
+finetune = [
+    "peft>=0.13",
+    "trl>=0.12",
+    # QLoRA 4-bit quantization is CUDA-only, so scope bitsandbytes to Linux (CI's
+    # runner + the GPU box). On macOS/other platforms core.finetune falls back to
+    # a non-quantized LoRA fine-tune (no 4-bit) so the path still runs locally.
+    "bitsandbytes>=0.44; platform_system == 'Linux'",
+    # NOTE: unsloth is deliberately NOT required here -- it is fragile to install
+    # across platforms/CUDA versions. peft+trl+bitsandbytes is the portable QLoRA
+    # path; install unsloth yourself (`pip install unsloth`) for its speedups.
+]
 # Experiment-tracking backends for the ExperimentTracker seam (core/trackers/).
 # Each is loaded lazily by its adapter (mlflow_tracker.py / wandb_tracker.py) so
 # `import langres` never pulls them -- installing the extra names the fix that
@@ -179,12 +198,13 @@ exclude-newer = "2026-06-18"
 
 [tool.pytest.ini_options]
 minversion = "6.0"
-addopts = "-v --cov=langres --cov-report=term-missing --cov-report=html --cov-fail-under=90 -m 'not integration'"
+addopts = "-v --cov=langres --cov-report=term-missing --cov-report=html --cov-fail-under=90 -m 'not integration and not finetune'"
 testpaths = ["tests"]
 pythonpath = ["src"]
 markers = [
     "slow: marks tests as slow running (e.g., embedding models, ML inference)",
     "integration: marks tests that require external API credentials or resources. DO NOT use for testcontainer database tests (fast enough for continuous testing).",
+    "finetune: marks tests that require the [finetune] extra (peft/trl/bitsandbytes). Run only in the dedicated `test-finetune` CI job (uv sync --all-extras); excluded elsewhere via `--no-extra finetune`.",
 ]
 
 [tool.coverage.run]
@@ -287,6 +307,6 @@ ignore_missing_imports = true
 # without [finetune]. Treat both as untyped uniformly and skip following their
 # imports, mirroring the litellm/dspy blocks; the backend annotates its own public
 # surface (it holds the model/tokenizer as `Any`).
-module = ["transformers.*", "peft.*"]
+module = ["transformers.*", "peft.*", "trl.*", "bitsandbytes.*"]
 ignore_missing_imports = true
 follow_imports = "skip"

--- a/src/langres/__init__.py
+++ b/src/langres/__init__.py
@@ -70,14 +70,17 @@ __all__ = [
     "LinkVerdict",
     "NoMatcherAvailableError",
     "PairwiseJudgement",
+    "QLoRA",
     "Resolver",
     "ReviewQueue",
     "dedupe",
     "derive_threshold",
     "derive_threshold_from_pairs",
+    "finetune",
     "gold_pairs_from_clusters",
     "harvest_labeled_pairs",
     "link",
+    "run_finetune",
     "select_for_review",
 ]
 
@@ -99,6 +102,13 @@ _LAZY_SYMBOLS: dict[str, str] = {
     "EvalReport": "langres.core.eval_report",
     "derive_threshold": "langres.core.calibration",
     "gold_pairs_from_clusters": "langres.core.benchmark",
+    # The finetune surface: the module is import-light (peft/trl/torch import
+    # lazily inside QLoRATrainer.train), so these symbols carry no [finetune] extra
+    # here -- an ImportError from importing the symbols is a genuine bug. The
+    # actionable "pip install langres[finetune]" hint is raised at train time.
+    "QLoRA": "langres.core.finetune",
+    "finetune": "langres.core.finetune",
+    "run_finetune": "langres.core.finetune",
 }
 
 #: ``name -> extra`` for the lazy symbols where a missing dependency has a

--- a/src/langres/core/finetune.py
+++ b/src/langres/core/finetune.py
@@ -1,0 +1,415 @@
+"""``finetune()``: QLoRA fine-tune a small LM on labeled pairs → a weightless ``model_ref``.
+
+The standalone training primitive of the training surface: given labeled candidate
+pairs, fine-tune a small base LM (LoRA / 4-bit QLoRA) to answer the yes/no match
+prompt, and return a :class:`~langres.core.matchers.model_ref.ModelRef` (base +
+adapter) that the existing :class:`~langres.core.matchers.llm_judge.LLMMatcher`
+serves in-process — no new matcher class, no Resolver. ``Resolver.fit(...,
+method=QLoRA(...))`` wraps this (see ``Resolver._fit_finetune``).
+
+**Import-light by construction.** The heavy training stack (``peft`` / ``trl`` /
+``bitsandbytes`` / ``torch`` / ``transformers``) is imported **lazily inside the
+trainer's ``train()``**, never at module load — so ``import langres`` and even
+``import langres.core.finetune`` never pull it (locked by
+``tests/test_import_budget.py``). The :class:`QLoRA` method object is plain
+config; the training mechanics live behind the injectable :class:`FinetuneTrainer`
+seam, so the orchestration (rendering, ref/report assembly, cost) is fully
+testable with a fake trainer and no GPU.
+
+Prompt/target rendering matches serving: each pair becomes a chat conversation
+``[{user: <the LLMMatcher prompt>}, {assistant: "Yes"|"No"}]`` rendered with the
+SAME template + record serializer the served :class:`LLMMatcher` uses, so what the
+model is trained on is exactly what it sees at inference.
+"""
+
+from __future__ import annotations
+
+import time
+from collections.abc import Sequence
+from dataclasses import dataclass
+from pathlib import Path
+from typing import TYPE_CHECKING, Any, Protocol
+
+from pydantic import Field
+
+from langres.core.matchers.model_ref import ModelRef, normalize_model_ref
+from langres.core.methods_api import Method
+
+if TYPE_CHECKING:
+    from langres.core.models import ERCandidate
+
+#: One rendered training example: a chat conversation the trainer tokenizes with
+#: the base model's chat template (``[{"role": "user", ...}, {"role":
+#: "assistant", "content": "Yes"|"No"}]``). Kept as plain dicts so the trainer
+#: seam has no langres-specific coupling.
+Conversation = list[dict[str, str]]
+
+#: The default fine-tune prompt: a yes/no-eliciting template (so the ``"Yes"`` /
+#: ``"No"`` assistant target is natural, and the served matcher's first-token
+#: logprob credence reads real yes/no mass). Used by BOTH training and serving so
+#: they match; ``{left}`` / ``{right}`` are filled with the two rendered records.
+#: Entity-noun-neutral on purpose -- one template serves every domain.
+FINETUNE_YES_NO_PROMPT = (
+    "Do these two records refer to the same real-world entity?\n\n"
+    "Record A:\n{left}\n\n"
+    "Record B:\n{right}\n\n"
+    "Answer with a single word: Yes or No."
+)
+
+#: A labeled candidate pair: ``(candidate, is_match)``. The training input shape,
+#: produced by the caller (``Resolver._fit_finetune`` zips ``align_pairs`` output).
+LabeledCandidate = tuple["ERCandidate[Any]", bool]
+
+
+class QLoRA(Method):
+    """Fine-tune ``base`` with (Q)LoRA — the ``method=`` object for ``kind="finetune"``.
+
+    Carries WHICH base to fine-tune plus the LoRA/QLoRA hyperparameters and the
+    cost knobs. ``base`` lives here (not as a separate ``finetune()`` argument) so
+    one object fully specifies the training for BOTH surfaces — the standalone
+    :func:`finetune` and ``Resolver.fit(method=...)`` (which has no other natural
+    place to name the base). It is plain, import-light config; the heavy training
+    is in :class:`QLoRATrainer`.
+
+    Attributes:
+        base: The model to fine-tune — an HF Hub id or local dir.
+        r / lora_alpha / lora_dropout / target_modules: Standard LoRA knobs
+            (``target_modules=None`` lets peft pick the attention/MLP projections
+            for the architecture).
+        epochs / learning_rate / max_seq_len / batch_size: SFT training knobs.
+        load_in_4bit: Request 4-bit QLoRA quantization. Honored only where CUDA +
+            bitsandbytes are available; on CPU/MPS the trainer falls back to a
+            non-quantized LoRA fine-tune (so the path still runs locally).
+        merge_adapter: Merge the trained adapter into the base weights and return a
+            single local-dir ``model_ref`` (heavier, self-contained) instead of a
+            ``{base, adapter}`` ref (lighter, needs peft to serve).
+        budget_gpu_hours: Advisory GPU-hour budget, surfaced in :meth:`describe`.
+        gpu_hourly_usd: $/GPU-hour used to derive the dollar cost from wall-clock
+            training seconds (``0.0`` — the honest default for local training —
+            yields ``$0``, mirroring the in-process serve path's cost).
+    """
+
+    kind = "finetune"
+
+    base: str
+    r: int = 16
+    lora_alpha: int = 32
+    lora_dropout: float = 0.05
+    target_modules: tuple[str, ...] | None = None
+    epochs: int = 3
+    learning_rate: float = 2e-4
+    max_seq_len: int = 1024
+    batch_size: int = 8
+    load_in_4bit: bool = True
+    merge_adapter: bool = False
+    budget_gpu_hours: float | None = None
+    gpu_hourly_usd: float = Field(default=0.0, ge=0.0)
+
+    def describe(self) -> str:
+        """One-liner: quantization, rank, and the advisory GPU-hour budget."""
+        quant = "4-bit QLoRA" if self.load_in_4bit else "LoRA"
+        budget = f", ~{self.budget_gpu_hours} GPU-hours" if self.budget_gpu_hours else ""
+        return f"fine-tune {self.base} ({quant} r={self.r}{budget})"
+
+
+@dataclass(frozen=True)
+class TrainOutcome:
+    """What a :class:`FinetuneTrainer` reports back after training.
+
+    ``adapter_dir`` is where the LoRA adapter (or merged model) was written;
+    ``merged`` says which — an adapter to load on top of ``base`` (``False``) or a
+    standalone merged model directory (``True``). ``train_seconds`` is the
+    wall-clock training time (the GPU-seconds cost fact); ``device`` records where
+    it ran (``"cuda"`` / ``"mps"`` / ``"cpu"``) for honest reporting.
+    """
+
+    adapter_dir: str
+    train_seconds: float
+    n_train: int
+    merged: bool
+    device: str
+
+
+class FinetuneTrainer(Protocol):
+    """The injectable training mechanics seam (kept out of the orchestration).
+
+    A trainer turns ``(base, conversations, method)`` into a saved adapter/model
+    under ``output_dir`` and reports a :class:`TrainOutcome`. The default
+    :class:`QLoRATrainer` runs peft/trl; tests inject a fake so the orchestration
+    is exercised with no GPU and no training stack imported.
+    """
+
+    def train(
+        self,
+        base: str,
+        conversations: list[Conversation],
+        method: QLoRA,
+        output_dir: str,
+    ) -> TrainOutcome: ...
+
+
+@dataclass(frozen=True)
+class FinetuneOutcome:
+    """The result of :func:`run_finetune`: the served ref plus its cost digest.
+
+    :func:`finetune` returns just the ``model_ref``; ``run_finetune`` returns this
+    fuller outcome so a caller (and ``Resolver._fit_finetune``) can read the
+    GPU-seconds, derived dollars, and merge status for a :class:`FitReport`.
+    """
+
+    model_ref: ModelRef
+    base: str
+    method: str
+    gpu_seconds: float
+    dollars: float
+    n_train: int
+    merged: bool
+    device: str
+
+
+def _yes_no(label: bool) -> str:
+    """The assistant target for the binary yes/no match protocol."""
+    return "Yes" if label else "No"
+
+
+def _render_conversation(
+    candidate: ERCandidate[Any],
+    label: bool,
+    *,
+    prompt_template: str,
+    record_serializer: Any | str | None,
+) -> Conversation:
+    """Render one labeled pair to a chat conversation matching the served prompt.
+
+    Reuses the LLMMatcher's own ``{left}``/``{right}`` substitution + record
+    serializer (lazily imported) so the training text is byte-identical to what the
+    served matcher sends, then appends the ``"Yes"``/``"No"`` assistant target.
+    Building a throwaway ``LLMMatcher`` (client-free) is the single source of truth
+    for the rendering — no drift.
+    """
+    # Lazy: importing llm_judge pulls litellm ([llm]); keep it out of module load.
+    from langres.core.matchers.llm_judge import LLMMatcher
+
+    renderer: LLMMatcher[Any] = LLMMatcher(
+        client=object(),
+        prompt_template=prompt_template,
+        record_serializer=record_serializer,
+    )
+    user_prompt = renderer._render_prompt(
+        renderer._serialize(candidate.left), renderer._serialize(candidate.right)
+    )
+    return [
+        {"role": "user", "content": user_prompt},
+        {"role": "assistant", "content": _yes_no(label)},
+    ]
+
+
+def run_finetune(
+    pairs: Sequence[LabeledCandidate],
+    method: QLoRA,
+    *,
+    output_dir: str | Path | None = None,
+    trainer: FinetuneTrainer | None = None,
+    prompt_template: str | None = None,
+    record_serializer: Any | str | None = None,
+) -> FinetuneOutcome:
+    """Fine-tune ``method.base`` on labeled ``pairs`` and return the served-ref digest.
+
+    Orchestration only — the heavy training is delegated to ``trainer`` (default
+    :class:`QLoRATrainer`, lazy peft/trl). Renders each pair to a yes/no chat
+    conversation (matching serving), trains, and assembles the
+    :class:`FinetuneOutcome` (ref + GPU-seconds + derived dollars + merge status).
+
+    Args:
+        pairs: Labeled candidate pairs ``(candidate, is_match)``.
+        method: The :class:`QLoRA` spec (base + hyperparameters + cost knobs).
+        output_dir: Where to write the adapter/model. Defaults to a fresh temp
+            directory (it must outlive this call so the ref can be served).
+        trainer: Injected training mechanics; defaults to :class:`QLoRATrainer`.
+        prompt_template: The ``{left}``/``{right}`` template; defaults to
+            :data:`FINETUNE_YES_NO_PROMPT`. Serve the resulting model with the SAME
+            template (``Resolver._fit_finetune`` does).
+        record_serializer: How each record renders into the prompt (forwarded to
+            the throwaway renderer so training matches serving).
+
+    Raises:
+        ValueError: If ``pairs`` is empty (nothing to train on).
+    """
+    materialized = list(pairs)
+    if not materialized:
+        raise ValueError("finetune requires at least one labeled pair to train on")
+
+    template = prompt_template if prompt_template is not None else FINETUNE_YES_NO_PROMPT
+    conversations = [
+        _render_conversation(
+            candidate,
+            label,
+            prompt_template=template,
+            record_serializer=record_serializer,
+        )
+        for candidate, label in materialized
+    ]
+
+    if output_dir is None:
+        import tempfile
+
+        output_dir = tempfile.mkdtemp(prefix="langres-finetune-")
+    output_dir = str(output_dir)
+
+    active_trainer = trainer if trainer is not None else QLoRATrainer()
+    outcome = active_trainer.train(method.base, conversations, method, output_dir)
+
+    model_ref = (
+        normalize_model_ref(outcome.adapter_dir)
+        if outcome.merged
+        else ModelRef(base=method.base, adapter=outcome.adapter_dir)
+    )
+    dollars = outcome.train_seconds / 3600.0 * method.gpu_hourly_usd
+    return FinetuneOutcome(
+        model_ref=model_ref,
+        base=method.base,
+        method=method.describe(),
+        gpu_seconds=outcome.train_seconds,
+        dollars=dollars,
+        n_train=outcome.n_train,
+        merged=outcome.merged,
+        device=outcome.device,
+    )
+
+
+def finetune(
+    pairs: Sequence[LabeledCandidate],
+    method: QLoRA,
+    *,
+    output_dir: str | Path | None = None,
+    trainer: FinetuneTrainer | None = None,
+    prompt_template: str | None = None,
+    record_serializer: Any | str | None = None,
+) -> ModelRef:
+    """Fine-tune ``method.base`` on labeled ``pairs`` → a weightless ``model_ref``.
+
+    The standalone primitive (plan example 3): returns a
+    :class:`~langres.core.matchers.model_ref.ModelRef` you serve through
+    ``LLMMatcher(model=ref)`` (in-process) or ``vllm serve`` — NOT a Resolver, NOT
+    a new component. Use :func:`run_finetune` instead when you also want the cost
+    digest (GPU-seconds / dollars / merge status); ``Resolver.fit(...,
+    method=QLoRA(...))`` builds the full :class:`FitReport`.
+
+    ``base`` lives on the ``QLoRA`` method (not a separate argument) so one object
+    fully specifies the training for both this primitive and the ``Resolver.fit``
+    surface. See :func:`run_finetune` for the arguments (identical) and errors.
+    """
+    return run_finetune(
+        pairs,
+        method,
+        output_dir=output_dir,
+        trainer=trainer,
+        prompt_template=prompt_template,
+        record_serializer=record_serializer,
+    ).model_ref
+
+
+class QLoRATrainer:
+    """Default :class:`FinetuneTrainer`: peft LoRA + trl SFT, 4-bit where CUDA allows.
+
+    All heavy imports (``torch`` / ``transformers`` / ``peft`` / ``trl`` /
+    ``bitsandbytes``) happen **inside** :meth:`train`, first-use only — importing
+    this class costs nothing. 4-bit QLoRA is used only when CUDA + bitsandbytes are
+    present; on CPU/MPS it falls back to a non-quantized LoRA fine-tune so the path
+    runs locally (the ``[finetune]`` extra scopes bitsandbytes to Linux for this
+    reason). Trains completion-only (the ``"Yes"``/``"No"`` assistant span) on the
+    base model's chat template, matching serving.
+    """
+
+    def train(  # pragma: no cover - real training runs in the test-finetune job / on GPU
+        self,
+        base: str,
+        conversations: list[Conversation],
+        method: QLoRA,
+        output_dir: str,
+    ) -> TrainOutcome:
+        # Lazy, first-use only: never import the training stack at module load.
+        try:
+            import torch
+            from datasets import Dataset
+            from peft import LoraConfig
+            from transformers import AutoModelForCausalLM, AutoTokenizer
+            from trl import SFTConfig, SFTTrainer
+        except ImportError as exc:
+            raise ImportError(
+                "QLoRA fine-tuning needs the training stack (peft + trl + "
+                "transformers/torch). Install it with `pip install "
+                "'langres[semantic,llm,finetune]'` (or `uv add ...`)."
+            ) from exc
+
+        device = (
+            "cuda"
+            if torch.cuda.is_available()
+            else ("mps" if torch.backends.mps.is_available() else "cpu")
+        )
+        use_4bit = method.load_in_4bit and device == "cuda"
+
+        tokenizer = AutoTokenizer.from_pretrained(base)
+        if tokenizer.pad_token_id is None:
+            tokenizer.pad_token = tokenizer.eos_token
+
+        model_kwargs: dict[str, Any] = {}
+        if use_4bit:
+            from transformers import BitsAndBytesConfig
+
+            model_kwargs["quantization_config"] = BitsAndBytesConfig(
+                load_in_4bit=True,
+                bnb_4bit_quant_type="nf4",
+                bnb_4bit_compute_dtype=torch.bfloat16,
+                bnb_4bit_use_double_quant=True,
+            )
+        model = AutoModelForCausalLM.from_pretrained(base, **model_kwargs)
+
+        lora = LoraConfig(
+            r=method.r,
+            lora_alpha=method.lora_alpha,
+            lora_dropout=method.lora_dropout,
+            target_modules=list(method.target_modules) if method.target_modules else None,
+            task_type="CAUSAL_LM",
+        )
+        dataset = Dataset.from_dict({"messages": conversations})
+        sft_config = SFTConfig(
+            output_dir=output_dir,
+            num_train_epochs=method.epochs,
+            per_device_train_batch_size=method.batch_size,
+            learning_rate=method.learning_rate,
+            max_length=method.max_seq_len,
+            assistant_only_loss=True,
+            report_to=[],
+            logging_steps=1,
+        )
+        sft_trainer = SFTTrainer(
+            model=model,
+            args=sft_config,
+            train_dataset=dataset,
+            peft_config=lora,
+            processing_class=tokenizer,
+        )
+
+        start = time.perf_counter()
+        sft_trainer.train()
+        train_seconds = time.perf_counter() - start
+
+        adapter_dir = output_dir
+        merged = False
+        if method.merge_adapter:
+            merged_model = sft_trainer.model.merge_and_unload()
+            merged_model.save_pretrained(output_dir)
+            tokenizer.save_pretrained(output_dir)
+            merged = True
+        else:
+            sft_trainer.model.save_pretrained(output_dir)
+            tokenizer.save_pretrained(output_dir)
+
+        return TrainOutcome(
+            adapter_dir=adapter_dir,
+            train_seconds=train_seconds,
+            n_train=len(conversations),
+            merged=merged,
+            device=device,
+        )

--- a/src/langres/core/finetune.py
+++ b/src/langres/core/finetune.py
@@ -364,6 +364,12 @@ class QLoRATrainer:
             else ("mps" if torch.backends.mps.is_available() else "cpu")
         )
         use_4bit = method.load_in_4bit and device == "cuda"
+        # Pin precision explicitly. trl/transformers otherwise auto-enable bf16 from
+        # a CUDA torch *build*, which then errors on a GPU-less runner ("Your setup
+        # doesn't support bf16/gpu") -- CI installs the CUDA wheel but has no GPU. Use
+        # bf16 only on a real bf16-capable CUDA GPU; CPU/MPS train in fp32. (device ==
+        # "cuda" is checked first so is_bf16_supported() runs only when CUDA exists.)
+        use_bf16 = device == "cuda" and torch.cuda.is_bf16_supported()
 
         tokenizer = AutoTokenizer.from_pretrained(base)
         if tokenizer.pad_token_id is None:
@@ -412,6 +418,8 @@ class QLoRATrainer:
             per_device_train_batch_size=method.batch_size,
             learning_rate=method.learning_rate,
             max_length=method.max_seq_len,
+            bf16=use_bf16,
+            fp16=False,
             report_to=[],
             logging_steps=1,
         )

--- a/src/langres/core/finetune.py
+++ b/src/langres/core/finetune.py
@@ -317,8 +317,17 @@ class QLoRATrainer:
     this class costs nothing. 4-bit QLoRA is used only when CUDA + bitsandbytes are
     present; on CPU/MPS it falls back to a non-quantized LoRA fine-tune so the path
     runs locally (the ``[finetune]`` extra scopes bitsandbytes to Linux for this
-    reason). Trains completion-only (the ``"Yes"``/``"No"`` assistant span) on the
-    base model's chat template, matching serving.
+    reason).
+
+    Trains full-sequence SFT on the yes/no chat conversation rendered with the base
+    model's own chat template (matching serving). Full-sequence — *not*
+    ``assistant_only_loss`` — deliberately: trl's assistant-only masking needs a
+    chat template carrying ``{% generation %}`` markers (or one on trl's short
+    hardcoded patch-list, effectively Qwen-only), which most small base LMs
+    (SmolLM2, Llama-family, ...) lack, so it raises at trainer construction. Since
+    langres must fine-tune *arbitrary* small bases, we train on the whole
+    (fixed-prefix) conversation; the discriminative signal is the final ``"Yes"`` /
+    ``"No"`` token and the constant prompt prefix is trivially learned.
     """
 
     def train(  # pragma: no cover - real training runs in the test-finetune job / on GPU
@@ -379,7 +388,6 @@ class QLoRATrainer:
             per_device_train_batch_size=method.batch_size,
             learning_rate=method.learning_rate,
             max_length=method.max_seq_len,
-            assistant_only_loss=True,
             report_to=[],
             logging_steps=1,
         )

--- a/src/langres/core/finetune.py
+++ b/src/langres/core/finetune.py
@@ -319,15 +319,22 @@ class QLoRATrainer:
     runs locally (the ``[finetune]`` extra scopes bitsandbytes to Linux for this
     reason).
 
-    Trains full-sequence SFT on the yes/no chat conversation rendered with the base
-    model's own chat template (matching serving). Full-sequence — *not*
-    ``assistant_only_loss`` — deliberately: trl's assistant-only masking needs a
-    chat template carrying ``{% generation %}`` markers (or one on trl's short
-    hardcoded patch-list, effectively Qwen-only), which most small base LMs
-    (SmolLM2, Llama-family, ...) lack, so it raises at trainer construction. Since
-    langres must fine-tune *arbitrary* small bases, we train on the whole
-    (fixed-prefix) conversation; the discriminative signal is the final ``"Yes"`` /
-    ``"No"`` token and the constant prompt prefix is trivially learned.
+    Trains COMPLETION-ONLY on the yes/no target using trl's prompt-completion
+    dataset format: the ``prompt`` is the user turn rendered with the base model's
+    own chat template + a generation prompt (byte-identical to what the served chat
+    model sees), and the ``completion`` is the bare ``"Yes"``/``"No"``. trl masks
+    the prompt tokens (``completion_only_loss`` defaults on for prompt-completion
+    data), so the gradient lands on the answer token.
+
+    This is *not* ``assistant_only_loss``: that needs a chat template carrying
+    ``{% generation %}`` markers (or one on trl's short hardcoded patch-list,
+    effectively Qwen-only), which most small bases (SmolLM2, Llama-family, ...)
+    lack, so it raises at trainer construction. And it is *not* full-sequence loss
+    either: with the one-token answer buried in a ~30-token prompt, full-sequence
+    loss spends nearly all its gradient reproducing the constant prompt and learns
+    no yes/no discrimination (measured: p_yes separation ~0.016 before AND after).
+    Completion-only masking is the portable middle path -- it works on any base and
+    still puts the signal on the decision token.
     """
 
     def train(  # pragma: no cover - real training runs in the test-finetune job / on GPU
@@ -381,7 +388,24 @@ class QLoRATrainer:
             target_modules=list(method.target_modules) if method.target_modules else None,
             task_type="CAUSAL_LM",
         )
-        dataset = Dataset.from_dict({"messages": conversations})
+        # Prompt-completion format (NOT a "messages" dataset): pre-apply the chat
+        # template to the user turn with a generation prompt, and hand the Yes/No as
+        # a bare completion. trl then trains COMPLETION-ONLY (``completion_only_loss``
+        # defaults on for prompt-completion data) -- the gradient lands on the answer
+        # token, not the constant prompt -- WITHOUT needing the ``{% generation %}``
+        # chat-template markers ``assistant_only_loss`` requires (which most small
+        # bases lack). The prompt is byte-identical to what the served chat model
+        # sees, so the first-token logprob probe reads the trained Yes/No mass.
+        prompt_completions = [
+            {
+                "prompt": tokenizer.apply_chat_template(
+                    [convo[0]], tokenize=False, add_generation_prompt=True
+                ),
+                "completion": convo[1]["content"],
+            }
+            for convo in conversations
+        ]
+        dataset = Dataset.from_list(prompt_completions)
         sft_config = SFTConfig(
             output_dir=output_dir,
             num_train_epochs=method.epochs,

--- a/src/langres/core/fit_report.py
+++ b/src/langres/core/fit_report.py
@@ -52,8 +52,16 @@ class FitReport(BaseModel):
             nothing trained.
         threshold: The clusterer decision threshold in force, or ``None``.
         metrics: Held-out pair P/R/F1 on ``valid``, or ``None`` when no split.
-        cost: Tokens/$ or GPU-seconds when a paid/GPU fit ran (filled by later
-            PRs), else ``None``.
+        cost: The derived dollar cost of a paid/GPU fit (tokens→$ or
+            GPU-seconds→$), else ``None``. For a local fine-tune with no
+            ``$/GPU-hour`` rate configured this is ``0.0`` (honest, like the
+            in-process serve path).
+        gpu_seconds: Wall-clock training seconds for a fine-tune fit (the
+            GPU-seconds cost *fact* ``cost`` is derived from), else ``None``.
+        model_ref: The weightless model reference a fine-tune produced (a base id
+            / local dir string, or a ``{base, adapter}`` dict whose shape also
+            encodes merge status), else ``None``. Serialize with
+            :func:`~langres.core.matchers.model_ref.to_config`.
         run_ref: The enclosing run's ``attempt_id`` (lineage reference to the
             machine :class:`~langres.core.runs.RunRecord`), or ``None``.
     """
@@ -69,6 +77,8 @@ class FitReport(BaseModel):
     threshold: float | None = None
     metrics: PairMetrics | None = None
     cost: float | None = None
+    gpu_seconds: float | None = None
+    model_ref: str | dict[str, str] | None = None
     run_ref: str | None = None
 
     @classmethod
@@ -85,6 +95,8 @@ class FitReport(BaseModel):
         threshold: float | None = None,
         metrics: PairMetrics | None = None,
         cost: float | None = None,
+        gpu_seconds: float | None = None,
+        model_ref: str | dict[str, str] | None = None,
         run_ref: str | None = None,
     ) -> FitReport:
         """Assemble a FitReport from the artefacts of one ``fit()`` call.
@@ -105,6 +117,8 @@ class FitReport(BaseModel):
             threshold=threshold,
             metrics=metrics,
             cost=cost,
+            gpu_seconds=gpu_seconds,
+            model_ref=model_ref,
             run_ref=run_ref,
         )
 
@@ -138,8 +152,12 @@ class FitReport(BaseModel):
         ]
         if self.threshold is not None:
             lines.append(f"- Threshold: {self.threshold:.4f}")
+        if self.model_ref is not None:
+            lines.append(f"- Model ref: {self.model_ref}")
+        if self.gpu_seconds is not None:
+            lines.append(f"- GPU-seconds: {self.gpu_seconds:.1f}")
         if self.cost is not None:
-            lines.append(f"- Cost: {self.cost}")
+            lines.append(f"- Cost: ${self.cost}")
         if self.run_ref is not None:
             lines.append(f"- Run: {self.run_ref}")
         lines.append("")

--- a/src/langres/core/resolver.py
+++ b/src/langres/core/resolver.py
@@ -849,7 +849,7 @@ class Resolver:
             ValueError: If neither ``pairs`` nor ``labels`` is given (fine-tuning
                 needs supervision), or both are.
         """
-        from langres.core.finetune import QLoRA, run_finetune
+        from langres.core.finetune import FINETUNE_YES_NO_PROMPT, QLoRA, run_finetune
         from langres.core.matchers.llm_judge import LLMMatcher
         from langres.core.matchers.model_ref import to_config
 
@@ -884,7 +884,14 @@ class Resolver:
         # Preserve the outgoing matcher's record rendering (so what the model is
         # trained on matches what it is served) when it is an LLMMatcher.
         render = self._llm_render_config()
-        outcome = run_finetune(train_pairs, method, **render)
+        # Train AND serve on the SAME yes/no prompt: the model learns the
+        # FINETUNE_YES_NO_PROMPT completion, so the served matcher must send that
+        # prompt (not LLMMatcher's default "Score:" template) and read it with the
+        # binary yes/no parser -- otherwise serving asks a differently-worded
+        # question than training taught.
+        outcome = run_finetune(
+            train_pairs, method, prompt_template=FINETUNE_YES_NO_PROMPT, **render
+        )
 
         # Repoint this Resolver at the fine-tuned model: an in-process,
         # logprob-scoring yes/no LLMMatcher over the produced model_ref.
@@ -892,6 +899,7 @@ class Resolver:
             model=to_config(outcome.model_ref),
             confidence="logprob",
             response_parser="binary_yes_no",
+            prompt_template=FINETUNE_YES_NO_PROMPT,
             **render,
         )
 
@@ -921,15 +929,15 @@ class Resolver:
         return self
 
     def _llm_render_config(self) -> dict[str, Any]:
-        """The current matcher's prompt/serializer config to keep train == serve.
+        """The current matcher's record serializer, to keep train == serve.
 
         When ``self.module`` is an :class:`~langres.core.matchers.llm_judge.LLMMatcher`
         this carries its ``record_serializer`` (by registered name) so a fine-tune
-        renders records the way they will be served; the yes/no prompt is the
-        finetune default (see :data:`~langres.core.finetune.FINETUNE_YES_NO_PROMPT`),
-        so ``prompt_template`` is intentionally left to that default rather than the
-        outgoing matcher's (which may be the ``Score:`` scoring prompt). Empty for a
-        non-LLM matcher (the finetune defaults apply).
+        renders records the way they will be served. Only the serializer -- NOT the
+        ``prompt_template``: ``_fit_finetune`` pins both training and serving to
+        :data:`~langres.core.finetune.FINETUNE_YES_NO_PROMPT` (the outgoing matcher's
+        prompt may be the ``Score:`` scoring template, which the yes/no fine-tune
+        does not use). Empty for a non-LLM matcher (the finetune defaults apply).
         """
         from langres.core.matchers.llm_judge import LLMMatcher
 

--- a/src/langres/core/resolver.py
+++ b/src/langres/core/resolver.py
@@ -830,16 +830,112 @@ class Resolver:
         seed: int,
         method: Method,
     ) -> Self:
-        """Fit via fine-tuning (``method.kind == "finetune"``) -- STUB.
+        """Fit via fine-tuning (``method.kind == "finetune"``): QLoRA train → serve.
 
-        Wired into ``fit``'s ``method=`` dispatch; the concrete QLoRA fine-tune
-        body (with GPU-seconds cost) lands in PR-F. Until then this raises with
-        that pointer.
+        Aligns the labeled ``pairs`` to candidates, fine-tunes ``method.base`` on
+        them (:func:`~langres.core.finetune.run_finetune`), repoints this
+        Resolver's matcher at the resulting ``model_ref`` as an in-process,
+        logprob-scoring :class:`~langres.core.matchers.llm_judge.LLMMatcher`, and
+        evaluates held-out pair P/R/F1 on the entity-disjoint ``valid`` split.
+        Records the GPU-seconds / derived-$ cost and the served ``model_ref`` in
+        :attr:`fit_report_`.
+
+        Heavy imports (``core.finetune`` → peft/trl on the training call;
+        ``LLMMatcher`` → litellm) are deferred to here so the ``method=None`` and
+        non-finetune fit paths never pay for them.
+
+        Raises:
+            TypeError: If ``method`` is not a :class:`~langres.core.finetune.QLoRA`.
+            ValueError: If neither ``pairs`` nor ``labels`` is given (fine-tuning
+                needs supervision), or both are.
         """
-        raise NotImplementedError(
-            f"method kind 'finetune' dispatch is wired but its fit path lands in "
-            f"PR-F ({method.describe()})."
+        from langres.core.finetune import QLoRA, run_finetune
+        from langres.core.matchers.llm_judge import LLMMatcher
+        from langres.core.matchers.model_ref import to_config
+
+        if not isinstance(method, QLoRA):
+            raise TypeError(
+                f"method kind 'finetune' requires a QLoRA method; got "
+                f"{type(method).__name__} ({method.describe()})."
+            )
+        if labels is not None and pairs is not None:
+            raise ValueError("pass either labels= or pairs= to a finetune fit, not both.")
+        if labels is None and pairs is None:
+            raise ValueError(
+                "fine-tuning needs labeled supervision: pass pairs=<id-keyed labels> "
+                "(align_pairs joins them + gives a held-out split) or "
+                "labels=<Sequence[bool] aligned with the blocked candidates>."
+            )
+
+        candidates = self.candidates(data)
+        coverage = None
+        if pairs is not None:
+            aligned = align_pairs(candidates, pairs, split=split, seed=seed)
+            train_pairs = list(zip(aligned.train.candidates, aligned.train.labels, strict=True))
+            valid_pairs = list(zip(aligned.valid.candidates, aligned.valid.labels, strict=True))
+            coverage = aligned.coverage
+            n_valid = len(aligned.valid.labels)
+        else:
+            train_pairs = list(zip(candidates, cast("Sequence[bool]", labels), strict=True))
+            valid_pairs = []
+            n_valid = 0
+            split = None
+
+        # Preserve the outgoing matcher's record rendering (so what the model is
+        # trained on matches what it is served) when it is an LLMMatcher.
+        render = self._llm_render_config()
+        outcome = run_finetune(train_pairs, method, **render)
+
+        # Repoint this Resolver at the fine-tuned model: an in-process,
+        # logprob-scoring yes/no LLMMatcher over the produced model_ref.
+        self.module = LLMMatcher(
+            model=to_config(outcome.model_ref),
+            confidence="logprob",
+            response_parser="binary_yes_no",
+            **render,
         )
+
+        metrics: PairMetrics | None = None
+        if valid_pairs:
+            judgements = list(self.module.forward(iter([c for c, _ in valid_pairs])))
+            gold_pairs = {
+                frozenset({str(c.left.id), str(c.right.id)}) for c, label in valid_pairs if label
+            }
+            metrics = classify_pairs(judgements, gold_pairs, self.clusterer.threshold)
+
+        self.fit_report_ = FitReport.build(
+            trainable=f"LLMMatcher (finetune: {outcome.method})",
+            trained=True,
+            n_train=outcome.n_train,
+            n_valid=n_valid,
+            split=split,
+            seed=seed,
+            coverage=coverage,
+            threshold=self.clusterer.threshold,
+            metrics=metrics,
+            cost=outcome.dollars,
+            gpu_seconds=outcome.gpu_seconds,
+            model_ref=to_config(outcome.model_ref),
+            run_ref=current_run.get(),
+        )
+        return self
+
+    def _llm_render_config(self) -> dict[str, Any]:
+        """The current matcher's prompt/serializer config to keep train == serve.
+
+        When ``self.module`` is an :class:`~langres.core.matchers.llm_judge.LLMMatcher`
+        this carries its ``record_serializer`` (by registered name) so a fine-tune
+        renders records the way they will be served; the yes/no prompt is the
+        finetune default (see :data:`~langres.core.finetune.FINETUNE_YES_NO_PROMPT`),
+        so ``prompt_template`` is intentionally left to that default rather than the
+        outgoing matcher's (which may be the ``Score:`` scoring prompt). Empty for a
+        non-LLM matcher (the finetune defaults apply).
+        """
+        from langres.core.matchers.llm_judge import LLMMatcher
+
+        if isinstance(self.module, LLMMatcher):
+            return {"record_serializer": self.module.config["record_serializer"]}
+        return {}
 
     def _fit_calibrate(
         self,

--- a/tests/core/test_finetune.py
+++ b/tests/core/test_finetune.py
@@ -26,7 +26,7 @@ from langres.core.finetune import (
     run_finetune,
 )
 from langres.core.matchers.model_ref import ModelRef
-from langres.core.models import CompanySchema
+from langres.core.models import CompanySchema, ERCandidate
 
 RECORDS = [
     {"id": "a", "name": "Acme Corp"},
@@ -306,3 +306,107 @@ def test_qlora_trainer_cpu_dry_run(tmp_path: Path) -> None:
     assert outcome.model_ref.base == "HuggingFaceTB/SmolLM2-135M-Instruct"
     assert outcome.model_ref.adapter is not None
     assert Path(outcome.model_ref.adapter).is_dir()
+
+
+# --- The full go/no-go: train -> save -> reload -> serve in-process -> evaluate ---
+
+_MATCH_NAMES = [
+    ("Acme Corp", "Acme Corporation"),
+    ("Globex Inc", "Globex Incorporated"),
+    ("Initech LLC", "Initech Limited"),
+    ("Umbrella Co", "Umbrella Company"),
+    ("Soylent Corp", "Soylent Corporation"),
+    ("Stark Industries", "Stark Ind."),
+    ("Wayne Enterprises", "Wayne Enterprise"),
+    ("Wonka Ltd", "Wonka Limited"),
+    ("Cyberdyne Systems", "Cyberdyne Sys"),
+    ("Tyrell Corp", "Tyrell Corporation"),
+]
+_NON_NAMES = [
+    ("Acme Corp", "Globex Inc"),
+    ("Initech LLC", "Umbrella Co"),
+    ("Soylent Corp", "Stark Industries"),
+    ("Wayne Enterprises", "Wonka Ltd"),
+    ("Cyberdyne Systems", "Tyrell Corp"),
+    ("Acme Corp", "Umbrella Co"),
+    ("Globex Inc", "Stark Industries"),
+    ("Initech LLC", "Wonka Ltd"),
+    ("Soylent Corp", "Tyrell Corp"),
+    ("Wayne Enterprises", "Cyberdyne Systems"),
+]
+
+
+def _balanced_pairs() -> list[tuple[ERCandidate[CompanySchema], bool]]:
+    """10 matching name-variant pairs + 10 non-matching pairs (balanced overfit set)."""
+    pairs: list[tuple[ERCandidate[CompanySchema], bool]] = []
+    for i, (left, right) in enumerate(_MATCH_NAMES):
+        c = ERCandidate(
+            left=CompanySchema(id=f"m{i}L", name=left),
+            right=CompanySchema(id=f"m{i}R", name=right),
+            blocker_name="test",
+        )
+        pairs.append((c, True))
+    for i, (left, right) in enumerate(_NON_NAMES):
+        c = ERCandidate(
+            left=CompanySchema(id=f"n{i}L", name=left),
+            right=CompanySchema(id=f"n{i}R", name=right),
+            blocker_name="test",
+        )
+        pairs.append((c, False))
+    return pairs
+
+
+def _serve_scores(model_cfg: Any, pairs: list[tuple[ERCandidate[CompanySchema], bool]]) -> Any:
+    """Serve ``model_cfg`` in-process on the yes/no prompt; return (F1, p_yes separation)."""
+    from langres.core.matchers.llm_judge import LLMMatcher
+    from langres.core.metrics import classify_pairs
+
+    matcher: LLMMatcher[Any] = LLMMatcher(
+        model=model_cfg,
+        confidence="logprob",
+        response_parser="binary_yes_no",
+        prompt_template=FINETUNE_YES_NO_PROMPT,
+    )
+    judgements = list(matcher.forward(iter([c for c, _ in pairs])))
+    gold = {frozenset({str(c.left.id), str(c.right.id)}) for c, y in pairs if y}
+    metrics = classify_pairs(judgements, gold, 0.5)
+    pos = [j.provenance["p_yes"] for (_, y), j in zip(pairs, judgements, strict=True) if y]
+    neg = [j.provenance["p_yes"] for (_, y), j in zip(pairs, judgements, strict=True) if not y]
+    separation = sum(pos) / len(pos) - sum(neg) / len(neg)
+    return metrics.f1, separation
+
+
+@pytest.mark.slow
+@pytest.mark.finetune
+def test_finetune_overfit_train_serve_evaluate() -> None:
+    """The whole loop learns: real QLoRA train -> reload -> in-process serve beats the base.
+
+    The go/no-go for the fine-tune surface. Fine-tunes SmolLM2-135M (real peft LoRA +
+    trl completion-only SFT) on 20 balanced yes/no pairs, reloads the produced
+    base+adapter ``model_ref``, serves it IN-PROCESS with the same finetune prompt +
+    logprob probe, and asserts the fine-tuned model scores the overfit set *and*
+    separates match/non-match ``p_yes`` **better than the untrained base** -- i.e.
+    training actually moved the served decisions (not just that the plumbing runs).
+    Marked ``slow`` + ``finetune`` so it runs only locally / on demand (real training
+    + model download), never in the fast suite or the CPU-dry-run CI job.
+    """
+    pytest.importorskip("peft")
+    pytest.importorskip("trl")
+    pytest.importorskip("torch")
+    from langres.core.matchers.model_ref import to_config
+
+    pairs = _balanced_pairs()
+    base_f1, base_sep = _serve_scores("HuggingFaceTB/SmolLM2-135M-Instruct", pairs)
+
+    method = QLoRA(base="HuggingFaceTB/SmolLM2-135M-Instruct", epochs=8, batch_size=4)
+    outcome = run_finetune(pairs, method)
+    assert outcome.gpu_seconds > 0.0
+    assert outcome.model_ref.adapter is not None
+
+    tuned_f1, tuned_sep = _serve_scores(to_config(outcome.model_ref), pairs)
+
+    # Training must both raise overfit F1 and widen match/non-match p_yes separation
+    # over the untrained base (the base collapses to all-positive at threshold 0.5).
+    assert tuned_f1 > base_f1
+    assert tuned_sep > base_sep
+    assert tuned_f1 >= 0.8  # overfits the 20-pair set (observed ~0.93)

--- a/tests/core/test_finetune.py
+++ b/tests/core/test_finetune.py
@@ -1,0 +1,309 @@
+"""Unit tests for ``langres.core.finetune`` -- the standalone QLoRA primitive.
+
+These lock the ORCHESTRATION (prompt/target rendering, ``model_ref`` + cost
+assembly, the :class:`QLoRA` method object) with an *injected fake trainer*, so
+they run with no GPU and never import peft/trl/torch. The real peft/trl training
+path (:class:`QLoRATrainer`) is exercised by the CPU dry-run under the
+``finetune`` marker (the ``test-finetune`` CI job) at the bottom of this file,
+never in the fast suite.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from langres.core.blockers.all_pairs import AllPairsBlocker
+from langres.core.finetune import (
+    FINETUNE_YES_NO_PROMPT,
+    Conversation,
+    FinetuneOutcome,
+    QLoRA,
+    TrainOutcome,
+    finetune,
+    run_finetune,
+)
+from langres.core.matchers.model_ref import ModelRef
+from langres.core.models import CompanySchema
+
+RECORDS = [
+    {"id": "a", "name": "Acme Corp"},
+    {"id": "b", "name": "Acme Corporation"},
+    {"id": "c", "name": "Beta Inc"},
+]
+
+
+def _labeled_pairs() -> list[tuple[Any, bool]]:
+    """Real ``(ERCandidate, is_match)`` pairs (as ``run_finetune`` receives them).
+
+    Blocks the 3 records into all-pairs candidates and labels only the ``{a, b}``
+    pair a match, so the rendered assistant targets carry both a ``"Yes"`` and a
+    ``"No"``.
+    """
+    candidates = list(AllPairsBlocker(schema=CompanySchema).stream(RECORDS))
+
+    def is_match(cand: Any) -> bool:
+        return {str(cand.left.id), str(cand.right.id)} == {"a", "b"}
+
+    return [(cand, is_match(cand)) for cand in candidates]
+
+
+class _FakeTrainer:
+    """A :class:`~langres.core.finetune.FinetuneTrainer` that records its call.
+
+    Writes a stub adapter dir (so the produced ref points at a real directory) and
+    returns a canned :class:`TrainOutcome` -- no GPU, no peft/trl. Captures the
+    ``(base, conversations, method, output_dir)`` it was handed so tests can assert
+    what the orchestration rendered and forwarded.
+    """
+
+    def __init__(
+        self, *, train_seconds: float = 12.0, merged: bool = False, device: str = "cpu"
+    ) -> None:
+        self.train_seconds = train_seconds
+        self.merged = merged
+        self.device = device
+        self.calls: list[dict[str, Any]] = []
+
+    def train(
+        self,
+        base: str,
+        conversations: list[Conversation],
+        method: QLoRA,
+        output_dir: str,
+    ) -> TrainOutcome:
+        Path(output_dir).mkdir(parents=True, exist_ok=True)
+        (Path(output_dir) / "adapter_config.json").write_text("{}")
+        self.calls.append(
+            {
+                "base": base,
+                "conversations": conversations,
+                "method": method,
+                "output_dir": output_dir,
+            }
+        )
+        return TrainOutcome(
+            adapter_dir=output_dir,
+            train_seconds=self.train_seconds,
+            n_train=len(conversations),
+            merged=self.merged,
+            device=self.device,
+        )
+
+
+# --- QLoRA method object: kind identity, describe(), config surface -----------
+
+
+def test_qlora_kind_is_finetune_classvar() -> None:
+    """``QLoRA.kind`` is the ``"finetune"`` dispatch identity, not a serialized field."""
+    assert QLoRA.kind == "finetune"
+    assert "kind" not in QLoRA.model_fields
+    assert "base" in QLoRA.model_fields
+
+
+def test_qlora_describe_reports_quant_rank_and_budget() -> None:
+    """``describe()`` is the 'what + cost' one-liner: base, quantization, rank, budget."""
+    d = QLoRA(base="tiny/model", r=8, budget_gpu_hours=2.5).describe()
+    assert "tiny/model" in d
+    assert "4-bit QLoRA" in d
+    assert "r=8" in d
+    assert "2.5 GPU-hours" in d
+
+
+def test_qlora_describe_drops_quant_and_budget_when_off() -> None:
+    """No 4-bit / no budget -> plain "LoRA" with no GPU-hours clause."""
+    d = QLoRA(base="tiny/model", load_in_4bit=False).describe()
+    assert "LoRA" in d and "4-bit" not in d
+    assert "GPU-hours" not in d
+
+
+def test_qlora_gpu_hourly_usd_rejects_negative() -> None:
+    """The $/GPU-hour cost knob is guarded non-negative (Field ge=0)."""
+    with pytest.raises(ValueError):
+        QLoRA(base="tiny/model", gpu_hourly_usd=-1.0)
+
+
+# --- run_finetune: rendering matches serving ---------------------------------
+
+
+def test_conversations_render_user_prompt_plus_yes_no_target() -> None:
+    """Each pair -> ``[{user: <finetune prompt>}, {assistant: "Yes"|"No"}]``.
+
+    The user turn carries the yes/no prompt + the serialized records; the
+    assistant turn is the binary target, so training text == what the served
+    matcher sees.
+    """
+    pairs = _labeled_pairs()
+    trainer = _FakeTrainer()
+
+    run_finetune(pairs, QLoRA(base="tiny/model"), trainer=trainer)
+
+    conversations = trainer.calls[0]["conversations"]
+    assert len(conversations) == len(pairs)
+    for (cand, label), convo in zip(pairs, conversations, strict=True):
+        assert [turn["role"] for turn in convo] == ["user", "assistant"]
+        assert convo[1]["content"] == ("Yes" if label else "No")
+        assert "same real-world entity" in convo[0]["content"]
+    # The matched pair's records are actually rendered into the user turn.
+    match_convo = next(
+        convo
+        for (cand, label), convo in zip(pairs, conversations, strict=True)
+        if label
+    )
+    assert "Acme Corp" in match_convo[0]["content"]
+    assert match_convo[1]["content"] == "Yes"
+
+
+def test_prompt_template_override_flows_into_rendering() -> None:
+    """A custom ``{left}``/``{right}`` template is what gets trained on (train==serve seam)."""
+    pairs = _labeled_pairs()
+    trainer = _FakeTrainer()
+
+    run_finetune(
+        pairs,
+        QLoRA(base="tiny/model"),
+        trainer=trainer,
+        prompt_template="CUSTOM {left} <=> {right}",
+    )
+
+    user_turn = trainer.calls[0]["conversations"][0][0]["content"]
+    assert user_turn.startswith("CUSTOM ")
+    assert "same real-world entity" not in user_turn
+
+
+# --- run_finetune: model_ref shape + cost digest -----------------------------
+
+
+def test_run_finetune_unmerged_returns_base_plus_adapter_ref() -> None:
+    """Unmerged QLoRA -> a ``ModelRef(base, adapter=<dir>)`` served without merging."""
+    pairs = _labeled_pairs()
+    trainer = _FakeTrainer(merged=False, device="cpu")
+
+    outcome = run_finetune(pairs, QLoRA(base="tiny/model"), trainer=trainer, output_dir="/tmp/x")
+
+    assert isinstance(outcome, FinetuneOutcome)
+    assert outcome.model_ref == ModelRef(base="tiny/model", adapter="/tmp/x")
+    assert outcome.base == "tiny/model"
+    assert outcome.merged is False
+    assert outcome.device == "cpu"
+    assert outcome.n_train == len(pairs)
+    assert "tiny/model" in outcome.method  # describe() string
+
+
+def test_run_finetune_merged_returns_self_contained_ref() -> None:
+    """``merge_adapter`` -> a single local-dir ref (``adapter is None``)."""
+    pairs = _labeled_pairs()
+    trainer = _FakeTrainer(merged=True)
+
+    outcome = run_finetune(
+        pairs, QLoRA(base="tiny/model", merge_adapter=True), trainer=trainer, output_dir="/tmp/m"
+    )
+
+    assert outcome.model_ref == ModelRef(base="/tmp/m", adapter=None)
+    assert outcome.merged is True
+
+
+def test_gpu_seconds_and_dollars_derive_from_train_seconds() -> None:
+    """GPU-seconds are the wall-clock fact; dollars = seconds/3600 * $/GPU-hour."""
+    pairs = _labeled_pairs()
+    trainer = _FakeTrainer(train_seconds=3600.0)
+
+    outcome = run_finetune(pairs, QLoRA(base="tiny/model", gpu_hourly_usd=2.0), trainer=trainer)
+
+    assert outcome.gpu_seconds == 3600.0
+    assert outcome.dollars == pytest.approx(2.0)
+
+
+def test_default_gpu_hourly_usd_is_free() -> None:
+    """The honest local-training default ($0/GPU-hour) yields $0 regardless of time."""
+    pairs = _labeled_pairs()
+    trainer = _FakeTrainer(train_seconds=999.0)
+
+    outcome = run_finetune(pairs, QLoRA(base="tiny/model"), trainer=trainer)
+
+    assert outcome.dollars == 0.0
+    assert outcome.gpu_seconds == 999.0
+
+
+# --- run_finetune: output dir + empty-input guard ----------------------------
+
+
+def test_output_dir_is_respected() -> None:
+    """A caller-supplied ``output_dir`` is where the adapter lands (and the ref points)."""
+    pairs = _labeled_pairs()
+    trainer = _FakeTrainer()
+
+    outcome = run_finetune(pairs, QLoRA(base="tiny/model"), trainer=trainer, output_dir="/tmp/here")
+
+    assert trainer.calls[0]["output_dir"] == "/tmp/here"
+    assert outcome.model_ref.adapter == "/tmp/here"
+
+
+def test_default_output_dir_is_a_fresh_temp_dir() -> None:
+    """Without ``output_dir`` a temp dir is created (it must outlive the call to serve)."""
+    pairs = _labeled_pairs()
+    trainer = _FakeTrainer()
+
+    outcome = run_finetune(pairs, QLoRA(base="tiny/model"), trainer=trainer)
+
+    adapter = outcome.model_ref.adapter
+    assert adapter is not None
+    assert "langres-finetune-" in adapter
+    assert Path(adapter).is_dir()
+
+
+def test_run_finetune_rejects_empty_pairs() -> None:
+    """Nothing to train on is a caller error, not a silent empty adapter."""
+    with pytest.raises(ValueError, match="at least one labeled pair"):
+        run_finetune([], QLoRA(base="tiny/model"), trainer=_FakeTrainer())
+
+
+# --- finetune(): the standalone primitive returns just the ref ----------------
+
+
+def test_finetune_returns_the_model_ref() -> None:
+    """``finetune()`` is ``run_finetune().model_ref`` -- the weightless served handle."""
+    pairs = _labeled_pairs()
+    trainer = _FakeTrainer()
+
+    ref = finetune(pairs, QLoRA(base="tiny/model"), trainer=trainer, output_dir="/tmp/f")
+
+    assert ref == ModelRef(base="tiny/model", adapter="/tmp/f")
+
+
+# --- The real peft/trl path: CPU dry-run (test-finetune job / --all-extras) ---
+
+
+@pytest.mark.finetune
+def test_qlora_trainer_cpu_dry_run(tmp_path: Path) -> None:
+    """Real peft+trl LoRA on a tiny model, CPU (no 4-bit) -- the ``[finetune]`` smoke.
+
+    Runs the DEFAULT :class:`QLoRATrainer` end-to-end: imports peft/trl/transformers,
+    fine-tunes a tiny instruct LM on a handful of yes/no pairs on CPU
+    (``load_in_4bit`` is ignored off CUDA), and asserts it produced a servable
+    adapter dir plus honest GPU-seconds. Marked ``finetune`` so it runs only in the
+    dedicated ``test-finetune`` CI job / locally with ``--all-extras`` -- never the
+    fast suite.
+    """
+    pytest.importorskip("peft")
+    pytest.importorskip("trl")
+    pytest.importorskip("torch")
+
+    pairs = _labeled_pairs()
+    method = QLoRA(
+        base="HuggingFaceTB/SmolLM2-135M-Instruct",
+        epochs=1,
+        batch_size=1,
+        max_seq_len=256,
+    )
+
+    outcome = run_finetune(pairs, method, output_dir=tmp_path)
+
+    assert outcome.n_train == len(pairs)
+    assert outcome.gpu_seconds > 0.0
+    assert outcome.device in {"cpu", "mps", "cuda"}
+    assert outcome.model_ref.base == "HuggingFaceTB/SmolLM2-135M-Instruct"
+    assert outcome.model_ref.adapter is not None
+    assert Path(outcome.model_ref.adapter).is_dir()

--- a/tests/core/test_finetune.py
+++ b/tests/core/test_finetune.py
@@ -140,17 +140,16 @@ def test_conversations_render_user_prompt_plus_yes_no_target() -> None:
 
     run_finetune(pairs, QLoRA(base="tiny/model"), trainer=trainer)
 
+    prompt_header = FINETUNE_YES_NO_PROMPT.split("{left}")[0]  # the default template's lead-in
     conversations = trainer.calls[0]["conversations"]
     assert len(conversations) == len(pairs)
     for (cand, label), convo in zip(pairs, conversations, strict=True):
         assert [turn["role"] for turn in convo] == ["user", "assistant"]
         assert convo[1]["content"] == ("Yes" if label else "No")
-        assert "same real-world entity" in convo[0]["content"]
+        assert prompt_header in convo[0]["content"]  # rendered from the default prompt
     # The matched pair's records are actually rendered into the user turn.
     match_convo = next(
-        convo
-        for (cand, label), convo in zip(pairs, conversations, strict=True)
-        if label
+        convo for (cand, label), convo in zip(pairs, conversations, strict=True) if label
     )
     assert "Acme Corp" in match_convo[0]["content"]
     assert match_convo[1]["content"] == "Yes"
@@ -170,7 +169,7 @@ def test_prompt_template_override_flows_into_rendering() -> None:
 
     user_turn = trainer.calls[0]["conversations"][0][0]["content"]
     assert user_turn.startswith("CUSTOM ")
-    assert "same real-world entity" not in user_turn
+    assert FINETUNE_YES_NO_PROMPT.split("{left}")[0] not in user_turn  # not the default
 
 
 # --- run_finetune: model_ref shape + cost digest -----------------------------

--- a/tests/core/test_resolver_fit_finetune.py
+++ b/tests/core/test_resolver_fit_finetune.py
@@ -85,6 +85,8 @@ def _predict_all_match(self: Any, candidates: Any) -> Any:
             right_id=str(cand.right.id),
             score=1.0,
             score_type="prob_llm",
+            decision_step="fake",
+            provenance={},
         )
 
 
@@ -184,7 +186,9 @@ def test_both_labels_and_pairs_raises() -> None:
         _resolver().fit(
             [{"id": "a", "name": "A"}, {"id": "b", "name": "B"}],
             labels=[True],
-            pairs=[LabeledPair(left_id="a", right_id="b", score=None, label=True, source="correction")],
+            pairs=[
+                LabeledPair(left_id="a", right_id="b", score=None, label=True, source="correction")
+            ],
             method=QLoRA(base="tiny/model"),
         )
 

--- a/tests/core/test_resolver_fit_finetune.py
+++ b/tests/core/test_resolver_fit_finetune.py
@@ -1,0 +1,197 @@
+"""Tests for ``Resolver.fit(..., method=QLoRA(...))`` -- the fine-tune surface (PR-F).
+
+``fit`` dispatches ``kind="finetune"`` to ``_fit_finetune``, which aligns the
+labeled supervision, delegates training to
+:func:`~langres.core.finetune.run_finetune` (here a *monkeypatched fake trainer*,
+so no GPU / no peft/trl), repoints the Resolver's matcher at the produced
+``model_ref`` as an in-process logprob :class:`LLMMatcher`, and records the
+``model_ref`` + GPU-seconds + held-out pair metrics in ``fit_report_``.
+
+These lock that wiring with a fake trainer; the REAL peft/trl training is the CPU
+dry-run in ``tests/core/test_finetune.py`` (the ``test-finetune`` job).
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any, ClassVar
+
+import pytest
+
+from langres.core.blockers.all_pairs import AllPairsBlocker
+from langres.core.clusterer import Clusterer
+from langres.core.finetune import TrainOutcome
+from langres.core.harvest import LabeledPair
+from langres.core.matchers.llm_judge import LLMMatcher
+from langres.core.methods_api import Method
+from langres.core.models import CompanySchema, PairwiseJudgement
+from langres.core.resolver import Resolver
+
+# a-b, c-d, e-f are three entity-disjoint matching pairs (all-pairs blocking
+# proposes each), so an entity-disjoint held-out split has whole pairs to hold.
+RECORDS = [
+    {"id": "a", "name": "Acme Corp"},
+    {"id": "b", "name": "Acme Corporation"},
+    {"id": "c", "name": "Beta Inc"},
+    {"id": "d", "name": "Beta Incorporated"},
+    {"id": "e", "name": "Cyan LLC"},
+    {"id": "f", "name": "Cyan Limited"},
+]
+
+
+def _resolver() -> Resolver:
+    """A Resolver whose matcher is an LLMMatcher (so ``_llm_render_config`` fires)."""
+    return Resolver(
+        blocker=AllPairsBlocker(schema=CompanySchema),
+        comparator=None,
+        matcher=LLMMatcher(client=object(), model="gpt-5-mini"),
+        clusterer=Clusterer(threshold=0.5),
+    )
+
+
+@pytest.fixture
+def fake_train_calls(monkeypatch: pytest.MonkeyPatch) -> list[dict[str, Any]]:
+    """Replace the default ``QLoRATrainer`` with a fake -- captures calls, no GPU.
+
+    ``run_finetune`` instantiates the module-global ``QLoRATrainer`` when no
+    trainer is injected (the ``Resolver._fit_finetune`` path), so patching it here
+    exercises the real orchestration end-to-end without importing peft/trl.
+    """
+    calls: list[dict[str, Any]] = []
+
+    class _FakeTrainer:
+        def train(
+            self, base: str, conversations: list[Any], method: Any, output_dir: str
+        ) -> TrainOutcome:
+            Path(output_dir).mkdir(parents=True, exist_ok=True)
+            calls.append({"base": base, "conversations": conversations, "output_dir": output_dir})
+            return TrainOutcome(
+                adapter_dir=output_dir,
+                train_seconds=8.0,
+                n_train=len(conversations),
+                merged=False,
+                device="cpu",
+            )
+
+    monkeypatch.setattr("langres.core.finetune.QLoRATrainer", _FakeTrainer)
+    return calls
+
+
+def _predict_all_match(self: Any, candidates: Any) -> Any:
+    """A fake ``LLMMatcher.forward`` that scores every valid candidate a match."""
+    for cand in candidates:
+        yield PairwiseJudgement(
+            left_id=str(cand.left.id),
+            right_id=str(cand.right.id),
+            score=1.0,
+            score_type="prob_llm",
+        )
+
+
+class _NotQLoRA(Method):
+    """A ``kind="finetune"`` method that is NOT a ``QLoRA`` -- the type-guard input."""
+
+    kind: ClassVar[str] = "finetune"
+
+    def describe(self) -> str:
+        return "not-a-qlora finetune"
+
+
+# --- labels= path: no split, repoint the matcher, report ref + GPU-seconds ----
+
+
+def test_labels_path_trains_repoints_and_reports(
+    fake_train_calls: list[dict[str, Any]],
+) -> None:
+    """``fit(labels=...)`` fine-tunes, repoints the matcher at the ref, fills the report."""
+    from langres.core.finetune import QLoRA
+
+    resolver = _resolver()
+
+    result = resolver.fit(
+        [{"id": "a", "name": "Acme Corp"}, {"id": "b", "name": "Acme Corporation"}],
+        labels=[True],  # the single a-b candidate is a match
+        method=QLoRA(base="tiny/model", gpu_hourly_usd=4.0),
+    )
+
+    assert result is resolver
+    report = resolver.fit_report_
+    assert report is not None
+    assert report.trained is True
+    assert "finetune" in report.trainable and "tiny/model" in report.trainable
+    assert report.n_train == 1
+    # unmerged QLoRA -> a base+adapter dict ref
+    assert isinstance(report.model_ref, dict)
+    assert report.model_ref["base"] == "tiny/model"
+    assert report.gpu_seconds == 8.0
+    assert report.cost == pytest.approx(8.0 / 3600.0 * 4.0)
+    # matcher is now an in-process logprob yes/no LLMMatcher over the produced ref
+    assert isinstance(resolver.module, LLMMatcher)
+    assert resolver.module.model_ref.base == "tiny/model"
+    assert resolver.module.model_ref.adapter is not None
+    assert resolver.module.confidence == "logprob"
+    assert resolver.module.config["response_parser"] == "binary_yes_no"
+    # the fake trainer actually saw the one rendered conversation
+    assert len(fake_train_calls) == 1
+    assert fake_train_calls[0]["base"] == "tiny/model"
+    assert len(fake_train_calls[0]["conversations"]) == 1
+
+
+# --- pairs= path: entity-disjoint held-out split + scored valid metrics -------
+
+
+def test_pairs_path_holds_out_valid_and_scores_it(
+    fake_train_calls: list[dict[str, Any]], monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """``fit(pairs=, split=)`` reports coverage, a held-out split, and valid metrics."""
+    from langres.core.finetune import QLoRA
+
+    monkeypatch.setattr(LLMMatcher, "forward", _predict_all_match)
+    resolver = _resolver()
+    pairs = [
+        LabeledPair(left_id="a", right_id="b", score=None, label=True, source="correction"),
+        LabeledPair(left_id="c", right_id="d", score=None, label=True, source="correction"),
+        LabeledPair(left_id="e", right_id="f", score=None, label=True, source="correction"),
+    ]
+
+    resolver.fit(RECORDS, pairs=pairs, split=0.5, seed=0, method=QLoRA(base="tiny/model"))
+
+    report = resolver.fit_report_
+    assert report is not None
+    assert report.split == 0.5
+    assert report.seed == 0
+    assert report.n_valid >= 1
+    assert report.coverage is not None
+    assert report.coverage.gold_coverage == pytest.approx(1.0)  # every positive has a candidate
+    assert report.metrics is not None
+    assert report.metrics.recall == pytest.approx(1.0)  # fake scores every valid pair a match
+
+
+# --- guards: QLoRA required; supervision required and exclusive ---------------
+
+
+def test_non_qlora_finetune_method_raises_typeerror() -> None:
+    """A ``kind="finetune"`` method that is not a ``QLoRA`` is a clear TypeError."""
+    with pytest.raises(TypeError, match=r"requires a QLoRA method.*not-a-qlora finetune"):
+        _resolver().fit([{"id": "a", "name": "A"}], method=_NotQLoRA())
+
+
+def test_both_labels_and_pairs_raises() -> None:
+    """Fine-tuning takes labels= XOR pairs=, never both."""
+    from langres.core.finetune import QLoRA
+
+    with pytest.raises(ValueError, match="not both"):
+        _resolver().fit(
+            [{"id": "a", "name": "A"}, {"id": "b", "name": "B"}],
+            labels=[True],
+            pairs=[LabeledPair(left_id="a", right_id="b", score=None, label=True, source="correction")],
+            method=QLoRA(base="tiny/model"),
+        )
+
+
+def test_neither_labels_nor_pairs_raises() -> None:
+    """Fine-tuning needs supervision -- no labels and no pairs is a clear error."""
+    from langres.core.finetune import QLoRA
+
+    with pytest.raises(ValueError, match="needs labeled supervision"):
+        _resolver().fit([{"id": "a", "name": "A"}], method=QLoRA(base="tiny/model"))

--- a/tests/core/test_resolver_fit_method.py
+++ b/tests/core/test_resolver_fit_method.py
@@ -1,10 +1,12 @@
 """Tests for the ``method=`` object seam on ``Resolver.fit`` (PR-M).
 
 ``fit(..., method=<Method>)`` dispatches on ``method.kind`` to the matching fit
-path *before* the module-hook isinstance chain. The concrete per-kind training
-bodies land in later PRs (MIPRO/PR-C, QLoRA/PR-F, Platt/PR-D), so every wired
-kind currently raises a clear ``NotImplementedError`` naming that PR -- but the
-dispatch + param plumbing is real, which is what these tests lock:
+path *before* the module-hook isinstance chain. The ``prompt``/``calibrate``
+bodies still land in later PRs (MIPRO/PR-C, Platt/PR-D), so those wired kinds
+raise a clear ``NotImplementedError`` naming that PR; ``finetune`` (PR-F) now
+routes to its real ``_fit_finetune`` handler, which rejects a non-``QLoRA``
+finetune method with a ``TypeError`` that still surfaces ``describe()``. Either
+way the dispatch + param plumbing is real, which is what these tests lock:
 
 - distinct ``kind`` values route to distinct branches (distinct error text);
 - an unrecognized ``kind`` falls through to a "no Method implements it" error;
@@ -87,9 +89,14 @@ def _resolver() -> Resolver:
 # --- dispatch: kind routes to its branch, all stubbed for now ---------------
 
 
-def test_finetune_kind_routes_to_pr_f_stub() -> None:
-    """A ``kind="finetune"`` method routes to the wired-but-stubbed PR-F branch."""
-    with pytest.raises(NotImplementedError, match=r"method kind 'finetune'.*lands in PR-F"):
+def test_finetune_kind_routes_to_finetune_handler() -> None:
+    """A ``kind="finetune"`` method routes to the real ``_fit_finetune`` handler (PR-F).
+
+    A non-``QLoRA`` finetune method reaches the handler and gets its QLoRA
+    type-guard TypeError -- distinct from the ``prompt``/``calibrate``
+    NotImplementedError branches, which is what proves the routing.
+    """
+    with pytest.raises(TypeError, match=r"method kind 'finetune' requires a QLoRA method"):
         _resolver().fit(RECORDS, method=_FinetuneMethod())
 
 
@@ -117,8 +124,12 @@ def test_unknown_kind_falls_through_to_no_impl_error() -> None:
 
 
 def test_error_carries_the_describe_string() -> None:
-    """The dispatch surfaces ``method.describe()`` at the call site (kind + cost)."""
-    with pytest.raises(NotImplementedError, match=r"fine-tune \(QLoRA, ~GPU-seconds\)"):
+    """The dispatch surfaces ``method.describe()`` at the call site (kind + cost).
+
+    The finetune handler's QLoRA type-guard error still embeds ``describe()``, so
+    the "what + cost" string reaches the caller exactly like the stub branches do.
+    """
+    with pytest.raises(TypeError, match=r"fine-tune \(QLoRA, ~GPU-seconds\)"):
         _resolver().fit(RECORDS, method=_FinetuneMethod())
 
 

--- a/tests/test_import_budget.py
+++ b/tests/test_import_budget.py
@@ -54,6 +54,11 @@ _HEAVY_MODULES = [
     # wandb lazily, never on a bare `import langres`.
     "mlflow",
     "wandb",
+    # Fine-tune stack ([finetune], PR-F): peft/trl/bitsandbytes import lazily
+    # inside core.finetune's QLoRATrainer.train, never on a bare `import langres`.
+    "peft",
+    "trl",
+    "bitsandbytes",
 ]
 
 _CHECK_SCRIPT = (
@@ -300,6 +305,37 @@ def test_import_langres_does_not_eagerly_import_lazy_root_export_modules() -> No
     )
     assert result.returncode == 0, (
         f"root-export laziness check failed.\nSTDOUT:\n{result.stdout}\nSTDERR:\n{result.stderr}"
+    )
+
+
+# The finetune surface ([finetune], PR-F) must be import-light: resolving the
+# ``langres.finetune``/``QLoRA`` symbols and importing ``langres.core.finetune``
+# must NOT pull the training stack (peft/trl/bitsandbytes) or torch/transformers --
+# they load lazily only inside ``QLoRATrainer.train``. So a core+[llm] user can
+# reference the symbols, build a ``QLoRA(...)`` spec, and inject a custom trainer
+# without the (Linux-only, heavy) QLoRA deps installed. Fresh-process subprocess
+# for an unpolluted ``sys.modules``.
+_FINETUNE_MODULES = ["peft", "trl", "bitsandbytes", "torch", "transformers"]
+
+_FINETUNE_IMPORT_LIGHT_SCRIPT = (
+    "import sys; import langres; "
+    "langres.finetune; langres.QLoRA; langres.run_finetune; "
+    "import langres.core.finetune; "
+    "leaked = [m for m in {modules!r} if m in sys.modules]; "
+    "assert not leaked, f'finetune surface leaked the training stack: {{leaked}}'; "
+    "print('OK')"
+).format(modules=_FINETUNE_MODULES)
+
+
+def test_finetune_surface_stays_import_light() -> None:
+    """``langres.finetune``/``QLoRA`` + ``core.finetune`` must not pull peft/trl/torch."""
+    result = subprocess.run(
+        [sys.executable, "-c", _FINETUNE_IMPORT_LIGHT_SCRIPT],
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode == 0, (
+        f"finetune import-budget check failed.\nSTDOUT:\n{result.stdout}\nSTDERR:\n{result.stderr}"
     )
 
 


### PR DESCRIPTION
## PR-F — `finetune()` + QLoRA method + `[finetune]` extra + GPU-seconds cost

Part of the **training-surface epic** (#125), into `feat/training-surface`. Fills the `method.kind == "finetune"` seam PR-M stubbed and adds the standalone `finetune()` primitive. This is the piece that makes the **capstone** (train→serve→evaluate) real. Rebased on the post-C integration HEAD `001382c` (additive union with PR-C's `_fit_prompt`/`describe()`; verified by hand, zero conflicts).

### What this adds
- **`src/langres/core/finetune.py`** (NEW) — `finetune(pairs, method=QLoRA(base=...)) -> ModelRef` (the standalone primitive; returns a weightless ref, not a Resolver/new component), `run_finetune()` (same + cost digest), the `QLoRA(Method)` object (`kind="finetune"`, carrying `base` + LoRA/QLoRA knobs + cost knobs `budget_gpu_hours`/`gpu_hourly_usd`), and `QLoRATrainer`.
- **`resolver.py`** — fills `_fit_finetune` (aligns pairs → `finetune()` → points the resolver's `LLMMatcher` at the produced `model_ref`, pinned to the same `FINETUNE_YES_NO_PROMPT` it trained on → `fit_report_`). Disjoint from `_fit_prompt`/`_fit_calibrate`.
- **`fit_report.py`** — +`gpu_seconds`, +`model_ref` (additive, default `None`).
- **`pyproject.toml`** — `[finetune]` extra (peft + trl + bitsandbytes; bitsandbytes Linux-gated since 4-bit QLoRA is CUDA-only) + markers.
- **CI** (`test.yml`/`lint.yml`/`security.yml`) — `uv sync --all-extras --no-extra finetune` so the heavy/fragile training stack stays off every normal job; a dedicated **non-blocking** `test-finetune` job installs the stack and runs `-m "finetune and not slow"`. The slow real-train test is local-only.
- **`__init__.py`** + import-budget guard — `finetune`/`QLoRA`/`run_finetune` stay import-light (no peft/trl/torch/transformers on `import langres`).

### The real train ran — go/no-go GREEN (the "see it run" gate)
On Mac/MPS (no CUDA — reported honestly), real `peft` LoRA + `trl` SFT of **SmolLM2-135M**, reloaded base+adapter `model_ref`, served in-process (logprob probe), evaluated on a 20-pair overfit set:
- untrained base: **F1 0.667** (all-positive collapse), p_yes sep +0.017
- fine-tuned: **F1 0.927** (P .905 / R .950), p_yes sep +0.092 — ~35s, $0 (local default `gpu_hourly_usd=0`). Locked as a `slow`+`finetune` test.

### Three real bugs the go/no-go caught (would have shipped broken)
1. `assistant_only_loss=True` isn't portable — trl only patches Qwen-family chat templates (`{% generation %}`); SmolLM2/Llama fail at trainer construction.
2. Full-sequence SFT doesn't learn — the 1-token Yes/No is buried in a ~30-token prompt, so gradient goes to reproducing the constant prompt (p_yes sep ~0.016 before AND after). Fix for 1+2: trl prompt-completion format (`completion_only_loss`, portable, no generation markers). **This is what moved F1 0.667→0.927.**
3. Train/serve prompt mismatch — `run_finetune` trained on `FINETUNE_YES_NO_PROMPT` but `_fit_finetune` built the served `LLMMatcher` without it (fell back to the "Score:" default while parsing binary_yes_no). Now both pinned to `FINETUNE_YES_NO_PROMPT`.

### Design decisions (approved)
- `base` lives on `QLoRA`, not as a `finetune(base, ...)` arg — one object fully specifies the training for BOTH `finetune()` and `Resolver.fit(method=...)` (single source of truth).
- bitsandbytes Linux-gated + non-quantized LoRA fallback on Mac/CPU (peft+trl portable core) so the path runs locally everywhere.
- `test-finetune` CI job is non-blocking (advisory) — a fragile/heavy training dep can't red-CI the epic; revisit gating post-epic.

### Gates (green on the rebased branch)
- ruff + format clean; mypy src clean (106 files).
- Full fast suite (CI mirror): **2892 passed**, 4 skipped, 98% cov (finetune.py 99%); includes PR-C's tests post-rebase.
- import-budget finetune guard passes; `mkdocs build --strict` clean; `uv lock --check` passes (no drift).

## Summary by Sourcery

Add a QLoRA-based fine-tuning primitive and wire Resolver.fit(kind="finetune") to train, serve, and report GPU cost and model references.

New Features:
- Introduce langres.core.finetune with a standalone finetune() primitive, a QLoRA method config, a pluggable trainer seam, and a run_finetune() helper that returns a model reference plus cost digest.
- Expose finetune, QLoRA, and run_finetune as import-light top-level langres symbols that do not eagerly import the heavy training stack.
- Extend FitReport to record GPU-seconds, derived dollar cost, and the produced model_ref, and surface them in its markdown rendering.

Enhancements:
- Implement the Resolver._fit_finetune path to align labeled pairs, delegate to run_finetune, repoint the matcher to the fine-tuned model via an in-process LLMMatcher, and evaluate held-out validation metrics with train/serve prompt alignment.
- Add an _llm_render_config helper on Resolver to keep training record serialization consistent with the current LLMMatcher while pinning both train and serve to a dedicated yes/no finetune prompt.
- Document component-level training in the technical overview, describing langres.finetune() as the QLoRA fine-tune surface for small-LM matchers.

Build:
- Introduce a [finetune] extra in pyproject.toml for the QLoRA training stack (peft, trl, bitsandbytes with Linux-only gating) and adjust mypy ignores for transformers/peft/trl/datasets.
- Add a pytest finetune marker and update default pytest addopts and coverage settings to exclude finetune tests from normal runs.

CI:
- Update test, lint, and security workflows to sync dependencies with --no-extra finetune and exclude finetune-marked tests from standard jobs, while adding a dedicated non-blocking test-finetune job that installs the finetune stack and runs CPU finetune tests.

Tests:
- Add orchestration-focused unit tests for langres.core.finetune using a fake trainer to validate prompt rendering, model_ref assembly, and cost calculation without GPUs or training deps.
- Add Resolver.fit(method=QLoRA(...)) tests that monkeypatch the trainer to verify supervision handling, matcher repointing, held-out validation metrics, and fit_report population.
- Extend import-budget tests to enforce that importing langres.finetune / QLoRA / run_finetune does not load peft, trl, bitsandbytes, torch, or transformers, and add real finetune and overfit end-to-end tests guarded by the finetune and slow markers.