### PR TITLE
PR-GEPA: GEPA reflective prompt-optimizer (3rd kind=prompt strategy)

### DIFF
--- a/docs/TECHNICAL_OVERVIEW.md
+++ b/docs/TECHNICAL_OVERVIEW.md
@@ -746,15 +746,24 @@ isinstance-on-the-module chain (`method=None` leaves that default byte-for-byte
 unchanged):
 
 - **prompt-optimize** (`kind="prompt"`, implemented) — `Bootstrap()` /
-  `MIPRO(auto=..., budget_usd=...)` from `langres.core.methods_prompt` compile a
-  `DSPyMatcher`'s prompt from labeled pairs (the optimizer's `BootstrapFewShot` /
-  `MIPROv2`). Supervision comes from `pairs=` (reusing `align_pairs` + the
-  entity-disjoint split, whose `valid` fold feeds `MIPROv2`'s valset) or
-  pre-aligned `labels=`. The `FitReport` names the demos learned, teacher model,
-  and declared budget. Requires a `DSPyMatcher` (else a clear error); DSPy stays
-  lazy-imported, so `Bootstrap()`/`MIPRO()` construct without pulling `dspy`.
-  `budget_usd` threads through the existing `SpendMonitor` seam (DSPy-compile
-  spend capture is deferred to #100, so it observes `$0` today).
+  `MIPRO(auto=..., budget_usd=...)` / `GEPA(auto=..., reflection_model=...,
+  max_metric_calls=..., budget_usd=...)` from `langres.core.methods_prompt`
+  compile a `DSPyMatcher`'s prompt from labeled pairs (the optimizer's
+  `BootstrapFewShot` / `MIPROv2` / `dspy.GEPA`). `GEPA` is the *reflective*
+  strategy: it reflects on execution traces — via a separate reflection LM
+  (`reflection_model`, defaulting to the matcher's own LM) — to rewrite the
+  *instruction*, and selects candidates on a Pareto frontier; carry either the
+  `auto` preset or a precise `max_metric_calls` budget (its native cost lever, and
+  mutually exclusive with `auto`). Supervision comes from `pairs=` (reusing
+  `align_pairs` + the entity-disjoint split, whose `valid` fold feeds the
+  `MIPROv2`/GEPA valset) or pre-aligned `labels=`. The `FitReport` names the demos
+  learned, teacher model, and declared budget. Requires a `DSPyMatcher` (else a
+  clear error); DSPy stays lazy-imported, so `Bootstrap()`/`MIPRO()`/`GEPA()`
+  construct without pulling `dspy`. Both `Bootstrap` and `GEPA` run zero-spend
+  under a `DummyLM` (GEPA reflects with the same dummy LM), so the unit suite
+  exercises them; `MIPRO` is paid-only. `budget_usd` threads through the existing
+  `SpendMonitor` seam (DSPy-compile spend capture is deferred to #100, so it
+  observes `$0` today).
 - **fine-tune** (`kind="finetune"`) / **calibrate** (`kind="calibrate"`) — wired
   stubs raising a clear NotImplementedError naming their PR.
 

--- a/src/langres/core/matchers/dspy_judge.py
+++ b/src/langres/core/matchers/dspy_judge.py
@@ -3,9 +3,9 @@
 This is the M4 "learnable scorer seam": a :class:`~langres.core.matcher.Matcher`
 whose match decision comes from a DSPy ``ChainOfThought`` program over a typed
 :class:`PairwiseMatchSignature`. Because the program is a DSPy artifact it can be
-**compiled** against a gold set (``BootstrapFewShot`` / ``MIPROv2``) to tune the
-prompt from data — the direct answer to M3's finding that a cheap judge's
-precision collapses under a generic, hand-written prompt.
+**compiled** against a gold set (``BootstrapFewShot`` / ``MIPROv2`` / ``GEPA``)
+to tune the prompt from data — the direct answer to M3's finding that a cheap
+judge's precision collapses under a generic, hand-written prompt.
 
 It mirrors :class:`~langres.core.matchers.llm_judge.LLMMatcher`'s serializable shape
 so a Resolver with a DSPyMatcher in the ``module`` slot can ``save`` / ``load``:
@@ -104,6 +104,31 @@ def _pair_metric(example: dspy.Example, prediction: Any, trace: Any = None) -> b
     is kept only when it reproduces the labeled match decision.
     """
     return bool(prediction.match) == bool(example.match)
+
+
+def _gepa_metric(
+    example: dspy.Example,
+    prediction: Any,
+    trace: Any = None,
+    pred_name: str | None = None,
+    pred_trace: Any = None,
+) -> float:
+    """GEPA-shaped compilation metric: 1.0 when the predicted ``match`` is correct.
+
+    ``dspy.GEPA`` validates (in its constructor) that the metric accepts *five*
+    arguments — ``(gold, pred, trace, pred_name, pred_trace)`` — and rejects the
+    three-argument :func:`_pair_metric` that ``BootstrapFewShot`` / ``MIPROv2``
+    take. This is the same match-decision metric, adapted to that signature and
+    returning a scalar score (``1.0``/``0.0``) GEPA can rank on its Pareto
+    frontier.
+
+    A *feedback-returning* metric — ``dspy.Prediction(score=..., feedback=...)``,
+    letting GEPA reflect on *why* a pair was misjudged rather than only on the
+    score — would sharpen the reflection, but it is a deliberate future
+    enhancement, not built now (simplicity-first): the scalar path already
+    exercises the full reflective-evolution loop.
+    """
+    return 1.0 if _pair_metric(example, prediction) else 0.0
 
 
 def _trainset_fingerprint(trainset: Sequence[dspy.Example]) -> str:
@@ -366,6 +391,9 @@ class DSPyMatcher(Matcher[SchemaT]):
         *,
         optimizer: str = "bootstrap",
         auto: str = "light",
+        reflection_model: str | None = None,
+        reflection_minibatch_size: int = 3,
+        max_metric_calls: int | None = None,
         tracker: ExperimentTracker | None = None,
         store: str | Path | RunStore | None = None,
         parent_run_id: str | None = None,
@@ -387,11 +415,24 @@ class DSPyMatcher(Matcher[SchemaT]):
                 gold ``match``) the optimizer tunes against.
             valset: Optional validation set (used by ``mipro``).
             optimizer: ``"bootstrap"`` (``BootstrapFewShot`` — deterministic under
-                ``DummyLM``, the zero-spend path) or ``"mipro"`` (``MIPROv2`` —
-                the paid path, exercised only by the example).
-            auto: ``MIPROv2``'s search-budget preset (``"light"`` / ``"medium"`` /
-                ``"heavy"``); ignored by ``"bootstrap"``. Threaded from the
-                ``MIPRO`` method's ``auto`` field by ``Resolver.fit``.
+                ``DummyLM``, the zero-spend path), ``"mipro"`` (``MIPROv2`` — the
+                paid path, exercised only by the example), or ``"gepa"``
+                (``dspy.GEPA`` — reflective Genetic-Pareto instruction evolution;
+                runs zero-spend under ``DummyLM`` for both the student and the
+                reflection LM).
+            auto: Search-budget preset (``"light"`` / ``"medium"`` / ``"heavy"``)
+                for ``"mipro"`` and ``"gepa"``; ignored by ``"bootstrap"``, and
+                by ``"gepa"`` when ``max_metric_calls`` is given. Threaded from
+                the method's ``auto`` field by ``Resolver.fit``.
+            reflection_model: ``"gepa"`` only — LM id for GEPA's reflection step.
+                ``None`` reuses this matcher's own LM (:meth:`_get_lm`), which is
+                what keeps the ``DummyLM`` path zero-spend while still satisfying
+                GEPA's required-reflection-LM contract.
+            reflection_minibatch_size: ``"gepa"`` only — examples reflected over
+                per step (``dspy.GEPA`` default 3).
+            max_metric_calls: ``"gepa"`` only — precise metric-call budget; when
+                set it supersedes ``auto`` (``dspy.GEPA`` takes exactly one budget
+                knob). ``None`` falls back to the ``auto`` preset.
             tracker: Experiment tracker for the compile run (``None`` — the
                 default — resolves to a no-op via ``resolve_tracker``).
             store: Where to persist the compile :class:`RunRecord` (default: none).
@@ -405,8 +446,10 @@ class DSPyMatcher(Matcher[SchemaT]):
             ``_compiled`` set, and ``_compile_run_id`` stamped — so callers can
             chain ``judge.compile(...).forward(...)``.
         """
-        if optimizer not in ("bootstrap", "mipro"):
-            raise ValueError(f"unknown optimizer {optimizer!r}; choose 'bootstrap' or 'mipro'")
+        if optimizer not in ("bootstrap", "mipro", "gepa"):
+            raise ValueError(
+                f"unknown optimizer {optimizer!r}; choose 'bootstrap', 'mipro', or 'gepa'"
+            )
         tracker = resolve_tracker(tracker)
         context = RunContext(
             experiment="dspy_compile",
@@ -433,6 +476,34 @@ class DSPyMatcher(Matcher[SchemaT]):
                 if optimizer == "bootstrap":
                     self._program = dspy.BootstrapFewShot(metric=_pair_metric).compile(
                         self._program, trainset=list(trainset), **kwargs
+                    )
+                elif optimizer == "gepa":
+                    # Reflective Genetic-Pareto evolution: GEPA runs the program on
+                    # the trainset, reflects (in natural language, via reflection_lm)
+                    # on the traces, and evolves the *instruction* on a Pareto
+                    # frontier. Two hard requirements from dspy.GEPA's constructor:
+                    #  (1) the metric must be 5-arg (_gepa_metric, not _pair_metric);
+                    #  (2) reflection_lm must be non-None -- reuse this matcher's own
+                    #      LM when unset (so a DummyLM student also reflects at $0).
+                    # GEPA also takes EXACTLY ONE budget knob, so pass max_metric_calls
+                    # when given, else the auto preset.
+                    reflection_lm = (
+                        dspy.LM(reflection_model) if reflection_model else self._get_lm()
+                    )
+                    gepa_budget = (
+                        {"max_metric_calls": max_metric_calls}
+                        if max_metric_calls is not None
+                        else {"auto": auto}
+                    )
+                    self._program = dspy.GEPA(
+                        metric=_gepa_metric,
+                        reflection_lm=reflection_lm,
+                        reflection_minibatch_size=reflection_minibatch_size,
+                        **gepa_budget,
+                    ).compile(
+                        self._program,
+                        trainset=list(trainset),
+                        valset=list(valset) if valset is not None else None,
                     )
                 else:  # "mipro"  # pragma: no cover - paid, non-deterministic path
                     # Exercised only by the paid example (MIPROv2 proposes+evaluates

--- a/src/langres/core/methods_prompt.py
+++ b/src/langres/core/methods_prompt.py
@@ -9,7 +9,12 @@ maps to one DSPy optimizer:
 - :class:`Bootstrap` -> ``BootstrapFewShot`` (deterministic under ``DummyLM`` --
   the zero-spend path the CI suite exercises);
 - :class:`MIPRO` -> ``MIPROv2`` (proposes+evaluates instructions via real LM
-  calls -- the paid path, exercised only by the example / a ``slow`` test).
+  calls -- the paid path, exercised only by the example / a ``slow`` test);
+- :class:`GEPA` -> ``dspy.GEPA`` (reflective Genetic-Pareto instruction
+  evolution: reflects on execution traces to rewrite the *instruction*, using a
+  separate reflection LM and Pareto selection). Like ``Bootstrap`` it runs
+  zero-spend under ``DummyLM`` -- for both the student and the reflection LM --
+  so the CI suite exercises it too.
 
 Import-light by construction (Pydantic only -- no ``dspy``/``litellm``): a
 ``Method`` is a *value* the caller constructs at the fit call site, so
@@ -21,15 +26,16 @@ import stays lazy inside
 
 .. note::
    The ``metric`` DSPy compiles against is fixed to the built-in match-decision
-   metric (``dspy_judge._pair_metric``); a user-selectable metric would be dead
-   config today, so these methods deliberately omit a ``metric`` knob.
+   metric (``dspy_judge._pair_metric``, adapted to GEPA's 5-argument metric
+   signature by ``dspy_judge._gepa_metric``); a user-selectable metric would be
+   dead config today, so these methods deliberately omit a ``metric`` knob.
 """
 
 from typing import Any, ClassVar, Literal
 
 from langres.core.methods_api import Method
 
-__all__ = ["Bootstrap", "MIPRO", "PromptMethod"]
+__all__ = ["GEPA", "Bootstrap", "MIPRO", "PromptMethod"]
 
 
 class PromptMethod(Method):
@@ -113,3 +119,67 @@ class MIPRO(PromptMethod):
     def describe(self) -> str:
         """One-liner: ``"prompt-optimize (MIPROv2, auto=<level>[, budget $N])"``."""
         return _with_budget(f"prompt-optimize (MIPROv2, auto={self.auto})", self.budget_usd)
+
+
+class GEPA(PromptMethod):
+    """Prompt-optimize by reflective Genetic-Pareto evolution (``dspy.GEPA``).
+
+    The reflective optimizer: GEPA runs the program on the labeled pairs,
+    reflects -- in natural language, through a separate *reflection LM* -- on the
+    execution traces to propose an improved instruction, and selects candidates
+    on a Pareto frontier over the validation scores (arXiv:2507.19457). Where
+    ``MIPROv2`` bootstraps demos, GEPA rewrites the *instruction itself* from
+    reflected feedback, which is why it needs a reflection LM (a strong one
+    helps) in addition to the scalar match metric.
+
+    A real run is paid -- both the student and the reflection LM make live calls
+    -- so pair it with a :attr:`budget_usd` cap. Unlike ``MIPRO`` it also runs
+    fully offline: drive both roles with a ``DummyLM`` and the compile is
+    zero-spend, so the unit suite exercises it (see the ``gepa`` branch of
+    :meth:`~langres.core.matchers.dspy_judge.DSPyMatcher.compile`).
+
+    Attributes:
+        auto: GEPA's search-budget preset (``"light"`` / ``"medium"`` /
+            ``"heavy"``) -- more reflection rounds for a better prompt. Ignored
+            when :attr:`max_metric_calls` is set (``dspy.GEPA`` accepts exactly
+            one budget knob). Threaded onto ``compile`` via :meth:`compile_kwargs`.
+        max_metric_calls: Optional precise budget -- the exact number of metric
+            evaluations GEPA may spend, its native cost lever. When set it takes
+            precedence over :attr:`auto` (the two are mutually exclusive).
+            ``None`` (the default) uses the :attr:`auto` preset.
+        reflection_model: LM id GEPA uses for the reflection step. ``None`` (the
+            default) reuses the matcher's own configured LM. GEPA benefits from a
+            strong reflection model, so naming a capable one here is the honest
+            knob for the reflection cost/quality trade-off.
+        reflection_minibatch_size: How many examples GEPA reflects over per step
+            (``dspy.GEPA``'s default is 3).
+    """
+
+    optimizer: ClassVar[str] = "gepa"
+
+    auto: Literal["light", "medium", "heavy"] = "light"
+    max_metric_calls: int | None = None
+    reflection_model: str | None = None
+    reflection_minibatch_size: int = 3
+
+    def compile_kwargs(self) -> dict[str, Any]:
+        """Thread GEPA's budget + reflection config onto ``DSPyMatcher.compile``."""
+        return {
+            "auto": self.auto,
+            "max_metric_calls": self.max_metric_calls,
+            "reflection_model": self.reflection_model,
+            "reflection_minibatch_size": self.reflection_minibatch_size,
+        }
+
+    def describe(self) -> str:
+        """One-liner: ``"prompt-optimize (GEPA reflective, <budget>[, budget $N])"``.
+
+        ``<budget>`` is ``max_metric_calls=<n>`` when that precise cap is set,
+        else the ``auto=<level>`` preset -- the knob GEPA will actually run under.
+        """
+        budget = (
+            f"max_metric_calls={self.max_metric_calls}"
+            if self.max_metric_calls is not None
+            else f"auto={self.auto}"
+        )
+        return _with_budget(f"prompt-optimize (GEPA reflective, {budget})", self.budget_usd)

--- a/tests/core/modules/test_dspy_judge.py
+++ b/tests/core/modules/test_dspy_judge.py
@@ -22,6 +22,7 @@ from langres.core.models import CompanySchema, ERCandidate, PairwiseJudgement
 from langres.core.matchers.dspy_judge import (
     DSPyMatcher,
     _clamp01,
+    _gepa_metric,
     _pair_metric,
     _salvage_usage,
 )
@@ -350,6 +351,96 @@ def test_compile_unknown_optimizer_raises() -> None:
     judge = _dummy_judge(_answers(10))
     with pytest.raises(ValueError, match="unknown optimizer"):
         judge.compile(_trainset(), optimizer="nope")
+
+
+# ---------------------------------------------------------------------------
+# Compilation — GEPA reflective optimizer (zero-spend under DummyLM)
+# ---------------------------------------------------------------------------
+
+
+def _mixed_trainset() -> list[dspy.Example]:
+    """A trainset with both a positive and a negative (GEPA reflects over both)."""
+    return [
+        dspy.Example(left="Acme", right="Acme Inc", match=True).with_inputs("left", "right"),
+        dspy.Example(left="Beta", right="Gamma", match=False).with_inputs("left", "right"),
+        dspy.Example(left="Acme", right="Acme LLC", match=True).with_inputs("left", "right"),
+        dspy.Example(left="Delta", right="Omega", match=False).with_inputs("left", "right"),
+    ]
+
+
+def test_gepa_metric_is_five_arg_and_wraps_pair_metric() -> None:
+    """``dspy.GEPA`` requires a 5-arg metric; ``_gepa_metric`` adapts the decision.
+
+    It must (a) accept ``(gold, pred, trace, pred_name, pred_trace)`` -- exactly
+    what ``dspy.GEPA.__init__`` binds to validate the metric -- and (b) return the
+    scalar ``1.0``/``0.0`` mirror of :func:`_pair_metric`.
+    """
+    import inspect
+
+    inspect.signature(_gepa_metric).bind(None, None, None, None, None)  # 5-arg contract
+
+    gold = dspy.Example(match=True)
+    assert _gepa_metric(gold, dspy.Prediction(match=True)) == 1.0
+    assert _gepa_metric(gold, dspy.Prediction(match=False)) == 0.0
+    # pred_name / pred_trace are accepted and ignored (per-predictor feedback is
+    # a future enhancement).
+    assert _gepa_metric(gold, dspy.Prediction(match=True), None, "predict", None) == 1.0
+
+
+def test_compile_gepa_sets_flag_zero_spend() -> None:
+    """``compile(optimizer='gepa')`` runs the full reflective loop at $0 under DummyLM.
+
+    Both the student and the reflection LM are the injected ``DummyLM``
+    (``reflection_model=None`` reuses the matcher's own LM), so GEPA reflects and
+    evolves without any network/paid call. A tight ``max_metric_calls`` keeps it
+    fast and deterministic.
+    """
+    judge = _dummy_judge(_answers(500))
+    returned = judge.compile(
+        _mixed_trainset(),
+        optimizer="gepa",
+        max_metric_calls=8,
+        reflection_minibatch_size=2,
+    )
+    assert returned is judge  # chainable
+    assert judge.compiled is True
+    # The reflective optimizer leaves the program tuned (an instruction it can
+    # score/forward with) -- forward still works after a GEPA compile.
+    judgements = list(judge.forward(iter([_candidate()])))
+    assert len(judgements) == 1
+
+
+def test_compile_gepa_builds_named_reflection_lm(mocker) -> None:  # type: ignore[no-untyped-def]
+    """A ``reflection_model`` builds a dedicated ``dspy.LM`` passed as GEPA's reflection_lm.
+
+    Covers the named-model branch without a paid call: ``dspy.GEPA`` is stubbed so
+    only the wiring (reflection LM construction + kwargs) is asserted.
+    """
+    reflection_sentinel = object()
+
+    def _fake_lm(model_id: str, *args: object, **kw: object) -> object:
+        return reflection_sentinel if model_id == "openrouter/openai/gpt-4o" else object()
+
+    mocker.patch("dspy.LM", side_effect=_fake_lm)
+    fake_program = object()
+    gepa_ctor = mocker.patch("dspy.GEPA")
+    gepa_ctor.return_value.compile.return_value = fake_program
+
+    judge = _dummy_judge(_answers(10))
+    judge.compile(
+        _mixed_trainset(),
+        optimizer="gepa",
+        reflection_model="openrouter/openai/gpt-4o",
+        auto="medium",
+    )
+
+    _, ctor_kwargs = gepa_ctor.call_args
+    assert ctor_kwargs["reflection_lm"] is reflection_sentinel
+    assert ctor_kwargs["metric"] is _gepa_metric
+    assert ctor_kwargs["auto"] == "medium"  # no max_metric_calls => auto preset
+    assert "max_metric_calls" not in ctor_kwargs  # exactly one budget knob
+    assert judge._program is fake_program
+    assert judge.compiled is True
 
 
 # ---------------------------------------------------------------------------

--- a/tests/core/test_resolver_fit_prompt.py
+++ b/tests/core/test_resolver_fit_prompt.py
@@ -23,7 +23,7 @@ from langres.core.harvest import LabeledPair
 from langres.core.matcher import Matcher
 from langres.core.matchers.dspy_judge import DSPyMatcher
 from langres.core.methods_api import Method
-from langres.core.methods_prompt import MIPRO, Bootstrap, PromptMethod
+from langres.core.methods_prompt import GEPA, MIPRO, Bootstrap, PromptMethod
 from langres.core.models import CompanySchema, ERCandidate, PairwiseJudgement
 from langres.core.reports import ScoreInspectionReport
 from langres.core.resolver import Resolver
@@ -59,17 +59,21 @@ def _dspy_resolver() -> tuple[Resolver, DSPyMatcher]:
 
 
 def test_prompt_methods_share_kind_prompt() -> None:
-    """Both concrete prompt methods route through the ``kind == "prompt"`` branch."""
+    """All concrete prompt methods route through the ``kind == "prompt"`` branch."""
     assert Bootstrap.kind == "prompt"
     assert MIPRO.kind == "prompt"
+    assert GEPA.kind == "prompt"
     assert issubclass(Bootstrap, PromptMethod) and issubclass(MIPRO, Method)
+    assert issubclass(GEPA, PromptMethod)
 
 
 def test_optimizer_is_classvar_not_a_field() -> None:
     """``optimizer`` is strategy-type identity, not serialized per-instance config."""
     assert Bootstrap.optimizer == "bootstrap"
     assert MIPRO.optimizer == "mipro"
+    assert GEPA.optimizer == "gepa"
     assert "optimizer" not in MIPRO.model_fields
+    assert "optimizer" not in GEPA.model_fields
     assert "kind" not in MIPRO.model_fields
 
 
@@ -90,10 +94,44 @@ def test_describe_renders_optimizer_and_budget() -> None:
     )
 
 
+def test_gepa_describe_renders_budget_knob_and_dollar_cap() -> None:
+    """GEPA's describe() shows the auto preset, or the precise call cap when set."""
+    assert GEPA().describe() == "prompt-optimize (GEPA reflective, auto=light)"
+    assert GEPA(auto="heavy", budget_usd=2.5).describe() == (
+        "prompt-optimize (GEPA reflective, auto=heavy), budget $2.5"
+    )
+    # max_metric_calls (when set) is the budget GEPA actually runs under, so it
+    # supersedes the auto preset in the descriptor.
+    assert GEPA(max_metric_calls=40).describe() == (
+        "prompt-optimize (GEPA reflective, max_metric_calls=40)"
+    )
+
+
 def test_compile_kwargs_maps_auto_for_mipro_only() -> None:
     """MIPRO threads its ``auto`` preset onto compile; Bootstrap adds nothing."""
     assert Bootstrap().compile_kwargs() == {}
     assert MIPRO(auto="medium").compile_kwargs() == {"auto": "medium"}
+
+
+def test_gepa_compile_kwargs_carries_budget_and_reflection_config() -> None:
+    """GEPA threads its budget + reflection knobs onto ``DSPyMatcher.compile``."""
+    assert GEPA().compile_kwargs() == {
+        "auto": "light",
+        "max_metric_calls": None,
+        "reflection_model": None,
+        "reflection_minibatch_size": 3,
+    }
+    assert GEPA(
+        auto="medium",
+        max_metric_calls=25,
+        reflection_model="openrouter/openai/gpt-4o",
+        reflection_minibatch_size=5,
+    ).compile_kwargs() == {
+        "auto": "medium",
+        "max_metric_calls": 25,
+        "reflection_model": "openrouter/openai/gpt-4o",
+        "reflection_minibatch_size": 5,
+    }
 
 
 # --- fit(method=Bootstrap()): the zero-spend compile-under-fit happy path ------

--- a/tests/core/test_resolver_fit_prompt.py
+++ b/tests/core/test_resolver_fit_prompt.py
@@ -187,6 +187,31 @@ def test_fit_prompt_accepts_prealigned_labels() -> None:
     assert resolver.fit_report_.coverage is None
 
 
+def test_fit_prompt_compiles_with_gepa_zero_spend() -> None:
+    """``fit(pairs, method=GEPA())`` runs GEPA's reflective loop at $0 under DummyLM.
+
+    GEPA needs many more LM calls than BootstrapFewShot (student rollouts +
+    reflection), so this resolver is built with a generous ``DummyLM`` answer
+    pool and a tight ``max_metric_calls`` budget -- still fully offline (the
+    reflection LM defaults to the matcher's own DummyLM).
+    """
+    matcher: DSPyMatcher[CompanySchema] = DSPyMatcher(
+        lm=DummyLM([_ANSWER] * 500), entity_noun="company"
+    )
+    resolver = Resolver.from_schema(CompanySchema, matcher=matcher)
+
+    out = resolver.fit(
+        RECORDS, pairs=PAIRS, method=GEPA(max_metric_calls=8, reflection_minibatch_size=2)
+    )
+
+    assert out is resolver
+    assert matcher.compiled is True
+    report = resolver.fit_report_
+    assert report is not None and report.trained is True
+    assert report.n_train == len(PAIRS)
+    assert "prompt-optimize (GEPA reflective, max_metric_calls=8)" in report.trainable
+
+
 # --- fit(method=...) error contracts -----------------------------------------
 
 

--- a/tests/test_import_budget.py
+++ b/tests/test_import_budget.py
@@ -81,6 +81,34 @@ def test_import_langres_excludes_heavy_modules_from_sys_modules() -> None:
     )
 
 
+# The prompt-optimize ``Method`` objects (``Bootstrap`` / ``MIPRO`` / ``GEPA``)
+# are pure config a caller constructs at the fit call site -- constructing one
+# (even ``GEPA(reflection_model=...)``, which names a DSPy optimizer) must never
+# pull ``dspy`` into ``sys.modules``. The heavy ``dspy`` import stays lazy inside
+# ``dspy_judge``, reached only when a fit actually compiles. Fresh-process so the
+# check is not masked by another test having already imported dspy.
+_METHODS_PROMPT_IMPORT_LIGHT_SCRIPT = (
+    "import sys; "
+    "from langres.core.methods_prompt import GEPA, MIPRO, Bootstrap; "
+    "Bootstrap(); MIPRO(auto='heavy'); GEPA(reflection_model='x', max_metric_calls=10); "
+    "assert 'dspy' not in sys.modules, 'methods_prompt pulled dspy on construct'; "
+    "print('OK')"
+)
+
+
+def test_methods_prompt_stays_import_light() -> None:
+    """Constructing a prompt-optimize ``Method`` must not import ``dspy`` (config only)."""
+    result = subprocess.run(
+        [sys.executable, "-c", _METHODS_PROMPT_IMPORT_LIGHT_SCRIPT],
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode == 0, (
+        f"methods_prompt import-budget check failed.\n"
+        f"STDOUT:\n{result.stdout}\nSTDERR:\n{result.stderr}"
+    )
+
+
 # The eval harness (``core.metrics`` / ``core.benchmark``) must be importable
 # without the ``[eval]`` extra: ``ranx`` (ranking metrics MRR/NDCG/MAP) is now
 # imported lazily inside ``evaluate_blocking_with_ranking`` only, so importing


### PR DESCRIPTION
## What

Adds **GEPA** (Genetic-Pareto reflective prompt evolution) as a third `kind="prompt"` optimizer alongside `Bootstrap`/`MIPRO`, wired through the existing `fit(method=...)` seam.

- `GEPA(PromptMethod)` in `core/methods_prompt.py` (`optimizer="gepa"`): fields `auto`, `max_metric_calls`, `reflection_model`, `reflection_minibatch_size`; `compile_kwargs()` + `describe()`. Import-light — no dspy at module load.
- `_gepa_metric` (5-arg adapter over the existing scalar `_pair_metric`) + the `"gepa"` compile branch in `core/matchers/dspy_judge.py`; `"gepa"` added to the allowed-optimizer set (an unknown optimizer still raises, message now lists `gepa`).
- `dspy_judge.py` and `methods_prompt.py` both **100% covered**.

## Why

langres's cost ladder is LLM-native prompt-optimization; GEPA is the reflective, Pareto-frontier strategy that complements MIPRO's Bayesian search. `dspy.GEPA` ships in the pinned dspy (3.0.3) — **no dependency bump**.

## Verification — real, zero-spend (not a mock)

The headline test is a genuine `resolver.fit(pairs, method=GEPA(max_metric_calls=8))` compile under **DummyLM as both student AND reflection LM** — GEPA runs its full reflective-evolution loop entirely offline (zero network/paid calls, ~0.1s) and sets `fit_report_`. The named-reflection-model branch (the one real-client line) is mock-covered; both budget knobs (`auto` vs `max_metric_calls`) are exercised.

GEPA's real API requires a **5-arg metric** `(gold, pred, trace, pred_name, pred_trace)` and a hard-required `reflection_lm` — hence the `_gepa_metric` adapter, and `reflection_model=None` resolving to the matcher's own configured LM.

## describe() (kind + cost visible pre-run)

- `GEPA()` → `prompt-optimize (GEPA reflective, auto=light)`
- `GEPA(auto="heavy", budget_usd=3.0)` → `prompt-optimize (GEPA reflective, auto=heavy), budget $3`
- `GEPA(max_metric_calls=40, reflection_model=...)` → `prompt-optimize (GEPA reflective, max_metric_calls=40)` (a precise call cap supersedes the auto preset, matching GEPA's exactly-one-budget-knob rule)

## Scope decisions (simplicity-first)

- Scalar 1.0/0.0 metric only; a feedback-returning `dspy.Prediction(score, feedback)` metric is noted as a future enhancement in the code, not built.
- Usage is documented in the `GEPA` / `compile()` docstrings; no paid example artifact added.

## Gates (rebased on `63418c2`, post-F)

- `uv run --all-extras pytest -m "not integration and not slow"` → **2900 passed, 4 skipped, 98.41% cov** (`dspy_judge` + `methods_prompt` both 100%)
- `uv run pytest tests/test_import_budget.py` → 37 passed, 4 skipped (dspy stays lazy — new `test_methods_prompt_stays_import_light`)
- `uv run --no-dev --group docs mkdocs build --strict` → clean
- ruff check + ruff format --check + mypy (strict) on the 5 changed files → clean

Part of the training-surface epic (#125) → integration branch `feat/training-surface`.

## Summary by Sourcery

Add GEPA as a third prompt-optimization strategy alongside Bootstrap and MIPRO, integrating it into DSPy-based prompt compilation and resolver fitting while keeping imports lightweight and coverage high.

New Features:
- Introduce the GEPA prompt method, exposing reflective Genetic-Pareto prompt optimization with configurable budget and reflection settings.
- Enable DSPyMatcher.compile to use a new 'gepa' optimizer that runs GEPA with a GEPA-shaped metric and reflection LM wiring.
- Extend resolver prompt fitting to support GEPA as a kind='prompt' method, producing fit reports that surface GEPA-specific budget descriptors.

Enhancements:
- Add a GEPA-specific metric adapter to satisfy dspy.GEPA's five-argument metric contract while preserving the existing match decision logic.
- Document GEPA's behavior, configuration, and cost model in technical docs and method docstrings, including its interaction with DummyLM and reflection LMs.
- Ensure prompt methods remain import-light by verifying that constructing Bootstrap, MIPRO, or GEPA does not eagerly import dspy.

Tests:
- Add unit tests covering GEPA metric behavior, GEPA compile paths (including named reflection model wiring), resolver.fit integration, and updated describe/compile_kwargs behavior for the new method.
- Extend import-budget tests to assert that prompt methods, including GEPA, do not trigger heavy dspy imports.