### PR TITLE
PR-D: Platt/isotonic score calibrator (fit(method=Platt()/Isotonic()))

### DIFF
--- a/docs/TECHNICAL_OVERVIEW.md
+++ b/docs/TECHNICAL_OVERVIEW.md
@@ -691,8 +691,10 @@ signature:
   (learn a high-recall blocking key/index from known match pairs). Contract-only
   for now — the concrete `TrainableVectorBlocker` is a later PR.
 - **Calibrator** — `CalibratorFitMixin.fit_calibrator(scores: Sequence[float], labels: Sequence[bool]) -> None`
-  (learn a score→probability map). Contract-only for now — the concrete
-  Platt/isotonic impl is a later PR.
+  (learn a score→probability map) + `transform(scores) -> list[float]` (apply
+  it). The concrete `Calibrator` (Platt logistic / isotonic, `[trained]`) in
+  `langres.core.calibration` implements it, consumed by
+  `Resolver.fit(method=Platt()/Isotonic())` — see the `method=` seam below.
 
 `Resolver.fit(data, labels=None, *, pairs=None, split=None, seed=0)` consumes the
 **matcher** mixins, detected with `isinstance(module, SupervisedFitMixin)` /
@@ -764,8 +766,24 @@ unchanged):
   exercises them; `MIPRO` is paid-only. `budget_usd` threads through the existing
   `SpendMonitor` seam (DSPy-compile spend capture is deferred to #100, so it
   observes `$0` today).
-- **fine-tune** (`kind="finetune"`) / **calibrate** (`kind="calibrate"`) — wired
-  stubs raising a clear NotImplementedError naming their PR.
+- **fine-tune** (`kind="finetune"`, implemented) — `QLoRA(base=..., ...)` from
+  `langres.core.finetune` fine-tunes a small LM on the labeled pairs, repoints
+  the Resolver's matcher at an in-process logprob-scoring `LLMMatcher` over the
+  produced `model_ref`, and records GPU-seconds / derived-$ + held-out P/R/F1 in
+  the `FitReport`. The training stack (peft/trl) stays lazy-imported.
+- **calibrate** (`kind="calibrate"`, implemented) — `Platt()` / `Isotonic()`
+  from `langres.core.methods_calibrate` fit a score→probability `Calibrator`
+  (`langres.core.calibration`, `[trained]`) from labeled pairs, attach it to the
+  Resolver, and map every raw judgement score to a calibrated probability in
+  `predict()`/`resolve()` (the clusterer then thresholds a real probability; the
+  matcher and clusterer are untouched). Supervision comes from `pairs=` (reusing
+  `align_pairs` + the entity-disjoint split) or pre-aligned `labels=`. When a
+  `valid` split exists the `FitReport` carries the **Brier/ECE before-vs-after**
+  on it — the honest proof the map calibrates. The learned params are a handful
+  of plain floats carried inline in the artifact, so `save`/`load` round-trips a
+  *fitted* calibrator with no pickle and no weight files (`transform` applies the
+  map with pure NumPy). `Platt()`/`Isotonic()` are import-light (no scikit-learn
+  until the fit runs).
 
 `Resolver.describe()` is the pre-fit honesty device: a per-component string
 tagging each pipeline role **TRAINABLE** (implements a `langres.core.fit`

--- a/src/langres/core/__init__.py
+++ b/src/langres/core/__init__.py
@@ -124,6 +124,7 @@ if TYPE_CHECKING:
         QdrantHybridIndex,
         VectorIndex,
     )
+    from langres.core.calibration import Calibrator
     from langres.core.matchers.llm_judge import LLMMatcher
     from langres.core.matchers.random_forest_judge import RandomForestMatcher
     from langres.core.matchers.select_judge import SelectMatcher
@@ -136,6 +137,7 @@ __all__ = [
     "ArtifactManifest",
     "benchmark",
     "Blocker",
+    "Calibrator",
     "CandidateStats",
     "Canonicalizer",
     "CascadeMatcher",
@@ -239,6 +241,7 @@ _LAZY_SUBMODULES: frozenset[str] = frozenset({"benchmark", "metrics", "optimizer
 #: needs an optional extra installed; see :data:`_EXTRA_BY_SYMBOL` for the
 #: ``pip install langres[<extra>]`` hint a missing dependency should surface.
 _LAZY_SYMBOLS: dict[str, str] = {
+    "Calibrator": "langres.core.calibration",
     "VectorBlocker": "langres.core.blockers.vector",
     "EmbeddingProvider": "langres.core.embeddings",
     "FakeEmbedder": "langres.core.embeddings",
@@ -272,6 +275,7 @@ _EXTRA_BY_SYMBOL: dict[str, str] = {
         "LLMMatcher": "llm",
         "SelectMatcher": "llm",
         "RandomForestMatcher": "trained",
+        "Calibrator": "trained",
         "MlflowTracker": "mlflow",
         "WandbTracker": "wandb",
     }.get(name, "semantic")

--- a/src/langres/core/calibration.py
+++ b/src/langres/core/calibration.py
@@ -1,23 +1,38 @@
-"""Data-driven threshold derivation for entity-resolution scorers.
+"""Score→threshold and score→probability calibration for ER scorers.
 
-Thresholds in the framework (module defaults, the cascade band) were hand-set --
-``0.5`` here, ``0.3``/``0.9`` there -- not read off the actual score
-distribution. This module is the minimal fix: one pure function that inspects a
-score distribution plus its gold labels and derives a threshold *from the data*.
+Two calibration roles live here, both label-aware and both ``[trained]`` (they
+need scikit-learn):
 
-It is deliberately a single-responsibility, side-effect-free function module: no
-serializable component, no Resolver slot (a runtime ``CalibratedModule`` is
-deferred to M4.5). Experiments and factories consume the returned ``float``
-directly. Calibration *quality* is characterized elsewhere with
-:mod:`langres.core.metrics` (``brier_score`` / ``expected_calibration_error``);
-this module only picks the cut.
+- :func:`derive_threshold` -- a pure function that reads a score distribution
+  plus its gold labels and picks a *decision cut* from the data (Youden's J or a
+  percentile), replacing the framework's hand-set ``0.5``/``0.3``/``0.9``
+  thresholds. It maps a distribution to a single ``float``; it does not change
+  what the scores *mean*.
+- :class:`Calibrator` -- a fittable component (the concrete
+  :class:`~langres.core.fit.CalibratorFitMixin`) that learns a score→probability
+  map (Platt scaling or isotonic regression) so a raw matcher score becomes a
+  real, comparable probability. It is a serializable Resolver slot: its learned
+  parameters are a handful of plain floats, so ``Resolver.save``/``load``
+  round-trips a *fitted* calibrator with no weight files and no pickle -- and the
+  learned map is applied with pure NumPy at predict time (scikit-learn is touched
+  only during ``fit_calibrator``, mirroring
+  :class:`~langres.core.matchers.random_forest_judge.RandomForestMatcher`'s
+  no-pickle forest state).
+
+Calibration *quality* is characterized with :mod:`langres.core.metrics`
+(``brier_score`` / ``expected_calibration_error``); :meth:`Resolver._fit_calibrate`
+reports the Brier/ECE before-vs-after a :class:`Calibrator` fit.
 """
 
 from collections.abc import Sequence
-from typing import Literal
+from typing import ClassVar, Literal, cast
 
 import numpy as np
+from sklearn.isotonic import IsotonicRegression
+from sklearn.linear_model import LogisticRegression
 from sklearn.metrics import roc_curve
+
+from langres.core.registry import register
 
 ThresholdMethod = Literal["youden", "percentile"]
 """How to derive the threshold from the score distribution.
@@ -118,3 +133,156 @@ def derive_threshold(
         return float(np.percentile(score_array, percentile))
 
     raise ValueError(f"method must be 'youden' or 'percentile', got {method!r}")
+
+
+CalibrationMethod = Literal["platt", "isotonic"]
+"""Which score→probability map a :class:`Calibrator` learns.
+
+``"platt"`` fits a one-feature logistic regression (``sigmoid(a·score + b)``) --
+a smooth, two-parameter map, best when miscalibration is a monotone
+over/under-confidence. ``"isotonic"`` fits a non-parametric monotone step map
+(``sklearn.isotonic.IsotonicRegression``) -- more flexible, needs more data, and
+can correct a non-monotone confidence curve.
+"""
+
+
+@register("calibrator")
+class Calibrator:
+    """A fittable score→probability map (Platt or isotonic) -- the concrete calibrator.
+
+    Implements :class:`~langres.core.fit.CalibratorFitMixin` structurally:
+    :meth:`fit_calibrator` learns the map from ``(scores, labels)``, and
+    :meth:`transform` applies it. A raw matcher score (a rank-ordered number that
+    is *not* a true probability) becomes a calibrated probability in ``[0, 1]``,
+    so a clustering threshold on it is meaningful and two judges' scores are
+    comparable.
+
+    **No pickle, no weight files.** The learned state is a handful of plain floats
+    (Platt: two coefficients; isotonic: a small ``(x, y)`` interpolation grid),
+    carried inline in :attr:`config` so ``Resolver.save``/``load`` round-trips a
+    *fitted* calibrator through the JSON manifest alone. scikit-learn is used only
+    inside :meth:`fit_calibrator` to *learn* the parameters; :meth:`transform`
+    applies them with pure NumPy, so a reloaded calibrator scores identically to a
+    freshly-fit one without ever reconstructing an sklearn estimator (mirrors
+    :class:`~langres.core.matchers.random_forest_judge.RandomForestMatcher`).
+
+    Attributes:
+        method: The strategy declared at construction (``"platt"`` | ``"isotonic"``)
+            -- visible up front so a trainable role is never hidden.
+    """
+
+    type_name: ClassVar[str] = "calibrator"
+
+    def __init__(
+        self, method: CalibrationMethod = "platt", *, params: dict[str, object] | None = None
+    ) -> None:
+        """Initialize a calibrator; unfitted unless ``params`` is supplied.
+
+        Args:
+            method: ``"platt"`` (logistic, default) or ``"isotonic"``.
+            params: The learned parameters, for reconstructing a *fitted*
+                calibrator from :attr:`config` (see :meth:`from_config`). Leave
+                ``None`` to build an unfit calibrator that :meth:`fit_calibrator`
+                then trains.
+
+        Raises:
+            ValueError: If ``method`` is not ``"platt"`` or ``"isotonic"``.
+        """
+        if method not in ("platt", "isotonic"):
+            raise ValueError(f"method must be 'platt' or 'isotonic', got {method!r}")
+        self.method: CalibrationMethod = method
+        self._params = params
+
+    @property
+    def fitted(self) -> bool:
+        """Whether :meth:`fit_calibrator` (or a fitted :meth:`from_config`) has run."""
+        return self._params is not None
+
+    def fit_calibrator(self, scores: Sequence[float], labels: Sequence[bool]) -> None:
+        """Learn the score→probability map from scores + gold labels.
+
+        Args:
+            scores: Raw matcher scores to calibrate, aligned with ``labels``.
+            labels: Gold match/non-match labels for each score.
+
+        Raises:
+            ValueError: If ``scores``/``labels`` differ in length or are empty, or
+                if the labels are a single class (calibration needs both a positive
+                and a negative to learn a map).
+        """
+        if len(scores) != len(labels):
+            raise ValueError(
+                f"scores and labels must have equal length, got {len(scores)} and {len(labels)}"
+            )
+        if not scores:
+            raise ValueError("scores and labels must be non-empty")
+        label_array = np.asarray(labels, dtype=bool)
+        if label_array.all() or not label_array.any():
+            raise ValueError(
+                "calibration needs both classes present in labels (at least one "
+                "match and one non-match); got a single class"
+            )
+        score_array = np.asarray(scores, dtype=float)
+        if self.method == "platt":
+            clf = LogisticRegression()
+            clf.fit(score_array.reshape(-1, 1), label_array.astype(int))
+            self._params = {
+                "coef": float(clf.coef_[0][0]),
+                "intercept": float(clf.intercept_[0]),
+            }
+        else:
+            iso = IsotonicRegression(out_of_bounds="clip")
+            iso.fit(score_array, label_array.astype(float))
+            self._params = {
+                "x": [float(v) for v in iso.X_thresholds_],
+                "y": [float(v) for v in iso.y_thresholds_],
+            }
+
+    def transform(self, scores: Sequence[float]) -> list[float]:
+        """Apply the learned map, returning calibrated probabilities in ``[0, 1]``.
+
+        Pure NumPy -- never touches scikit-learn -- so a reloaded calibrator maps
+        identically to a freshly-fit one. Platt evaluates ``sigmoid(a·s + b)``;
+        isotonic linearly interpolates the fitted ``(x, y)`` grid, clipping to its
+        endpoints (matching ``out_of_bounds="clip"``).
+
+        Raises:
+            RuntimeError: If called before :meth:`fit_calibrator`.
+        """
+        if self._params is None:
+            raise RuntimeError(
+                "Calibrator.transform() called before fit: fit_calibrator(scores, "
+                "labels) first, or reconstruct a fitted calibrator via from_config()."
+            )
+        score_array = np.asarray(scores, dtype=float)
+        if self.method == "platt":
+            coef = cast("float", self._params["coef"])
+            intercept = cast("float", self._params["intercept"])
+            probs = 1.0 / (1.0 + np.exp(-(coef * score_array + intercept)))
+        else:
+            xs = np.asarray(cast("list[float]", self._params["x"]), dtype=float)
+            ys = np.asarray(cast("list[float]", self._params["y"]), dtype=float)
+            probs = np.interp(score_array, xs, ys)
+        # Guard the [0, 1] contract against floating-point drift so a calibrated
+        # score never trips PairwiseJudgement.score's ge=0/le=1 validation.
+        return [float(p) for p in np.clip(probs, 0.0, 1.0)]
+
+    __call__ = transform
+
+    @property
+    def config(self) -> dict[str, object]:
+        """Full serializable config: strategy + inline learned params (or ``None``).
+
+        The learned params ARE the config (Platt: 2 floats; isotonic: a small
+        grid), so :meth:`from_config` reconstructs a *fitted* calibrator with no
+        sidecar state -- the ``[trained]`` extra is needed only to import this
+        module, never to apply a reloaded map.
+        """
+        return {"method": self.method, "params": self._params}
+
+    @classmethod
+    def from_config(cls, config: dict[str, object]) -> "Calibrator":
+        """Reconstruct a calibrator (fitted iff ``config`` carries ``params``)."""
+        method = cast("CalibrationMethod", config["method"])
+        params = cast("dict[str, object] | None", config.get("params"))
+        return cls(method=method, params=params)

--- a/src/langres/core/fit.py
+++ b/src/langres/core/fit.py
@@ -19,9 +19,11 @@ Three pipeline roles can be trained, each with its own fit signature:
   high-recall blocking key/index from known match pairs). Contract-only here;
   the concrete ``TrainableVectorBlocker`` is a later PR -- this makes learned
   blocking *expressible* in the role taxonomy.
-- **Calibrator** -- ``CalibratorFitMixin`` (``fit_calibrator(scores, labels)``:
-  learn a score->probability map). Contract-only here; the concrete
-  Platt/isotonic impl is a later PR.
+- **Calibrator** -- ``CalibratorFitMixin`` (``fit_calibrator(scores, labels)``
+  learns a score->probability map; ``transform(scores)`` applies it). The
+  concrete Platt/isotonic
+  :class:`~langres.core.calibration.Calibrator` implements it, consumed by
+  ``Resolver.fit(method=Platt()/Isotonic())``.
 
 See ``Resolver.fit()`` for how the matcher mixins are consumed, and
 docs/TECHNICAL_OVERVIEW.md ("Fit-hook contract") for the full picture.
@@ -104,13 +106,16 @@ class BlockerFitMixin(Protocol):
 
 @runtime_checkable
 class CalibratorFitMixin(Protocol):
-    """A calibrator that learns a score->probability map from scores + labels.
+    """A calibrator that learns a score->probability map and applies it.
 
-    Implement ``fit_calibrator(scores, labels)`` to opt in; no subclassing
-    required (structural typing via ``isinstance()``). Contract-only for now --
-    the concrete Platt/isotonic impl is a later PR; this makes score calibration
-    *expressible* as its own fit role, distinct from a matcher's
-    ``fit(candidates, labels)``.
+    Implement ``fit_calibrator(scores, labels)`` (learn) and ``transform(scores)``
+    (apply) to opt in; no subclassing required (structural typing via
+    ``isinstance()``). The role is two-sided: a fitted calibrator is only useful
+    if the predict path can push scores through it, so the apply half is part of
+    the contract. The concrete Platt/isotonic
+    :class:`~langres.core.calibration.Calibrator` implements both;
+    :meth:`~langres.core.resolver.Resolver._fit_calibrate` fits it and
+    :meth:`~langres.core.resolver.Resolver.predict` applies it.
     """
 
     def fit_calibrator(self, scores: Sequence[float], labels: Sequence[bool]) -> None:
@@ -120,5 +125,16 @@ class CalibratorFitMixin(Protocol):
             scores: The matcher scores to calibrate, positionally aligned with
                 ``labels``.
             labels: Gold match/non-match labels for each score.
+        """
+        ...  # pragma: no cover — Protocol method body, never executed
+
+    def transform(self, scores: Sequence[float]) -> list[float]:
+        """Map raw scores to calibrated probabilities in ``[0, 1]``.
+
+        Args:
+            scores: Raw matcher scores to calibrate.
+
+        Returns:
+            One calibrated probability per input score.
         """
         ...  # pragma: no cover — Protocol method body, never executed

--- a/src/langres/core/fit_report.py
+++ b/src/langres/core/fit_report.py
@@ -32,6 +32,29 @@ from langres.core.harvest import GoldCoverage
 from langres.core.metrics import PairMetrics
 
 
+class CalibrationDelta(BaseModel):
+    """Before-vs-after calibration quality for a ``method="calibrate"`` fit.
+
+    Measured on the held-out ``valid`` split (the honest test): the matcher's raw
+    scores vs the scores mapped through the fitted
+    :class:`~langres.core.calibration.Calibrator`. Lower is better for both -- a
+    real calibrator drives ``brier``/``ece`` down.
+
+    Attributes:
+        method: The calibrator map fitted (``"platt"`` / ``"isotonic"``).
+        brier_before / brier_after: :func:`~langres.core.metrics.brier_score` on
+            the raw vs calibrated valid scores (the headline number).
+        ece_before / ece_after: :func:`~langres.core.metrics.expected_calibration_error`
+            on the same (a secondary, binning-dependent diagnostic).
+    """
+
+    method: str
+    brier_before: float
+    brier_after: float
+    ece_before: float
+    ece_after: float
+
+
 class FitReport(BaseModel):
     """Digest of one ``Resolver.fit()`` call. Build with :meth:`build`.
 
@@ -62,6 +85,8 @@ class FitReport(BaseModel):
             / local dir string, or a ``{base, adapter}`` dict whose shape also
             encodes merge status), else ``None``. Serialize with
             :func:`~langres.core.matchers.model_ref.to_config`.
+        calibration: Before-vs-after Brier/ECE for a ``method="calibrate"`` fit
+            (on the ``valid`` split), else ``None``.
         run_ref: The enclosing run's ``attempt_id`` (lineage reference to the
             machine :class:`~langres.core.runs.RunRecord`), or ``None``.
     """
@@ -79,6 +104,7 @@ class FitReport(BaseModel):
     cost: float | None = None
     gpu_seconds: float | None = None
     model_ref: str | dict[str, str] | None = None
+    calibration: CalibrationDelta | None = None
     run_ref: str | None = None
 
     @classmethod
@@ -97,6 +123,7 @@ class FitReport(BaseModel):
         cost: float | None = None,
         gpu_seconds: float | None = None,
         model_ref: str | dict[str, str] | None = None,
+        calibration: CalibrationDelta | None = None,
         run_ref: str | None = None,
     ) -> FitReport:
         """Assemble a FitReport from the artefacts of one ``fit()`` call.
@@ -119,6 +146,7 @@ class FitReport(BaseModel):
             cost=cost,
             gpu_seconds=gpu_seconds,
             model_ref=model_ref,
+            calibration=calibration,
             run_ref=run_ref,
         )
 
@@ -182,7 +210,11 @@ class FitReport(BaseModel):
 
         lines.append("## Held-out pair metrics (valid split)")
         if self.metrics is None:
-            if self.split is not None:
+            if self.n_valid > 0:
+                # A held-out split exists but this fit reports no pair P/R/F1 (e.g.
+                # a calibrate fit, whose held-out signal is the calibration delta).
+                lines.append("- No held-out pair P/R/F1 computed for this fit.")
+            elif self.split is not None:
                 lines.append(
                     "- The requested split produced no held-out pairs (all labeled "
                     "entities are connected -- no entity-disjoint valid is possible)."
@@ -198,6 +230,15 @@ class FitReport(BaseModel):
                 f"- TP/FP/FN: {m.tp}/{m.fp}/{m.fn} @ threshold {m.threshold:.4f}",
             ]
         lines.append("")
+
+        if self.calibration is not None:
+            cal = self.calibration
+            lines += [
+                f"## Calibration ({cal.method}, valid split — lower is better)",
+                f"- Brier: {cal.brier_before:.4f} → {cal.brier_after:.4f}",
+                f"- ECE:   {cal.ece_before:.4f} → {cal.ece_after:.4f}",
+                "",
+            ]
 
         return "\n".join(lines)
 

--- a/src/langres/core/methods_calibrate.py
+++ b/src/langres/core/methods_calibrate.py
@@ -1,0 +1,75 @@
+"""Calibration :class:`~langres.core.methods_api.Method` s (``kind == "calibrate"``).
+
+The concrete strategies :meth:`Resolver.fit(method=...) <langres.core.resolver.Resolver.fit>`
+dispatches to when you want to turn a matcher's raw scores into real, comparable
+probabilities: learn a score→probability map from labeled pairs. Each strategy
+names one :class:`~langres.core.calibration.Calibrator` map:
+
+- :class:`Platt` -> logistic (Platt) scaling -- ``sigmoid(a·score + b)``, a
+  two-parameter smooth map for monotone over/under-confidence;
+- :class:`Isotonic` -> non-parametric isotonic regression -- a flexible monotone
+  step map that needs more data.
+
+Import-light by construction (Pydantic only -- no scikit-learn): a ``Method`` is a
+*value* the caller constructs at the fit call site, so constructing ``Platt()``
+must never pull scikit-learn into ``sys.modules`` (locked by
+``tests/test_import_budget.py``). The heavy scikit-learn import stays in
+:mod:`langres.core.calibration`, reached only when
+:meth:`~langres.core.resolver.Resolver.fit` actually fits the calibrator -- the
+same split ``methods_prompt`` uses to keep ``dspy`` out of a bare import.
+"""
+
+from typing import ClassVar
+
+from langres.core.methods_api import Method
+
+__all__ = ["CalibrateMethod", "Isotonic", "Platt"]
+
+
+class CalibrateMethod(Method):
+    """Base for the score-calibration strategies (``kind == "calibrate"``).
+
+    Fixes the contract :meth:`~langres.core.resolver.Resolver._fit_calibrate`
+    reads: a :attr:`strategy` naming the
+    :class:`~langres.core.calibration.Calibrator` map to fit. Like
+    :attr:`~langres.core.methods_api.Method.kind`, :attr:`strategy` is a
+    ``ClassVar`` -- strategy-type identity, not serialized config -- so the base
+    declares it and each concrete subclass sets it. Mirrors
+    :class:`~langres.core.methods_prompt.PromptMethod`'s ``optimizer``.
+    """
+
+    kind: ClassVar[str] = "calibrate"
+    #: The :class:`~langres.core.calibration.Calibrator` map this strategy fits
+    #: (``"platt"`` / ``"isotonic"``). Set by concrete subclasses; unset on the
+    #: base (never instantiated).
+    strategy: ClassVar[str]
+
+
+class Platt(CalibrateMethod):
+    """Calibrate by Platt scaling: a one-feature logistic map ``sigmoid(a·s + b)``.
+
+    The two-parameter, smooth calibrator -- best when the matcher ranks well but
+    is systematically over/under-confident. Fits from as few as a handful of
+    labeled pairs (needs both a positive and a negative).
+    """
+
+    strategy: ClassVar[str] = "platt"
+
+    def describe(self) -> str:
+        """One-liner: ``"calibrate (Platt scaling)"``."""
+        return "calibrate (Platt scaling)"
+
+
+class Isotonic(CalibrateMethod):
+    """Calibrate by isotonic regression: a non-parametric monotone step map.
+
+    More flexible than :class:`Platt` (it can correct a non-monotone confidence
+    curve) at the cost of needing more labeled data to avoid overfitting the step
+    grid.
+    """
+
+    strategy: ClassVar[str] = "isotonic"
+
+    def describe(self) -> str:
+        """One-liner: ``"calibrate (isotonic regression)"``."""
+        return "calibrate (isotonic regression)"

--- a/src/langres/core/registry.py
+++ b/src/langres/core/registry.py
@@ -51,6 +51,11 @@ _SCHEMA_REGISTRY: dict[str, type[BaseModel]] = {}
 # langres[llm]`` / ``langres[semantic]``), so importing them must be deferred
 # to the first actual access, exactly like ``dspy_judge``.
 #
+# ``calibrator`` (the Platt/isotonic ``Calibrator``) lives in
+# ``langres.core.calibration``, which imports scikit-learn at module scope (the
+# ``[trained]`` extra) -- so a saved Resolver carrying a fitted calibrator resolves
+# its ``type_name`` here without ``calibration`` being on the eager-import path.
+#
 # ``cascade_judge`` is pure-core (no heavy deps) and IS eager-imported today, so
 # this entry is redundant *right now* — it is kept deliberately as the same
 # saved-artifact safety net as its ``random_forest``/``correlation_clusterer`` peers
@@ -59,6 +64,7 @@ _SCHEMA_REGISTRY: dict[str, type[BaseModel]] = {}
 # future eager-import trim (like W0.4's) drops it from ``core/__init__.py``. It
 # is here for parity with those peers, not because it needs dep deferral.
 _LAZY_COMPONENT_MODULES: dict[str, str] = {
+    "calibrator": "langres.core.calibration",
     "cascade_judge": "langres.core.matchers.cascade_judge",
     "composite_blocker": "langres.core.blockers.composite",
     "correlation_clusterer": "langres.core.clusterers.correlation",

--- a/src/langres/core/resolver.py
+++ b/src/langres/core/resolver.py
@@ -52,11 +52,16 @@ from langres.core.fit import (
     SupervisedFitMixin,
     UnsupervisedFitMixin,
 )
-from langres.core.fit_report import FitReport
+from langres.core.fit_report import CalibrationDelta, FitReport
 from langres.core.harvest import Correction, LabeledPair, align_pairs
 from langres.core.methods_api import Method
 from langres.core.matchers.weighted_average import WeightedAverageMatcher
-from langres.core.metrics import PairMetrics, classify_pairs
+from langres.core.metrics import (
+    PairMetrics,
+    brier_score,
+    classify_pairs,
+    expected_calibration_error,
+)
 from langres.core.models import ERCandidate, PairwiseJudgement
 from langres.core.matcher import Matcher
 from langres.core.registry import get_component
@@ -332,6 +337,11 @@ class Resolver:
             (e.g. a self-contained ``RapidfuzzMatcher``).
         matcher: The scorer Matcher that yields PairwiseJudgements.
         clusterer: Groups matched pairs into entity clusters.
+        calibrator: Optional fitted
+            :class:`~langres.core.fit.CalibratorFitMixin` that maps each
+            judgement's raw ``score`` to a calibrated probability before
+            clustering. ``None`` (the default) leaves scores untouched; set by
+            ``fit(method=Platt()/Isotonic())``.
 
     Example:
         comparator = Comparator.from_schema(CompanySchema, weights={"name": 0.6, ...})
@@ -352,11 +362,15 @@ class Resolver:
         comparator: Comparator[Any] | None,
         matcher: Matcher[Any],
         clusterer: Clusterer,
+        calibrator: CalibratorFitMixin | None = None,
     ) -> None:
         self.blocker = blocker
         self.comparator = comparator
         self.module = matcher
         self.clusterer = clusterer
+        # Optional score->probability map, set by fit(method=Platt()/Isotonic())
+        # and applied in _judgements(); None leaves raw scores untouched.
+        self.calibrator = calibrator
         # Set by fit(); the sklearn trailing-underscore "produced by fit" digest.
         # None until fit() runs (never serialized -- it is a fit-time artifact).
         self.fit_report_: FitReport | None = None
@@ -959,14 +973,153 @@ class Resolver:
         seed: int,
         method: Method,
     ) -> Self:
-        """Fit via score calibration (``method.kind == "calibrate"``) -- STUB.
+        """Fit via score calibration (``method.kind == "calibrate"``): learn a score→prob map.
 
-        Wired into ``fit``'s ``method=`` dispatch; the concrete Platt/isotonic
-        calibration body lands in PR-D. Until then this raises with that pointer.
+        Scores the labeled train candidates with the current matcher, fits a fresh
+        :class:`~langres.core.calibration.Calibrator` (strategy from
+        ``method.strategy``) on those ``(score, label)`` pairs, and attaches it as
+        :attr:`calibrator` so :meth:`predict`/:meth:`resolve` map every raw score
+        to a calibrated probability. Supervision comes from id-keyed ``pairs``
+        (joined via :func:`~langres.core.harvest.align_pairs`, whose optional
+        entity-disjoint ``split`` gives a held-out fold) or pre-aligned ``labels``.
+
+        The honest test: when a ``valid`` split exists, the ``FitReport`` carries
+        the Brier/ECE **before vs after** calibration on that held-out fold (raw
+        matcher scores vs the fitted map) -- a real calibrator drives both down.
+        Does NOT retrain or touch the matcher, and does NOT change the clusterer:
+        calibration only makes the score a true probability so the existing
+        threshold is meaningful.
+
+        Raises:
+            ImportError: If scikit-learn (the ``[trained]`` extra) is not installed.
+            ValueError: If ``method`` exposes no ``.strategy`` (not a
+                :class:`~langres.core.methods_calibrate.CalibrateMethod`); if both
+                ``labels`` and ``pairs`` are given, or neither; or if the matcher
+                emits no scores to calibrate (a pure decider).
         """
-        raise NotImplementedError(
-            f"method kind 'calibrate' dispatch is wired but its fit path lands in "
-            f"PR-D ({method.describe()})."
+        try:
+            from langres.core.calibration import Calibrator
+        except ImportError as exc:  # pragma: no cover - core-only env
+            raise ImportError(
+                "score calibration (method='calibrate') needs scikit-learn (the "
+                "'trained' extra): pip install 'langres[trained]' "
+                "(or uv add 'langres[trained]')."
+            ) from exc
+
+        strategy = getattr(method, "strategy", None)
+        if strategy is None:
+            raise ValueError(
+                f"method.kind='calibrate' needs a CalibrateMethod exposing .strategy "
+                f"(e.g. Platt()/Isotonic()); got {type(method).__name__} "
+                f"({method.describe()})."
+            )
+        if labels is not None and pairs is not None:
+            raise ValueError(
+                "pass either labels= (pre-aligned with the blocked candidates) or "
+                "pairs= (id-keyed labels align_pairs() joins), not both."
+            )
+
+        coverage = None
+        valid_candidates: Sequence[ERCandidate[Any]] = []
+        valid_labels: Sequence[bool] = []
+        if pairs is not None:
+            aligned = align_pairs(self.candidates(data), pairs, split=split, seed=seed)
+            train_candidates: Sequence[ERCandidate[Any]] = aligned.train.candidates
+            train_labels: Sequence[bool] = aligned.train.labels
+            valid_candidates = aligned.valid.candidates
+            valid_labels = aligned.valid.labels
+            coverage = aligned.coverage
+        elif labels is not None:
+            train_candidates = self.candidates(data)
+            train_labels = labels
+        else:
+            raise ValueError(
+                f"score calibration ({method.describe()}) needs gold labels: pass "
+                "pairs=<id-keyed labels> or labels=<pre-aligned with the blocked "
+                "candidates>."
+            )
+
+        train_scores, train_score_labels = self._scored_labeled_pairs(
+            train_candidates, train_labels
+        )
+        if not train_scores:
+            raise ValueError(
+                f"{type(self.module).__name__} produced no scores to calibrate: score "
+                "calibration needs a ranking matcher (one that emits "
+                "PairwiseJudgement.score), not a pure decider."
+            )
+        calibrator = Calibrator(method=strategy)
+        calibrator.fit_calibrator(train_scores, train_score_labels)
+        self.calibrator = calibrator
+
+        calibration = self._calibration_delta(strategy, calibrator, valid_candidates, valid_labels)
+
+        self.fit_report_ = FitReport.build(
+            trainable=f"Calibrator ({strategy})",
+            trained=True,
+            n_train=len(train_score_labels),
+            n_valid=len(valid_labels),
+            split=split,
+            seed=seed,
+            coverage=coverage,
+            threshold=self.clusterer.threshold,
+            calibration=calibration,
+            run_ref=current_run.get(),
+        )
+        return self
+
+    def _scored_labeled_pairs(
+        self, candidates: Sequence[ERCandidate[Any]], labels: Sequence[bool]
+    ) -> tuple[list[float], list[bool]]:
+        """Score ``candidates`` with the matcher and join scores back to labels by id.
+
+        Returns ``(scores, labels)`` for the ranking judgements only (``score is
+        not None``), keyed by the unordered ``{left_id, right_id}`` pair so the
+        join is robust to any reordering/filtering the matcher's ``forward`` does.
+        """
+        label_by_pair = {
+            frozenset({str(c.left.id), str(c.right.id)}): bool(label)
+            for c, label in zip(candidates, labels, strict=True)
+        }
+        scores: list[float] = []
+        aligned_labels: list[bool] = []
+        for judgement in self.module.forward(iter(candidates)):
+            if judgement.score is None:
+                continue
+            key = frozenset({judgement.left_id, judgement.right_id})
+            if key in label_by_pair:
+                scores.append(judgement.score)
+                aligned_labels.append(label_by_pair[key])
+        return scores, aligned_labels
+
+    def _calibration_delta(
+        self,
+        strategy: str,
+        calibrator: CalibratorFitMixin,
+        valid_candidates: Sequence[ERCandidate[Any]],
+        valid_labels: Sequence[bool],
+    ) -> CalibrationDelta | None:
+        """Brier/ECE before-vs-after calibration on the held-out ``valid`` split.
+
+        ``None`` when there is no valid split (nothing held out to measure on) or
+        the matcher emits no scores over it. Raw matcher scores are already in
+        ``[0, 1]`` (``PairwiseJudgement.score``'s contract), so both metrics are
+        always defined on the "before" side.
+        """
+        if not valid_candidates:
+            return None
+        valid_scores, valid_score_labels = self._scored_labeled_pairs(
+            valid_candidates, valid_labels
+        )
+        if not valid_scores:
+            return None
+        after = calibrator.transform(valid_scores)
+        return CalibrationDelta(
+            method=strategy,
+            brier_before=brier_score(valid_scores, valid_score_labels),
+            brier_after=brier_score(after, valid_score_labels),
+            ece_before=expected_calibration_error(valid_scores, valid_score_labels),
+            ece_after=expected_calibration_error(after, valid_score_labels),
         )
 
     def _fit_from_pairs(
@@ -1067,8 +1220,46 @@ class Resolver:
         return list(self._candidates(records))
 
     def _judgements(self, records: list[Any]) -> Iterator[PairwiseJudgement]:
-        """Block records into candidates and score them into judgements."""
-        return self.module.forward(self._candidates(records))
+        """Block records into candidates, score them, and calibrate if fitted.
+
+        When :attr:`calibrator` is set (by ``fit(method=Platt()/Isotonic())``),
+        every ranking judgement's raw ``score`` is mapped to a calibrated
+        probability before it reaches :meth:`predict`/:meth:`resolve` -- so the
+        clusterer thresholds on a real probability. Pure pass-through otherwise.
+        """
+        judgements = self.module.forward(self._candidates(records))
+        if self.calibrator is None:
+            return judgements
+        return self._apply_calibrator(judgements, self.calibrator)
+
+    def _apply_calibrator(
+        self, judgements: Iterator[PairwiseJudgement], calibrator: CalibratorFitMixin
+    ) -> Iterator[PairwiseJudgement]:
+        """Map each ranking judgement's ``score`` through the fitted calibrator.
+
+        Deciders (``score is None``) pass through untouched -- there is no score to
+        calibrate. A mapped judgement keeps its ids/decision, retags
+        ``score_type="calibrated_prob"``, and records the raw score under
+        ``provenance["calibration"]`` for auditability.
+        """
+        for judgement in judgements:
+            if judgement.score is None:
+                yield judgement
+                continue
+            calibrated = calibrator.transform([judgement.score])[0]
+            yield judgement.model_copy(
+                update={
+                    "score": calibrated,
+                    "score_type": "calibrated_prob",
+                    "provenance": {
+                        **judgement.provenance,
+                        "calibration": {
+                            "method": getattr(calibrator, "method", None),
+                            "raw_score": judgement.score,
+                        },
+                    },
+                }
+            )
 
     def predict(self, records: list[Any]) -> list[PairwiseJudgement]:
         """Return the scored pairwise judgements before clustering.
@@ -1197,15 +1388,19 @@ class Resolver:
     # ------------------------------------------------------------------
 
     def _slots(self) -> list[tuple[str, object]]:
-        """Ordered (slot_name, component) pairs, skipping an absent comparator.
+        """Ordered (slot_name, component) pairs, skipping absent optional slots.
 
         The slot name doubles as the sidecar subdirectory name for components
-        that own out-of-band state.
+        that own out-of-band state. The comparator and calibrator are optional
+        slots, emitted only when set; the clusterer stays last so the legacy
+        positional load fallback (``ordered[-1]`` is the clusterer) still holds.
         """
         slots: list[tuple[str, object]] = [("blocker", self.blocker)]
         if self.comparator is not None:
             slots.append(("comparator", self.comparator))
         slots.append(("module", self.module))
+        if self.calibrator is not None:
+            slots.append(("calibrator", self.calibrator))
         slots.append(("clusterer", self.clusterer))
         return slots
 
@@ -1325,12 +1520,14 @@ class Resolver:
         # with a custom ``type_name`` (e.g. a "phonetic_comparator" Comparator)
         # still loads into the right slot. Older/hand-written manifests have no
         # ``slot``; those fall back to positional + type_name identification.
+        calibrator_spec: ComponentSpec | None = None
         by_slot = {spec.slot: spec for spec in manifest.components if spec.slot}
         if by_slot:
             blocker_spec = by_slot.get("blocker")
             comparator_spec = by_slot.get("comparator")
             module_spec = by_slot.get("module")
             clusterer_spec = by_slot.get("clusterer")
+            calibrator_spec = by_slot.get("calibrator")
             if blocker_spec is None or module_spec is None or clusterer_spec is None:
                 raise ValueError(
                     "Malformed artifact manifest: missing required slot among "
@@ -1366,12 +1563,18 @@ class Resolver:
         )
         module = _rebuild_component(module_spec, state_dir=in_dir / "module")
         clusterer = _rebuild_component(clusterer_spec, state_dir=in_dir / "clusterer")
+        calibrator = (
+            _rebuild_component(calibrator_spec, state_dir=in_dir / "calibrator")
+            if calibrator_spec is not None
+            else None
+        )
 
         return cls(
             blocker=blocker,
             comparator=comparator,
             matcher=module,
             clusterer=clusterer,
+            calibrator=calibrator,
         )
 
     @staticmethod

--- a/tests/core/test_calibration.py
+++ b/tests/core/test_calibration.py
@@ -1,16 +1,21 @@
-"""Tests for the data-driven threshold helper ``derive_threshold``.
+"""Tests for the calibration module: ``derive_threshold`` + the ``Calibrator``.
 
-All tests are deterministic and cost $0: they exercise the pure function on
-small synthetic score/label sets. Coverage focuses on the two derivation
-methods (Youden's J and percentile), the in-range guarantee, and every
-degenerate input (all-one-class, single point, ties, mismatched lengths,
-empty, bad arguments).
+All tests are deterministic and cost $0: they exercise pure functions / the
+NumPy-applied calibrator on small synthetic score/label sets. Coverage focuses
+on the two threshold-derivation methods (Youden's J and percentile) and their
+degenerate inputs, plus the fittable Platt/isotonic :class:`Calibrator` -- the
+honest before/after Brier/ECE proof, its fit guards, and the JSON config
+round-trip that reconstructs a fitted, scikit-learn-free map.
 """
+
+import json
 
 import numpy as np
 import pytest
 
-from langres.core.calibration import derive_threshold
+from langres.core.calibration import Calibrator, derive_threshold
+from langres.core.fit import CalibratorFitMixin
+from langres.core.metrics import brier_score, expected_calibration_error
 
 
 def test_youden_separates_clean_bimodal() -> None:
@@ -162,3 +167,120 @@ def test_unknown_method_raises() -> None:
     """An unrecognized method is a clear error (defensive, beyond the type hint)."""
     with pytest.raises(ValueError, match="method"):
         derive_threshold([0.1, 0.9], [False, True], method="bogus")  # type: ignore[arg-type]
+
+
+# ---------------------------------------------------------------------------
+# Calibrator: the fittable score->probability map (Platt / isotonic).
+# ---------------------------------------------------------------------------
+
+
+def _miscalibrated_set(n: int = 400, seed: int = 1) -> tuple[list[float], list[bool]]:
+    """A deliberately miscalibrated set: correct ranking, over-confident scores.
+
+    Outcomes are Bernoulli(raw), but the observed score squashes ``raw`` away from
+    0.5 (``0.5 + sign·sqrt|raw-0.5|``) -- the ranking is preserved while the score
+    systematically over-states its confidence, so a real calibrator must lower
+    both Brier and ECE.
+    """
+    rng = np.random.default_rng(seed)
+    raw = rng.uniform(0.0, 1.0, n)
+    labels = rng.uniform(0.0, 1.0, n) < raw
+    scores = np.clip(0.5 + np.sign(raw - 0.5) * np.sqrt(np.abs(raw - 0.5)), 0.0, 1.0)
+    return scores.tolist(), [bool(x) for x in labels]
+
+
+@pytest.mark.parametrize("method", ["platt", "isotonic"])
+def test_calibration_lowers_brier_and_ece(method: str) -> None:
+    """The honest proof: fitting a calibrator drives Brier AND ECE down.
+
+    On a set that ranks correctly but is over-confident, both Platt and isotonic
+    must produce a strictly better Brier score and a no-worse ECE than the raw,
+    uncalibrated scores -- otherwise the map is not really calibrating.
+    """
+    scores, labels = _miscalibrated_set()
+    brier_before = brier_score(scores, labels)
+    ece_before = expected_calibration_error(scores, labels)
+
+    cal = Calibrator(method)  # type: ignore[arg-type]
+    cal.fit_calibrator(scores, labels)
+    calibrated = cal.transform(scores)
+
+    assert all(0.0 <= p <= 1.0 for p in calibrated)
+    assert brier_score(calibrated, labels) < brier_before
+    assert expected_calibration_error(calibrated, labels) <= ece_before
+
+
+def test_calibrator_satisfies_the_fit_protocol() -> None:
+    """A Calibrator IS a CalibratorFitMixin (structural: fit_calibrator + transform)."""
+    assert isinstance(Calibrator("platt"), CalibratorFitMixin)
+
+
+def test_platt_is_the_default_method() -> None:
+    """Omitting ``method`` builds a Platt (logistic) calibrator."""
+    assert Calibrator().method == "platt"
+
+
+def test_unknown_method_rejected_at_construction() -> None:
+    """An unsupported strategy is a clear error, not a late surprise at fit."""
+    with pytest.raises(ValueError, match="platt.*isotonic"):
+        Calibrator("sigmoidal")  # type: ignore[arg-type]
+
+
+def test_transform_before_fit_raises() -> None:
+    """Applying an unfit calibrator is a clear RuntimeError, not silent garbage."""
+    cal = Calibrator("platt")
+    assert not cal.fitted
+    with pytest.raises(RuntimeError, match="before fit"):
+        cal.transform([0.5])
+
+
+def test_fit_needs_both_classes() -> None:
+    """A single-class label set cannot define a calibration map."""
+    cal = Calibrator("platt")
+    with pytest.raises(ValueError, match="both classes"):
+        cal.fit_calibrator([0.1, 0.5, 0.9], [True, True, True])
+
+
+def test_fit_rejects_mismatched_and_empty() -> None:
+    """Length-mismatched and empty inputs are clear errors."""
+    cal = Calibrator("isotonic")
+    with pytest.raises(ValueError, match="equal length"):
+        cal.fit_calibrator([0.1, 0.2, 0.3], [True, False])
+    with pytest.raises(ValueError, match="non-empty"):
+        cal.fit_calibrator([], [])
+
+
+@pytest.mark.parametrize("method", ["platt", "isotonic"])
+def test_from_config_round_trips_a_fitted_calibrator(method: str) -> None:
+    """save/load fidelity: config -> JSON -> from_config maps identically.
+
+    The learned params are plain floats carried inline in ``config`` (no weight
+    files), and ``transform`` is pure NumPy -- so a reconstructed calibrator
+    scores byte-identically to the freshly-fit one it came from.
+    """
+    scores, labels = _miscalibrated_set(n=120, seed=3)
+    cal = Calibrator(method)  # type: ignore[arg-type]
+    cal.fit_calibrator(scores, labels)
+
+    config = json.loads(json.dumps(cal.config))  # prove the config is JSON-safe
+    rebuilt = Calibrator.from_config(config)
+
+    assert rebuilt.method == method
+    assert rebuilt.fitted
+    probe = [0.0, 0.15, 0.37, 0.5, 0.63, 0.88, 1.0]
+    assert rebuilt.transform(probe) == cal.transform(probe)
+
+
+def test_transform_clips_to_unit_interval() -> None:
+    """Isotonic outputs stay in [0, 1] even for out-of-range inputs (clip)."""
+    cal = Calibrator("isotonic")
+    cal.fit_calibrator([0.2, 0.4, 0.6, 0.8], [False, False, True, True])
+    out = cal.transform([-5.0, 0.5, 5.0])
+    assert all(0.0 <= p <= 1.0 for p in out)
+
+
+def test_call_is_transform() -> None:
+    """``calibrator(scores)`` is sugar for ``calibrator.transform(scores)``."""
+    cal = Calibrator("platt")
+    cal.fit_calibrator([0.1, 0.4, 0.6, 0.9], [False, False, True, True])
+    assert cal([0.3, 0.7]) == cal.transform([0.3, 0.7])

--- a/tests/core/test_resolver_fit_calibrate.py
+++ b/tests/core/test_resolver_fit_calibrate.py
@@ -1,0 +1,219 @@
+"""Tests for the score-calibration fit path + ``Platt``/``Isotonic`` methods (PR-D).
+
+Two seams land here on top of the PR-M ``method=`` dispatch:
+
+- **``fit(method=Platt()/Isotonic())``** learns a score→probability
+  :class:`~langres.core.calibration.Calibrator` from labeled pairs (the
+  ``method.kind == "calibrate"`` branch, now real), attaches it to the Resolver,
+  and applies it in ``predict()``/``resolve()``. Every test is deterministic and
+  ``$0`` (a ``WeightedAverageMatcher`` over company names -- no LM calls).
+- The concrete ``Platt``/``Isotonic`` :class:`Method` objects are unit-tested
+  here too (kind, strategy identity, ``describe()``).
+
+The *quality* proof (calibration lowers Brier/ECE) lives on the ``Calibrator``
+itself in ``tests/core/test_calibration.py``; these tests exercise the Resolver
+wiring: dispatch, ``describe()``, the calibrated predict path, the ``FitReport``
+delta, and the save/load round-trip of a fitted calibrator.
+"""
+
+from pathlib import Path
+
+import pytest
+
+from langres.core.harvest import LabeledPair
+from langres.core.methods_api import Method
+from langres.core.methods_calibrate import CalibrateMethod, Isotonic, Platt
+from langres.core.models import CompanySchema
+from langres.core.resolver import Resolver
+
+# Six disconnected groups; each is one entity-disjoint component carrying two
+# positives (X~X, Y~Y) and one negative (X!Y). An entity-disjoint ``split`` holds
+# out WHOLE groups, so both train and valid see both classes -- the shape the
+# calibrate fit and its held-out Brier/ECE delta need.
+_BASES = [
+    ("Acme", "Beta"),
+    ("Gamma", "Delta"),
+    ("Epsilon", "Zeta"),
+    ("Eta", "Theta"),
+    ("Iota", "Kappa"),
+    ("Lambda", "Mu"),
+]
+
+
+def _dataset() -> tuple[list[dict[str, str]], list[LabeledPair]]:
+    records: list[dict[str, str]] = []
+    pairs: list[LabeledPair] = []
+    for g, (x, y) in enumerate(_BASES):
+        x0, x1, y0, y1 = f"g{g}x0", f"g{g}x1", f"g{g}y0", f"g{g}y1"
+        records += [
+            {"id": x0, "name": f"{x} Corp"},
+            {"id": x1, "name": f"{x} Corporation"},
+            {"id": y0, "name": f"{y} Inc"},
+            {"id": y1, "name": f"{y} Incorporated"},
+        ]
+        pairs += [
+            LabeledPair(left_id=x0, right_id=x1, score=None, label=True, source="correction"),
+            LabeledPair(left_id=y0, right_id=y1, score=None, label=True, source="correction"),
+            LabeledPair(left_id=x0, right_id=y0, score=None, label=False, source="correction"),
+        ]
+    return records, pairs
+
+
+def _resolver() -> Resolver:
+    return Resolver.from_schema(CompanySchema, matcher="string", threshold=0.5)
+
+
+# --- Method objects: kind, strategy identity, describe() --------------------
+
+
+def test_calibrate_methods_share_kind_calibrate() -> None:
+    """Both concrete calibrate methods route through the ``kind == "calibrate"`` branch."""
+    assert Platt.kind == "calibrate"
+    assert Isotonic.kind == "calibrate"
+    assert issubclass(Platt, CalibrateMethod) and issubclass(Isotonic, Method)
+
+
+def test_strategy_is_classvar_not_a_field() -> None:
+    """``strategy`` is strategy-type identity, not serialized per-instance config."""
+    assert Platt.strategy == "platt"
+    assert Isotonic.strategy == "isotonic"
+    assert "strategy" not in Platt.model_fields
+    assert "kind" not in Platt.model_fields
+
+
+def test_describe_names_the_strategy() -> None:
+    assert Platt().describe() == "calibrate (Platt scaling)"
+    assert Isotonic().describe() == "calibrate (isotonic regression)"
+
+
+# --- describe(): the calibrator row -----------------------------------------
+
+
+def test_describe_shows_calibrator_none_before_fit() -> None:
+    """A fresh Resolver reports no calibrator, frozen."""
+    row = next(
+        line for line in _resolver().describe().splitlines() if line.startswith("calibrator")
+    )
+    assert "<none>" in row and "frozen" in row
+
+
+def test_describe_shows_calibrator_trainable_after_fit() -> None:
+    """Once fitted, the calibrator row names the component and is TRAINABLE."""
+    records, pairs = _dataset()
+    resolver = _resolver().fit(records, pairs=pairs, method=Platt())
+    row = next(line for line in resolver.describe().splitlines() if line.startswith("calibrator"))
+    assert "Calibrator" in row and "TRAINABLE" in row
+
+
+# --- The calibrate fit path --------------------------------------------------
+
+
+@pytest.mark.parametrize("method_cls", [Platt, Isotonic])
+def test_fit_calibrate_attaches_calibrator_and_report(method_cls: type[CalibrateMethod]) -> None:
+    """``fit(method=...)`` sets ``calibrator`` + a trained ``fit_report_``."""
+    records, pairs = _dataset()
+    resolver = _resolver()
+    returned = resolver.fit(records, pairs=pairs, method=method_cls())
+
+    assert returned is resolver  # chains
+    assert resolver.calibrator is not None
+    assert resolver.calibrator.method == method_cls.strategy
+    report = resolver.fit_report_
+    assert report is not None and report.trained
+    assert report.trainable == f"Calibrator ({method_cls.strategy})"
+    assert report.n_train > 0
+
+
+def test_fit_calibrate_reports_brier_ece_before_after_on_valid() -> None:
+    """With a split, the report carries the held-out Brier/ECE before-vs-after."""
+    records, pairs = _dataset()
+    resolver = _resolver().fit(records, pairs=pairs, method=Platt(), split=0.4, seed=0)
+
+    delta = resolver.fit_report_.calibration
+    assert delta is not None
+    assert delta.method == "platt"
+    # The synthetic set is over-confident, so calibration must not worsen it.
+    assert delta.brier_after <= delta.brier_before
+    assert delta.ece_after <= delta.ece_before
+    assert "Calibration (platt" in resolver.fit_report_.to_markdown()
+
+
+def test_no_split_leaves_calibration_delta_none() -> None:
+    """Without a held-out split there is nothing to measure before/after on."""
+    records, pairs = _dataset()
+    resolver = _resolver().fit(records, pairs=pairs, method=Platt())
+    assert resolver.fit_report_.calibration is None
+
+
+def test_predict_returns_calibrated_probabilities() -> None:
+    """After a calibrate fit, ``predict()`` scores are calibrated probs, not raw."""
+    records, pairs = _dataset()
+    resolver = _resolver()
+    raw = {(j.left_id, j.right_id): j.score for j in resolver.predict(records)}
+
+    resolver.fit(records, pairs=pairs, method=Platt())
+    calibrated = resolver.predict(records)
+
+    assert calibrated  # non-empty
+    changed = 0
+    for j in calibrated:
+        assert j.score is not None and 0.0 <= j.score <= 1.0
+        assert j.score_type == "calibrated_prob"
+        assert j.provenance["calibration"]["method"] == "platt"
+        if abs(raw[(j.left_id, j.right_id)] - j.score) > 1e-9:
+            changed += 1
+    assert changed > 0  # calibration actually moved the scores
+
+
+def test_save_load_round_trips_a_fitted_calibrator(tmp_path: Path) -> None:
+    """A fitted calibrator round-trips through save/load with identical predictions."""
+    records, pairs = _dataset()
+    resolver = _resolver().fit(records, pairs=pairs, method=Isotonic())
+    before = {(j.left_id, j.right_id): j.score for j in resolver.predict(records)}
+
+    resolver.save(tmp_path / "artifact")
+    reloaded = Resolver.load(tmp_path / "artifact")
+
+    assert reloaded.calibrator is not None
+    assert reloaded.calibrator.method == "isotonic"
+    after = {(j.left_id, j.right_id): j.score for j in reloaded.predict(records)}
+    assert before.keys() == after.keys()
+    assert all(abs(before[k] - after[k]) < 1e-12 for k in before)
+
+
+def test_uncalibrated_resolver_saves_without_calibrator_slot(tmp_path: Path) -> None:
+    """No calibrator => no calibrator slot in the manifest (optional slot stays absent)."""
+    resolver = _resolver()
+    resolver.save(tmp_path / "artifact")
+    manifest = (tmp_path / "artifact" / "resolver.json").read_text()
+    assert "calibrator" not in manifest
+    assert Resolver.load(tmp_path / "artifact").calibrator is None
+
+
+# --- Error paths -------------------------------------------------------------
+
+
+def test_calibrate_without_labels_raises() -> None:
+    """Calibration needs supervision; neither labels nor pairs is an error."""
+    records, _ = _dataset()
+    with pytest.raises(ValueError, match="needs gold labels"):
+        _resolver().fit(records, method=Platt())
+
+
+def test_calibrate_with_both_labels_and_pairs_raises() -> None:
+    """Passing both supervision channels is a clear error."""
+    records, pairs = _dataset()
+    with pytest.raises(ValueError, match="either labels|not both"):
+        _resolver().fit(records, labels=[True], pairs=pairs, method=Platt())
+
+
+def test_calibrate_with_non_calibrate_method_raises() -> None:
+    """A method whose kind is not 'calibrate' never reaches _fit_calibrate; a
+    bare CalibrateMethod (no .strategy) is rejected with an actionable message."""
+    records, pairs = _dataset()
+
+    class _Bare(CalibrateMethod):
+        """A CalibrateMethod subclass that forgot to set .strategy."""
+
+    with pytest.raises(ValueError, match="needs a CalibrateMethod exposing .strategy"):
+        _resolver().fit(records, pairs=pairs, method=_Bare())

--- a/tests/core/test_resolver_fit_calibrate.py
+++ b/tests/core/test_resolver_fit_calibrate.py
@@ -16,14 +16,16 @@ wiring: dispatch, ``describe()``, the calibrated predict path, the ``FitReport``
 delta, and the save/load round-trip of a fitted calibrator.
 """
 
+from collections.abc import Iterator
 from pathlib import Path
+from typing import Any
 
 import pytest
 
 from langres.core.harvest import LabeledPair
 from langres.core.methods_api import Method
 from langres.core.methods_calibrate import CalibrateMethod, Isotonic, Platt
-from langres.core.models import CompanySchema
+from langres.core.models import CompanySchema, ERCandidate, PairwiseJudgement
 from langres.core.resolver import Resolver
 
 # Six disconnected groups; each is one entity-disjoint component carrying two
@@ -217,3 +219,28 @@ def test_calibrate_with_non_calibrate_method_raises() -> None:
 
     with pytest.raises(ValueError, match="needs a CalibrateMethod exposing .strategy"):
         _resolver().fit(records, pairs=pairs, method=_Bare())
+
+
+class _DeciderOnlyMatcher:
+    """A matcher that decides but never ranks (``score=None``) -- nothing to calibrate."""
+
+    def forward(self, candidates: Iterator[ERCandidate[Any]]) -> Iterator[PairwiseJudgement]:
+        for candidate in candidates:
+            yield PairwiseJudgement(
+                left_id=str(candidate.left.id),
+                right_id=str(candidate.right.id),
+                decision=True,
+                score=None,
+                score_type="prob_llm",
+                decision_step="decider",
+                provenance={},
+            )
+
+
+def test_calibrate_on_scoreless_matcher_raises() -> None:
+    """A pure decider emits no scores, so calibration has nothing to fit -- clear error."""
+    records, pairs = _dataset()
+    resolver = _resolver()
+    resolver.module = _DeciderOnlyMatcher()  # type: ignore[assignment]
+    with pytest.raises(ValueError, match="no scores to calibrate"):
+        resolver.fit(records, pairs=pairs, method=Platt())

--- a/tests/core/test_resolver_fit_method.py
+++ b/tests/core/test_resolver_fit_method.py
@@ -1,12 +1,13 @@
 """Tests for the ``method=`` object seam on ``Resolver.fit`` (PR-M).
 
 ``fit(..., method=<Method>)`` dispatches on ``method.kind`` to the matching fit
-path *before* the module-hook isinstance chain. The ``prompt``/``calibrate``
-bodies still land in later PRs (MIPRO/PR-C, Platt/PR-D), so those wired kinds
-raise a clear ``NotImplementedError`` naming that PR; ``finetune`` (PR-F) now
-routes to its real ``_fit_finetune`` handler, which rejects a non-``QLoRA``
-finetune method with a ``TypeError`` that still surfaces ``describe()``. Either
-way the dispatch + param plumbing is real, which is what these tests lock:
+path *before* the module-hook isinstance chain. All three concrete kinds now
+route to real handlers (``prompt``/PR-C, ``finetune``/PR-F, ``calibrate``/PR-D):
+each rejects a malformed method for its kind with a distinct, handler-specific
+error (a non-``DSPyMatcher`` module, a non-``QLoRA`` method, a calibrate method
+missing ``.strategy``) that still surfaces ``describe()``. That distinct error
+text is what proves the routing; the dispatch + param plumbing is real, which is
+what these tests lock:
 
 - distinct ``kind`` values route to distinct branches (distinct error text);
 - an unrecognized ``kind`` falls through to a "no Method implements it" error;
@@ -59,7 +60,7 @@ class _FinetuneMethod(Method):
 
 
 class _CalibrateMethod(Method):
-    """Fake calibrate strategy (kind wired to PR-D)."""
+    """A malformed calibrate strategy: right kind, but no ``.strategy`` set."""
 
     kind: ClassVar[str] = "calibrate"
 
@@ -111,9 +112,14 @@ def test_prompt_kind_routes_to_pr_c_prompt_fit() -> None:
         _resolver().fit(RECORDS, method=_PromptMethod())
 
 
-def test_calibrate_kind_routes_to_pr_d_stub() -> None:
-    """A ``kind="calibrate"`` method routes to the PR-D branch."""
-    with pytest.raises(NotImplementedError, match=r"method kind 'calibrate'.*lands in PR-D"):
+def test_calibrate_kind_routes_to_calibrate_handler() -> None:
+    """A ``kind="calibrate"`` method routes to the real PR-D ``_fit_calibrate`` branch.
+
+    ``_fit_calibrate`` needs a ``CalibrateMethod`` exposing ``.strategy``; the fake
+    here has none, so it raises that clear error -- which *proves routing* (a
+    different branch than prompt/finetune) without needing gold pairs.
+    """
+    with pytest.raises(ValueError, match=r"needs a CalibrateMethod exposing .strategy"):
         _resolver().fit(RECORDS, method=_CalibrateMethod())
 
 


### PR DESCRIPTION
## What

Adds probability **calibration** as a first-class fittable role: a `Calibrator` (Platt / isotonic) that learns a score→probability map, driven through the existing `fit(method=Platt()/Isotonic())` seam. Completes the last of the epic's four contracts (`CalibratorFitMixin` was contract-only) and DoD example 5's `calibrator — TRAINABLE` line.

## Design

- **`Calibrator`** in `core/calibration.py` implementing `CalibratorFitMixin` — Platt (sklearn `LogisticRegression`) + isotonic (`IsotonicRegression`). sklearn is touched **only** during `fit_calibrator`; `transform()` applies learned params with pure NumPy (sigmoid / `np.interp`), so predict/load never import sklearn (mirrors `RandomForestMatcher`'s no-pickle state).
- **`Platt` / `Isotonic` method objects** in a NEW import-light `core/methods_calibrate.py` (pydantic-only, `CalibrateMethod` base + `strategy` ClassVar). Kept OUT of `calibration.py` because that module imports sklearn at top — constructing `Platt()` pulls zero sklearn (import-budget safe).
- **Persistence:** learned params inline in `config` (Platt = 2 floats `{coef,intercept}`; isotonic = a small `{x,y}` grid), no weight files. Save/load round-trips predictions identical to 1e-12. New optional `"calibrator"` manifest slot.
- `_fit_calibrate` (was a `NotImplementedError` stub) now aligns pairs, fits the calibrator on the matcher's scores, attaches `self.calibrator`, and reports a `CalibrationDelta` (Brier/ECE before→after) in the `FitReport`. The calibrator is applied in the predict path.
- Widened `CalibratorFitMixin` with `transform()` (the apply half predict needs; was fit-only, no existing implementers → safe).

## Real Brier/ECE (actually run)

- Standalone (over-confident 400-pt set): Platt Brier 0.199→0.176, ECE 0.155→0.077; Isotonic Brier 0.199→0.162, ECE 0.155→0.000.
- End-to-end `resolver.fit(..., method=Platt(), split=0.4)`: Brier 0.667→0.222, ECE 0.667→~0 (both strategies). Surfaced in `FitReport.calibration` + `to_markdown()`.

## Scope

- Two named Method classes (parity with `Bootstrap`/`MIPRO`). `describe()` unchanged — shows `calibrator: Calibrator — TRAINABLE`.
- No Bands/three-band (deferred); `derive_threshold` untouched.
- Public root-export of `Platt`/`Isotonic`/`Calibrator` left for the integration→main PR (task #13); `Calibrator` added to `langres.core.__all__` + lazy `[trained]` symbol.

## Gates

- `uv run --all-extras pytest -m "not integration and not slow"` → 2921 passed, 98.34% cov (calibration.py + methods_calibrate 100%)
- `uv run pytest tests/test_import_budget.py` → 30 passed (`import langres` pulls neither sklearn nor `core.calibration`)
- `uv run --no-dev --group docs mkdocs build --strict` → clean
- mypy + ruff → clean

Part of the training-surface epic (#125) → `feat/training-surface`.

## Summary by Sourcery

Add a trainable score calibration role with a concrete Calibrator component and integrate it into Resolver.fit, prediction, persistence, and fit reporting.

New Features:
- Introduce a Calibrator component that learns score-to-probability mappings using Platt scaling or isotonic regression and expose it as a trainable role.
- Add Platt and Isotonic Method classes to drive calibrator training via Resolver.fit(method=...).
- Include calibration quality metrics (before vs after Brier score and ECE) in FitReport and its Markdown rendering.

Enhancements:
- Wire the Resolver to fit and apply an optional calibrator in the prediction path and to persist it as an optional slot in saved artifacts.
- Extend the calibration module from threshold derivation to also support serializable Platt/isotonic calibration with NumPy-only inference.
- Clarify and widen the CalibratorFitMixin protocol to cover both fitting and transforming scores, and document the calibrate fit path in the technical overview.

Documentation:
- Update the technical overview to describe the implemented Calibrator role, its integration via Resolver.fit(method=Platt()/Isotonic()), and the behavior of the calibrate method kind.

Tests:
- Add unit tests for the Calibrator implementation, its JSON round-trip, and its effect on Brier/ECE metrics.
- Add resolver-level tests for the calibrate fit path, calibrated predictions, fit report calibration deltas, and save/load behavior of fitted calibrators.
- Extend existing Resolver.fit(method=...) dispatch tests to cover the real calibrate handler and update expectations accordingly.