### PR TITLE
PR-G: capstone — train→serve→evaluate (the DoD) + CPU-pin guard

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -48,6 +48,11 @@ flywheel harvest → closed-loop flywheel → person:
   (needs the `[trained]` extra).
 - **`person_resolution.py`** — the embeddings + LLM "strong path" on a second
   entity type: semantic blocking (MiniLM + FAISS) feeding an LLM judge.
+- **`finetune_capstone.py`** — the training-surface capstone: **train your own
+  matcher** end to end — fine-tune SmolLM2-135M with LoRA on a real benchmark
+  slice, serve the weightless `model_ref` in-process, and evaluate held-out F1,
+  reporting the honest cost in GPU-seconds. A REAL (small) fine-tune, slow on
+  CPU/MPS; needs the `[finetune,semantic,llm]` extras (see its docstring).
 
 ## Example Data
 

--- a/examples/finetune_capstone.py
+++ b/examples/finetune_capstone.py
@@ -20,6 +20,14 @@ On a CUDA GPU it is a couple of minutes; on CPU / Apple-Silicon MPS it is SLOW
 LoRA fine-tune when there is no CUDA. Local training has **no dollar cost**; the
 honest cost fact is GPU-seconds (printed below).
 
+What to expect (the flow is the lesson, not the score): SmolLM2-135M is a
+deliberately tiny base, so the held-out F1 *at the default 0.5 cut* is LOW. The
+fine-tune reliably finds the true matches (high recall) but over-includes
+non-matches (low precision), because the small model's Yes-confidence clusters
+near the 0.5 fence. That is not a broken flow -- it is a small, uncalibrated base.
+The two levers to raise it, both elsewhere on this same training surface: a
+larger base, or a calibrated decision threshold instead of the naive 0.5.
+
 Needs the training + serving + blocking extras:
 
     uv sync --extra finetune --extra semantic --extra llm
@@ -106,6 +114,11 @@ def main() -> None:
         f"P={result.pair.precision:.3f} R={result.pair.recall:.3f} F1={result.pair.f1:.3f}\n"
         f"honest cost: {outcome.gpu_seconds:.1f} GPU-seconds on {outcome.device} "
         f"(${outcome.dollars:.4f})"
+    )
+    print(
+        "\nRecall-heavy, low precision at the 0.5 cut is expected for a 135M base "
+        "(see the module docstring): it finds the matches but over-includes. Raise "
+        "it with a larger base or a calibrated threshold -- same training surface."
     )
 
 

--- a/examples/finetune_capstone.py
+++ b/examples/finetune_capstone.py
@@ -1,0 +1,113 @@
+"""Capstone: fine-tune your own matcher, serve it in-process, and evaluate it.
+
+The training surface end to end, on a real (small) benchmark slice --
+**train -> serve -> evaluate** through the public API, reporting F1 *and* the
+honest cost (GPU-seconds). This is the script to read to learn "how do I train
+my own matcher end to end?"
+
+The flow is five public calls, one per step:
+
+  1. ``candidates_for(bench, split="train")`` -> blocked candidate pairs + gold
+  2. label from gold, then balance             -> ``(candidate, is_match)`` pairs
+  3. ``run_finetune(pairs, QLoRA(base=...))``   -> a weightless ``model_ref`` + GPU-seconds
+  4. ``LLMMatcher(model=model_ref, ...)``        -> serve the fine-tuned model IN-PROCESS
+  5. ``evaluate(matcher, test_cands, gold)``     -> honest held-out pair P/R/F1
+
+This is a REAL fine-tune, not a mock. It downloads SmolLM2-135M and a small
+embedding model (a few hundred MB total) and runs real peft LoRA + trl SFT.
+On a CUDA GPU it is a couple of minutes; on CPU / Apple-Silicon MPS it is SLOW
+(~10-20 min) but it DOES run -- the QLoRA trainer falls back to a non-quantized
+LoRA fine-tune when there is no CUDA. Local training has **no dollar cost**; the
+honest cost fact is GPU-seconds (printed below).
+
+Needs the training + serving + blocking extras:
+
+    uv sync --extra finetune --extra semantic --extra llm
+      finetune  -> peft + trl + torch      (the fine-tune itself)
+      semantic  -> sentence-transformers + faiss   (candidates_for's blocker)
+      llm       -> litellm                 (LLMMatcher serves the model_ref)
+
+Run it:
+
+    # On macOS, KMP_DUPLICATE_LIB_OK avoids a faiss/torch OpenMP double-load crash.
+    KMP_DUPLICATE_LIB_OK=TRUE OMP_NUM_THREADS=1 \\
+        uv run python examples/finetune_capstone.py
+"""
+
+import random
+from typing import Any
+
+from langres.core import LLMMatcher
+from langres.core.finetune import FINETUNE_YES_NO_PROMPT, QLoRA, run_finetune
+from langres.core.matchers.model_ref import to_config
+from langres.eval import candidates_for, evaluate, get_benchmark
+
+# SmolLM2-135M is tiny + fast + has a chat template -- a good "see it run" base.
+# Swap in "Qwen/Qwen3-0.6B" (bigger, slower, stronger) once you have a GPU.
+BASE = "HuggingFaceTB/SmolLM2-135M-Instruct"
+BENCH = "fodors_zagat"  # a small, real restaurant-matching benchmark
+
+
+def _is_match(candidate: Any, gold: set[frozenset[str]]) -> bool:
+    """Label a candidate pair from the benchmark's gold: is it a true match?"""
+    return frozenset({str(candidate.left.id), str(candidate.right.id)}) in gold
+
+
+def main() -> None:
+    bench = get_benchmark(BENCH)
+
+    # 1. BLOCK the TRAIN split into candidate pairs + gold (the public eval seam).
+    #    candidates_for uses the benchmark's own vector blocker, so this needs the
+    #    [semantic] extra and downloads a small embedding model the first time.
+    train_cands, train_gold = candidates_for(bench, split="train")
+
+    # 2. LABEL each candidate from gold, then BALANCE. Blocking output is heavily
+    #    negative (~3% positive here); a 1:1 set stops the fine-tune from trivially
+    #    learning "always No" and never separating matches from non-matches.
+    pos = [(c, True) for c in train_cands if _is_match(c, train_gold)]
+    neg = [(c, False) for c in train_cands if not _is_match(c, train_gold)]
+    random.Random(0).shuffle(neg)
+    train_pairs = pos + neg[: len(pos)]
+    random.Random(1).shuffle(train_pairs)
+    print(f"train: {len(train_pairs)} balanced pairs ({len(pos)} match / {len(pos)} non-match)")
+
+    # 3. FINE-TUNE SmolLM2-135M with LoRA on the yes/no match prompt. The method
+    #    object carries WHICH base + the LoRA/cost knobs; kind="finetune" means the
+    #    cost is GPU-seconds (local training = $0). run_finetune returns the honest
+    #    digest (ref + GPU-seconds + device); finetune() is the one-liner when you
+    #    only want the model_ref.
+    method = QLoRA(base=BASE, epochs=3, batch_size=8)
+    outcome = run_finetune(train_pairs, method)
+    print(
+        f"trained on {outcome.n_train} pairs in {outcome.gpu_seconds:.1f} GPU-seconds "
+        f"on {outcome.device} (${outcome.dollars:.4f}) -> {outcome.method}\n"
+        f"model_ref: {to_config(outcome.model_ref)}"
+    )
+
+    # 4. SERVE the fine-tuned model IN-PROCESS -- no server, no API key: LLMMatcher
+    #    loads base + LoRA adapter via the transformers backend. Serve with the SAME
+    #    prompt the model was trained on (FINETUNE_YES_NO_PROMPT) and read the answer
+    #    with the logprob yes/no probe. Asking a differently-worded question than
+    #    training taught would score nonsense -- train and serve must match.
+    matcher = LLMMatcher(
+        model=to_config(outcome.model_ref),
+        confidence="logprob",
+        response_parser="binary_yes_no",
+        prompt_template=FINETUNE_YES_NO_PROMPT,
+    )
+
+    # 5. EVALUATE on the held-out TEST split -> honest pair P/R/F1 at a fixed cut.
+    #    threshold=0.5 grades ONCE at that cut (no argmax fitted to the test gold),
+    #    so the F1 is a real held-out estimate, not an optimistic upper bound.
+    test_cands, test_gold = candidates_for(bench, split="test")
+    result = evaluate(matcher, test_cands, test_gold, threshold=0.5)
+    print(
+        f"\nheld-out {BENCH} test ({len(test_cands)} pairs): "
+        f"P={result.pair.precision:.3f} R={result.pair.recall:.3f} F1={result.pair.f1:.3f}\n"
+        f"honest cost: {outcome.gpu_seconds:.1f} GPU-seconds on {outcome.device} "
+        f"(${outcome.dollars:.4f})"
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/finetune_capstone.py
+++ b/examples/finetune_capstone.py
@@ -50,8 +50,12 @@ from langres.core.finetune import FINETUNE_YES_NO_PROMPT, QLoRA, run_finetune
 from langres.core.matchers.model_ref import to_config
 from langres.eval import candidates_for, evaluate, get_benchmark
 
-# SmolLM2-135M is tiny + fast + has a chat template -- a good "see it run" base.
-# Swap in "Qwen/Qwen3-0.6B" (bigger, slower, stronger) once you have a GPU.
+# SmolLM2-135M is tiny + fast + has a plain chat template -- a good "see it run"
+# base. Swap in a larger *same-family* instruct model for more headroom (e.g.
+# "HuggingFaceTB/SmolLM2-360M-Instruct"). Avoid "thinking" models (e.g. Qwen3):
+# they emit a reasoning turn before the answer, so the first-token Yes/No logprob
+# probe this serves with reads the think-tag, not the decision -- a different
+# serving contract than this example's.
 BASE = "HuggingFaceTB/SmolLM2-135M-Instruct"
 BENCH = "fodors_zagat"  # a small, real restaurant-matching benchmark
 

--- a/tests/core/test_finetune.py
+++ b/tests/core/test_finetune.py
@@ -276,19 +276,27 @@ def test_finetune_returns_the_model_ref() -> None:
 
 
 @pytest.mark.finetune
-def test_qlora_trainer_cpu_dry_run(tmp_path: Path) -> None:
-    """Real peft+trl LoRA on a tiny model, CPU (no 4-bit) -- the ``[finetune]`` smoke.
+def test_qlora_trainer_cpu_dry_run(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Real peft+trl LoRA on a tiny model, PINNED to CPU (no 4-bit) -- the ``[finetune]`` smoke.
 
     Runs the DEFAULT :class:`QLoRATrainer` end-to-end: imports peft/trl/transformers,
-    fine-tunes a tiny instruct LM on a handful of yes/no pairs on CPU
-    (``load_in_4bit`` is ignored off CUDA), and asserts it produced a servable
-    adapter dir plus honest GPU-seconds. Marked ``finetune`` so it runs only in the
-    dedicated ``test-finetune`` CI job / locally with ``--all-extras`` -- never the
-    fast suite.
+    fine-tunes a tiny instruct LM on a handful of yes/no pairs, and asserts it produced
+    a servable adapter dir plus honest GPU-seconds. **Forces the CPU path** (patches
+    torch's cuda/mps availability to False) so this genuinely exercises CPU precision
+    handling on ANY dev box -- a Mac otherwise auto-detects MPS, which is exactly how
+    the `bf16/gpu` CPU-only regression slipped past local runs and only failed on the
+    linux CI runner. Marked ``finetune`` so it runs only in the dedicated
+    ``test-finetune`` CI job / locally with ``--all-extras`` -- never the fast suite.
     """
     pytest.importorskip("peft")
     pytest.importorskip("trl")
-    pytest.importorskip("torch")
+    torch = pytest.importorskip("torch")
+
+    # Pin CPU: no cuda, no mps -> QLoRATrainer.train detects "cpu" and must configure
+    # SFTConfig for CPU (bf16/fp16 off). Patches the same torch predicates transformers
+    # reads, so the whole stack agrees on CPU.
+    monkeypatch.setattr(torch.cuda, "is_available", lambda: False)
+    monkeypatch.setattr(torch.backends.mps, "is_available", lambda: False)
 
     pairs = _labeled_pairs()
     method = QLoRA(
@@ -302,7 +310,7 @@ def test_qlora_trainer_cpu_dry_run(tmp_path: Path) -> None:
 
     assert outcome.n_train == len(pairs)
     assert outcome.gpu_seconds > 0.0
-    assert outcome.device in {"cpu", "mps", "cuda"}
+    assert outcome.device == "cpu"  # the pinned path actually ran on CPU
     assert outcome.model_ref.base == "HuggingFaceTB/SmolLM2-135M-Instruct"
     assert outcome.model_ref.adapter is not None
     assert Path(outcome.model_ref.adapter).is_dir()

--- a/tests/core/test_finetune_capstone.py
+++ b/tests/core/test_finetune_capstone.py
@@ -1,0 +1,99 @@
+"""Acceptance test for the fine-tune CAPSTONE: the full PUBLIC train->serve->evaluate flow.
+
+Where ``test_finetune.py::test_finetune_overfit_train_serve_evaluate`` is the
+go/no-go for the trainer INTERNALS (hand-built pairs -> run_finetune -> serve),
+this is the acceptance of the user-facing CAPSTONE (``examples/finetune_capstone.py``):
+every step goes through the PUBLIC surface --
+
+  * ``candidates_for(get_benchmark("fodors_zagat"), split=...)`` for real blocked
+    candidate pairs + gold (the eval facade + a real benchmark, not fixtures),
+  * ``run_finetune(pairs, QLoRA(...))`` for the model_ref + GPU-seconds,
+  * a JSON round-trip of ``to_config(model_ref)`` -> ``normalize_model_ref`` (the
+    "weightless ref survives save/reload" claim),
+  * ``LLMMatcher(model=ref, ...)`` in-process serve with the finetune prompt,
+  * ``evaluate(matcher, held_out, gold, threshold=0.5)`` for an honest held-out F1.
+
+It trains on a small TRAIN-split slice and evaluates on a disjoint TEST-split
+slice, so the F1 is genuine generalization (the two splits are entity-disjoint by
+benchmark construction), and asserts F1 clears a floor AND the run reports a real
+cost (GPU-seconds > 0, on a recorded device). Marked ``slow`` + ``finetune`` so it
+runs only in the dedicated ``test-finetune`` job / on demand, never in the fast
+suite (real model downloads + real training).
+"""
+
+from __future__ import annotations
+
+# faiss (candidates_for's blocker) and torch (the fine-tune) each ship their own
+# OpenMP runtime; loading both in one process can hard-crash on macOS. Allow the
+# duplicate load before either is imported. Harmless where it does not apply.
+import os
+
+os.environ.setdefault("KMP_DUPLICATE_LIB_OK", "TRUE")
+
+import json
+from typing import Any
+
+import pytest
+
+pytestmark = [pytest.mark.slow, pytest.mark.finetune]
+
+BASE = "HuggingFaceTB/SmolLM2-135M-Instruct"
+
+
+def _balanced(cands: list[Any], gold: set[frozenset[str]], k: int) -> list[tuple[Any, bool]]:
+    """Up to ``k`` gold-positive candidates + ``k`` negatives, labeled, stable order."""
+    pos = [c for c in cands if frozenset({str(c.left.id), str(c.right.id)}) in gold]
+    neg = [c for c in cands if frozenset({str(c.left.id), str(c.right.id)}) not in gold]
+    return [(c, True) for c in pos[:k]] + [(c, False) for c in neg[:k]]
+
+
+def test_capstone_train_serve_evaluate_public_flow() -> None:
+    """The whole public capstone runs: fine-tune -> reload ref -> serve -> held-out F1."""
+    pytest.importorskip("peft")
+    pytest.importorskip("trl")
+    pytest.importorskip("torch")
+    pytest.importorskip("sentence_transformers")
+
+    from langres.core import LLMMatcher
+    from langres.core.finetune import FINETUNE_YES_NO_PROMPT, QLoRA, run_finetune
+    from langres.core.matchers.model_ref import normalize_model_ref, to_config
+    from langres.eval import candidates_for, evaluate, get_benchmark
+
+    bench = get_benchmark("fodors_zagat")
+
+    # TRAIN: block the train split, label from gold, balance a small slice.
+    train_cands, train_gold = candidates_for(bench, split="train")
+    train_pairs = _balanced(train_cands, train_gold, k=24)
+    assert sum(1 for _, y in train_pairs if y) >= 8  # enough positive signal to learn
+
+    method = QLoRA(base=BASE, epochs=5, batch_size=8)
+    outcome = run_finetune(train_pairs, method)
+
+    # COST is real and honest: GPU-seconds > 0 on a recorded device; a base+adapter
+    # ref (nothing merged); n_train matches what we trained on.
+    assert outcome.gpu_seconds > 0.0
+    assert outcome.device in {"cuda", "mps", "cpu"}
+    assert outcome.model_ref.adapter is not None
+    assert outcome.n_train == len(train_pairs)
+
+    # SAVE -> RELOAD the weightless model_ref through JSON (base id + adapter path,
+    # no weight blob) and serve the reloaded ref -- proving the ref round-trips.
+    reloaded = normalize_model_ref(json.loads(json.dumps(to_config(outcome.model_ref))))
+    matcher: LLMMatcher[Any] = LLMMatcher(
+        model=to_config(reloaded),
+        confidence="logprob",
+        response_parser="binary_yes_no",
+        prompt_template=FINETUNE_YES_NO_PROMPT,
+    )
+
+    # EVALUATE on a disjoint TEST-split slice at a fixed cut -> honest held-out F1.
+    test_cands, test_gold = candidates_for(bench, split="test")
+    eval_pairs = _balanced(test_cands, test_gold, k=20)
+    eval_cands = [c for c, _ in eval_pairs]
+    eval_gold = {frozenset({str(c.left.id), str(c.right.id)}) for c, y in eval_pairs if y}
+    result = evaluate(matcher, eval_cands, eval_gold, threshold=0.5)
+
+    assert result.graded_threshold == 0.5  # graded once at the honest fixed cut
+    # Floor, not a quality claim: a real trained matcher clears it; noise does not.
+    # (Observed on this slice: see the PR report; floor set conservatively below it.)
+    assert result.pair.f1 >= 0.5

--- a/tests/core/test_finetune_capstone.py
+++ b/tests/core/test_finetune_capstone.py
@@ -11,14 +11,22 @@ every step goes through the PUBLIC surface --
   * a JSON round-trip of ``to_config(model_ref)`` -> ``normalize_model_ref`` (the
     "weightless ref survives save/reload" claim),
   * ``LLMMatcher(model=ref, ...)`` in-process serve with the finetune prompt,
-  * ``evaluate(matcher, held_out, gold, threshold=0.5)`` for an honest held-out F1.
+  * ``evaluate(matcher, held_out, gold, threshold=0.5)`` for the honest fixed cut.
 
-It trains on a small TRAIN-split slice and evaluates on a disjoint TEST-split
-slice, so the F1 is genuine generalization (the two splits are entity-disjoint by
-benchmark construction), and asserts F1 clears a floor AND the run reports a real
-cost (GPU-seconds > 0, on a recorded device). Marked ``slow`` + ``finetune`` so it
-runs only in the dedicated ``test-finetune`` job / on demand, never in the fast
-suite (real model downloads + real training).
+**Why the gate is "beats the untrained base on ranking", not an F1 floor.**
+Measured on this real, hard slice (SmolLM2-135M, held-out Fodors-Zagat): the
+UNTRAINED base is the trivial always-"Yes" predictor -- F1@0.5 = 0.667 on a
+balanced slice, but match/non-match separation ~0.004 and ROC-AUC ~0.583.
+Fine-tuning pulls matches and non-matches apart (separation ~0.031, AUC ~0.64)
+yet its F1 *at the fixed 0.5 cut* DROPS to ~0.54, because the small model's
+Yes-mass clusters near 0.5 and it starts (correctly) saying "No" to some pairs.
+So an F1@0.5 floor is a DISHONEST gate here: the do-nothing base clears it while
+the model that actually learned to discriminate fails it -- a fixed-threshold
+artifact, exactly what a calibrator fixes. The honest, robust learning signal is
+threshold-free ranking that BEATS the same untrained base. That is what we gate.
+
+Marked ``slow`` + ``finetune`` so it runs only in the dedicated ``test-finetune``
+job / on demand, never in the fast suite (real model downloads + real training).
 """
 
 from __future__ import annotations
@@ -47,8 +55,42 @@ def _balanced(cands: list[Any], gold: set[frozenset[str]], k: int) -> list[tuple
     return [(c, True) for c in pos[:k]] + [(c, False) for c in neg[:k]]
 
 
+def _rank_signal(model_cfg: Any, pairs: list[tuple[Any, bool]]) -> tuple[float, float]:
+    """Serve ``model_cfg`` on the held-out slice; return (mean-p_yes separation, ROC-AUC).
+
+    Both are THRESHOLD-FREE ranking signals -- how well the served model pulls
+    matches above non-matches -- so they measure learning without the fixed-0.5-cut
+    artifact that makes F1 reward the trivial always-"Yes" base (see module docstring).
+    """
+    from langres.core import LLMMatcher
+    from langres.core.finetune import FINETUNE_YES_NO_PROMPT
+    from langres.eval import roc_auc_score
+
+    matcher: LLMMatcher[Any] = LLMMatcher(
+        model=model_cfg,
+        confidence="logprob",
+        response_parser="binary_yes_no",
+        prompt_template=FINETUNE_YES_NO_PROMPT,
+    )
+    judgements = list(matcher.forward(iter([c for c, _ in pairs])))
+    p_yes = [j.provenance["p_yes"] for j in judgements]
+    labels = [y for _, y in pairs]
+    pos = [p for p, y in zip(p_yes, labels, strict=True) if y]
+    neg = [p for p, y in zip(p_yes, labels, strict=True) if not y]
+    separation = sum(pos) / len(pos) - sum(neg) / len(neg)
+    return separation, roc_auc_score(labels, p_yes)
+
+
 def test_capstone_train_serve_evaluate_public_flow() -> None:
-    """The whole public capstone runs: fine-tune -> reload ref -> serve -> held-out F1."""
+    """The whole public capstone runs and LEARNS: fine-tune beats the untrained base.
+
+    Real QLoRA train on a small Fodors-Zagat TRAIN-split slice -> JSON round-trip
+    the weightless model_ref -> in-process serve -> rank a disjoint TEST-split
+    slice. Asserts the run reports real GPU-seconds AND the fine-tuned model
+    separates matches from non-matches *better than the same untrained base* on two
+    threshold-free signals (mean-p_yes separation and ROC-AUC). Also runs the public
+    ``evaluate(..., threshold=0.5)`` to prove that path composes at the honest cut.
+    """
     pytest.importorskip("peft")
     pytest.importorskip("trl")
     pytest.importorskip("torch")
@@ -66,7 +108,16 @@ def test_capstone_train_serve_evaluate_public_flow() -> None:
     train_pairs = _balanced(train_cands, train_gold, k=24)
     assert sum(1 for _, y in train_pairs if y) >= 8  # enough positive signal to learn
 
-    method = QLoRA(base=BASE, epochs=5, batch_size=8)
+    # Held-out ranking slice from the disjoint TEST split (entity-disjoint by
+    # benchmark construction -> genuine generalization, not memorization).
+    test_cands, test_gold = candidates_for(bench, split="test")
+    eval_pairs = _balanced(test_cands, test_gold, k=20)
+
+    # BASELINE: the SAME base, untrained, on the same held-out slice. This is the
+    # honest floor -- training must beat THIS, not a magic constant.
+    base_sep, base_auc = _rank_signal(BASE, eval_pairs)
+
+    method = QLoRA(base=BASE, epochs=8, batch_size=8)
     outcome = run_finetune(train_pairs, method)
 
     # COST is real and honest: GPU-seconds > 0 on a recorded device; a base+adapter
@@ -79,21 +130,26 @@ def test_capstone_train_serve_evaluate_public_flow() -> None:
     # SAVE -> RELOAD the weightless model_ref through JSON (base id + adapter path,
     # no weight blob) and serve the reloaded ref -- proving the ref round-trips.
     reloaded = normalize_model_ref(json.loads(json.dumps(to_config(outcome.model_ref))))
-    matcher: LLMMatcher[Any] = LLMMatcher(
-        model=to_config(reloaded),
-        confidence="logprob",
-        response_parser="binary_yes_no",
-        prompt_template=FINETUNE_YES_NO_PROMPT,
+    tuned_sep, tuned_auc = _rank_signal(to_config(reloaded), eval_pairs)
+
+    # LEARNED: the fine-tuned model out-ranks the untrained base on BOTH signals.
+    # (Observed: base sep~0.004 auc~0.583 -> tuned sep~0.031 auc~0.64; margins in
+    # the PR report. The base barely separates; training pulls the classes apart.)
+    assert tuned_sep > base_sep
+    assert tuned_auc > base_auc
+
+    # The public evaluate() path also composes at the honest fixed cut (F1@0.5 is
+    # low here -- the small model needs a calibrated threshold; see the module
+    # docstring -- so we assert the path/threshold, not an F1 magnitude).
+    result = evaluate(
+        LLMMatcher(
+            model=to_config(reloaded),
+            confidence="logprob",
+            response_parser="binary_yes_no",
+            prompt_template=FINETUNE_YES_NO_PROMPT,
+        ),
+        [c for c, _ in eval_pairs],
+        {frozenset({str(c.left.id), str(c.right.id)}) for c, y in eval_pairs if y},
+        threshold=0.5,
     )
-
-    # EVALUATE on a disjoint TEST-split slice at a fixed cut -> honest held-out F1.
-    test_cands, test_gold = candidates_for(bench, split="test")
-    eval_pairs = _balanced(test_cands, test_gold, k=20)
-    eval_cands = [c for c, _ in eval_pairs]
-    eval_gold = {frozenset({str(c.left.id), str(c.right.id)}) for c, y in eval_pairs if y}
-    result = evaluate(matcher, eval_cands, eval_gold, threshold=0.5)
-
-    assert result.graded_threshold == 0.5  # graded once at the honest fixed cut
-    # Floor, not a quality claim: a real trained matcher clears it; noise does not.
-    # (Observed on this slice: see the PR report; floor set conservatively below it.)
-    assert result.pair.f1 >= 0.5
+    assert result.graded_threshold == 0.5


### PR DESCRIPTION
## What

The epic's **definition of done**: a committed, runnable **train→serve→evaluate** slice through the public API, plus a `@slow @finetune` acceptance test. Proves the full LLM-native training rung end-to-end (PR-F finetune + PR-E in-process serve + eval), not just in unit tests.

Also rides in the rescued **CPU-pin regression guard** (cherry-picked `2d88dc0`, orphaned from PR-F's branch by the merge race) — forces `test_qlora_trainer_cpu_dry_run` onto CPU so the bf16/CPU precision path is exercised on any dev box, closing the "CPU-pinned test" half of the post-epic follow-up (#14).

## Deliverables (both actually RUN on Mac/MPS, $0)

- `examples/finetune_capstone.py` — tutorial-style full public flow (+ `examples/README.md` entry).
- `tests/core/test_finetune_capstone.py` — `@slow @finetune` public-flow acceptance test.

## Dataset / base

Fodors-Zagat (small real benchmark — train 2436 blocked cands / 79 pos; test 1023 / 33 pos) + SmolLM2-135M-Instruct (tiny/fast, plain chat template).

**Finding (documented in the example):** Qwen3-0.6B breaks the serving contract — it defaults to thinking-mode and emits a reasoning turn first, so the first-token Yes/No logprob probe reads `<think>` and returns `p_yes=None`. The example steers base-model swaps toward a larger *same-family* non-thinking model (SmolLM2-360M).

## Real numbers (measured)

- Example (epochs=3, 158 balanced train pairs → 1023-pair held-out test, threshold=0.5): P=0.039, R=1.000, **F1=0.075**, **66.3 GPU-seconds on MPS ($0)**.
- Acceptance test (epochs=8, 48 train → 40-pair held-out): fine-tune out-ranks the untrained base — mean-p_yes separation 0.004→0.031, ROC-AUC 0.583→0.64 (reproducible over 2 trials); ~30–47 GPU-s; passes in 88.8s.

## Honest gate — deliberate deviation from "assert F1 clears a floor"

On this data an F1@0.5 floor is a **dishonest** gate: the untrained 135M base is a trivial always-"Yes" predictor → F1@0.5 = 0.667 on a balanced slice, while genuine fine-tuning (which improves ranking/AUC) *drops* F1@0.5 to ~0.54 because the small model's Yes-mass clusters at the 0.5 fence — a fixed-threshold artifact (exactly what PR-D's calibrator addresses). A naive F1 floor would reward the do-nothing base and fail the model that learned.

The acceptance gate instead asserts the fine-tune **out-ranks the same untrained base on separation AND ROC-AUC** (mirrors PR-F's beats-base go/no-go) + real GPU-seconds + `model_ref` JSON round-trip. The public `evaluate(threshold=0.5)` path is still exercised (asserts `graded_threshold`, not an F1 magnitude). The example is honestly framed as recall-heavy/low-precision at 0.5, pointing to the two levers: a bigger base and a calibrated threshold.

## Public API used (verified against live code)

- `candidates_for(get_benchmark(name), split="train"|"test") -> (list[ERCandidate], set[frozenset[str]])` (needs `[semantic]`)
- `run_finetune(pairs, QLoRA(base=...)) -> FinetuneOutcome(model_ref, gpu_seconds, dollars, device, ...)`
- `LLMMatcher(model=to_config(ref), confidence="logprob", response_parser="binary_yes_no", prompt_template=FINETUNE_YES_NO_PROMPT)` — same train==serve prompt contract as `_fit_finetune`
- `evaluate(matcher, candidates, gold_pairs, threshold=0.5) -> JudgePairEval` (read `.pair.precision/recall/f1`, `.graded_threshold`)

## Notes for the integration PR

- Public-surface re-exports (task #13) intentionally NOT added here — the example imports from `langres.core.finetune` / `langres.core.matchers.model_ref` (deeper paths); the integration→main PR shortens them.
- macOS-only: `test_finetune_capstone.py` sets `KMP_DUPLICATE_LIB_OK=TRUE` at module top (faiss+torch OpenMP double-load segfaults on macOS-arm64 otherwise); the example docstring documents it. Linux CI unaffected.

## Gates

- `uv run --all-extras pytest -m "not integration and not slow"` → 2893 passed, 4 skipped, 98.40% cov
- `uv run pytest tests/test_import_budget.py` → 36 passed (example/test not imported by `langres`)
- `uv run --no-dev --group docs mkdocs build --strict` → clean
- capstone acceptance test → passed (88.8s real MPS training)

Part of the training-surface epic (#125) → `feat/training-surface`. **Closes the DoD.**

## Summary by Sourcery

Add a capstone example and acceptance test that exercise the full public train→serve→evaluate flow on a real benchmark, and introduce a CPU-pinned QLoRA smoke test to guard the CPU precision path.

New Features:
- Provide a tutorial-style finetuning capstone script that trains, serves, and evaluates a matcher end-to-end via the public API.
- Add a slow finetune acceptance test that verifies the capstone public flow learns and beats the untrained base model on ranking metrics.

Bug Fixes:
- Ensure the QLoRA trainer smoke test is pinned to CPU so the bf16/CPU precision path is reliably exercised and guarded across developer environments.

Enhancements:
- Document the finetuning capstone example in the examples README with required extras and expected behavior.
- Add macOS-specific OpenMP duplicate-lib handling in the finetune capstone acceptance test to prevent faiss/torch crashes during real training runs.

Tests:
- Introduce a comprehensive slow finetune capstone test that runs real training, serves via model_ref, evaluates held-out performance, and asserts improvement over the base model.
- Strengthen the QLoRA trainer CPU dry-run test to explicitly force CPU execution and assert the reported device is CPU.