### PR TITLE
ci: pin actions to commit SHAs + run coverage on merge to main

### DIFF
--- a/.claude/rules/testing.md
+++ b/.claude/rules/testing.md
@@ -31,11 +31,12 @@ code. Verify as you go.** Read before writing tests or running the suite.
 - Mark slow tests with `@pytest.mark.slow`, integration tests with `@pytest.mark.integration`
   - **Mark any heavy test `@pytest.mark.slow`** (loads embedding/ML models, runs
     torch inference, etc.). CI runs the **fast** subset (`not slow`) on every
-    PR; the **slow** tests + the coverage gate run on the **weekly** `test-full`
-    job (and on demand via *Run workflow*). So per-PR CI does not gate coverage
-    or exercise slow ML paths — mislabeling a heavy test as fast slows every PR,
-    and the coverage floor is verified weekly, not per-PR. Run the full suite
-    locally (`uv run pytest`) before merging a change to ML/embedding code.
+    PR; the **slow** tests + the coverage gate run on **every merge to main
+    (push)** + **on demand** (`workflow_dispatch`) via the `test-full` job. So
+    per-PR CI does not gate coverage or exercise slow ML paths — mislabeling a
+    heavy test as fast slows every PR, and the coverage floor is verified on
+    each merge to main, not per-PR. Run the full suite locally
+    (`uv run pytest`) before merging a change to ML/embedding code.
 - Run tests: `uv run pytest` (pre-push hook runs non-slow, non-integration tests automatically)
 - Check coverage: `uv run pytest --cov`; keep `core/**` in the 95–100% tier
   (the repo-wide gate is a relaxed 90% floor — see `pyproject.toml`)

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -23,10 +23,10 @@ jobs:
       contents: read
     steps:
       - name: Checkout
-        uses: actions/checkout@v7
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@v4
+        uses: github/codeql-action/init@99df26d4f13ea111d4ec1a7dddef6063f76b97e9 # v4
         with:
           languages: python
           # security-extended adds lower-severity/precision queries on top of
@@ -34,6 +34,6 @@ jobs:
           queries: security-extended
 
       - name: Perform CodeQL analysis
-        uses: github/codeql-action/analyze@v4
+        uses: github/codeql-action/analyze@99df26d4f13ea111d4ec1a7dddef6063f76b97e9 # v4
         with:
           category: "/language:python"

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -39,10 +39,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v7
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
 
       - name: Install uv and set the python version
-        uses: astral-sh/setup-uv@v7
+        uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7
         with:
           version: "0.11.24"
           python-version: "3.13"
@@ -55,7 +55,7 @@ jobs:
 
       - name: Upload Pages artifact
         if: github.event_name != 'pull_request'
-        uses: actions/upload-pages-artifact@v5
+        uses: actions/upload-pages-artifact@fc324d3547104276b827a68afc52ff2a11cc49c9 # v5
         with:
           path: site
 
@@ -72,4 +72,4 @@ jobs:
     steps:
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v5
+        uses: actions/deploy-pages@cd2ce8fcbc39b97be8ca5fce6e763baed58fa128 # v5

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -16,10 +16,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v7
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
 
       - name: Set up uv
-        uses: astral-sh/setup-uv@v7
+        uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7
         with:
           version: "0.11.24"
           enable-cache: true

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -14,10 +14,10 @@ jobs:
       contents: read
 
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
 
       - name: Set up Python
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6
         with:
           python-version: '3.12'
 

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -24,12 +24,12 @@ jobs:
       id-token: write # to publish results (publish_results: true)
     steps:
       - name: Checkout
-        uses: actions/checkout@v7
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
         with:
           persist-credentials: false
 
       - name: Run analysis
-        uses: ossf/scorecard-action@v2.4.3
+        uses: ossf/scorecard-action@4eaacf0543bb3f2c246792bd56e8cdeffafb205a # v2.4.3
         with:
           results_file: results.sarif
           results_format: sarif
@@ -38,13 +38,13 @@ jobs:
           publish_results: true
 
       - name: Upload artifact
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: SARIF file
           path: results.sarif
           retention-days: 5
 
       - name: Upload to code-scanning
-        uses: github/codeql-action/upload-sarif@v4
+        uses: github/codeql-action/upload-sarif@99df26d4f13ea111d4ec1a7dddef6063f76b97e9 # v4
         with:
           sarif_file: results.sarif

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -20,10 +20,10 @@ jobs:
       contents: read
     steps:
       - name: Checkout
-        uses: actions/checkout@v7
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
 
       - name: Set up uv
-        uses: astral-sh/setup-uv@v7
+        uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7
         with:
           version: "0.11.24"
           enable-cache: true

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,14 +1,15 @@
 name: Test
 
 # Per-PR: run the FAST suite only (slow ML tests excluded -- see the `test`
-# job). The full suite incl. slow tests + the coverage gate runs weekly and on
-# demand via the `test-full` job, so slow embedding/ML tests don't cost ~10min
-# on every PR. Jobs are gated by event with `if:` below.
+# job). The full suite incl. slow tests + the 95% coverage gate runs on every
+# merge to main (push) + on demand (workflow_dispatch) via the `test-full` job,
+# so slow embedding/ML tests don't cost ~10min on every PR. This repo is public,
+# so Actions minutes are free/unlimited -- per-merge coverage is worth it, while
+# the fast suite still runs per-PR. Jobs are gated by event with `if:` below.
 on:
   pull_request:
-  schedule:
-    # Weekly on Monday at 06:00 UTC (full suite incl. slow tests)
-    - cron: "0 6 * * 1"
+  push:
+    branches: [main]
   workflow_dispatch:
 
 concurrency:
@@ -29,12 +30,12 @@ jobs:
         python-version: ["3.13"]
     steps:
       - name: Checkout
-        uses: actions/checkout@v7
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
         with:
           fetch-depth: 0
 
       - name: Install uv and set the python version
-        uses: astral-sh/setup-uv@v7
+        uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7
         with:
           version: "0.11.24"
           python-version: ${{ matrix.python-version }}
@@ -67,10 +68,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v7
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
 
       - name: Set up uv
-        uses: astral-sh/setup-uv@v7
+        uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7
         with:
           version: "0.11.24"
           python-version: "3.13"
@@ -95,11 +96,12 @@ jobs:
         run: uv run python examples/flywheel_min.py
 
   # Full suite INCLUDING the slow embedding/ML tests, plus the 95% coverage gate
-  # (inherited from pyproject addopts). Runs weekly + on demand only -- NOT per
-  # PR -- so ML regressions and the coverage floor are still enforced on a
-  # cadence without paying ~10min on every push. Trigger a run before a release
-  # or a risky ML change with the "Run workflow" button (workflow_dispatch).
-  # Do NOT mark this a required status check (it is skipped on PR events).
+  # (inherited from pyproject addopts). Runs on every merge to main (push) + on
+  # demand (workflow_dispatch) -- NOT per PR -- so ML regressions and the
+  # coverage floor are enforced on every merge without paying ~10min on every
+  # PR. Trigger an ad-hoc run before a release or a risky ML change with the
+  # "Run workflow" button (workflow_dispatch). Do NOT mark this a required
+  # status check (it is skipped on PR events).
   test-full:
     if: github.event_name != 'pull_request'
     # 4-vCPU: the slow ML tests' torch inference uses all 4 cores via torch's
@@ -111,12 +113,12 @@ jobs:
         python-version: ["3.13"]
     steps:
       - name: Checkout
-        uses: actions/checkout@v7
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
         with:
           fetch-depth: 0
 
       - name: Install uv and set the python version
-        uses: astral-sh/setup-uv@v7
+        uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7
         with:
           version: "0.11.24"
           python-version: ${{ matrix.python-version }}
@@ -135,8 +137,8 @@ jobs:
 
       - name: Upload coverage to Codecov
         # Advisory, never a merge gate: fail_ci_if_error stays false so a Codecov
-        # hiccup can't turn this weekly run red. Token is required for uploads.
-        uses: codecov/codecov-action@v5
+        # hiccup can't turn this merge-to-main run red. Token is required for uploads.
+        uses: codecov/codecov-action@0fb7174895f61a3b6b78fc075e0cd60383518dac # v5
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: ./coverage.xml


### PR DESCRIPTION
Two small CI/security chores in one PR.

## 1. Pin all GitHub Actions to commit SHAs
Every `uses:` across `.github/workflows/*.yml` is now pinned to a full 40-char commit SHA, with the human tag kept as a trailing `# vX` comment (e.g. `actions/checkout@9c091bb… # v7`). This clears the OpenSSF Scorecard **PinnedDependencies** alerts (~19). GitHub-owned actions (`actions/*`, `github/codeql-action/*`) are flagged by Scorecard too, so they're pinned as well.

SHAs point at the commit the **current** tag references — no version bumps. The `github-actions` Dependabot updater already configured for this repo understands the `<sha> # vX` format, so it keeps these current going forward.

| Action | Tag | SHA |
|---|---|---|
| actions/checkout | v7 | 9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 |
| astral-sh/setup-uv | v7 | 37802adc94f370d6bfd71619e3f0bf239e1f3b78 |
| actions/setup-python | v6 | ece7cb06caefa5fff74198d8649806c4678c61a1 |
| actions/upload-artifact | v7 | 043fb46d1a93c77aae656e7c1c64a875d1fc6a0a |
| actions/upload-pages-artifact | v5 | fc324d3547104276b827a68afc52ff2a11cc49c9 |
| actions/deploy-pages | v5 | cd2ce8fcbc39b97be8ca5fce6e763baed58fa128 |
| codecov/codecov-action | v5 | 0fb7174895f61a3b6b78fc075e0cd60383518dac |
| github/codeql-action/* | v4 | 99df26d4f13ea111d4ec1a7dddef6063f76b97e9 |
| ossf/scorecard-action | v2.4.3 | 4eaacf0543bb3f2c246792bd56e8cdeffafb205a |

## 2. Coverage on merge to main (test.yml only)
The `test-full` job (full suite incl. slow ML tests + the 95% coverage gate) now runs on `push: [main]` instead of the weekly Monday cron. Rationale: public repo → free/unlimited Actions minutes, so per-merge coverage is worth more than a weekly snapshot. `workflow_dispatch` is kept for ad-hoc runs; the fast per-PR suite (`test` / `test-core-only`, PR-only) is unchanged. The `schedule:` cron block is removed.

No job-gating change needed: `test-full` already carries `if: github.event_name != 'pull_request'`, so it now fires on push-to-main + workflow_dispatch. `security.yml` and `scorecard.yml` weekly crons are left untouched.

## Docs
`.claude/rules/testing.md` updated to describe the slow-test/coverage cadence as "every merge to main (push) + on demand (workflow_dispatch)". Explanatory comments in `test.yml` updated to match. `docs/DEPENDENCIES.md` weekly refs (security.yml + Dependabot) left as-is — they don't describe test.yml.

Validation: all workflows parse as YAML; `actionlint` not installed locally (skipped — GitHub validates on push).

## Summary by Sourcery

Pin GitHub Actions to specific commit SHAs and adjust CI so the full test suite with coverage runs on every merge to main instead of a weekly schedule.

CI:
- Pin all workflow action usages (checkout, setup-uv, setup-python, Codecov, Pages, CodeQL, Scorecard, upload-artifact) to 40-character commit SHAs for more secure, reproducible CI.
- Run the `test-full` job (slow tests + 95% coverage gate) on push to `main` and workflow_dispatch rather than via a weekly cron schedule.

Documentation:
- Update testing guidelines to describe slow-test and coverage cadence as every merge to main plus on-demand runs via workflow_dispatch.