### PR TITLE
chore: roll 7-day dep quarantine to 2026-07-08 + uv lock --upgrade

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -173,7 +173,7 @@ docs = [
 # 7-day supply-chain quarantine: resolution only picks packages published at
 # least 7 days ago, giving time for malicious uploads to be caught and
 # yanked. Roll this forward with `make upgrade-deps`.
-exclude-newer = "2026-06-18"
+exclude-newer = "2026-07-08"
 # To block a known-bad version, uncomment and set:
 # constraint-dependencies = ["somepkg!=1.2.3"]
 


### PR DESCRIPTION
## What

Roll the 7-day supply-chain quarantine forward and re-resolve.

`[tool.uv] exclude-newer`: **`2026-06-18` → `2026-07-08`** (today−7), via
`make upgrade-deps` (rewrites the date + `uv lock --upgrade`).

> **Note — `uv.lock` is gitignored in this repo** (`.gitignore:4`). It is not a
> tracked file, so this PR touches **only `pyproject.toml`**. The lockfile is
> regenerated locally / in CI from the rolled-forward `exclude-newer`. The
> version deltas below were reproduced by resolving cleanly at the old vs. new
> window (`uv lock --upgrade` at each date).

## Version deltas (rolling `2026-06-18` → `2026-07-08`)

Core runtime deps (`networkx`, `numpy`, `pydantic`, `rapidfuzz`) did **not**
move. All major bumps are in dev-tooling / transitive space — none in the
production `link()` / `dedupe()` core path.

### Direct dependencies / extras (from `pyproject.toml`)

Core:
- `pydantic-settings`: 2.14.1 → 2.14.2

`[llm]` extra:
- `litellm`: 1.89.2 → 1.91.0
- `openai`: 2.43.0 → 2.44.0

`[semantic]` extra:
- `torch`: 2.12.1 → 2.13.0

`dev` group:
- **`guarddog`: 2.1.0 → 3.1.0  ⚠️ MAJOR** (dev-only malware scanner; restructured its own dep tree — see churn below)
- `langfuse`: 4.9.0 → 4.13.2
- `mypy`: 2.1.0 → 2.2.0
- `pip-audit`: 2.9.0 → 2.10.1
- `pytest`: 9.1.0 → 9.1.1
- `ruff`: 0.15.18 → 0.15.20
- `types-networkx`: 3.6.1.20260612 → 3.6.1.20260624
- `wandb`: 0.27.2 → 0.28.0

### Transitive — major bumps flagged

- **`cyclonedx-python-lib`: 9.1.0 → 11.11.0  ⚠️ MAJOR** (via pip-audit / guarddog 3.x SBOM)
- **`lxml`: 5.4.0 → 6.1.1  ⚠️ MAJOR**
- **`pymdown-extensions`: 10.21.3 → 11.0.1  ⚠️ MAJOR** (docs, via mkdocs-material)
- **`setuptools`: 75.9.1 → 83.0.0  ⚠️ MAJOR**
- **`termcolor`: 2.5.0 → 3.3.0  ⚠️ MAJOR**

Notable transitive minors: `scipy` 1.17.1→1.18.0, `urllib3` 2.2.3→2.7.0,
`opentelemetry-*` 1.42.1→1.43.0, `fastapi` 0.137.2→0.139.0, `uvicorn`
0.49.0→0.51.0, `numba` 0.65.1→0.66.0, `pygit2` 1.16.0→1.18.2, `pillow`
12.2.0→12.3.0, `grpcio` 1.81.1→1.82.1, `typing-extensions` 4.15.0→4.16.0,
plus ~50 more patch/minor bumps.

Dependency-tree churn from **guarddog 2.1.0 → 3.1.0** (swapped its
scanning/SBOM backend):
- Added (new only): `boto3` 1.43.43, `botocore` 1.43.43, `jmespath` 1.1.0, `s3transfer` 0.19.0, `nono-py` 0.12.0, `tomli-w` 1.2.0
- Dropped (old only): `semgrep`, `ruamel-yaml`(+`-clib`), `boltons`, `bracex`, `click-option-group`, `exceptiongroup`, `face`, `glom`, `peewee`, `toml`, `wcmatch`

## Validation

| Step | Result |
|---|---|
| `uv sync --all-extras` | ✅ pass |
| Fast suite (`pytest -m "not integration and not slow"`) — per-PR CI | ✅ 2773 passed, 4 skipped, 104 deselected; coverage 98.68% |
| `mypy src/` | ✅ no issues (101 files) |
| `ruff check` | ✅ all checks passed |
| Slow ML suite (`pytest -m "not integration and slow"`) | ✅ 92 passed, no segfault (12:46) — sub-suite coverage-gate `FAIL 46%` is a marker-subset artifact, not a test failure |

No test failures and no regression traceable to any dependency bump.
