### PR TITLE
Public-surface: lazy re-exports of training symbols + DoD-example validation

### DIFF
--- a/src/langres/__init__.py
+++ b/src/langres/__init__.py
@@ -19,12 +19,17 @@ This package provides:
   exceptions a front-door user must catch (fail-fast ``matcher="auto"``; a judge
   that abstained on the pair; the spend cap).
 
-Import weight: most root exports are cheap and eager. ``EvalReport``,
-``gold_pairs_from_clusters`` and ``derive_threshold`` resolve lazily via PEP
-562 ``__getattr__`` (same pattern as ``langres.core``) so a bare ``import
-langres`` never pulls the eval-report/benchmark modules -- or scikit-learn,
-which ``derive_threshold`` needs (the ``[trained]`` extra) -- into
-``sys.modules``. See ``tests/test_import_budget.py``.
+Import weight: most root exports are cheap and eager -- including the
+training-surface pieces that make ``Resolver.fit`` legible: the method objects
+``Method`` / ``Bootstrap`` / ``MIPRO`` / ``GEPA`` (prompt) and ``Platt`` /
+``Isotonic`` (calibrate), the ``align_pairs`` pairs->candidates bridge, and the
+``FitReport`` digest (all import-light config/primitives; dspy/sklearn stay lazy
+inside their fit paths). ``EvalReport``, ``gold_pairs_from_clusters``,
+``derive_threshold`` and ``LLMMatcher`` resolve lazily via PEP 562
+``__getattr__`` (same pattern as ``langres.core``) so a bare ``import langres``
+never pulls the eval-report/benchmark modules -- or scikit-learn
+(``derive_threshold``, the ``[trained]`` extra) or litellm (``LLMMatcher``, the
+``[llm]`` extra) -- into ``sys.modules``. See ``tests/test_import_budget.py``.
 """
 
 import importlib
@@ -34,14 +39,22 @@ from typing import TYPE_CHECKING, Any
 
 from langres.clients.openrouter import BudgetExceeded
 from langres.core import (
+    Bootstrap,
     CompanySchema,
     Correction,
     CorrectionLog,
     ERCandidate,
+    FitReport,
+    GEPA,
+    Isotonic,
     JudgementLog,
+    MIPRO,
+    Method,
     PairwiseJudgement,
+    Platt,
     Resolver,
     ReviewQueue,
+    align_pairs,
     derive_threshold_from_pairs,
     harvest_labeled_pairs,
     select_for_review,
@@ -56,8 +69,10 @@ if TYPE_CHECKING:
     from langres.core.benchmark import gold_pairs_from_clusters
     from langres.core.calibration import derive_threshold
     from langres.core.eval_report import EvalReport
+    from langres.core.matchers.llm_judge import LLMMatcher
 
 __all__ = [
+    "Bootstrap",
     "BudgetExceeded",
     "CompanySchema",
     "DEFAULT_AUTO_MODEL",
@@ -65,14 +80,22 @@ __all__ = [
     "CorrectionLog",
     "ERCandidate",
     "EvalReport",
+    "FitReport",
+    "GEPA",
+    "Isotonic",
     "MatcherAbstainedError",
+    "Method",
+    "MIPRO",
     "JudgementLog",
     "LinkVerdict",
+    "LLMMatcher",
     "NoMatcherAvailableError",
     "PairwiseJudgement",
+    "Platt",
     "QLoRA",
     "Resolver",
     "ReviewQueue",
+    "align_pairs",
     "dedupe",
     "derive_threshold",
     "derive_threshold_from_pairs",
@@ -102,6 +125,10 @@ _LAZY_SYMBOLS: dict[str, str] = {
     "EvalReport": "langres.core.eval_report",
     "derive_threshold": "langres.core.calibration",
     "gold_pairs_from_clusters": "langres.core.benchmark",
+    # The LLM matcher (serve a fine-tuned model_ref, a vLLM api_base, or a paid
+    # judge). Importing the class pulls litellm -> the [llm] extra, so it stays
+    # lazy: a bare `import langres` never touches litellm.
+    "LLMMatcher": "langres.core.matchers.llm_judge",
     # The finetune surface: the module is import-light (peft/trl/torch import
     # lazily inside QLoRATrainer.train), so these symbols carry no [finetune] extra
     # here -- an ImportError from importing the symbols is a genuine bug. The
@@ -116,6 +143,7 @@ _LAZY_SYMBOLS: dict[str, str] = {
 #: an ImportError from them is a genuine bug and propagates unchanged.
 _EXTRA_BY_SYMBOL: dict[str, str] = {
     "derive_threshold": "trained",
+    "LLMMatcher": "llm",
 }
 
 

--- a/src/langres/core/__init__.py
+++ b/src/langres/core/__init__.py
@@ -44,10 +44,12 @@ from langres.core.debugging import (
 from langres.core.feature import ComparisonLevel, ComparisonVector, FeatureSpec
 from langres.core.fit import SupervisedFitMixin, UnsupervisedFitMixin
 from langres.core.groups import ERCandidateGroup, derive_groups_from_pairs
+from langres.core.fit_report import FitReport
 from langres.core.harvest import (
     Correction,
     CorrectionLog,
     LabeledPair,
+    align_pairs,
     derive_threshold_from_pairs,
     harvest_labeled_pairs,
 )
@@ -63,6 +65,9 @@ from langres.core.method_registry import (
     list_methods,
     register_method,
 )
+from langres.core.methods_api import Method
+from langres.core.methods_calibrate import Isotonic, Platt
+from langres.core.methods_prompt import Bootstrap, GEPA, MIPRO
 from langres.core.models import (
     CompanySchema,
     EntityProtocol,
@@ -227,6 +232,17 @@ __all__ = [
     "RunRecord",
     "RunStore",
     "WandbTracker",
+    # Training surface: the pairs->candidates bridge, the fit digest, and the
+    # method objects passed to Resolver.fit(method=...) (import-light config;
+    # dspy/sklearn stay lazy in dspy_judge/calibration).
+    "align_pairs",
+    "Bootstrap",
+    "FitReport",
+    "GEPA",
+    "Isotonic",
+    "Method",
+    "MIPRO",
+    "Platt",
 ]
 
 #: Names resolved to a *submodule of this package* on first access -- unlike

--- a/tests/test_public_surface_dod.py
+++ b/tests/test_public_surface_dod.py
@@ -1,0 +1,202 @@
+"""The training-surface DoD examples import + run with the clean top-level names.
+
+Acceptance for the public-surface wiring (task #13): every example the plan
+promises imports with the names it *shows* -- ``from langres import ...`` -- and
+the two fully-offline ones RUN end to end at ``$0``:
+
+- **#1 supervised RandomForest fit** and **#5 describe() + calibrate fit** run
+  FULLY OFFLINE here (deterministic, no LM, no network).
+- **#2 DSPy/MIPRO prompt-tune** and **#4 vLLM serve** need a served LLM endpoint,
+  so they are IMPORT+CONSTRUCT-validated only: the method / matcher objects build
+  with the clean imports, but the paid/endpoint call is never executed.
+- **#3 QLoRA capstone** has its own end-to-end MPS run in
+  ``tests/core/test_finetune_capstone.py``; here we only confirm its public
+  imports resolve.
+
+Also guards the wiring itself: the surfaced symbols are importable from
+``langres`` (and the method objects from ``langres.core``) and are in ``__all__``.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from langres.core.harvest import LabeledPair
+
+# Clean top-level imports -- the whole point of this PR. If any fails to resolve,
+# collection fails loudly (that IS the regression guard for the wiring).
+from langres import (
+    GEPA,
+    MIPRO,
+    Bootstrap,
+    CompanySchema,
+    FitReport,
+    Isotonic,
+    Method,
+    Platt,
+    Resolver,
+    align_pairs,
+)
+
+
+def test_surfaced_symbols_are_in_public_all() -> None:
+    """Every newly surfaced name is exported (in ``__all__``) from where it should be."""
+    import langres
+    import langres.core as core
+
+    root_names = {
+        "Method",
+        "Bootstrap",
+        "MIPRO",
+        "GEPA",
+        "Platt",
+        "Isotonic",
+        "align_pairs",
+        "FitReport",
+        "LLMMatcher",
+    }
+    assert root_names <= set(langres.__all__)
+    # LLMMatcher stays LAZY at the root ([llm]); the light method/fit symbols are
+    # also in langres.core.__all__.
+    assert (root_names - {"LLMMatcher"}) <= set(core.__all__)
+    # Method-object identity is shared between the two surfaces (one class, two names).
+    assert langres.MIPRO is core.MIPRO and langres.Platt is core.Platt
+    assert (Method, Bootstrap, GEPA, Isotonic, FitReport) == (
+        core.Method,
+        core.Bootstrap,
+        core.GEPA,
+        core.Isotonic,
+        core.FitReport,
+    )
+
+
+def test_dod1_random_forest_supervised_fit_runs_offline() -> None:
+    """DoD #1: from_schema(matcher="random_forest") -> fit(pairs=...) -> resolve, at $0."""
+    pytest.importorskip("sklearn")
+
+    resolver = Resolver.from_schema(CompanySchema, matcher="random_forest")
+    # Two entity-disjoint components so a 0.5 split holds a whole component out.
+    records = [
+        {"id": "a1", "name": "Acme"},
+        {"id": "a2", "name": "Acme"},
+        {"id": "a3", "name": "Aardvark"},
+        {"id": "b1", "name": "Beta"},
+        {"id": "b2", "name": "Beta"},
+        {"id": "b3", "name": "Bumble"},
+    ]
+    pairs = [
+        LabeledPair(left_id="a1", right_id="a2", score=None, label=True, source="correction"),
+        LabeledPair(left_id="a1", right_id="a3", score=None, label=False, source="correction"),
+        LabeledPair(left_id="b1", right_id="b2", score=None, label=True, source="correction"),
+        LabeledPair(left_id="b1", right_id="b3", score=None, label=False, source="correction"),
+    ]
+
+    resolver.fit(records, pairs=pairs, split=0.5, seed=0)
+
+    report = resolver.fit_report_
+    assert isinstance(report, FitReport)
+    assert report.trained is True
+    assert report.n_train > 0
+    assert isinstance(resolver.resolve(records), list)
+
+
+# Six entity-disjoint groups, each with two positives + one negative, so an
+# entity-disjoint split keeps both classes on both sides -- the shape a calibrate
+# fit and its held-out delta need (mirrors tests/core/test_resolver_fit_calibrate).
+_CAL_BASES = [
+    ("Acme", "Beta"),
+    ("Gamma", "Delta"),
+    ("Epsilon", "Zeta"),
+    ("Eta", "Theta"),
+    ("Iota", "Kappa"),
+    ("Lambda", "Mu"),
+]
+
+
+def _calibration_dataset() -> tuple[list[dict[str, str]], list[LabeledPair]]:
+    records: list[dict[str, str]] = []
+    pairs: list[LabeledPair] = []
+    for g, (x, y) in enumerate(_CAL_BASES):
+        x0, x1, y0, y1 = f"g{g}x0", f"g{g}x1", f"g{g}y0", f"g{g}y1"
+        records += [
+            {"id": x0, "name": f"{x} Corp"},
+            {"id": x1, "name": f"{x} Corporation"},
+            {"id": y0, "name": f"{y} Inc"},
+            {"id": y1, "name": f"{y} Incorporated"},
+        ]
+        pairs += [
+            LabeledPair(left_id=x0, right_id=x1, score=None, label=True, source="correction"),
+            LabeledPair(left_id=y0, right_id=y1, score=None, label=True, source="correction"),
+            LabeledPair(left_id=x0, right_id=y0, score=None, label=False, source="correction"),
+        ]
+    return records, pairs
+
+
+def test_dod5_describe_and_calibrate_fit_runs_offline() -> None:
+    """DoD #5: describe() shows the trainable slots; fit(method=Platt()) trains a calibrator, at $0."""
+    pytest.importorskip("sklearn")
+
+    resolver = Resolver.from_schema(CompanySchema, matcher="string", threshold=0.5)
+
+    # describe() pre-fit: the calibrator slot exists and is frozen/empty.
+    pre = next(line for line in resolver.describe().splitlines() if line.startswith("calibrator"))
+    assert "<none>" in pre and "frozen" in pre
+
+    records, pairs = _calibration_dataset()
+    resolver.fit(records, pairs=pairs, method=Platt())
+
+    post = next(line for line in resolver.describe().splitlines() if line.startswith("calibrator"))
+    assert "Calibrator" in post and "TRAINABLE" in post
+    assert isinstance(resolver.fit_report_, FitReport)
+
+
+def test_dod2_mipro_method_constructs_with_clean_import() -> None:
+    """DoD #2 (import+construct only -- running MIPRO needs a served LLM, not executed here)."""
+    method = MIPRO(auto="light", budget_usd=5.0)
+    assert method.kind == "prompt"
+    assert "MIPROv2" in method.describe()
+    # Bootstrap/GEPA are the sibling prompt optimizers on the same clean surface.
+    assert Bootstrap().kind == "prompt" and GEPA().kind == "prompt"
+
+
+def test_dod4_vllm_llmmatcher_constructs_with_clean_import() -> None:
+    """DoD #4 (import+construct only -- forward() would hit the vLLM endpoint, not called)."""
+    pytest.importorskip("litellm")
+    from langres import LLMMatcher
+
+    matcher: LLMMatcher[Any] = LLMMatcher(
+        model="hosted_vllm/my-finetuned-model",
+        api_base="http://localhost:8000/v1",
+        response_parser="binary_yes_no",
+        confidence="logprob",
+    )
+    # Constructed, not called: the client is built lazily on first forward().
+    assert matcher is not None
+    assert isinstance(Isotonic(), Method)  # the other calibrate method, same surface
+
+
+def test_dod3_capstone_public_imports_resolve() -> None:
+    """DoD #3: the QLoRA capstone example's public imports all resolve (run lives elsewhere)."""
+    pytest.importorskip("litellm")  # LLMMatcher access pulls litellm ([llm])
+    from langres import LLMMatcher, QLoRA, run_finetune
+    from langres.core.finetune import FINETUNE_YES_NO_PROMPT
+    from langres.core.matchers.model_ref import to_config
+    from langres.eval import candidates_for, evaluate, get_benchmark
+
+    assert all(
+        obj is not None
+        for obj in (
+            LLMMatcher,
+            QLoRA,
+            run_finetune,
+            FINETUNE_YES_NO_PROMPT,
+            to_config,
+            candidates_for,
+            evaluate,
+            get_benchmark,
+        )
+    )
+    # align_pairs (the pairs->candidates bridge) is now a clean top-level import too.
+    assert callable(align_pairs)


### PR DESCRIPTION
## What

Surfaces the training-surface symbols at the `langres` / `langres.core` top level so the DoD examples import with the clean names they show. The last sub-PR of the training-surface epic (#125) before `feat/training-surface → main`.

## Symbols + placement

- **`langres.core` (eager, import-light):** `Method`, `Bootstrap`, `MIPRO`, `GEPA`, `Platt`, `Isotonic`, `align_pairs`, `FitReport`.
- **`langres` root:** the same eight re-exported eagerly, PLUS `LLMMatcher` (lazy, `[llm]`).
- **Eager vs lazy (verified):** importing `methods_api`/`methods_prompt`/`methods_calibrate`/`harvest`/`fit_report` on a base env pulls none of torch/dspy/litellm/sklearn/peft/trl, so those symbols are eager (matching the root's "cheap and eager" rule). Only genuinely heavy symbols stay lazy: `LLMMatcher` → `[llm]`, and `Calibrator`/`derive_threshold` → `[trained]` (already wired by PR-D/PR-F).
- `Calibrator` left at `langres.core` only — no DoD example imports the component (they use `Platt()` / `calibrate=`), so not root-exported (avoids over-export).
- Capstone imports left as-is: `QLoRA`/`run_finetune`/`LLMMatcher` are now also at root, but `FINETUNE_YES_NO_PROMPT` (a niche finetune constant) deliberately not surfaced — surfacing it would split one clean import into two (net worse).

## The critical gate: import budget

`uv run pytest tests/test_import_budget.py` → **37 passed, 4 skipped** — a bare `import langres` still pulls no heavy dep (torch/dspy/litellm/sklearn/peft/trl). The eager method/fit/align symbols are confirmed light; `LLMMatcher`'s litellm loads only on first access.

## DoD examples validated (committed `tests/test_public_surface_dod.py`, 6 passed)

With the clean `from langres import ...` names:
- **#1 supervised RandomForest fit** → RUNS fully offline, $0 (`from_schema(matcher="random_forest")` → `fit(pairs=)` → `resolve`; `fit_report_` trained). ✅
- **#5 `describe()` + Platt calibrate** → RUNS fully offline, $0 (describe shows calibrator frozen pre-fit → TRAINABLE post-fit). ✅
- **#2 MIPRO prompt-tune** → import + construct (`MIPRO(auto="light", budget_usd=5.0)`, `kind=="prompt"`; running it needs a served LLM → not executed). ✅
- **#4 vLLM serve** → import + construct (`LLMMatcher(model="hosted_vllm/…", api_base=…)` builds; `forward()` would hit the endpoint → not called). ✅
- **#3 QLoRA capstone** → public imports resolve (`QLoRA`/`run_finetune`/`LLMMatcher` now also at root); the end-to-end MPS run stays in `tests/core/test_finetune_capstone.py`. ✅
- Plus a wiring guard: every surfaced name is importable + in `__all__` (root/core) with shared method-object identity.

## Gates

- `uv run pytest tests/test_import_budget.py` → 37 passed, 4 skipped
- `uv run --all-extras pytest -m "not integration and not slow"` → 2939 passed, 4 skipped, 98.34% cov
- `uv run --no-dev --group docs mkdocs build --strict` → clean
- mypy + ruff → clean

## Deferred (optional follow-ups)

- `Calibrator` at root for family symmetry (one-line lazy `[trained]` add) — omitted to avoid over-export.
- Docs-polish pass adopting the shorter `from langres import ...` names in `.md` docs — deep-path imports still valid (change is additive); out of scope for this wiring PR.

Part of the training-surface epic (#125) → `feat/training-surface`. The last sub-PR before →main.

## Summary by Sourcery

Expose training-related symbols at the langres and langres.core top-levels while keeping heavy dependencies lazily loaded, and validate the public surface with DoD-style tests.

New Features:
- Surface training method objects, fit report, and pairs-to-candidates bridge at the langres and langres.core public APIs for cleaner usage in examples.
- Expose LLMMatcher at the langres root as a lazily loaded symbol controlled by the [llm] extra.

Enhancements:
- Clarify import-weight documentation for root exports, explicitly distinguishing eager training symbols from lazily loaded heavy components.
- Extend langres.core.__all__ to include the training-surface symbols so they share identities with their root-level counterparts.

Tests:
- Add DoD-style tests to verify clean top-level imports, symbol export in __all__, offline training flows, and import+construct behavior for LLM-dependent and finetune examples.
- Update import budget tests implicitly relied upon to ensure bare imports do not pull heavy dependencies.