### PR TITLE
ci: adopt setup-uv in publish workflow + bump all workflows to latest uv 0.11.28 / setup-uv v8.3.2

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -42,9 +42,9 @@ jobs:
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
 
       - name: Install uv and set the python version
-        uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7
+        uses: astral-sh/setup-uv@11f9893b081a58869d3b5fccaea48c9e9e46f990 # v8.3.2
         with:
-          version: "0.11.24"
+          version: "0.11.28"
           python-version: "3.13"
 
       - name: Build site (strict)

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -19,9 +19,9 @@ jobs:
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
 
       - name: Set up uv
-        uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7
+        uses: astral-sh/setup-uv@11f9893b081a58869d3b5fccaea48c9e9e46f990 # v8.3.2
         with:
-          version: "0.11.24"
+          version: "0.11.28"
           enable-cache: true
 
       - name: Install dependencies

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -22,7 +22,12 @@ jobs:
           python-version: '3.12'
 
       - name: Install uv
-        run: curl -LsSf https://astral.sh/uv/install.sh | sh
+        # Pinned action instead of `curl … | sh`: a hash-pinned install avoids
+        # running an unpinned remote script in the release pipeline (Scorecard
+        # PinnedDependencies). Same pin/version used across the CI workflows.
+        uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7
+        with:
+          version: "0.11.24"
 
       - name: Build package
         run: uv build

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -25,9 +25,9 @@ jobs:
         # Pinned action instead of `curl … | sh`: a hash-pinned install avoids
         # running an unpinned remote script in the release pipeline (Scorecard
         # PinnedDependencies). Same pin/version used across the CI workflows.
-        uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7
+        uses: astral-sh/setup-uv@11f9893b081a58869d3b5fccaea48c9e9e46f990 # v8.3.2
         with:
-          version: "0.11.24"
+          version: "0.11.28"
 
       - name: Build package
         run: uv build

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -23,9 +23,9 @@ jobs:
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
 
       - name: Set up uv
-        uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7
+        uses: astral-sh/setup-uv@11f9893b081a58869d3b5fccaea48c9e9e46f990 # v8.3.2
         with:
-          version: "0.11.24"
+          version: "0.11.28"
           enable-cache: true
 
       - name: Install dependencies

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -35,9 +35,9 @@ jobs:
           fetch-depth: 0
 
       - name: Install uv and set the python version
-        uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7
+        uses: astral-sh/setup-uv@11f9893b081a58869d3b5fccaea48c9e9e46f990 # v8.3.2
         with:
-          version: "0.11.24"
+          version: "0.11.28"
           python-version: ${{ matrix.python-version }}
           enable-cache: true
 
@@ -71,9 +71,9 @@ jobs:
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
 
       - name: Set up uv
-        uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7
+        uses: astral-sh/setup-uv@11f9893b081a58869d3b5fccaea48c9e9e46f990 # v8.3.2
         with:
-          version: "0.11.24"
+          version: "0.11.28"
           python-version: "3.13"
           enable-cache: true
 
@@ -118,9 +118,9 @@ jobs:
           fetch-depth: 0
 
       - name: Install uv and set the python version
-        uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7
+        uses: astral-sh/setup-uv@11f9893b081a58869d3b5fccaea48c9e9e46f990 # v8.3.2
         with:
-          version: "0.11.24"
+          version: "0.11.28"
           python-version: ${{ matrix.python-version }}
           enable-cache: true
 

--- a/docs/DOCS.md
+++ b/docs/DOCS.md
@@ -395,7 +395,7 @@ jobs:
           python-version: '3.12'
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v4
+        uses: astral-sh/setup-uv@v8
 
       - name: Install dependencies
         run: |


### PR DESCRIPTION
Two related CI/supply-chain changes:

**1. `publish.yml`** — replace the unpinned `curl -LsSf https://astral.sh/uv/install.sh | sh` (an unpinned remote script in the PyPI release pipeline) with the official `astral-sh/setup-uv` action — the uv docs' recommended GitHub Actions method. Clears the last actionable Scorecard `PinnedDependenciesID` alert.

**2. All workflows** — bump `astral-sh/setup-uv` v7 → **v8.3.2** (SHA-pinned) and the pinned uv version 0.11.24 → **0.11.28** (latest) across test/lint/security/docs/publish. Both releases are ≥7 days old (uv 0.11.28: 2026-07-07; setup-uv v8.3.2: 2026-07-08), consistent with the repo's 7-day supply-chain freshness policy. Also refreshes a stale `setup-uv@v4` example in `docs/DOCS.md`.

Follows #137 (pin all actions) and #138 (roll dep quarantine). SHA pins keep the Scorecard pinned-dependencies check green; Dependabot's github-actions updater maintains them via the `# vX` comments.