### PR TITLE
chore: drop dead pre-commit.ci ci: block from hook config

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,13 +1,6 @@
-# pre-commit.ci (https://pre-commit.ci) is a maintainer-side install: enable it
-# for this repository via the pre-commit.ci GitHub App -- nothing in this file
-# activates it by itself. The ci: block makes this config compatible once it IS
-# enabled: the local `language: system` hooks below (mypy, pytest) need the
-# repo's uv environment and cannot run on pre-commit.ci's runners, so they are
-# skipped there (GitHub Actions lint.yml/test.yml already cover both).
-ci:
-  skip: [mypy, pytest]
-  autoupdate_schedule: monthly
-
+# Git hook definitions. Consumed by prek (https://prek.j178.dev/), a drop-in
+# reader of this pre-commit-format config. mypy/pytest run as local
+# `language: system` hooks; CI (GitHub Actions lint.yml/test.yml) also covers them.
 repos:
   # Standard pre-commit hooks for file hygiene
   - repo: https://github.com/pre-commit/pre-commit-hooks


### PR DESCRIPTION
## Summary
- Now that prek replaces pre-commit (#142), the `ci:` block (a pre-commit.ci directive) is dead config — prek ignores it, and pre-commit.ci is not enabled on this repo (no pre-commit.ci check appears on PRs).
- Replaced the pre-commit.ci-focused comment at the top of `.pre-commit-config.yaml` with a short note that prek consumes this file.
- Only `.pre-commit-config.yaml` changed; all hook definitions below `repos:` are byte-identical (ruff, mypy, pytest, pre-commit-hooks repos untouched).

## Verification
```
$ uvx prek run --all-files
```
Config parsed with no error; hooks ran successfully (ruff-check, ruff-format, check-yaml, check-toml, check-merge-conflict, debug-statements, detect-private-key, check-ast all passed). `trailing-whitespace`/`end-of-file-fixer` auto-fixed unrelated pre-existing files during the run; those were reverted so this PR touches only `.pre-commit-config.yaml`. `mypy` failed on pre-existing missing-optional-dependency errors (torch/sentence_transformers/openai/fastembed not installed in this environment) — unrelated to this change.

## Test plan
- [x] `uvx prek run --all-files` — config parses, hooks execute
- [x] `git diff` limited to `.pre-commit-config.yaml`, top-of-file block only

## Summary by Sourcery

Remove unused pre-commit.ci configuration now that hooks are run via prek and update the header comment in .pre-commit-config.yaml accordingly.

Chores:
- Delete obsolete pre-commit.ci ci: block from .pre-commit-config.yaml.
- Refresh top-of-file comment in .pre-commit-config.yaml to note that prek consumes this pre-commit-style config.