### PR TITLE
feat(data-profile): composable, memory-efficient DataProfileReport (PR-1)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -57,6 +57,9 @@ pip-delete-this-directory.txt
 # Eval tearsheet written by examples/quickstart_eval.py
 tearsheet.html
 
+# Data-profile tearsheet written by examples/quickstart_profile.py
+data_profile.html
+
 # Unit test / coverage reports
 htmlcov/
 .tox/

--- a/docs/plans/20260715_data_layer_plan.md
+++ b/docs/plans/20260715_data_layer_plan.md
@@ -27,8 +27,10 @@ gaps (exploration 2026-07-15):
 
 **Decision (maintainer, 2026-07-15):** build these as **one coherent data-layer arc**
 (shared substrate + the first two miners + the tearsheet together), with the **full
-metric battery including embeddings**, and — the load-bearing constraint —
-**flexible / composable / graceful**, not a monolith.
+metric battery including embeddings**, and — the load-bearing constraints —
+**flexible / composable / graceful, not a monolith**; **embeddings precomputed &
+consumed-only** (never generated; multiple first-class, one default); and **text-first,
+HTML optional** (the object is the source of truth, rendering is a thin layer).
 
 ---
 
@@ -48,10 +50,21 @@ you compose**.
    judgement log, no gold) means *that section is simply absent* — never an exception,
    never a blocked report. A profiler validates its own inputs and no-ops when they're
    missing.
-4. **Multiple embeddings are first-class.** You pass N embedding models
-   (`{model_name: matrix}`) and get **one section per model** plus a **comparison
-   panel** (separability side-by-side). Adding an embedder is passing one more entry.
-5. **Reuse the `$0` tearsheet infra.** Inline-SVG (`core/_svg.py`), self-contained
+4. **Embeddings are consumed, never generated; multiple are first-class.** The report
+   takes **precomputed** embeddings — by in-memory matrix *or* by location (a `.npy`
+   path, parquet, a vector-store handle) — keyed by model name. It never loads an
+   embedder or generates vectors, so it carries **no `[semantic]` dependency** (profiling
+   a given matrix needs only numpy). **Good default = one embedding model (+ one blocker
+   view)**; a user who wants more passes N sources → **one section per model + a
+   comparison panel**. Adding an embedder is one more entry.
+5. **Text-first; HTML is a nice-to-have renderer.** The computed stats object is the
+   source of truth; rendering is a thin layer over it. `print`/markdown/dict are the
+   **primary** surfaces (many users live in a terminal or notebook and never open HTML);
+   the `$0` HTML tearsheet is **optional** (§2.5). This mirrors QuantStats
+   (`reports.metrics()` text vs `reports.html()`), statsmodels (`.summary()` vs
+   `.as_html()`), ydata-profiling (`description_set` vs `.to_file`) and sklearn
+   (`classification_report(output_dict=…)`).
+6. **Reuse the `$0` tearsheet infra.** Inline-SVG (`core/_svg.py`), self-contained
    HTML, no CDN/matplotlib, light/dark — the exact pattern `EvalReport` already proves.
 
 The miners obey the same ethos: **plain composable functions** producing `LabeledPair`s
@@ -70,11 +83,13 @@ report a *bag of sections* instead of a monolith.
 # core/data_profile.py  (leaf module — same layering rules as eval_report.py)
 class ProfileSection(BaseModel):                 # frozen
     title: str
-    def to_dict(self) -> dict: ...               # model_dump
+    def to_dict(self) -> dict: ...               # model_dump (machine / JSON)
     def to_markdown(self) -> str: ...            # this block's markdown
+    def __repr__(self) -> str: ...               # -> to_markdown; prints cleanly in a REPL/notebook
     @property
     def summary(self) -> dict: ...               # numeric headline
-    def panels(self) -> list[str]: ...           # inline-SVG/HTML <section>s (reuses _svg)
+    def rows(self) -> list[dict]: ...            # tabular rows -> pd.DataFrame(section.rows()), no pandas dep
+    def panels(self) -> list[str]: ...           # inline-SVG/HTML <section>s (reuses _svg) — HTML only
 ```
 
 Concrete sections (each `ProfileSection`):
@@ -84,7 +99,8 @@ Concrete sections (each `ProfileSection`):
 | `LabelStructureSection` | `gold_clusters`, `gold_pairs` (+ optional splits) | positive prevalence (pos:neg), cluster-size distribution, singleton rate, linkage-vs-dedup shape, train/valid/test balance + **leakage check** |
 | `CorpusFieldSection` | `corpus` (records `.model_dump()`), per source | per-field null/missing rate, cardinality/entropy, value- & token-length distribution, source lopsidedness |
 | `SeparabilitySection` | a pair-set + a **pluggable signal** (string sim default; or an embedding cosine) | score histogram **positives vs negatives**, overlap/AUC — "how hard is this dataset" |
-| `EmbeddingSection` (one **per model**) | an embedding matrix + `model_name` (+ `gold_pairs` for the labeled view) | model name/dim (provenance), vector-norm dist, **cosine positives-vs-negatives**, recall@k of true match in embedding space |
+| `BlockingSection` (one **per blocker**, default one) | a blocker's candidate pairs + `gold_pairs` | candidate count, **reduction ratio**, **pair-completeness** (recall ceiling), candidates-per-record skew — "how blockable is this data" |
+| `EmbeddingSection` (one **per model**, default one) | a **precomputed** `EmbeddingSource` (matrix *or* location) + `model_name` (+ `gold_pairs` for the labeled view) | model name/dim (provenance), vector-norm dist, **cosine positives-vs-negatives**, recall@k of true match in embedding space |
 | `EmbeddingComparisonSection` | ≥2 `EmbeddingSection`s | separability by model side-by-side — "which embedder suits this data" |
 | `MiningReadinessSection` | a mined `LabeledPair` set (+ optional judgement log) | hard-pos/neg counts, class balance after mining, difficulty histogram (EL2N \|1−p\|), **label-noise estimate** |
 
@@ -93,11 +109,15 @@ Concrete sections (each `ProfileSection`):
 ```python
 class DataProfileReport(BaseModel):              # frozen
     sections: list[ProfileSection]
-    def to_html(self, *, title=...) -> str: ...  # renders present sections' panels only
-    def to_markdown(self) -> str: ...
-    def to_dict(self) -> dict: ...
+    # primary surfaces (text-first):
+    def to_markdown(self) -> str: ...            # concatenate sections' markdown
+    def __repr__(self) -> str: ...               # -> to_markdown; `print(report)` just works
+    def to_dict(self) -> dict: ...               # {section.title: section.to_dict()}
     @property
-    def summary(self) -> dict: ...
+    def summary(self) -> dict: ...               # flattened headline numbers
+    def __getitem__(self, title: str) -> ProfileSection: ...   # pull one section out
+    # optional renderer (nice-to-have):
+    def to_html(self, *, title=...) -> str: ...  # renders present sections' panels only
 ```
 
 The report **holds whatever sections you gave it** and renders exactly those. It does
@@ -112,9 +132,15 @@ family = a new `ProfileSection` subclass + a profiler function; the report is un
 ```python
 label = profile_label_structure(gold_clusters, gold_pairs)
 fields = profile_fields(corpus)
-emb    = profile_embeddings({"all-MiniLM-L6-v2": m1, "bge-large-en": m2},
-                            gold_pairs=gold_pairs)   # -> [Section, Section, ComparisonSection]
-DataProfileReport([label, fields, *emb]).to_html()   # renders only these
+emb    = profile_embeddings(                            # precomputed sources, matrix OR location
+    [ArraySource("all-MiniLM-L6-v2", ids, m1),         #   in-memory matrix
+     NpySource("bge-large-en", "vecs/bge.npy", ids)],  #   or a path on disk
+    gold_pairs=gold_pairs)                              # -> [Section, Section, ComparisonSection]
+
+report = DataProfileReport([label, fields, *emb])
+print(report)                    # text-first: markdown table straight to the terminal
+report.summary                   # {"pos_prevalence": 0.0012, "n_clusters": 1076, ...}
+report.to_html("report.html")    # optional nice-to-have tearsheet
 ```
 
 **(b) Convenience with sensible defaults — everything optional, nothing blocks:**
@@ -122,13 +148,15 @@ DataProfileReport([label, fields, *emb]).to_html()   # renders only these
 ```python
 DataProfileReport.from_benchmark(
     get_benchmark("abt_buy"),
-    embeddings={"all-MiniLM-L6-v2": m1},   # OMIT -> no embedding section, no error
-    include={"labels", "fields", "separability", "embeddings"},  # optional subset selector
+    embeddings=[ArraySource("all-MiniLM-L6-v2", ids, m1)],  # OMIT -> no embedding section, no error
+    blocker=VectorBlocker(...),           # OMIT -> no blocking section, no error
+    include={"labels", "fields", "separability"},           # optional subset selector
 )
 ```
 
-Omitting `embeddings=` yields a report without the embedding sections — *no exception*.
-`include=` narrows the default set. Both paths return the same `DataProfileReport`.
+**Default set** = labels + fields + separability + (blocking if a blocker is passed) +
+(one embedding section per source passed). Omitting `embeddings=`/`blocker=` drops those
+sections — *no exception*. `include=` narrows further. Both paths return the same object.
 
 ### 2.4 Shared HTML scaffold (non-invasive)
 
@@ -137,6 +165,34 @@ churning it, lift the ~20-line CSS + a `section(title, body)` helper into a tiny
 `core/_report_html.py`; `DataProfileReport` uses it, `EvalReport` is **left untouched**
 (optional later migration, not in this arc — surgical-changes rule). `core/_svg.py`
 chart primitives are already fully shareable as-is.
+
+### 2.5 `EmbeddingSource` — precomputed, matrix or location
+
+The report never generates embeddings. It consumes them through a one-method value so
+matrices, files, and vector stores are interchangeable and new backends need no profiler
+change:
+
+```python
+class EmbeddingSource(Protocol):
+    name: str                                    # model id, for provenance + comparison
+    def vectors_for(self, ids: Sequence[str]) -> np.ndarray: ...   # aligned to record ids
+```
+
+Concrete now: `ArraySource(name, ids, matrix)` (in-memory) and `NpySource(name, path,
+ids)` (a `.npy` on disk). Later, trivially: a parquet source, a Qdrant/faiss handle —
+each just implements `vectors_for`. Profiling only touches numpy; no `[semantic]` dep.
+
+### 2.6 Render targets — text-first, HTML optional (matches the field)
+
+Every section and the report expose the same ladder, so **HTML is never required**:
+
+| Surface | Method | Use | Precedent |
+|---|---|---|---|
+| **Print / terminal / notebook** | `print(report)` / `__repr__` / `to_markdown()` | the default way to read it | statsmodels `.summary()`, QuantStats `reports.metrics()`, pandas `df.info()` |
+| **Headline numbers** | `.summary` (dict) | log it, assert on it, glance | sklearn `classification_report(output_dict=True)` |
+| **Machine / JSON** | `.to_dict()` | persist, diff across runs, feed a dashboard | ydata-profiling `.to_json()` |
+| **Tabular** | `section.rows()` → `pd.DataFrame(...)` | analysis, no pandas dep forced | pandas `describe()` returns a frame |
+| **Tearsheet (nice-to-have)** | `.to_html()` | shareable `$0` self-contained page | QuantStats `reports.html()`, statsmodels `.as_html()` |
 
 ---
 
@@ -154,9 +210,13 @@ Every metric maps to data already in the codebase — nothing needs new pipeline
 - **Separability** ← any pair-set + a pluggable per-pair signal: default a cheap
   `StringComparator` similarity (core-dep only), or an embedding cosine when a matrix is
   present. Reuses the pos/non-pos split logic already in `EvalReport._histogram`.
-- **Embeddings** ← a caller-supplied matrix + `model_name` (numpy only). We **consume**
-  vectors; we do not force generation (see §5). `embeddings.py` already knows
-  `model_name`/`embedding_dim`.
+- **Embeddings** ← a caller-supplied **precomputed** `EmbeddingSource` (matrix or a
+  location) + `model_name` (numpy only). We **consume** vectors; we never generate them
+  (§2.5). `embeddings.py` already knows `model_name`/`embedding_dim` for anyone producing
+  the matrix upstream.
+- **Blocking** ← a blocker's candidate pairs vs `gold_pairs`; reduction ratio +
+  pair-completeness reuse `core/metrics.reduction_ratio` and the blocker-recall path
+  already in `core/analysis.py`.
 - **Mining readiness** ← a mined `LabeledPair` set (§4) + optional `JudgementLog` rows
   for the EL2N difficulty view.
 
@@ -190,15 +250,16 @@ never rework.
 | Need | Dep | Status | Where |
 |---|---|---|---|
 | Numeric profiling (norms, histograms, cosine) | numpy | **core** (already) | all sections |
-| Profile a *given* embedding matrix | numpy only | **core** | `EmbeddingSection` consumes vectors |
-| *Generate* embeddings (optional convenience) | sentence-transformers | `[semantic]`, **lazy** | optional `from_embedder` helper only |
+| Profile a *given* embedding matrix/source | numpy only | **core** | `EmbeddingSection` consumes precomputed vectors |
 | Hard-positive classifier + confident-learning | scikit-learn | `[trained]` (already) | `mine_misclassified`, `denoise_pairs` |
 | Packaged label-noise (later) | cleanlab | **new, optional, deferred** | Wave 3+ if the built-in isn't enough |
+| ~~Generate embeddings~~ | ~~sentence-transformers~~ | **out of scope** | the report never generates — consumed only (§2.5) |
 
-Import-budget rule (`tests/test_import_budget.py`): `core/data_profile.py` is a **leaf**
-that imports only `core.{metrics,benchmark,models,_svg,_report_html}` + numpy. Profiling
-a matrix must **not** pull sentence-transformers; only the optional *generator* helper
-does, behind the lazy `[semantic]` gate.
+The report pulls **no embedding dependency at all** — a decisive simplification from the
+first draft. Import-budget rule (`tests/test_import_budget.py`): `core/data_profile.py`
+is a **leaf** that imports only `core.{metrics,benchmark,models,_svg,_report_html}` +
+numpy, and pulls **no** sentence-transformers / torch / pandas into a bare `import
+langres`.
 
 ## 6. Testing & layering
 
@@ -236,13 +297,21 @@ does, behind the lazy `[semantic]` gate.
 rule. The miners export via the training/`core` surface next to `harvest`/`align_pairs`.
 (Alternative: a dedicated `langres.profile` namespace — flagged as an open decision.)
 
-## 9. Open design decisions (for maintainer review)
+## 9. Decisions
 
+**Settled (maintainer, 2026-07-15):**
+- **Embeddings are consumed-only** — precomputed, by matrix *or* location, multiple
+  first-class, one default. The report generates nothing and carries no `[semantic]` dep.
+- **Text-first, HTML optional** — `print`/markdown/dict are the primary surfaces (field
+  standard: QuantStats/statsmodels/ydata/sklearn); the tearsheet is a nice-to-have.
+- **Good defaults, extensible** — default = labels + fields + separability + one blocker
+  + one embedding; power users add N blockers/embedders; `include=` narrows.
+
+**Still open (recommendation given, will proceed unless redirected):**
 1. **Public namespace:** `langres.eval.DataProfileReport` (report lives with `EvalReport`)
    vs. a dedicated `langres.profile` / `langres.data` facade. *Rec: reuse `langres.eval`*
    — fewer surfaces, and it's the reporting home already.
 2. **Label-noise rail dep:** built-in confident-learning (sklearn, no new dep) now, with
    Cleanlab as an optional extra later. *Rec: built-in first.*
-3. **Separability default signal:** cheap `StringComparator` sim (core-only, always
-   available) as the default "how hard" signal, embeddings when supplied. *Rec: yes —
-   keeps the section dependency-free by default.*
+3. **pandas interop:** expose `section.rows()` (list[dict]) so `pd.DataFrame(...)` works,
+   *without* adding a pandas dependency. *Rec: yes — DX win, zero dep cost.*

--- a/docs/plans/20260715_data_layer_plan.md
+++ b/docs/plans/20260715_data_layer_plan.md
@@ -3,7 +3,19 @@
 > **Status:** Design + execution plan (2026-07-15). Turns the #86 data-prep survey
 > (`docs/research/20260707_data_prep_hard_case_mining_survey.md`) and the
 > training-surface design (`docs/research/20260714_training_surface_design.md` §5.1)
-> into a buildable, **composable** data-layer arc. Precedes any code — for review.
+> into a buildable, **composable** data-layer arc.
+>
+> **Build status (2026-07-15):**
+> - **PR-1 — the profile report: SHIPPED.** The `DataProfileReport` seam + the full
+>   section battery (`HeroSection`, `LabelStructureSection`, `CorpusFieldSection`,
+>   `SeparabilitySection`, `EmbeddingSection`, `EmbeddingComparisonSection`), the
+>   memory-efficient consumed-only `EmbeddingSource` (`ArraySource` / `NpySource`),
+>   the `from_benchmark` / `from_records` builders (+ the `[semantic]`-gated
+>   `from_embedder` on-ramp), the `langres.eval` public surface, the offline
+>   `examples/quickstart_profile.py`, and the `docs/reference/data-profile.md`
+>   reference all landed (Waves 0–2 of §7).
+> - **PR-2 — the mining seam + mining-readiness: not started** (§4 + the
+>   `MiningReadinessSection` of §2.1; Wave 3 of §7). Unchanged from this plan.
 
 ---
 
@@ -272,16 +284,18 @@ langres`.
 
 ## 7. Build sequence (each wave in its own worktree)
 
-- **Wave 1 — seam + tabular sections.** `ProfileSection` base, `DataProfileReport`
-  container, `core/_report_html.py` scaffold, `LabelStructureSection`,
-  `CorpusFieldSection`, `.to_html()` shell. *Exit:* profile a benchmark's labels+fields
+- **Wave 1 — seam + tabular sections. ✅ SHIPPED (PR-1).** `ProfileSection` base,
+  `DataProfileReport` container, `core/_report_html.py` scaffold, `LabelStructureSection`,
+  `CorpusFieldSection`, `.to_html()` shell. *Exit met:* profile a benchmark's labels+fields
   to a self-contained HTML tearsheet at `$0`; composing a subset works; omitting inputs
   never raises.
-- **Wave 2 — separability + embeddings (multi-model).** `SeparabilitySection`,
-  `EmbeddingSection`, `EmbeddingComparisonSection`, `profile_embeddings({...})`, optional
-  `from_embedder` behind `[semantic]`. *Exit:* pass 2 embedders → 2 sections + comparison
-  in the tearsheet; no embedder → report still renders.
-- **Wave 3 — mining seam + readiness.** `mine_misclassified`, `sample_negatives`,
+- **Wave 2 — separability + embeddings (multi-model) + builders + hero. ✅ SHIPPED (PR-1).**
+  `SeparabilitySection`, `EmbeddingSection`, `EmbeddingComparisonSection`,
+  `profile_embedding`/`profile_embedding_comparison`, `HeroSection`, the
+  `from_benchmark`/`from_records` builders, and the optional `from_embedder` behind
+  `[semantic]`. *Exit met:* pass 2 embedders → 2 sections + comparison in the tearsheet;
+  no embedder → report still renders.
+- **Wave 3 — mining seam + readiness. ← PR-2 (not started).** `mine_misclassified`, `sample_negatives`,
   `denoise_pairs`, `MiningReadinessSection`. *Exit:* mine hard positives + random
   negatives on one benchmark, denoise, profile the mined set in the tearsheet.
 - **Stage 3 (north-star, separate epic):** `attribute_examples` + `flipped` + `ColVal`

--- a/docs/plans/20260715_data_layer_plan.md
+++ b/docs/plans/20260715_data_layer_plan.md
@@ -1,0 +1,248 @@
+# Data Layer — Composable Profile Report + Mining Seam (design & plan)
+
+> **Status:** Design + execution plan (2026-07-15). Turns the #86 data-prep survey
+> (`docs/research/20260707_data_prep_hard_case_mining_survey.md`) and the
+> training-surface design (`docs/research/20260714_training_surface_design.md` §5.1)
+> into a buildable, **composable** data-layer arc. Precedes any code — for review.
+
+---
+
+## 0. Why now, and what we're building
+
+We are about to start experiments (the autoresearch loop #145; the replication /
+training-loop targets T1 silver→student, **T2 AnyMatch generalist**). Before that we
+want the **instrumentation the pipeline is missing on the *data* side**. Two confirmed
+gaps (exploration 2026-07-15):
+
+1. **No dataset profiler.** Every report today is keyed to *pipeline output* or to
+   *gold vs. prediction* (`CandidateInspectionReport`, `ScoreInspectionReport`,
+   `ClusterInspectionReport`, `EvalReport`, the blocker metrics). Nothing takes raw
+   records / a gold pair-set / an embedding matrix and profiles **the data itself** —
+   class balance, per-field stats, gold cluster-size distribution, embedding
+   distribution. This is the "QuantStats-style tearsheet, but for ER data" idea.
+2. **No "mine the training set first" step.** The training surface landed
+   (`Resolver.fit(pairs=…, method=QLoRA|MIPRO|Platt)`, `finetune()`), but it *assumes
+   labeled pairs are handed in*. The AnyMatch-style miners were designed with the
+   maintainer (§5.1 of the training-surface doc) but never built.
+
+**Decision (maintainer, 2026-07-15):** build these as **one coherent data-layer arc**
+(shared substrate + the first two miners + the tearsheet together), with the **full
+metric battery including embeddings**, and — the load-bearing constraint —
+**flexible / composable / graceful**, not a monolith.
+
+---
+
+## 1. Design principles — the composability contract (load-bearing)
+
+This is the part that must be right. The report is **not** one function that computes
+everything and errors if a piece is absent. It is a set of **independent metric blocks
+you compose**.
+
+1. **Independent profiler blocks (SRP).** Each metric family — label structure, field
+   stats, separability, embeddings, mining-readiness — is a self-contained profiler
+   producing a self-contained section. One responsibility each; no cross-talk.
+2. **Compose the subset you want.** "Sometimes I only care about a few metrics" is a
+   first-class path: build only the sections you want and hand them to the report.
+   There is no all-or-nothing entry point.
+3. **Graceful degradation — never block.** A missing input (no embeddings, no
+   judgement log, no gold) means *that section is simply absent* — never an exception,
+   never a blocked report. A profiler validates its own inputs and no-ops when they're
+   missing.
+4. **Multiple embeddings are first-class.** You pass N embedding models
+   (`{model_name: matrix}`) and get **one section per model** plus a **comparison
+   panel** (separability side-by-side). Adding an embedder is passing one more entry.
+5. **Reuse the `$0` tearsheet infra.** Inline-SVG (`core/_svg.py`), self-contained
+   HTML, no CDN/matplotlib, light/dark — the exact pattern `EvalReport` already proves.
+
+The miners obey the same ethos: **plain composable functions** producing `LabeledPair`s
+(as already decided in §5.1), routed by the consumer — not a monolithic strategy engine.
+
+---
+
+## 2. Architecture — the profiler seam
+
+### 2.1 `ProfileSection` — the composable unit
+
+A small Pydantic base every metric block subclasses. This is the seam that makes the
+report a *bag of sections* instead of a monolith.
+
+```python
+# core/data_profile.py  (leaf module — same layering rules as eval_report.py)
+class ProfileSection(BaseModel):                 # frozen
+    title: str
+    def to_dict(self) -> dict: ...               # model_dump
+    def to_markdown(self) -> str: ...            # this block's markdown
+    @property
+    def summary(self) -> dict: ...               # numeric headline
+    def panels(self) -> list[str]: ...           # inline-SVG/HTML <section>s (reuses _svg)
+```
+
+Concrete sections (each `ProfileSection`):
+
+| Section | Built from | Reports |
+|---|---|---|
+| `LabelStructureSection` | `gold_clusters`, `gold_pairs` (+ optional splits) | positive prevalence (pos:neg), cluster-size distribution, singleton rate, linkage-vs-dedup shape, train/valid/test balance + **leakage check** |
+| `CorpusFieldSection` | `corpus` (records `.model_dump()`), per source | per-field null/missing rate, cardinality/entropy, value- & token-length distribution, source lopsidedness |
+| `SeparabilitySection` | a pair-set + a **pluggable signal** (string sim default; or an embedding cosine) | score histogram **positives vs negatives**, overlap/AUC — "how hard is this dataset" |
+| `EmbeddingSection` (one **per model**) | an embedding matrix + `model_name` (+ `gold_pairs` for the labeled view) | model name/dim (provenance), vector-norm dist, **cosine positives-vs-negatives**, recall@k of true match in embedding space |
+| `EmbeddingComparisonSection` | ≥2 `EmbeddingSection`s | separability by model side-by-side — "which embedder suits this data" |
+| `MiningReadinessSection` | a mined `LabeledPair` set (+ optional judgement log) | hard-pos/neg counts, class balance after mining, difficulty histogram (EL2N \|1−p\|), **label-noise estimate** |
+
+### 2.2 `DataProfileReport` — a pure container over sections
+
+```python
+class DataProfileReport(BaseModel):              # frozen
+    sections: list[ProfileSection]
+    def to_html(self, *, title=...) -> str: ...  # renders present sections' panels only
+    def to_markdown(self) -> str: ...
+    def to_dict(self) -> dict: ...
+    @property
+    def summary(self) -> dict: ...
+```
+
+The report **holds whatever sections you gave it** and renders exactly those. It does
+not know how to compute anything — composition lives at the edges. Adding a new metric
+family = a new `ProfileSection` subclass + a profiler function; the report is untouched
+(open/closed).
+
+### 2.3 The two ways to build it
+
+**(a) Compose explicitly — the "only the metrics I want" path:**
+
+```python
+label = profile_label_structure(gold_clusters, gold_pairs)
+fields = profile_fields(corpus)
+emb    = profile_embeddings({"all-MiniLM-L6-v2": m1, "bge-large-en": m2},
+                            gold_pairs=gold_pairs)   # -> [Section, Section, ComparisonSection]
+DataProfileReport([label, fields, *emb]).to_html()   # renders only these
+```
+
+**(b) Convenience with sensible defaults — everything optional, nothing blocks:**
+
+```python
+DataProfileReport.from_benchmark(
+    get_benchmark("abt_buy"),
+    embeddings={"all-MiniLM-L6-v2": m1},   # OMIT -> no embedding section, no error
+    include={"labels", "fields", "separability", "embeddings"},  # optional subset selector
+)
+```
+
+Omitting `embeddings=` yields a report without the embedding sections — *no exception*.
+`include=` narrows the default set. Both paths return the same `DataProfileReport`.
+
+### 2.4 Shared HTML scaffold (non-invasive)
+
+`EvalReport` keeps its `_CSS` + `_panel_*` idiom *inside* the class. To share without
+churning it, lift the ~20-line CSS + a `section(title, body)` helper into a tiny
+`core/_report_html.py`; `DataProfileReport` uses it, `EvalReport` is **left untouched**
+(optional later migration, not in this arc — surgical-changes rule). `core/_svg.py`
+chart primitives are already fully shareable as-is.
+
+---
+
+## 3. The metric battery, grounded in real data sources
+
+Every metric maps to data already in the codebase — nothing needs new pipeline plumbing:
+
+- **Label structure** ← `gold_clusters: list[set[str]]` + `gold_pairs: set[frozenset[str]]`
+  (the `Benchmark.load()` contract, `core/benchmark.py:396`); splits from
+  `_deepmatcher_loader.load_pair_splits` / `fixed_split_pair_benchmark`. Leakage check =
+  entity-disjointness across splits (same union-find as `harvest._entity_disjoint_split`).
+- **Field stats** ← `record.model_dump()` over the corpus; "source" from the record
+  (e.g. `AbtBuySchema.source`). Null = the same emptiness rule `StringComparator` uses
+  (`core/comparator.py:247`).
+- **Separability** ← any pair-set + a pluggable per-pair signal: default a cheap
+  `StringComparator` similarity (core-dep only), or an embedding cosine when a matrix is
+  present. Reuses the pos/non-pos split logic already in `EvalReport._histogram`.
+- **Embeddings** ← a caller-supplied matrix + `model_name` (numpy only). We **consume**
+  vectors; we do not force generation (see §5). `embeddings.py` already knows
+  `model_name`/`embedding_dim`.
+- **Mining readiness** ← a mined `LabeledPair` set (§4) + optional `JudgementLog` rows
+  for the EL2N difficulty view.
+
+## 4. The mining seam (first two miners + the required rail)
+
+Plain functions producing `LabeledPair` (`core/harvest.py:113`), consistent with §5.1.
+This arc builds the **first two + the denoise rail**; the rest are staged (§7).
+
+- `mine_misclassified(candidates, labels, *, classifier=…, cap=…) -> list[LabeledPair]`
+  — AnyMatch **hard-positive** mining: train a fast tabular classifier on the
+  comparison vectors, keep the **positives it misclassifies** (the hard boundary
+  cases). **Reuse the existing sklearn `[trained]` extra** (`RandomForestMatcher`
+  already depends on it) — no AutoGluon; the paper's signal is just "positives a quick
+  classifier gets wrong."
+- `sample_negatives(dataset, *, ratio=2.0, seed=0) -> list[LabeledPair]` — AnyMatch's
+  2:1 **random** negatives. AnyMatch is deliberately hard-*positive* + *random*-negative;
+  we keep "mine hard positives" and "sample/mine negatives" as **separate** functions
+  (opposite failure modes — survey §1.1).
+- `denoise_pairs(pairs, *, method="confident_learning") -> tuple[clean, flagged]` — the
+  **required label-noise rail** (survey §4): any "model got it wrong" signal can't tell
+  *genuinely hard* from *mislabeled*. Ship a light built-in (cross-validated
+  confident-joint using the sklearn we already have); **Cleanlab optional** later, not a
+  new hard dep now.
+
+The report's `MiningReadinessSection` then profiles the miner output — so the tearsheet
+and the miners close a loop (mine → profile the mined set → decide) and the report is
+never rework.
+
+## 5. Dependencies to front-load
+
+| Need | Dep | Status | Where |
+|---|---|---|---|
+| Numeric profiling (norms, histograms, cosine) | numpy | **core** (already) | all sections |
+| Profile a *given* embedding matrix | numpy only | **core** | `EmbeddingSection` consumes vectors |
+| *Generate* embeddings (optional convenience) | sentence-transformers | `[semantic]`, **lazy** | optional `from_embedder` helper only |
+| Hard-positive classifier + confident-learning | scikit-learn | `[trained]` (already) | `mine_misclassified`, `denoise_pairs` |
+| Packaged label-noise (later) | cleanlab | **new, optional, deferred** | Wave 3+ if the built-in isn't enough |
+
+Import-budget rule (`tests/test_import_budget.py`): `core/data_profile.py` is a **leaf**
+that imports only `core.{metrics,benchmark,models,_svg,_report_html}` + numpy. Profiling
+a matrix must **not** pull sentence-transformers; only the optional *generator* helper
+does, behind the lazy `[semantic]` gate.
+
+## 6. Testing & layering
+
+- Leaf module; nothing in `reports.py`/`module.py` imports it; import-budget test guards
+  the bare-`import langres` budget.
+- Tiered coverage: this is `core` contract → **95–100%**. Each profiler function and
+  section gets unit tests incl. the **graceful-degradation cases** (missing embeddings,
+  empty gold, single-source corpus → section absent, *no raise*) and the
+  **multi-embedding** case (2 models → 2 sections + comparison).
+
+## 7. Build sequence (each wave in its own worktree)
+
+- **Wave 1 — seam + tabular sections.** `ProfileSection` base, `DataProfileReport`
+  container, `core/_report_html.py` scaffold, `LabelStructureSection`,
+  `CorpusFieldSection`, `.to_html()` shell. *Exit:* profile a benchmark's labels+fields
+  to a self-contained HTML tearsheet at `$0`; composing a subset works; omitting inputs
+  never raises.
+- **Wave 2 — separability + embeddings (multi-model).** `SeparabilitySection`,
+  `EmbeddingSection`, `EmbeddingComparisonSection`, `profile_embeddings({...})`, optional
+  `from_embedder` behind `[semantic]`. *Exit:* pass 2 embedders → 2 sections + comparison
+  in the tearsheet; no embedder → report still renders.
+- **Wave 3 — mining seam + readiness.** `mine_misclassified`, `sample_negatives`,
+  `denoise_pairs`, `MiningReadinessSection`. *Exit:* mine hard positives + random
+  negatives on one benchmark, denoise, profile the mined set in the tearsheet.
+- **Stage 3 (north-star, separate epic):** `attribute_examples` + `flipped` + `ColVal`
+  schema-free serializer → `TrainedLMMatcher` → the **leave-one-out generalist harness**
+  (pool mined pairs across the 10-dataset registry, hold one out, zero-shot eval) — the
+  AnyMatch "one ER model across all benchmarks" payoff (F1 81.96 reference). Consumes
+  Waves 1–3; scoped in its own plan.
+
+## 8. Public surface
+
+`DataProfileReport` + the profiler functions export via `langres.eval` alongside
+`EvalReport` (data-and-eval reporting live together), following the import-light eager
+rule. The miners export via the training/`core` surface next to `harvest`/`align_pairs`.
+(Alternative: a dedicated `langres.profile` namespace — flagged as an open decision.)
+
+## 9. Open design decisions (for maintainer review)
+
+1. **Public namespace:** `langres.eval.DataProfileReport` (report lives with `EvalReport`)
+   vs. a dedicated `langres.profile` / `langres.data` facade. *Rec: reuse `langres.eval`*
+   — fewer surfaces, and it's the reporting home already.
+2. **Label-noise rail dep:** built-in confident-learning (sklearn, no new dep) now, with
+   Cleanlab as an optional extra later. *Rec: built-in first.*
+3. **Separability default signal:** cheap `StringComparator` sim (core-only, always
+   available) as the default "how hard" signal, embeddings when supplied. *Rec: yes —
+   keeps the section dependency-free by default.*

--- a/docs/reference/data-profile.md
+++ b/docs/reference/data-profile.md
@@ -1,0 +1,85 @@
+# DataProfileReport
+
+A self-contained HTML **data**-profile tearsheet -- and its text-first surfaces --
+that profiles *the data itself* (not the pipeline output): class balance, gold
+cluster structure, per-field data quality, how separable matches are from
+non-matches, and how your precomputed embeddings are distributed.
+
+## What it profiles
+
+The report is a **bag of sections**, one self-contained `ProfileSection` per
+metric family:
+
+| Section | Reports |
+|---|---|
+| `HeroSection` | the at-a-glance KPIs: records, clusters, positive-pair prevalence, `1:N` class imbalance, separability AUC |
+| `LabelStructureSection` | gold cluster-size distribution, singleton rate, positive-pair prevalence + class imbalance |
+| `CorpusFieldSection` | per-field non-null rate, cardinality, value-length distribution (most-missing first) |
+| `SeparabilitySection` | matches-vs-non-matches similarity histogram + AUC for a signal (rapidfuzz string by default, or an embedding cosine) |
+| `EmbeddingSection` | one precomputed model's L2-norm distribution (provenance, health) |
+| `EmbeddingComparisonSection` | several models' norm distributions as shared-axis small multiples |
+
+## The composability contract (graceful degradation)
+
+The report **holds whatever sections you give it and renders exactly those** -- it
+computes nothing itself. Two consequences:
+
+- **Compose the subset you want.** Build only the sections you care about and hand
+  them to `DataProfileReport([...])`, or use `from_benchmark` / `from_records` and
+  narrow with `include=` (a selector of section *kinds*; an unknown kind raises).
+- **A missing input is never an error.** No gold clustering -> no label-structure
+  or separability section. No `schema` -> no string separability. No embeddings ->
+  no embedding sections. The section is simply absent; the report still renders.
+
+## Text-first; HTML optional
+
+Every section and the report expose the same render ladder, so **HTML is never
+required**:
+
+- `print(report)` / `report.to_markdown()` -- the primary way to read it.
+- `report.summary` -- a flat dict of headline numbers (log it, assert on it).
+- `report.to_dict()` -- the machine/JSON surface (persist, diff across runs).
+- `section.rows()` -- `pd.DataFrame(section.rows())`-ready, with no pandas dependency.
+- `report.to_html()` -- the optional `$0`, self-contained tearsheet (inline SVG, no
+  CDN, no matplotlib, light/dark aware).
+
+## Memory-efficient embeddings (precomputed, consumed-only)
+
+The report **never generates embeddings** -- it consumes vectors a pipeline
+already paid to compute, through the read-only `EmbeddingSource` protocol. It
+carries **no `[semantic]` dependency**: profiling a given matrix needs only numpy.
+
+- `ArraySource(name, ids, matrix)` -- wraps an in-memory matrix (tests, small corpora).
+- `NpySource(name, path, ids)` -- memmaps a `.npy` (`mmap_mode="r"`) and gathers only
+  the requested rows, so a 30 GB matrix profiles in `O(batch * dim)` memory.
+- `NpySource.from_anchor_store(state_dir, name)` -- reuses a persisted vector index.
+
+If you have no vectors yet, the `[semantic]`-gated `from_embedder(records, model,
+out_path=...)` embeds once with sentence-transformers, writes a `.npy` (+ an ids
+sidecar), and returns an `NpySource` -- a separate on-ramp that keeps the report
+itself dependency-free.
+
+## Usage
+
+```python
+from langres.core.data_profile import ArraySource, DataProfileReport
+
+# Precomputed vectors (from a VectorBlocker, an AnchorStore, or a .npy on disk).
+emb = ArraySource("all-MiniLM-L6-v2", ids, matrix)
+
+report = DataProfileReport.from_records(
+    records,                 # list of field dicts
+    gold=gold_clusters,      # optional: enables label structure + separability
+    schema=MySchema,         # optional: enables the string-similarity signal
+    embeddings=[emb],        # optional: one embedding section per source
+    include={"hero", "label_structure", "separability"},  # optional kind selector
+)
+
+print(report)                # text-first: markdown to the terminal
+report.summary               # {"Overview.prevalence": 0.0012, ...}
+report.to_html("out.html")   # optional $0 tearsheet
+```
+
+`from_benchmark("abt_buy", embeddings=[...])` is the registered-benchmark twin.
+
+::: langres.core.data_profile

--- a/examples/quickstart_profile.py
+++ b/examples/quickstart_profile.py
@@ -1,0 +1,87 @@
+"""Quickstart: profile a dataset -- the data, not the pipeline -- for free.
+
+Before you judge a single pair, the data itself has a story: how rare a true match
+is (class imbalance), how clean the fields are, whether *any* signal separates
+matches from non-matches, and how your embeddings are distributed. This example
+builds a :class:`~langres.core.data_profile.DataProfileReport` over a toy corpus +
+gold clustering + two (synthetic) embedding models, then shows the **text-first**
+surfaces (``print``/markdown/dict/rows) and writes a single self-contained
+``data_profile.html`` tearsheet -- a KPI hero, label structure, string- and
+cosine-separability charts, per-field stats, and side-by-side embedding norms.
+
+Fully offline on purpose: no API key, no network, no torch, no
+sentence-transformers. The two embedding sources are plain in-memory
+:class:`~langres.core.data_profile.ArraySource` matrices (what a
+``VectorBlocker``'s corpus, an ``AnchorStore``, or a ``.npy`` on disk would give
+you). The report *consumes* precomputed vectors -- it never generates them -- so
+this whole quickstart runs on a bare core-only install.
+
+Run it:
+    uv run python examples/quickstart_profile.py
+"""
+
+from pathlib import Path
+
+import numpy as np
+
+from langres.core.data_profile import ArraySource, DataProfileReport
+from langres.core.models import CompanySchema
+
+# A toy cross-source corpus and its true clustering (what a small labeled sample
+# gives you). Four entities: three matched pairs and one singleton.
+records = [
+    {"id": "1", "name": "Acme Corporation"},
+    {"id": "2", "name": "Acme Corp"},
+    {"id": "3", "name": "Globex Inc"},
+    {"id": "4", "name": "Globex Incorporated"},
+    {"id": "5", "name": "Initech"},
+    {"id": "6", "name": "Initech LLC"},
+    {"id": "7", "name": "Unrelated Bakery"},
+]
+gold_clusters = [{"1", "2"}, {"3", "4"}, {"5", "6"}, {"7"}]
+
+# Two synthetic embedding models over the SAME record ids. Each record's vector is
+# its cluster's base direction plus noise, so within-cluster cosine runs high --
+# giving the cosine-separability chart something real to show. Different dims (8 vs
+# 16) and scales make the side-by-side norm comparison (and its dims-differ caveat)
+# render. No sentence-transformers involved: these are plain matrices.
+rng = np.random.default_rng(0)
+ids = [record["id"] for record in records]
+cluster_of = {rid: ci for ci, cluster in enumerate(gold_clusters) for rid in cluster}
+
+
+def _synthetic_matrix(dim: int, scale: float) -> np.ndarray:
+    bases = {ci: rng.normal(size=dim) for ci in range(len(gold_clusters))}
+    rows = [(bases[cluster_of[rid]] + rng.normal(scale=0.35, size=dim)) * scale for rid in ids]
+    return np.asarray(rows)
+
+
+embeddings = [
+    ArraySource("mini-8d", ids, _synthetic_matrix(dim=8, scale=1.0)),
+    ArraySource("large-16d", ids, _synthetic_matrix(dim=16, scale=2.5)),
+]
+
+# BUILD: compose the default section set (hero -> labels -> separability ->
+# fields -> embeddings -> comparison). Omitting embeddings= would simply drop the
+# embedding sections -- no error. schema= enables the rapidfuzz string signal.
+report = DataProfileReport.from_records(
+    records,
+    gold=gold_clusters,
+    schema=CompanySchema,
+    embeddings=embeddings,
+)
+
+# 1. TEXT-FIRST: print the whole report as markdown (the default way to read it).
+print(report)
+
+# 2. HEADLINE NUMBERS: a flat dict you can log or assert on.
+print("\nsummary:", report.summary)
+
+# 3. TABULAR: any section's rows() feed pd.DataFrame(...) with no pandas dep.
+label = report["Label structure"]
+print("\nlabel-structure rows:", label.rows())
+
+# 4. TEARSHEET (nice-to-have): one self-contained HTML file, $0, no server.
+out_path = Path("data_profile.html")
+out_path.write_text(report.to_html(title="langres data profile"), encoding="utf-8")
+print(f"\nWrote {out_path.resolve()} -- open it in a browser (no server needed).")

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -106,3 +106,4 @@ nav:
       - Clusterers: reference/clusterers.md
       - Flywheel (log / review / harvest / calibration): reference/flywheel.md
       - EvalReport: reference/eval-report.md
+      - DataProfileReport: reference/data-profile.md

--- a/src/langres/__init__.py
+++ b/src/langres/__init__.py
@@ -68,6 +68,7 @@ if TYPE_CHECKING:
     # to `mypy --strict` without executing the imports below on a bare import.
     from langres.core.benchmark import gold_pairs_from_clusters
     from langres.core.calibration import derive_threshold
+    from langres.core.data_profile import DataProfileReport
     from langres.core.eval_report import EvalReport
     from langres.core.matchers.llm_judge import LLMMatcher
 
@@ -78,6 +79,7 @@ __all__ = [
     "DEFAULT_AUTO_MODEL",
     "Correction",
     "CorrectionLog",
+    "DataProfileReport",
     "ERCandidate",
     "EvalReport",
     "FitReport",
@@ -123,6 +125,7 @@ except PackageNotFoundError:  # pragma: no cover - only hit on uninstalled sourc
 #: scikit-learn at module scope (the ``[trained]`` extra).
 _LAZY_SYMBOLS: dict[str, str] = {
     "EvalReport": "langres.core.eval_report",
+    "DataProfileReport": "langres.core.data_profile",
     "derive_threshold": "langres.core.calibration",
     "gold_pairs_from_clusters": "langres.core.benchmark",
     # The LLM matcher (serve a fine-tuned model_ref, a vLLM api_base, or a paid

--- a/src/langres/core/_report_html.py
+++ b/src/langres/core/_report_html.py
@@ -1,0 +1,237 @@
+"""Shared, dependency-free HTML/render scaffold for the ``$0`` report family.
+
+This is the leaf both :mod:`langres.core.eval_report` and the data-profile
+report (:mod:`langres.core.data_profile`) render through. It carries the same
+guarantee ``eval_report`` already proves: inline styles, no CDN, no matplotlib,
+no ML stack -- a self-contained HTML page buildable on a bare core-only install.
+An import-budget test (``tests/test_import_budget.py``) locks that this module
+never drags in a heavy dependency.
+
+**Why this exists (and why it duplicates ``eval_report`` for now).**
+``EvalReport`` keeps its ``_CSS`` + panel idiom *inside* the class. Rather than
+churn that shipped module, this arc *lifts* the reusable pieces (the stylesheet,
+the number/markdown formatters, the histogram binner, the never-raise AUC/AP
+guards) here so the profile report can share them. ``eval_report`` is left
+untouched (a later, optional migration -- surgical-changes rule), so the small
+overlap is a deliberate, transient duplicate.
+
+Contents:
+- :func:`document` -- the doctype + ``<head>`` + ``<body>`` shell (mirrors
+  ``EvalReport.to_html``'s wrapper).
+- :func:`section` -- one ``<section><h2>...</h2>...</section>`` block.
+- :func:`_num` -- format a number, mapping ``None``/NaN/Inf to ``"n/a"``.
+- :func:`_md_cell` -- make a value safe inside a Markdown table cell.
+- :func:`_histogram` -- count values into ascending half-open bins.
+- :func:`safe_auc` / :func:`safe_ap` -- ROC-AUC / average-precision guards that
+  return ``None`` (never raise) on empty input, dropping non-finite
+  ``(score, label)`` pairs before calling the underlying metric.
+
+Pure standard library plus (optionally) numpy; ``core.metrics`` is the only
+langres import, and it is itself import-light.
+"""
+
+from __future__ import annotations
+
+import html
+import math
+from collections.abc import Sequence
+
+from langres.core.metrics import average_precision_score, roc_auc_score
+
+# Explicit shared surface. ``_num`` / ``_md_cell`` / ``_histogram`` are
+# underscore-named (module-internal by convention) but are *intentionally*
+# provided for the profiler sections that land in Wave 1 -- listing them here
+# documents that they are exported-for-reuse, not dead code.
+__all__ = [
+    "document",
+    "section",
+    "safe_auc",
+    "safe_ap",
+    "_num",
+    "_md_cell",
+    "_histogram",
+]
+
+# Inline stylesheet: neutral, theme-aware, no external fonts or assets. Copied
+# verbatim from ``eval_report._CSS`` so both reports look identical; the two
+# copies converge if ``eval_report`` is later migrated onto this scaffold.
+_CSS = """
+:root { color-scheme: light dark; --fg: #1a1a1a; --bg: #ffffff; --muted: #666;
+  --line: #ddd; --tp: #2a9d8f; --fp: #e76f51; --fn: #e9c46a; --tn: #8ecae6; }
+@media (prefers-color-scheme: dark) {
+  :root { --fg: #e6e6e6; --bg: #16181d; --muted: #9aa; --line: #333; } }
+body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif;
+  color: var(--fg); background: var(--bg); margin: 0 auto; max-width: 820px;
+  padding: 24px; line-height: 1.5; }
+h1 { font-size: 1.5rem; margin: 0 0 4px; }
+h2 { font-size: 1.05rem; margin: 0 0 8px; border-bottom: 1px solid var(--line);
+  padding-bottom: 4px; }
+section { margin: 24px 0; }
+.summary { color: var(--muted); font-variant-numeric: tabular-nums; margin: 0 0 8px; }
+.empty { color: var(--muted); font-style: italic; }
+table { border-collapse: collapse; font-variant-numeric: tabular-nums; }
+th, td { padding: 4px 10px; text-align: left; border: 1px solid var(--line); }
+table.kv th { color: var(--muted); font-weight: 500; }
+table.confusion td { text-align: right; font-weight: 600; }
+table.confusion td.tp { color: var(--tp); } table.confusion td.fp { color: var(--fp); }
+table.confusion td.fn { color: var(--fn); } table.confusion td.tn { color: var(--tn); }
+table.errors { width: 100%; font-size: 0.9rem; }
+svg { display: block; margin: 4px 0; }
+""".strip()
+
+
+def document(title: str, body: str, *, summary_html: str = "") -> str:
+    """Wrap ``body`` in a self-contained HTML document (no external assets).
+
+    Mirrors the shell ``EvalReport.to_html`` builds: a ``<!doctype html>`` page
+    with the shared inline :data:`_CSS`, an escaped ``<h1>`` title, an optional
+    summary line, and the caller-supplied ``body`` (already-rendered
+    ``<section>`` HTML). Zero network requests, no CDN, no matplotlib.
+
+    Args:
+        title: Page title -- HTML-escaped into both ``<title>`` and ``<h1>``.
+        body: Pre-rendered HTML for the page body (typically joined
+            ``<section>`` blocks). Emitted as-is; callers are responsible for
+            escaping any untrusted text inside it (use :func:`section`).
+        summary_html: Optional pre-rendered HTML for a one-line summary under
+            the title. Emitted as-is (hence the ``_html`` suffix); pass ``""``
+            (default) to omit the summary paragraph entirely.
+
+    Returns:
+        A complete ``<!doctype html>...`` string.
+    """
+    summary = f'<p class="summary">{summary_html}</p>\n' if summary_html else ""
+    return (
+        "<!doctype html>\n"
+        '<html lang="en">\n<head>\n<meta charset="utf-8">\n'
+        '<meta name="viewport" content="width=device-width, initial-scale=1">\n'
+        f"<title>{html.escape(title)}</title>\n"
+        f"<style>{_CSS}</style>\n</head>\n<body>\n"
+        f"<h1>{html.escape(title)}</h1>\n"
+        f"{summary}"
+        f"{body}\n"
+        "</body>\n</html>\n"
+    )
+
+
+def section(title: str, body_html: str) -> str:
+    """Render one ``<section><h2>title</h2>body_html</section>`` block.
+
+    The ``title`` is HTML-escaped; ``body_html`` is emitted as-is (it is
+    pre-rendered HTML -- a table, an inline ``<svg>``, a paragraph). This is the
+    single place the ``<section>`` idiom lives, so every profiler section renders
+    a consistent frame.
+
+    Args:
+        title: Section heading -- HTML-escaped.
+        body_html: Pre-rendered HTML for the section body (emitted verbatim).
+
+    Returns:
+        A ``<section>...</section>`` string.
+    """
+    return f"<section><h2>{html.escape(title)}</h2>{body_html}</section>"
+
+
+def _num(value: float | None, digits: int = 3) -> str:
+    """Format a number for display, mapping ``None``/NaN/Inf to ``"n/a"``.
+
+    A blank or ``"n/a"`` cell is the honest render of an undefined metric; it
+    must never surface as the literal ``NaN``/``Infinity`` string in the HTML.
+    """
+    if value is None or not math.isfinite(value):
+        return "n/a"
+    return f"{value:.{digits}f}"
+
+
+def _md_cell(text: str) -> str:
+    """Make a value safe inside a Markdown table cell.
+
+    A value may contain a ``|`` (the column delimiter) or a newline; either
+    silently corrupts table alignment. Escape the pipe and flatten newlines so
+    the Markdown and HTML render paths stay symmetric.
+    """
+    return str(text).replace("|", "\\|").replace("\n", " ").replace("\r", " ")
+
+
+def _histogram(values: Sequence[float], edges: Sequence[float]) -> list[float]:
+    """Count ``values`` into the half-open bins defined by ascending ``edges``.
+
+    ``len(edges) == B + 1`` yields ``B`` counts. The last bin is closed on the
+    right so a value equal to the final edge (e.g. ``1.0``) is counted, not
+    dropped. Non-finite values are ignored.
+    """
+    n_bins = len(edges) - 1
+    counts = [0.0] * max(n_bins, 0)
+    for value in values:
+        if not math.isfinite(value):
+            continue
+        for b in range(n_bins):
+            lo = edges[b]
+            hi = edges[b + 1]
+            if lo <= value < hi or (b == n_bins - 1 and value == hi):
+                counts[b] += 1.0
+                break
+    return counts
+
+
+def safe_auc(y_true: Sequence[bool], scores: Sequence[float]) -> float | None:
+    """ROC-AUC that never raises: ``None`` on empty, non-finite scores dropped.
+
+    :func:`~langres.core.metrics.roc_auc_score` *raises* on an empty input or a
+    non-finite score (a broken ranking). This guard drops every
+    ``(score, label)`` pair whose score is non-finite *before* calling it, and
+    returns ``None`` when nothing usable remains -- so a section can always
+    compute a headline number without a try/except at every call site.
+
+    A single-class label vector (all positive or all negative) still yields the
+    underlying metric's documented ``nan`` "undefined statistic" return, which
+    :func:`_num` renders as ``"n/a"``.
+
+    Args:
+        y_true: Ground-truth boolean labels (positive class is ``True``).
+        scores: Continuous scores aligned with ``y_true``.
+
+    Returns:
+        The ROC-AUC over the finite-scored pairs, or ``None`` when none remain.
+    """
+    labels, clean = _finite_pairs(y_true, scores)
+    if not clean:
+        return None
+    return roc_auc_score(labels, clean)
+
+
+def safe_ap(y_true: Sequence[bool], scores: Sequence[float]) -> float | None:
+    """Average precision that never raises: ``None`` on empty, non-finite dropped.
+
+    The AP counterpart of :func:`safe_auc` -- same never-raise contract over
+    :func:`~langres.core.metrics.average_precision_score`.
+
+    Args:
+        y_true: Ground-truth boolean labels (positive class is ``True``).
+        scores: Continuous scores aligned with ``y_true``.
+
+    Returns:
+        The average precision over the finite-scored pairs, or ``None`` when
+        none remain.
+    """
+    labels, clean = _finite_pairs(y_true, scores)
+    if not clean:
+        return None
+    return average_precision_score(labels, clean)
+
+
+def _finite_pairs(
+    y_true: Sequence[bool], scores: Sequence[float]
+) -> tuple[list[bool], list[float]]:
+    """Drop ``(label, score)`` pairs whose score is non-finite; return the rest.
+
+    The shared filter behind :func:`safe_auc` / :func:`safe_ap`: a non-finite
+    score makes a ranking undefined, so it is removed before the metric sees it.
+    """
+    labels: list[bool] = []
+    clean: list[float] = []
+    for label, score in zip(y_true, scores, strict=True):
+        if math.isfinite(score):
+            labels.append(bool(label))
+            clean.append(float(score))
+    return labels, clean

--- a/src/langres/core/_svg.py
+++ b/src/langres/core/_svg.py
@@ -364,7 +364,9 @@ def bar_chart(
     x0 = bin_edges[0] if bin_edges else 0.0
     x1 = bin_edges[-1] if bin_edges else 1.0
 
-    scaled = [(label, stroke, _rescale_counts(counts, normalize)) for label, stroke, counts in series]
+    scaled = [
+        (label, stroke, _rescale_counts(counts, normalize)) for label, stroke, counts in series
+    ]
 
     finite_counts = [c for _, _, counts in scaled for c in counts if math.isfinite(c)]
     y_max = max(finite_counts) if finite_counts else 0.0

--- a/src/langres/core/_svg.py
+++ b/src/langres/core/_svg.py
@@ -298,6 +298,26 @@ def line_chart(
     return "".join(parts)
 
 
+def _rescale_counts(counts: list[float], mode: Literal["none", "density", "max"]) -> list[float]:
+    """Scale one series' ``counts`` for the ``bar_chart`` ``normalize`` mode.
+
+    ``"none"`` returns ``counts`` unchanged (the identity -- so existing callers
+    are byte-for-byte unaffected). ``"density"`` divides by the sum of the
+    series' finite counts (each series then sums to 1). ``"max"`` divides by the
+    series' finite maximum (each series then peaks at 1). Non-finite entries are
+    passed through untouched (``bar_chart`` drops them at render time), and a
+    degenerate total (``<= 0``: an empty or all-zero series) is left as-is to
+    avoid a divide-by-zero -- no bars would be drawn for it either way.
+    """
+    if mode == "none":
+        return counts
+    finite = [c for c in counts if math.isfinite(c)]
+    total = sum(finite) if mode == "density" else (max(finite) if finite else 0.0)
+    if total <= 0.0:
+        return counts
+    return [c / total if math.isfinite(c) else c for c in counts]
+
+
 def bar_chart(
     bin_edges: list[float],
     series: list[tuple[str, str, list[float]]],
@@ -306,6 +326,7 @@ def bar_chart(
     height: int = 260,
     x_label: str = "",
     y_label: str = "",
+    normalize: Literal["none", "density", "max"] = "none",
 ) -> str:
     """Render an overlaid grouped bar chart as a self-contained ``<svg>`` string.
 
@@ -323,6 +344,14 @@ def bar_chart(
         height: SVG height in pixels.
         x_label: X-axis title (html-escaped).
         y_label: Y-axis title (html-escaped).
+        normalize: How to scale each series before drawing (default ``"none"``,
+            which leaves counts untouched -- existing callers are unaffected).
+            ``"density"`` scales each series so it sums to 1; ``"max"`` scales
+            each series to its own maximum. Both make a positives-vs-negatives
+            histogram legible under ER class imbalance (1:1000+), where the raw
+            negative bars would otherwise dwarf the positives into invisibility.
+            Scaling is per-series, so the two series share the y-axis on
+            comparable footing.
 
     Returns:
         A complete ``<svg ...>...</svg>`` string.
@@ -335,7 +364,9 @@ def bar_chart(
     x0 = bin_edges[0] if bin_edges else 0.0
     x1 = bin_edges[-1] if bin_edges else 1.0
 
-    finite_counts = [c for _, _, counts in series for c in counts if math.isfinite(c)]
+    scaled = [(label, stroke, _rescale_counts(counts, normalize)) for label, stroke, counts in series]
+
+    finite_counts = [c for _, _, counts in scaled for c in counts if math.isfinite(c)]
     y_max = max(finite_counts) if finite_counts else 0.0
     if y_max <= 0.0:
         y_max = 1.0  # avoid a degenerate y range; no bars are drawn either way
@@ -358,7 +389,7 @@ def bar_chart(
     )
 
     n_bins = max(len(bin_edges) - 1, 0)
-    for _label, stroke, counts in series:
+    for _label, stroke, counts in scaled:
         fill = _esc(stroke)
         for i in range(min(n_bins, len(counts))):
             count = counts[i]
@@ -375,6 +406,6 @@ def bar_chart(
                 f'fill="{fill}" fill-opacity="0.55"/>'
             )
 
-    parts.extend(_legend([(label, stroke) for label, stroke, _ in series], plot_left, plot_top))
+    parts.extend(_legend([(label, stroke) for label, stroke, _ in scaled], plot_left, plot_top))
     parts.append("</svg>")
     return "".join(parts)

--- a/src/langres/core/data_profile/__init__.py
+++ b/src/langres/core/data_profile/__init__.py
@@ -1,0 +1,21 @@
+"""Composable data-profile report: the ``ProfileSection`` bag + its container.
+
+Wave 0 ships the seam only -- the frozen :class:`ProfileSection` base and the
+:class:`DataProfileReport` container (:mod:`langres.core.data_profile.base`),
+plus the render scaffold (:mod:`langres.core._report_html`) and the streaming
+accumulators (:mod:`langres.core.data_profile.accumulators`).
+
+Later waves add, without touching the frozen base:
+- Wave 1/2 -- concrete sections (``LabelStructureSection``, ``CorpusFieldSection``,
+  ``SeparabilitySection``, ``EmbeddingSection``, ...), the ``EmbeddingSource``
+  protocol, and the profiler functions that build them.
+- Wave 2 -- ``builders`` (the module ``DataProfileReport.from_benchmark`` /
+  ``from_records`` delegate to) so the convenience constructors light up.
+
+A leaf module: import-light (numpy + stdlib + ``core.metrics``), guarded by
+``tests/test_import_budget.py``.
+"""
+
+from langres.core.data_profile.base import DataProfileReport, ProfileSection
+
+__all__ = ["DataProfileReport", "ProfileSection"]

--- a/src/langres/core/data_profile/__init__.py
+++ b/src/langres/core/data_profile/__init__.py
@@ -1,21 +1,85 @@
 """Composable data-profile report: the ``ProfileSection`` bag + its container.
 
-Wave 0 ships the seam only -- the frozen :class:`ProfileSection` base and the
-:class:`DataProfileReport` container (:mod:`langres.core.data_profile.base`),
-plus the render scaffold (:mod:`langres.core._report_html`) and the streaming
-accumulators (:mod:`langres.core.data_profile.accumulators`).
+The public surface of the data-layer profiler (plan §2). The report is a *bag of
+sections* -- one self-contained :class:`ProfileSection` per metric family (label
+structure, corpus fields, separability, embeddings, the KPI hero), composed into a
+:class:`DataProfileReport` that renders exactly the sections it is given. Build one
+explicitly from the profiler functions, or via the convenience constructors
+:func:`from_benchmark` / :func:`from_records` (and the ``[semantic]``-gated
+:func:`from_embedder` on-ramp).
 
-Later waves add, without touching the frozen base:
-- Wave 1/2 -- concrete sections (``LabelStructureSection``, ``CorpusFieldSection``,
-  ``SeparabilitySection``, ``EmbeddingSection``, ...), the ``EmbeddingSource``
-  protocol, and the profiler functions that build them.
-- Wave 2 -- ``builders`` (the module ``DataProfileReport.from_benchmark`` /
-  ``from_records`` delegate to) so the convenience constructors light up.
-
-A leaf module: import-light (numpy + stdlib + ``core.metrics``), guarded by
-``tests/test_import_budget.py``.
+A leaf, import-light package: numpy + stdlib + ``core.metrics`` + the shared
+render scaffold (:mod:`langres.core._report_html`). It *consumes* precomputed
+embeddings (an :class:`EmbeddingSource`); it never generates them, so it carries
+no ``[semantic]`` dependency (``from_embedder`` imports sentence-transformers
+lazily inside its body). ``tests/test_import_budget.py`` locks the budget: a bare
+``import langres`` -- and importing this package -- pulls no torch / faiss /
+sentence-transformers / litellm.
 """
 
 from langres.core.data_profile.base import DataProfileReport, ProfileSection
+from langres.core.data_profile.builders import (
+    from_benchmark,
+    from_embedder,
+    from_records,
+)
+from langres.core.data_profile.corpus_field import (
+    CorpusFieldSection,
+    FieldStat,
+    profile_corpus_fields,
+)
+from langres.core.data_profile.embedding_section import (
+    EmbeddingComparisonSection,
+    EmbeddingSection,
+    profile_embedding,
+    profile_embedding_comparison,
+)
+from langres.core.data_profile.embedding_source import (
+    ArraySource,
+    EmbeddingSource,
+    NpySource,
+    cosine_signal,
+)
+from langres.core.data_profile.hero import HeroSection, build_hero
+from langres.core.data_profile.label_structure import (
+    LabelStructureSection,
+    profile_label_structure,
+)
+from langres.core.data_profile.separability import (
+    SeparabilitySection,
+    SimilaritySignal,
+    profile_separability,
+    string_signal,
+)
 
-__all__ = ["DataProfileReport", "ProfileSection"]
+__all__ = [
+    # Seam
+    "ProfileSection",
+    "DataProfileReport",
+    # Sections
+    "HeroSection",
+    "LabelStructureSection",
+    "CorpusFieldSection",
+    "FieldStat",
+    "SeparabilitySection",
+    "EmbeddingSection",
+    "EmbeddingComparisonSection",
+    # Profiler functions
+    "build_hero",
+    "profile_label_structure",
+    "profile_corpus_fields",
+    "profile_separability",
+    "profile_embedding",
+    "profile_embedding_comparison",
+    # Signals + embedding sources
+    "SimilaritySignal",
+    "string_signal",
+    "cosine_signal",
+    "EmbeddingSource",
+    "ArraySource",
+    "NpySource",
+    # Convenience constructors
+    "from_benchmark",
+    "from_records",
+    "from_embedder",
+]

--- a/src/langres/core/data_profile/accumulators.py
+++ b/src/langres/core/data_profile/accumulators.py
@@ -1,0 +1,184 @@
+"""Streaming accumulators for profiling a corpus/embedding matrix in batches.
+
+Two minimal, mergeable accumulators so a profiler can stream a large corpus (or
+an embedding matrix that does not fit comfortably in memory) in batches and still
+report exact fixed-bin histograms and running mean/std -- then combine partial
+accumulators computed over shards.
+
+Deliberately minimal (the plan's middle-path decision): running **sums**, not
+Welford's online variance and not reservoir sampling. For the profile report's
+purpose -- headline mean/std and a fixed-edge histogram -- summing ``n``,
+``sum(x)``, ``sum(x^2)`` is exact enough and trivially mergeable, and a
+fixed-edge histogram with under/overflow bins captures the shape without
+retaining samples. Both drop non-finite values before accumulating (a ``NaN``
+norm or a ``+inf`` field length is noise, not a data point).
+
+numpy only (a langres core dependency); no heavy/optional imports.
+"""
+
+from __future__ import annotations
+
+import math
+from collections.abc import Iterable
+
+import numpy as np
+from numpy.typing import NDArray
+
+
+def _finite(batch: Iterable[float]) -> NDArray[np.float64]:
+    """Flatten ``batch`` to a 1-D float array with every non-finite value dropped.
+
+    Accepts an ``ndarray`` (any shape/dtype) or any other iterable of numbers
+    (list, tuple, generator); the latter is materialised so a one-shot generator
+    is handled correctly.
+    """
+    source = batch if isinstance(batch, np.ndarray) else list(batch)
+    arr = np.asarray(source, dtype=np.float64).ravel()
+    return arr[np.isfinite(arr)]
+
+
+class OnlineHistogram:
+    """A fixed-edge histogram with under/overflow bins, updatable in batches.
+
+    ``n_bins`` equal-width in-range bins span ``[lo, hi]`` (the last bin is
+    closed on the right, so a value exactly ``hi`` lands in it, matching
+    ``numpy.histogram``). Two extra bins catch everything outside the range: an
+    underflow bin (``x < lo``) and an overflow bin (``x > hi``). This makes the
+    histogram robust to a bad ``[lo, hi]`` guess -- out-of-range mass is counted,
+    never silently dropped.
+
+    Attributes:
+        lo: Lower edge of the in-range span.
+        hi: Upper edge of the in-range span.
+        n_bins: Number of equal-width in-range bins.
+        edges: The ``n_bins + 1`` in-range bin edges (``numpy`` array).
+    """
+
+    def __init__(self, lo: float, hi: float, n_bins: int) -> None:
+        """Create an empty histogram over ``[lo, hi]`` with ``n_bins`` in-range bins.
+
+        Raises:
+            ValueError: If ``n_bins < 1`` or ``hi <= lo`` (a degenerate range
+                has no well-defined bins).
+        """
+        if n_bins < 1:
+            raise ValueError(f"n_bins must be >= 1, got {n_bins}")
+        if not math.isfinite(lo) or not math.isfinite(hi) or hi <= lo:
+            raise ValueError(f"require finite lo < hi, got lo={lo!r} hi={hi!r}")
+        self.lo = float(lo)
+        self.hi = float(hi)
+        self.n_bins = int(n_bins)
+        # Explicit float64 dtype: numpy's ``linspace`` return type is
+        # ``floating[Any]``; pinning it here keeps ``self.edges`` typed as
+        # ``NDArray[np.float64]`` for both mypy and Pyright.
+        self.edges: NDArray[np.float64] = np.linspace(
+            self.lo, self.hi, self.n_bins + 1, dtype=np.float64
+        )
+        # Layout: [underflow, bin_0, ..., bin_{n-1}, overflow] -> length n_bins + 2.
+        self._counts: NDArray[np.int64] = np.zeros(self.n_bins + 2, dtype=np.int64)
+
+    def update(self, batch: Iterable[float]) -> OnlineHistogram:
+        """Add a batch of values (non-finite dropped). Returns ``self`` (fluent)."""
+        arr = _finite(batch)
+        if arr.size:
+            under = int(np.count_nonzero(arr < self.lo))
+            over = int(np.count_nonzero(arr > self.hi))
+            in_range = arr[(arr >= self.lo) & (arr <= self.hi)]
+            hist, _ = np.histogram(in_range, bins=self.edges)
+            self._counts[0] += under
+            self._counts[1:-1] += hist.astype(np.int64)
+            self._counts[-1] += over
+        return self
+
+    def merge(self, other: OnlineHistogram) -> OnlineHistogram:
+        """Return a NEW histogram summing ``self`` and ``other`` (neither mutated).
+
+        Raises:
+            ValueError: If the two histograms do not share ``(lo, hi, n_bins)``.
+        """
+        if (other.lo, other.hi, other.n_bins) != (self.lo, self.hi, self.n_bins):
+            raise ValueError("cannot merge histograms with different binning")
+        merged = OnlineHistogram(self.lo, self.hi, self.n_bins)
+        merged._counts = self._counts + other._counts
+        return merged
+
+    @property
+    def counts(self) -> NDArray[np.int64]:
+        """Full count vector ``[underflow, bin_0..bin_{n-1}, overflow]`` (length ``n_bins + 2``)."""
+        return self._counts.copy()
+
+    @property
+    def bin_counts(self) -> NDArray[np.int64]:
+        """Just the ``n_bins`` in-range counts (underflow/overflow excluded)."""
+        return self._counts[1:-1].copy()
+
+    @property
+    def underflow(self) -> int:
+        """Count of values below ``lo``."""
+        return int(self._counts[0])
+
+    @property
+    def overflow(self) -> int:
+        """Count of values above ``hi``."""
+        return int(self._counts[-1])
+
+
+class RunningStats:
+    """Running mean/std/variance over batches via summed moments (not Welford).
+
+    Accumulates ``n``, ``sum(x)`` and ``sum(x^2)``; mean and (population)
+    variance derive from those. Exact and trivially mergeable -- the intended
+    tradeoff for a profile headline (the plan's middle-path decision). Non-finite
+    values are dropped before accumulating.
+    """
+
+    def __init__(self) -> None:
+        """Create an empty accumulator (no samples yet)."""
+        self._n = 0
+        self._sum = 0.0
+        self._sum_sq = 0.0
+
+    def update(self, batch: Iterable[float]) -> RunningStats:
+        """Add a batch of values (non-finite dropped). Returns ``self`` (fluent)."""
+        arr = _finite(batch)
+        if arr.size:
+            self._n += int(arr.size)
+            self._sum += float(arr.sum())
+            self._sum_sq += float(np.square(arr).sum())
+        return self
+
+    def merge(self, other: RunningStats) -> RunningStats:
+        """Return a NEW accumulator summing ``self`` and ``other`` (neither mutated)."""
+        merged = RunningStats()
+        merged._n = self._n + other._n
+        merged._sum = self._sum + other._sum
+        merged._sum_sq = self._sum_sq + other._sum_sq
+        return merged
+
+    @property
+    def count(self) -> int:
+        """Number of finite values accumulated."""
+        return self._n
+
+    @property
+    def mean(self) -> float:
+        """Arithmetic mean, or ``nan`` when no values have been seen."""
+        return self._sum / self._n if self._n else float("nan")
+
+    @property
+    def variance(self) -> float:
+        """Population variance (ddof=0), or ``nan`` when empty.
+
+        Clamped at ``0.0`` so floating-point cancellation in
+        ``E[x^2] - E[x]^2`` can never surface a tiny negative variance.
+        """
+        if self._n == 0:
+            return float("nan")
+        mean = self._sum / self._n
+        return max(self._sum_sq / self._n - mean * mean, 0.0)
+
+    @property
+    def std(self) -> float:
+        """Population standard deviation (ddof=0), or ``nan`` when empty."""
+        var = self.variance
+        return math.sqrt(var) if math.isfinite(var) else float("nan")

--- a/src/langres/core/data_profile/base.py
+++ b/src/langres/core/data_profile/base.py
@@ -1,0 +1,220 @@
+"""The composable seam of the data-profile report: ``ProfileSection`` + ``DataProfileReport``.
+
+This is the load-bearing contract from the data-layer plan (§2): the report is a
+*bag of sections*, not a monolith. Each metric family (label structure, field
+stats, separability, embeddings, mining readiness -- all landing in later waves)
+is a self-contained :class:`ProfileSection`; :class:`DataProfileReport` is a pure
+container that holds whatever sections it is given and renders exactly those.
+Adding a metric family is a new subclass + a profiler function -- the container
+is never touched (open/closed).
+
+**Frozen contract.** This module's public surface is frozen after Wave 0: later
+waves add *subclasses* and *profiler functions* elsewhere, never edits here. The
+two convenience constructors (:meth:`DataProfileReport.from_benchmark` /
+:meth:`~DataProfileReport.from_records`) are deliberately *thin delegators* to a
+``builders`` module that lands in Wave 2 -- imported locally so this module stays
+valid now and those methods light up later without a signature change.
+
+**Layering.** A leaf, like :mod:`langres.core.eval_report`: it renders through the
+shared :mod:`langres.core._report_html` scaffold and pulls no heavy dependency
+(an import-budget test locks it). Text-first is primary -- ``print``/markdown/dict
+are the default surfaces; ``to_html`` is the optional ``$0`` tearsheet.
+"""
+
+from __future__ import annotations
+
+import abc
+import importlib
+from typing import Any, cast
+
+from pydantic import BaseModel, ConfigDict, SerializeAsAny
+
+from langres.core import _report_html
+
+
+class ProfileSection(BaseModel, abc.ABC):
+    """One self-contained metric block of a :class:`DataProfileReport`.
+
+    A frozen Pydantic model that every concrete profiler section subclasses.
+    Each subclass reports exactly one metric family and exposes the same render
+    ladder (text / dict / tabular / HTML panel), so the container can compose an
+    arbitrary subset without knowing what any of them compute.
+
+    Subclasses must set a distinct :attr:`kind` (a discriminator, so a dumped
+    report is re-identifiable) and implement :meth:`to_markdown`,
+    :attr:`summary`, :meth:`rows`, and :meth:`panels`.
+
+    Attributes:
+        title: Human-readable section heading; also the key
+            :meth:`DataProfileReport.__getitem__` looks the section up by.
+        kind: A stable discriminator string. The base declares it as ``str``;
+            each subclass pins a ``Literal[...]`` with a default so instances
+            self-identify in a dumped/serialised report.
+    """
+
+    model_config = ConfigDict(frozen=True)
+
+    title: str
+    kind: str
+
+    @abc.abstractmethod
+    def to_markdown(self) -> str:
+        """This section's Markdown block (heading + body). Primary text surface."""
+        raise NotImplementedError
+
+    @property
+    @abc.abstractmethod
+    def summary(self) -> dict[str, Any]:
+        """This section's headline numbers as a flat dict (log it, assert on it)."""
+        raise NotImplementedError
+
+    @abc.abstractmethod
+    def rows(self) -> list[dict[str, Any]]:
+        """This section's tabular rows -- ``pd.DataFrame(section.rows())``, no pandas dep."""
+        raise NotImplementedError
+
+    @abc.abstractmethod
+    def panels(self) -> list[str]:
+        """This section's HTML ``<section>`` panels (inline SVG/tables); HTML render only."""
+        raise NotImplementedError
+
+    def to_dict(self) -> dict[str, Any]:
+        """This section as a plain dict (``model_dump()``); machine / JSON surface."""
+        return self.model_dump()
+
+    def __repr__(self) -> str:
+        """Render as Markdown so a section prints cleanly in a REPL/notebook."""
+        return self.to_markdown()
+
+
+class DataProfileReport(BaseModel):
+    """A frozen container over the :class:`ProfileSection`\\ s you compose.
+
+    Holds whatever sections it is given and renders exactly those -- it computes
+    nothing itself (composition lives at the edges). Text-first: ``print`` /
+    :meth:`to_markdown` / :meth:`to_dict` / :attr:`summary` are the primary
+    surfaces; :meth:`to_html` is the optional ``$0`` tearsheet.
+
+    Construct it directly from a list of sections (positional, as in the plan)::
+
+        report = DataProfileReport([label_section, field_section])
+
+    or via the convenience constructors :meth:`from_benchmark` /
+    :meth:`from_records` (which delegate to the Wave 2 ``builders`` module).
+
+    Attributes:
+        sections: The composed sections, in render order. Typed with
+            ``SerializeAsAny`` so ``model_dump()`` keeps each concrete
+            subclass's own fields rather than narrowing to the base.
+    """
+
+    model_config = ConfigDict(frozen=True)
+
+    sections: list[SerializeAsAny[ProfileSection]]
+
+    def __init__(self, sections: list[ProfileSection] | None = None, **data: Any) -> None:
+        """Accept ``sections`` positionally (``DataProfileReport([...])``).
+
+        Pydantic's generated ``__init__`` is keyword-only; the plan's ergonomics
+        (and the acceptance check ``DataProfileReport([])``) want a positional
+        list. Forward it into the field, then defer to normal validation.
+        """
+        if sections is not None:
+            data["sections"] = sections
+        super().__init__(**data)
+
+    # ------------------------------------------------------------- text surfaces
+    def to_markdown(self) -> str:
+        """Concatenate the sections' Markdown blocks under a report heading."""
+        parts: list[str] = ["# Data profile", ""]
+        if not self.sections:
+            parts.append("_No sections._")
+        else:
+            for section in self.sections:
+                parts.append(section.to_markdown())
+                parts.append("")
+        return "\n".join(parts).rstrip() + "\n"
+
+    def __repr__(self) -> str:
+        """Render as Markdown so ``print(report)`` just works in a REPL/notebook."""
+        return self.to_markdown()
+
+    def to_dict(self) -> dict[str, Any]:
+        """The report as a plain dict (``model_dump()``).
+
+        One-way (dump-out): the sections serialise with their concrete
+        subclass fields (``SerializeAsAny``), but reloading a dumped report
+        coerces each section back to the :class:`ProfileSection` base -- so this
+        is for persistence / diffing / dashboards, not round-tripping.
+        """
+        return self.model_dump()
+
+    @property
+    def summary(self) -> dict[str, Any]:
+        """The sections' headline numbers flattened into one dict."""
+        out: dict[str, Any] = {}
+        for section in self.sections:
+            out.update(section.summary)
+        return out
+
+    def __getitem__(self, title: str) -> SerializeAsAny[ProfileSection]:
+        """Pull one section out by its :attr:`~ProfileSection.title`.
+
+        Raises:
+            KeyError: If no section has that title.
+        """
+        for section in self.sections:
+            if section.title == title:
+                return section
+        raise KeyError(title)
+
+    # -------------------------------------------------------------- html surface
+    def to_html(self, *, title: str = "Data profile") -> str:
+        """Render a single self-contained HTML document over the present sections.
+
+        Only the sections you gave it contribute -- each section's
+        :meth:`~ProfileSection.panels` are emitted in order through the shared
+        :mod:`langres.core._report_html` scaffold. An empty report renders a
+        valid, section-less page (never an error), matching the plan's
+        graceful-degradation contract.
+
+        Args:
+            title: Page and document title.
+
+        Returns:
+            A complete ``<!doctype html>...`` string with inline styles and
+            inline SVG only (no external assets).
+        """
+        body_parts: list[str] = []
+        for section in self.sections:
+            body_parts.extend(section.panels())
+        return _report_html.document(title, "\n".join(body_parts))
+
+    # ---------------------------------------------------- convenience constructors
+    @classmethod
+    def from_benchmark(cls, *args: Any, **kwargs: Any) -> DataProfileReport:
+        """Profile a benchmark (labels + fields + ... ) with sensible defaults.
+
+        A thin delegator to the ``builders`` module (Wave 2): the heavy lifting
+        -- composing the default section set, honouring optional
+        ``embeddings=``/``blocker=`` inputs, applying an ``include=`` subset --
+        lives there so this frozen base never changes as that logic firms up.
+        Resolved *dynamically* (``importlib``) rather than a static ``from ...
+        import``: ``builders`` does not exist until Wave 2, and resolving it
+        dynamically keeps this frozen module type-clean both before and after it
+        lands (a static import would need a ``# type: ignore`` that Wave 2 would
+        then have to remove -- editing a module that must stay frozen).
+        """
+        builders = importlib.import_module("langres.core.data_profile.builders")
+        return cast("DataProfileReport", builders.from_benchmark(*args, **kwargs))
+
+    @classmethod
+    def from_records(cls, *args: Any, **kwargs: Any) -> DataProfileReport:
+        """Profile raw records (+ optional gold / embeddings) with sensible defaults.
+
+        The bring-your-own-data counterpart of :meth:`from_benchmark`; delegates
+        to the same Wave 2 ``builders`` module, resolved dynamically for the same
+        frozen-module reason documented there.
+        """
+        builders = importlib.import_module("langres.core.data_profile.builders")
+        return cast("DataProfileReport", builders.from_records(*args, **kwargs))

--- a/src/langres/core/data_profile/base.py
+++ b/src/langres/core/data_profile/base.py
@@ -24,8 +24,7 @@ are the default surfaces; ``to_html`` is the optional ``$0`` tearsheet.
 from __future__ import annotations
 
 import abc
-import importlib
-from typing import Any, cast
+from typing import Any
 
 from pydantic import BaseModel, ConfigDict, SerializeAsAny
 
@@ -195,26 +194,26 @@ class DataProfileReport(BaseModel):
     def from_benchmark(cls, *args: Any, **kwargs: Any) -> DataProfileReport:
         """Profile a benchmark (labels + fields + ... ) with sensible defaults.
 
-        A thin delegator to the ``builders`` module (Wave 2): the heavy lifting
-        -- composing the default section set, honouring optional
-        ``embeddings=``/``blocker=`` inputs, applying an ``include=`` subset --
-        lives there so this frozen base never changes as that logic firms up.
-        Resolved *dynamically* (``importlib``) rather than a static ``from ...
-        import``: ``builders`` does not exist until Wave 2, and resolving it
-        dynamically keeps this frozen module type-clean both before and after it
-        lands (a static import would need a ``# type: ignore`` that Wave 2 would
-        then have to remove -- editing a module that must stay frozen).
+        A thin delegator to the ``builders`` module: the heavy lifting -- composing
+        the default section set, honouring optional ``embeddings=`` inputs, applying
+        an ``include=`` subset -- lives there so this base stays a stable, minimal
+        surface. The import is deferred into the method body (not module scope) so a
+        bare ``import langres.core.data_profile`` never pulls ``builders`` (and its
+        leaf profilers) at import time -- the package's import-light budget -- while
+        still handing mypy the real ``builders.from_benchmark`` return type.
         """
-        builders = importlib.import_module("langres.core.data_profile.builders")
-        return cast("DataProfileReport", builders.from_benchmark(*args, **kwargs))
+        from langres.core.data_profile.builders import from_benchmark as _impl
+
+        return _impl(*args, **kwargs)
 
     @classmethod
     def from_records(cls, *args: Any, **kwargs: Any) -> DataProfileReport:
         """Profile raw records (+ optional gold / embeddings) with sensible defaults.
 
-        The bring-your-own-data counterpart of :meth:`from_benchmark`; delegates
-        to the same Wave 2 ``builders`` module, resolved dynamically for the same
-        frozen-module reason documented there.
+        The bring-your-own-data counterpart of :meth:`from_benchmark`; delegates to
+        the same ``builders`` module via the same deferred body import, for the same
+        import-light reason documented there.
         """
-        builders = importlib.import_module("langres.core.data_profile.builders")
-        return cast("DataProfileReport", builders.from_records(*args, **kwargs))
+        from langres.core.data_profile.builders import from_records as _impl
+
+        return _impl(*args, **kwargs)

--- a/src/langres/core/data_profile/builders.py
+++ b/src/langres/core/data_profile/builders.py
@@ -321,9 +321,7 @@ def _assemble(
     prepends the derived hero and applies the ``include=`` kind filter.
     """
     sources = list(embeddings or [])
-    id_map: dict[Hashable, Mapping[str, Any]] = {
-        record[id_key]: record for record in records if id_key in record
-    }
+    id_map = _index_by_id(records, id_key)
     corpus_ids = list(id_map)
 
     body: list[ProfileSection] = []
@@ -362,6 +360,40 @@ def _assemble(
     return DataProfileReport(sections)
 
 
+def _index_by_id(
+    records: Sequence[Mapping[str, Any]],
+    id_key: str,
+) -> dict[Hashable, Mapping[str, Any]]:
+    """Index ``records`` by their ``id_key``, **first-wins** on a duplicate id.
+
+    A duplicate id cannot be addressed twice, so -- matching the embedding side's
+    :class:`~langres.core.data_profile.embedding_source._RowGatherSource`
+    convention -- the first occurrence wins and later duplicates are dropped
+    (a naive ``{r[id_key]: r ...}`` comprehension would silently keep the *last*).
+    Records missing ``id_key`` are skipped. Any dropped duplicate is logged with
+    its count -- never silent, since a wrong id map corrupts every id-keyed lookup
+    (e.g. the separability signal) downstream.
+    """
+    id_map: dict[Hashable, Mapping[str, Any]] = {}
+    n_duplicate_ids = 0
+    for record in records:
+        if id_key not in record:
+            continue
+        identifier = record[id_key]
+        if identifier in id_map:
+            n_duplicate_ids += 1  # first-wins: keep the existing, drop this one
+            continue
+        id_map[identifier] = record
+    if n_duplicate_ids:
+        logger.warning(
+            "data-profile: dropped %d duplicate %r id(s) (kept the first occurrence "
+            "of each); a last-wins map would silently corrupt id-keyed lookups",
+            n_duplicate_ids,
+            id_key,
+        )
+    return id_map
+
+
 def _build_separability(
     *,
     id_map: Mapping[Hashable, Mapping[str, Any]],
@@ -374,17 +406,20 @@ def _build_separability(
     """Build the separability section(s): string by default, cosine per source.
 
     Needs a gold clustering (for the positive pairs) -- returns ``[]`` without one.
-    Positives are every within-cluster pair; negatives are a deterministic numpy
-    sample of non-matching pairs (capped, logged). A string-similarity section is
-    added when a ``schema`` is available, and one cosine-similarity section per
-    embedding source, each named distinctly so their titles never collide.
+    Positives are within-cluster pairs (reservoir-sampled to ``negatives_cap`` so a
+    pathological gold cluster cannot blow up memory); negatives are a deterministic
+    numpy sample of non-matching pairs (capped, logged), excluded via an
+    ``id -> cluster`` map rather than a materialised positive-pair set. A
+    string-similarity section is added when a ``schema`` is available, and one
+    cosine-similarity section per embedding source, each named distinctly so their
+    titles never collide.
     """
     if clusters is None:
         return []
 
-    positives = _positive_pairs(clusters)
-    positive_set = {frozenset(pair) for pair in positives}
-    negatives = _sample_negative_pairs(list(id_map), positive_set, negatives_cap, seed)
+    positives = _positive_pairs(clusters, cap=negatives_cap, seed=seed)
+    member_cluster = _member_cluster_index(clusters)
+    negatives = _sample_negative_pairs(list(id_map), member_cluster, negatives_cap, seed)
     if not positives and not negatives:
         return []
 
@@ -410,26 +445,81 @@ def _build_separability(
 
 def _positive_pairs(
     clusters: Sequence[Collection[Hashable]],
+    *,
+    cap: int = _DEFAULT_NEGATIVES_CAP,
+    seed: int = _NEGATIVES_SEED,
 ) -> list[tuple[Hashable, Hashable]]:
-    """Every within-cluster id pair (the ER positives); singletons contribute none."""
-    pairs: list[tuple[Hashable, Hashable]] = []
+    """Up to ``cap`` within-cluster id pairs (the ER positives); singletons contribute none.
+
+    Every within-cluster pair is a positive, but one pathological gold cluster (a
+    bad-merge "default entity" of thousands of members) yields ``O(size**2)`` pairs
+    -- millions of tuples -- which would defeat the package's memory-efficiency
+    contract. So the pairs are **reservoir-sampled to** ``cap`` *during* generation
+    (``O(cap)`` memory, seeded for reproducibility), and any truncation is logged --
+    never silent, mirroring the negatives. A corpus small enough to stay under
+    ``cap`` yields the exact same full pair set an un-capped enumeration would;
+    ``cap`` bites only on the pathological case. ``cap`` matches the per-class
+    scoring cap
+    :func:`~langres.core.data_profile.separability.profile_separability` applies, so
+    no positive information is lost (it subsamples to ``cap`` for scoring anyway).
+    """
+    reservoir: list[tuple[Hashable, Hashable]] = []
+    n_seen = 0
+    rng = np.random.default_rng(seed)
     for cluster in clusters:
         members = list(cluster)
         for i in range(len(members)):
             for j in range(i + 1, len(members)):
-                pairs.append((members[i], members[j]))
-    return pairs
+                n_seen += 1
+                if n_seen <= cap:
+                    reservoir.append((members[i], members[j]))
+                else:
+                    # Reservoir sampling (Algorithm R): the n-th pair replaces a
+                    # uniformly-random slot with probability cap/n, so the kept set
+                    # stays a uniform sample of every pair seen -- without ever
+                    # holding more than `cap` of them in memory.
+                    replace = int(rng.integers(0, n_seen))
+                    if replace < cap:
+                        reservoir[replace] = (members[i], members[j])
+    if n_seen > cap:
+        logger.warning(
+            "data-profile separability: sampled %d of %d positive pairs (cap=%d)",
+            cap,
+            n_seen,
+            cap,
+        )
+    return reservoir
+
+
+def _member_cluster_index(
+    clusters: Sequence[Collection[Hashable]],
+) -> dict[Hashable, int]:
+    """Map each record id to its gold-cluster index (for same-cluster exclusion).
+
+    A pair is a positive iff both ids fall in the same gold cluster. Sampling
+    negatives against this ``O(n_records)`` map -- rather than a materialised set of
+    every positive *pair* -- keeps the exclusion memory-linear even when one cluster
+    contributes ``O(size**2)`` positives (see :func:`_positive_pairs`). First-wins
+    on the (malformed) case of an id in two clusters.
+    """
+    index_of: dict[Hashable, int] = {}
+    for index, cluster in enumerate(clusters):
+        for member in cluster:
+            index_of.setdefault(member, index)
+    return index_of
 
 
 def _sample_negative_pairs(
     ids: Sequence[Hashable],
-    positive_pairs: set[frozenset[Hashable]],
+    member_cluster: Mapping[Hashable, int],
     cap: int,
     seed: int,
 ) -> list[tuple[Hashable, Hashable]]:
     """A deterministic numpy sample of up to ``cap`` non-matching id pairs.
 
-    Draws random id pairs (seeded), rejecting self-pairs, positives, and repeats.
+    Draws random id pairs (seeded), rejecting self-pairs, same-cluster pairs (the
+    positives -- tested against ``member_cluster``, an ``id -> cluster index`` map,
+    so the full positive-pair set never has to be materialised), and repeats.
     Bounded by an attempt ceiling so a corpus with few possible negatives cannot
     spin. Logs the cap it targets (never silent).
     """
@@ -451,8 +541,10 @@ def _sample_negative_pairs(
         if i == j:
             continue
         left, right = ids[i], ids[j]
+        left_cluster = member_cluster.get(left)
+        same_cluster = left_cluster is not None and left_cluster == member_cluster.get(right)
         key = frozenset((left, right))
-        if len(key) != 2 or key in positive_pairs or key in seen:
+        if len(key) != 2 or same_cluster or key in seen:
             continue
         seen.add(key)
         negatives.append((left, right))

--- a/src/langres/core/data_profile/builders.py
+++ b/src/langres/core/data_profile/builders.py
@@ -1,0 +1,493 @@
+"""Convenience builders: compose the default section set with sensible defaults.
+
+The Wave 2 seam :class:`~langres.core.data_profile.base.DataProfileReport`'s two
+convenience constructors (:meth:`~DataProfileReport.from_benchmark` /
+:meth:`~DataProfileReport.from_records`) delegate to. Everything here is pure
+composition over the Wave-1 profiler functions -- it computes nothing new. Both
+entry points converge on one internal assembler (:func:`_assemble`) so the two
+paths return the *same* pinned section layout:
+
+    hero -> label-structure -> separability -> corpus-fields -> embeddings ->
+    embedding-comparison
+
+Each section is included only when its input is present; omitting an input drops
+that section silently (never a raise). ``include=`` narrows the set further -- it
+is a **selector of section kinds** (it validates its keys and raises on an unknown
+one, because a typo there means "select nothing you meant to"), never a data
+input.
+
+**Import-light.** Module scope is stdlib + numpy + the leaf profiler modules --
+no ``[semantic]`` stack. :func:`from_benchmark` imports ``get_benchmark`` locally
+(only when handed a name), and :func:`from_embedder` -- the one place vectors are
+*produced* rather than consumed -- imports ``sentence-transformers`` inside its
+body, so a bare ``import langres.core.data_profile`` never pulls a heavy dep.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from collections.abc import Collection, Hashable, Mapping, Sequence
+from pathlib import Path
+from typing import TYPE_CHECKING, Any
+
+import numpy as np
+
+from langres.core.data_profile.base import DataProfileReport, ProfileSection
+from langres.core.data_profile.corpus_field import profile_corpus_fields
+from langres.core.data_profile.embedding_section import (
+    profile_embedding,
+    profile_embedding_comparison,
+)
+from langres.core.data_profile.embedding_source import (
+    EmbeddingSource,
+    NpySource,
+    cosine_signal,
+)
+from langres.core.data_profile.hero import build_hero
+from langres.core.data_profile.label_structure import profile_label_structure
+from langres.core.data_profile.separability import (
+    SeparabilitySection,
+    profile_separability,
+    string_signal,
+)
+
+if TYPE_CHECKING:
+    from pydantic import BaseModel
+
+    from langres.core.benchmark import Benchmark
+
+logger = logging.getLogger(__name__)
+
+#: The section kinds ``include=`` may select. A superset of what any single call
+#: emits (a call only ever produces the kinds its inputs support); ``include=``
+#: filters that produced set. Validated so an unknown key fails loudly.
+_KNOWN_KINDS: frozenset[str] = frozenset(
+    {
+        "hero",
+        "label_structure",
+        "separability",
+        "corpus_field",
+        "embedding",
+        "embedding_comparison",
+    }
+)
+
+#: Default cap on how many negative (non-matching) pairs are sampled per report
+#: for the separability chart. Bounds the scan on a huge corpus; logged when it
+#: bites (never silent). Positives come from the gold clusters directly.
+_DEFAULT_NEGATIVES_CAP = 50_000
+
+#: Seed for the deterministic negative-pair sample (reproducible profiles).
+_NEGATIVES_SEED = 0
+
+
+# ---------------------------------------------------------------------------
+# Public convenience constructors
+# ---------------------------------------------------------------------------
+
+
+def from_benchmark(
+    benchmark_or_name: "str | Benchmark[Any]",
+    *,
+    include: Collection[str] | None = None,
+    embeddings: Sequence[EmbeddingSource] | None = None,
+    negatives_cap: int = _DEFAULT_NEGATIVES_CAP,
+    top_n_fields: int = 50,
+    seed: int = _NEGATIVES_SEED,
+) -> DataProfileReport:
+    """Profile a registered benchmark (or a benchmark object) with sensible defaults.
+
+    Resolves ``benchmark_or_name`` (via :func:`~langres.data.registry.get_benchmark`
+    when given a name), loads its full corpus + gold clustering, and composes the
+    default section set over them: a KPI hero, label structure, separability
+    (rapidfuzz ``string_signal`` by default, plus a cosine signal per embedding
+    source when ``embeddings=`` is given), corpus fields, one embedding section per
+    source, and an embedding comparison when two or more sources are passed.
+
+    Args:
+        benchmark_or_name: A registered benchmark name (e.g. ``"abt_buy"``) or an
+            already-built benchmark object exposing ``load()`` (and ``schema`` for
+            the string separability signal).
+        include: Optional selector of section *kinds* to keep (see
+            :data:`_KNOWN_KINDS`). ``None`` keeps every section the inputs support.
+            An unknown kind raises :class:`ValueError`.
+        embeddings: Optional precomputed
+            :class:`~langres.core.data_profile.embedding_source.EmbeddingSource` s
+            (aligned to the corpus ids). Omitting them drops the embedding sections
+            -- never a raise.
+        negatives_cap: Cap on sampled non-matching pairs for the separability
+            chart (logged when it truncates).
+        top_n_fields: Row cap for the corpus-field table.
+        seed: Seed for the deterministic negative-pair sample.
+
+    Returns:
+        A :class:`DataProfileReport` over the pinned default section layout.
+
+    Raises:
+        ValueError: If ``include`` names a kind not in :data:`_KNOWN_KINDS`.
+    """
+    if isinstance(benchmark_or_name, str):
+        # Local import: only a name lookup needs the registry, and keeping it out
+        # of module scope preserves the import-light budget of this package.
+        from langres.data.registry import get_benchmark
+
+        bench: Any = get_benchmark(benchmark_or_name)
+    else:
+        bench = benchmark_or_name
+
+    corpus, gold_clusters, _gold_pairs = bench.load()
+    records = [record.model_dump() for record in corpus]
+    schema = getattr(bench, "schema", None)
+
+    return _assemble(
+        records=records,
+        clusters=gold_clusters,
+        schema=schema,
+        embeddings=embeddings,
+        include=include,
+        negatives_cap=negatives_cap,
+        top_n_fields=top_n_fields,
+        seed=seed,
+        id_key="id",
+    )
+
+
+def from_records(
+    records: Sequence[Mapping[str, Any]],
+    *,
+    gold: Sequence[Collection[Hashable]] | None = None,
+    schema: "type[BaseModel] | None" = None,
+    embeddings: Sequence[EmbeddingSource] | None = None,
+    include: Collection[str] | None = None,
+    id_key: str = "id",
+    negatives_cap: int = _DEFAULT_NEGATIVES_CAP,
+    top_n_fields: int = 50,
+    seed: int = _NEGATIVES_SEED,
+) -> DataProfileReport:
+    """Profile raw records (+ optional gold / embeddings) -- the BYO-data counterpart.
+
+    The bring-your-own-data twin of :func:`from_benchmark`, composing the same
+    pinned section set over records you hand in directly. Every input beyond
+    ``records`` is optional and drops its section(s) when omitted (never a raise):
+    no ``gold`` -> no label-structure or separability; no ``schema`` -> no string
+    separability; no ``embeddings`` -> no embedding sections.
+
+    Args:
+        records: The corpus as a sequence of field mappings (dicts). Pydantic
+            records should be dumped first (``[r.model_dump() for r in ...]``).
+        gold: Optional gold clustering -- a sequence of clusters, each a collection
+            of record ids. Drives label structure and separability positives.
+        schema: Optional Pydantic entity schema; enables the rapidfuzz
+            ``string_signal`` separability.
+        embeddings: Optional precomputed
+            :class:`~langres.core.data_profile.embedding_source.EmbeddingSource` s.
+        include: Optional selector of section *kinds* (see :func:`from_benchmark`).
+        id_key: The record field holding the id used for pairs / embedding
+            alignment (default ``"id"``).
+        negatives_cap: Cap on sampled non-matching pairs for separability.
+        top_n_fields: Row cap for the corpus-field table.
+        seed: Seed for the deterministic negative-pair sample.
+
+    Returns:
+        A :class:`DataProfileReport` over the pinned default section layout.
+
+    Raises:
+        ValueError: If ``include`` names a kind not in :data:`_KNOWN_KINDS`.
+    """
+    return _assemble(
+        records=[dict(record) for record in records],
+        clusters=gold,
+        schema=schema,
+        embeddings=embeddings,
+        include=include,
+        negatives_cap=negatives_cap,
+        top_n_fields=top_n_fields,
+        seed=seed,
+        id_key=id_key,
+    )
+
+
+def from_embedder(
+    records: Sequence[Mapping[str, Any]],
+    model: str,
+    *,
+    out_path: str | Path,
+    id_key: str = "id",
+    text_key: str | None = None,
+    batch_size: int = 64,
+    normalize: bool = False,
+) -> NpySource:
+    """Embed ``records`` once with a sentence-transformer and persist an ``NpySource``.
+
+    The ``[semantic]``-gated on-ramp for users who have *no* precomputed vectors
+    yet. It is a **separate** step from the report itself: the report still never
+    generates embeddings -- this helper produces a ``.npy`` (+ an ids sidecar) once,
+    then hands back a memory-efficient
+    :class:`~langres.core.data_profile.embedding_source.NpySource` you pass into
+    ``from_benchmark``/``from_records`` like any other source. Mirrors
+    ``langres.eval.candidates_for``: a paid/heavy step kept off the report's
+    import-light, ``$0`` path.
+
+    Args:
+        records: The corpus as field mappings; one embedding per record.
+        model: A sentence-transformers model id (e.g. ``"all-MiniLM-L6-v2"``);
+            also the resulting source's ``name``.
+        out_path: Where to write the ``.npy`` (a ``.npy`` suffix is enforced). An
+            ``<stem>.ids.json`` sidecar is written beside it so the source
+            self-aligns on a later bare ``NpySource(model, out_path)``.
+        id_key: Record field holding the id (default ``"id"``).
+        text_key: Record field to embed. When ``None`` (default), every non-empty
+            string field except ``id_key`` is joined into the embedding text.
+        batch_size: Encoder batch size.
+        normalize: L2-normalize the vectors (a cosine store); marks the source
+            ``pre_normalized`` with ``metric="cosine"``.
+
+    Returns:
+        An :class:`~langres.core.data_profile.embedding_source.NpySource` over the
+        written vectors, aligned to the records' ids.
+
+    Raises:
+        ImportError: If the ``[semantic]`` extra (sentence-transformers) is not
+            installed -- with an actionable ``pip install`` hint.
+        KeyError: If a record is missing ``id_key``.
+    """
+    try:
+        # Local import: producing vectors is the one heavy step here; keeping it
+        # inside the body preserves the module's import-light budget so a bare
+        # ``import langres.core.data_profile`` never pulls sentence-transformers.
+        from sentence_transformers import SentenceTransformer
+    except ImportError as exc:  # pragma: no cover - exercised only without [semantic]
+        raise ImportError(
+            "from_embedder needs the [semantic] extra (sentence-transformers) to "
+            "generate embeddings. Install it: pip install langres[semantic]. "
+            "(The report itself never generates embeddings -- pass precomputed "
+            "vectors via ArraySource/NpySource to skip this step.)"
+        ) from exc
+
+    dict_records = [dict(record) for record in records]
+    ids: list[Hashable] = [record[id_key] for record in dict_records]
+    texts = [_embed_text(record, id_key=id_key, text_key=text_key) for record in dict_records]
+
+    encoder = SentenceTransformer(model)
+    matrix = np.asarray(
+        encoder.encode(
+            texts,
+            batch_size=batch_size,
+            normalize_embeddings=normalize,
+            convert_to_numpy=True,
+        )
+    )
+
+    out = Path(out_path)
+    if out.suffix != ".npy":
+        out = out.with_suffix(".npy")
+    out.parent.mkdir(parents=True, exist_ok=True)
+    np.save(out, matrix)
+    # Sidecar so a later ``NpySource(model, out)`` (no id_order) self-aligns.
+    out.with_name(f"{out.stem}.ids.json").write_text(
+        json.dumps([str(identifier) for identifier in ids])
+    )
+
+    return NpySource(
+        model,
+        out,
+        ids,
+        pre_normalized=normalize,
+        metric="cosine" if normalize else None,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Internal assembly (shared by both public constructors)
+# ---------------------------------------------------------------------------
+
+
+def _assemble(
+    *,
+    records: list[dict[str, Any]],
+    clusters: Sequence[Collection[Hashable]] | None,
+    schema: "type[BaseModel] | None",
+    embeddings: Sequence[EmbeddingSource] | None,
+    include: Collection[str] | None,
+    negatives_cap: int,
+    top_n_fields: int,
+    seed: int,
+    id_key: str,
+) -> DataProfileReport:
+    """Compose the pinned default section set; ``include=`` narrows it.
+
+    Builds each section only when its input is present, in the pinned order, then
+    prepends the derived hero and applies the ``include=`` kind filter.
+    """
+    sources = list(embeddings or [])
+    id_map: dict[Hashable, Mapping[str, Any]] = {
+        record[id_key]: record for record in records if id_key in record
+    }
+    corpus_ids = list(id_map)
+
+    body: list[ProfileSection] = []
+
+    label = profile_label_structure(clusters, n_records=len(records))
+    if label is not None:
+        body.append(label)
+
+    body.extend(
+        _build_separability(
+            id_map=id_map,
+            schema=schema,
+            clusters=clusters,
+            sources=sources,
+            negatives_cap=negatives_cap,
+            seed=seed,
+        )
+    )
+
+    fields = profile_corpus_fields(records, top_n=top_n_fields)
+    if fields is not None:
+        body.append(fields)
+
+    for source in sources:
+        body.append(profile_embedding(source, corpus_ids))
+    if len(sources) >= 2:
+        body.append(profile_embedding_comparison(sources, corpus_ids))
+
+    hero = build_hero(body)
+    sections: list[ProfileSection] = ([hero] if hero is not None else []) + body
+
+    if include is not None:
+        _validate_include(include)
+        sections = [section for section in sections if section.kind in include]
+
+    return DataProfileReport(sections)
+
+
+def _build_separability(
+    *,
+    id_map: Mapping[Hashable, Mapping[str, Any]],
+    schema: "type[BaseModel] | None",
+    clusters: Sequence[Collection[Hashable]] | None,
+    sources: Sequence[EmbeddingSource],
+    negatives_cap: int,
+    seed: int,
+) -> list[SeparabilitySection]:
+    """Build the separability section(s): string by default, cosine per source.
+
+    Needs a gold clustering (for the positive pairs) -- returns ``[]`` without one.
+    Positives are every within-cluster pair; negatives are a deterministic numpy
+    sample of non-matching pairs (capped, logged). A string-similarity section is
+    added when a ``schema`` is available, and one cosine-similarity section per
+    embedding source, each named distinctly so their titles never collide.
+    """
+    if clusters is None:
+        return []
+
+    positives = _positive_pairs(clusters)
+    positive_set = {frozenset(pair) for pair in positives}
+    negatives = _sample_negative_pairs(list(id_map), positive_set, negatives_cap, seed)
+    if not positives and not negatives:
+        return []
+
+    out: list[SeparabilitySection] = []
+    if schema is not None:
+        section = profile_separability(
+            positives, negatives, string_signal(id_map, schema), name="string", cap=negatives_cap
+        )
+        if section is not None:
+            out.append(section)
+    for source in sources:
+        section = profile_separability(
+            positives,
+            negatives,
+            cosine_signal(source),
+            name=f"cosine · {source.name}",
+            cap=negatives_cap,
+        )
+        if section is not None:
+            out.append(section)
+    return out
+
+
+def _positive_pairs(
+    clusters: Sequence[Collection[Hashable]],
+) -> list[tuple[Hashable, Hashable]]:
+    """Every within-cluster id pair (the ER positives); singletons contribute none."""
+    pairs: list[tuple[Hashable, Hashable]] = []
+    for cluster in clusters:
+        members = list(cluster)
+        for i in range(len(members)):
+            for j in range(i + 1, len(members)):
+                pairs.append((members[i], members[j]))
+    return pairs
+
+
+def _sample_negative_pairs(
+    ids: Sequence[Hashable],
+    positive_pairs: set[frozenset[Hashable]],
+    cap: int,
+    seed: int,
+) -> list[tuple[Hashable, Hashable]]:
+    """A deterministic numpy sample of up to ``cap`` non-matching id pairs.
+
+    Draws random id pairs (seeded), rejecting self-pairs, positives, and repeats.
+    Bounded by an attempt ceiling so a corpus with few possible negatives cannot
+    spin. Logs the cap it targets (never silent).
+    """
+    n = len(ids)
+    if n < 2 or cap <= 0:
+        return []
+    logger.info("data-profile separability: sampling up to %d negative pairs (cap)", cap)
+    rng = np.random.default_rng(seed)
+    negatives: list[tuple[Hashable, Hashable]] = []
+    seen: set[frozenset[Hashable]] = set()
+    # A generous attempt ceiling: enough to fill the cap on a normal corpus, yet
+    # a hard stop so a tiny/degenerate corpus (few possible negatives) terminates.
+    max_attempts = max(cap * 20, 40)
+    for _ in range(max_attempts):
+        if len(negatives) >= cap:
+            break
+        i = int(rng.integers(0, n))
+        j = int(rng.integers(0, n))
+        if i == j:
+            continue
+        left, right = ids[i], ids[j]
+        key = frozenset((left, right))
+        if len(key) != 2 or key in positive_pairs or key in seen:
+            continue
+        seen.add(key)
+        negatives.append((left, right))
+    return negatives
+
+
+def _validate_include(include: Collection[str]) -> None:
+    """Reject any ``include=`` key that is not a known section kind.
+
+    ``include`` selects kinds; a typo means "silently drop a section you wanted",
+    so an unknown kind is a loud :class:`ValueError`, not a no-op.
+    """
+    unknown = sorted(set(include) - _KNOWN_KINDS)
+    if unknown:
+        raise ValueError(
+            f"include= got unknown section kind(s) {unknown}; "
+            f"valid kinds are {sorted(_KNOWN_KINDS)}"
+        )
+
+
+def _embed_text(
+    record: Mapping[str, Any], *, id_key: str, text_key: str | None
+) -> str:
+    """The text to embed for one record.
+
+    Uses ``record[text_key]`` when a key is given; otherwise joins every non-empty
+    string field except ``id_key`` -- a sensible generic default for a schema-free
+    record.
+    """
+    if text_key is not None:
+        value = record.get(text_key)
+        return str(value) if value is not None else ""
+    parts = [
+        value
+        for key, value in record.items()
+        if key != id_key and isinstance(value, str) and value.strip()
+    ]
+    return " ".join(parts)

--- a/src/langres/core/data_profile/builders.py
+++ b/src/langres/core/data_profile/builders.py
@@ -473,9 +473,7 @@ def _validate_include(include: Collection[str]) -> None:
         )
 
 
-def _embed_text(
-    record: Mapping[str, Any], *, id_key: str, text_key: str | None
-) -> str:
+def _embed_text(record: Mapping[str, Any], *, id_key: str, text_key: str | None) -> str:
     """The text to embed for one record.
 
     Uses ``record[text_key]`` when a key is given; otherwise joins every non-empty

--- a/src/langres/core/data_profile/corpus_field.py
+++ b/src/langres/core/data_profile/corpus_field.py
@@ -1,0 +1,314 @@
+"""Corpus-field profile section: per-field completeness, cardinality, and length.
+
+The second tabular block of the data-profile report. Given the records, it walks
+every field and reports the three signals that decide whether a field is worth
+comparing on: how often it is populated (non-null rate), how discriminative it is
+(cardinality -- distinct / total), and how long its values run (mean/median
+length, plus a compact length sparkline). Fields are ordered **most-missing
+first** so the holes in the data surface at the top, and an all-null field is
+**flagged, never dropped** -- a silently missing field is exactly the kind of
+data problem a profile exists to expose.
+
+Generic by construction: :func:`profile_corpus_fields` takes a plain
+``Sequence`` of record mappings (``id -> value`` field dicts), never a
+benchmark-coupled type. No records means nothing to profile, and the profiler
+returns ``None`` so the section is simply absent (graceful degradation).
+"""
+
+from __future__ import annotations
+
+import html
+import logging
+import statistics
+from collections.abc import Mapping, Sequence
+from typing import Any, Literal
+
+from pydantic import BaseModel, ConfigDict
+
+from langres.core import _report_html
+from langres.core.data_profile.base import ProfileSection
+
+logger = logging.getLogger(__name__)
+
+#: Default cap on how many field rows the table shows. Fields beyond the cap
+#: (after the most-missing-first sort) are dropped from the table, and the
+#: truncation is logged -- never silent.
+_DEFAULT_TOP_N = 50
+
+#: Width (characters) of the per-field length sparkline.
+_SPARK_WIDTH = 8
+
+#: Unicode block-elements low->high, for the length sparkline.
+_SPARK_BLOCKS = "▁▂▃▄▅▆▇█"
+
+
+def _is_present(value: Any) -> bool:
+    """True when a field value counts as populated (not null / not blank).
+
+    ``None`` and whitespace-only strings are missing (mirroring the Comparator's
+    MISSING rule, where an empty string is not a comparable value). Any non-string
+    value (an ``int``, a ``bool``) is present.
+    """
+    if value is None:
+        return False
+    if isinstance(value, str):
+        return value.strip() != ""
+    return True
+
+
+def _length_histogram(lengths: Sequence[int], width: int = _SPARK_WIDTH) -> list[int]:
+    """Bucket value lengths into ``width`` equal-width bins over ``[min, max]``.
+
+    Returns ``width`` counts. When every value has the same length (a degenerate
+    range) all mass lands in the first bucket -- the sparkline then shows a single
+    spike, honestly conveying "one length".
+    """
+    if not lengths:
+        return []
+    lo, hi = min(lengths), max(lengths)
+    counts = [0] * width
+    if hi == lo:
+        counts[0] = len(lengths)
+        return counts
+    span = hi - lo
+    for length in lengths:
+        idx = min(int((length - lo) / span * width), width - 1)
+        counts[idx] += 1
+    return counts
+
+
+def _sparkline(counts: Sequence[int]) -> str:
+    """Render bucket ``counts`` as a unicode block sparkline (empty string if all zero).
+
+    A pure-unicode indicator so the same string renders in Markdown *and* HTML
+    (no inline SVG needed, no escaping hazard). Each bucket maps to a block by its
+    height relative to the tallest bucket.
+    """
+    peak = max(counts) if counts else 0
+    if peak <= 0:
+        return ""
+    top = len(_SPARK_BLOCKS) - 1
+    return "".join(_SPARK_BLOCKS[round(count / peak * top)] for count in counts)
+
+
+class FieldStat(BaseModel):
+    """Per-field completeness / cardinality / length stats for one corpus field.
+
+    Attributes:
+        name: The field key.
+        n_present: Records with a populated value for this field.
+        n_total: Total records profiled (the denominator for ``non_null_rate``).
+        non_null_rate: ``n_present / n_total``.
+        n_distinct: Distinct populated values (by string form).
+        uniqueness: ``n_distinct / n_present`` (1.0 == a key); ``None`` when the
+            field is all-null.
+        mean_len: Mean populated-value length; ``None`` when all-null.
+        median_len: Median populated-value length; ``None`` when all-null.
+        all_null: True when the field is populated in no record (flagged, not
+            dropped).
+        len_hist: Length-distribution bucket counts backing the sparkline (empty
+            when all-null).
+    """
+
+    model_config = ConfigDict(frozen=True)
+
+    name: str
+    n_present: int
+    n_total: int
+    non_null_rate: float
+    n_distinct: int
+    uniqueness: float | None
+    mean_len: float | None
+    median_len: float | None
+    all_null: bool
+    len_hist: list[int]
+
+
+class CorpusFieldSection(ProfileSection):
+    """Per-field data-quality table over a record corpus.
+
+    A frozen :class:`ProfileSection` holding one :class:`FieldStat` per shown
+    field (sorted most-missing-first, capped at ``top_n``) plus the total field
+    count so any truncation stays visible. Build it with
+    :func:`profile_corpus_fields`.
+
+    Attributes:
+        n_records: Records profiled.
+        n_fields_total: Distinct field keys seen across all records (before the
+            ``top_n`` cap).
+        fields: The shown per-field stats, most-missing first.
+    """
+
+    kind: Literal["corpus_field"] = "corpus_field"
+
+    n_records: int
+    n_fields_total: int
+    fields: list[FieldStat]
+
+    @property
+    def _n_all_null(self) -> int:
+        return sum(1 for f in self.fields if f.all_null)
+
+    @property
+    def _truncated(self) -> int:
+        return self.n_fields_total - len(self.fields)
+
+    # ------------------------------------------------------------ row rendering
+    _HEADERS = ("field", "non-null", "distinct", "unique", "mean len", "median len", "length", "flags")
+
+    def _display_cells(self, field: FieldStat) -> tuple[str, ...]:
+        """One field's cells as display strings (markdown + HTML share this)."""
+        return (
+            field.name,
+            _report_html._num(field.non_null_rate),
+            f"{field.n_distinct:,}",
+            _report_html._num(field.uniqueness),
+            _report_html._num(field.mean_len, digits=1),
+            _report_html._num(field.median_len, digits=1),
+            _sparkline(field.len_hist),
+            "all-null" if field.all_null else "",
+        )
+
+    # ------------------------------------------------------------ text surfaces
+    def to_markdown(self) -> str:
+        """Markdown: the field table, most-missing first, with a truncation note."""
+        lines = [
+            f"## {self.title}",
+            "",
+            f"{self.n_records:,} records; {self.n_fields_total:,} fields"
+            + (f"; {self._n_all_null} all-null" if self._n_all_null else ""),
+            "",
+            "| " + " | ".join(self._HEADERS) + " |",
+            "|" + "---|" * len(self._HEADERS),
+        ]
+        for field in self.fields:
+            cells = [_report_html._md_cell(c) for c in self._display_cells(field)]
+            lines.append("| " + " | ".join(cells) + " |")
+        if not self.fields:
+            lines.append("| _(no fields)_ |" + " |" * (len(self._HEADERS) - 1))
+        if self._truncated > 0:
+            lines += ["", f"_Showing {len(self.fields)} of {self.n_fields_total} fields "
+                      f"(most-missing first); {self._truncated} truncated._"]
+        return "\n".join(lines)
+
+    @property
+    def summary(self) -> dict[str, Any]:
+        """Headline counts as a flat, title-namespaced dict."""
+        return {
+            f"{self.title}.n_records": self.n_records,
+            f"{self.title}.n_fields": self.n_fields_total,
+            f"{self.title}.n_fields_shown": len(self.fields),
+            f"{self.title}.n_all_null_fields": self._n_all_null,
+        }
+
+    def rows(self) -> list[dict[str, Any]]:
+        """One row per shown field -- ``pd.DataFrame(section.rows())``-ready (no ``len_hist``)."""
+        return [
+            {
+                "field": f.name,
+                "non_null_rate": f.non_null_rate,
+                "n_distinct": f.n_distinct,
+                "uniqueness": f.uniqueness,
+                "mean_len": f.mean_len,
+                "median_len": f.median_len,
+                "all_null": f.all_null,
+            }
+            for f in self.fields
+        ]
+
+    # -------------------------------------------------------------- html panel
+    def panels(self) -> list[str]:
+        """A single ``<section>``: the field table (all names HTML-escaped)."""
+        head = "<tr>" + "".join(f"<th>{html.escape(h)}</th>" for h in self._HEADERS) + "</tr>"
+        body_rows = []
+        for field in self.fields:
+            cells = "".join(f"<td>{html.escape(c)}</td>" for c in self._display_cells(field))
+            body_rows.append(f"<tr>{cells}</tr>")
+        table = f'<table class="errors">{head}{"".join(body_rows)}</table>'
+        note = ""
+        if self._truncated > 0:
+            note = (
+                f'<p class="empty">Showing {len(self.fields)} of {self.n_fields_total} '
+                f"fields (most-missing first); {self._truncated} truncated.</p>"
+            )
+        return [_report_html.section(self.title, table + note)]
+
+
+def profile_corpus_fields(
+    records: Sequence[Mapping[str, Any]] | None,
+    *,
+    top_n: int = _DEFAULT_TOP_N,
+    title: str = "Corpus fields",
+) -> CorpusFieldSection | None:
+    """Profile a record corpus into a :class:`CorpusFieldSection`.
+
+    Args:
+        records: The corpus -- a sequence of field mappings (``id -> value``).
+            ``None`` or empty means nothing to profile, and the profiler returns
+            ``None`` (the section is omitted). Field keys are the union across all
+            records; a record missing a key counts as null for that field.
+        top_n: Maximum field rows to show. After the most-missing-first sort, any
+            fields beyond ``top_n`` are dropped from the table and the truncation
+            is logged (never silent). :attr:`~CorpusFieldSection.n_fields_total`
+            still reports the full count.
+        title: Section heading; also namespaces this section's :attr:`summary` keys.
+
+    Returns:
+        A :class:`CorpusFieldSection`, or ``None`` when ``records`` is falsy.
+    """
+    if not records:
+        return None
+
+    n_records = len(records)
+    field_names: list[str] = []
+    seen: set[str] = set()
+    for record in records:
+        for key in record:
+            if key not in seen:
+                seen.add(key)
+                field_names.append(key)
+
+    stats = [_profile_field(name, records, n_records) for name in field_names]
+    # Most-missing first (highest null rate == lowest non-null rate); name
+    # tie-break keeps the order deterministic.
+    stats.sort(key=lambda f: (f.non_null_rate, f.name))
+
+    n_fields_total = len(stats)
+    if n_fields_total > top_n:
+        logger.warning(
+            "profile_corpus_fields: showing %d of %d fields (most-missing first); "
+            "%d truncated by top_n=%d",
+            top_n,
+            n_fields_total,
+            n_fields_total - top_n,
+            top_n,
+        )
+        stats = stats[:top_n]
+
+    return CorpusFieldSection(
+        title=title,
+        n_records=n_records,
+        n_fields_total=n_fields_total,
+        fields=stats,
+    )
+
+
+def _profile_field(name: str, records: Sequence[Mapping[str, Any]], n_records: int) -> FieldStat:
+    """Compute one field's :class:`FieldStat` over the corpus."""
+    present = [record[name] for record in records if name in record and _is_present(record[name])]
+    n_present = len(present)
+    distinct = {str(value) for value in present}
+    lengths = [len(str(value)) for value in present]
+
+    return FieldStat(
+        name=name,
+        n_present=n_present,
+        n_total=n_records,
+        non_null_rate=n_present / n_records,
+        n_distinct=len(distinct),
+        uniqueness=(len(distinct) / n_present) if n_present else None,
+        mean_len=statistics.fmean(lengths) if lengths else None,
+        median_len=statistics.median(lengths) if lengths else None,
+        all_null=n_present == 0,
+        len_hist=_length_histogram(lengths),
+    )

--- a/src/langres/core/data_profile/corpus_field.py
+++ b/src/langres/core/data_profile/corpus_field.py
@@ -154,7 +154,16 @@ class CorpusFieldSection(ProfileSection):
         return self.n_fields_total - len(self.fields)
 
     # ------------------------------------------------------------ row rendering
-    _HEADERS = ("field", "non-null", "distinct", "unique", "mean len", "median len", "length", "flags")
+    _HEADERS = (
+        "field",
+        "non-null",
+        "distinct",
+        "unique",
+        "mean len",
+        "median len",
+        "length",
+        "flags",
+    )
 
     def _display_cells(self, field: FieldStat) -> tuple[str, ...]:
         """One field's cells as display strings (markdown + HTML share this)."""
@@ -187,8 +196,11 @@ class CorpusFieldSection(ProfileSection):
         if not self.fields:
             lines.append("| _(no fields)_ |" + " |" * (len(self._HEADERS) - 1))
         if self._truncated > 0:
-            lines += ["", f"_Showing {len(self.fields)} of {self.n_fields_total} fields "
-                      f"(most-missing first); {self._truncated} truncated._"]
+            lines += [
+                "",
+                f"_Showing {len(self.fields)} of {self.n_fields_total} fields "
+                f"(most-missing first); {self._truncated} truncated._",
+            ]
         return "\n".join(lines)
 
     @property

--- a/src/langres/core/data_profile/embedding_section.py
+++ b/src/langres/core/data_profile/embedding_section.py
@@ -1,0 +1,652 @@
+"""Embedding profile sections: the norm distribution of a model, and a compare.
+
+Two :class:`~langres.core.data_profile.base.ProfileSection` subclasses plus their
+profiler functions:
+
+- :class:`EmbeddingSection` / :func:`profile_embedding` -- streams a corpus's
+  vectors through an :class:`~langres.core.data_profile.embedding_source.EmbeddingSource`
+  and reports the **L2-norm distribution** (a histogram + mean/median/std). Norm
+  is the cheapest, most revealing embedding health signal: a spike of zero norms
+  means empty inputs, a fat tail means outliers, and an all-``1.0`` spike means
+  the store is *pre-normalized* (a cosine index) -- in which case a norm chart is
+  uninformative and the section renders a caveat instead of a flat bar (a
+  keep-with-hint, never a broken chart).
+- :class:`EmbeddingComparisonSection` / :func:`profile_embedding_comparison` --
+  the same norm distribution for several models as **small multiples on one
+  shared axis**, so their norm scales are visually comparable. With fewer than
+  two models it degrades to a keep-with-hint placeholder rather than vanishing.
+
+**Memory.** Every pass streams ``corpus_ids`` in fixed batches and holds at most
+one batch of vectors (``O(batch * dim)``), never the whole matrix -- the whole
+point of the :class:`EmbeddingSource` seam. The histogram range is derived in a
+first stats pass and filled in a second, so both the range and the shared
+comparison axis are exact while memory stays bounded.
+
+Leaf module: numpy + stdlib + pydantic + the shared render scaffold; no heavy
+imports.
+"""
+
+from __future__ import annotations
+
+import html
+import logging
+import math
+from collections.abc import Hashable, Sequence
+
+import numpy as np
+from numpy.typing import NDArray
+from pydantic import BaseModel, ConfigDict, Field
+
+from langres.core import _report_html, _svg
+from langres.core.data_profile.accumulators import OnlineHistogram, RunningStats
+from langres.core.data_profile.base import ProfileSection
+from langres.core.data_profile.embedding_source import EmbeddingSource, _ensure_source
+
+logger = logging.getLogger(__name__)
+
+# Norm-histogram bar color -- explicit (not currentColor) so it renders in light
+# and dark themes, matching the eval-report panel palette.
+_COLOR_NORM = "#4361ee"
+
+#: Default number of in-range histogram bins for a norm distribution.
+_DEFAULT_BINS = 30
+
+
+# --------------------------------------------------------------------- streaming
+def _good_norms(matrix: NDArray[np.floating]) -> tuple[NDArray[np.float64], int]:
+    """L2 norms of the usable rows of a batch, plus the count of dropped rows.
+
+    A row is *dropped* (and counted) when its norm is non-finite (a ``NaN``/
+    ``Inf`` vector) or exactly zero (an all-zero vector) -- both are degenerate
+    for a norm distribution and for cosine, so they are excluded from the stats
+    and surfaced as a count instead.
+
+    Returns:
+        ``(good_norms, n_dropped)`` where ``good_norms`` holds the finite,
+        strictly-positive norms.
+    """
+    if matrix.shape[0] == 0:
+        return np.empty(0, dtype=np.float64), 0
+    norms = np.linalg.norm(np.asarray(matrix, dtype=np.float64), axis=1)
+    usable = np.isfinite(norms) & (norms > 0.0)
+    n_dropped = int((~usable).sum())
+    return norms[usable], n_dropped
+
+
+def _apply_cap(corpus_ids: Sequence[Hashable], cap: int | None) -> tuple[list[Hashable], int]:
+    """Truncate ``corpus_ids`` to at most ``cap`` ids, logging when it bites.
+
+    ``cap`` is an explicit, logged bound on how many ids are streamed -- the lever
+    for profiling a slice of a very large corpus. Returns the (possibly
+    truncated) id list and the number of ids dropped.
+    """
+    ids = list(corpus_ids)
+    if cap is not None and len(ids) > cap:
+        dropped = len(ids) - cap
+        logger.info(
+            "profile_embedding: cap=%d truncated the corpus %d -> %d (dropped %d)",
+            cap,
+            len(ids),
+            cap,
+            dropped,
+        )
+        return ids[:cap], dropped
+    return ids, 0
+
+
+def _stream_stats(
+    source: EmbeddingSource, ids: Sequence[Hashable], batch: int
+) -> tuple[RunningStats, float, float, int]:
+    """First pass: running mean/std, global min/max norm, and dropped-row count.
+
+    Streams ``ids`` in fixed batches (``O(batch * dim)`` memory). The exact global
+    min/max is what lets the second pass build a histogram over the true data
+    range (rather than guessing one from the first batch).
+
+    Returns:
+        ``(stats, global_min, global_max, n_dropped)``. ``global_min`` is ``+inf``
+        and ``global_max`` is ``-inf`` when no usable row was seen.
+    """
+    stats = RunningStats()
+    n_dropped = 0
+    global_min = math.inf
+    global_max = -math.inf
+    for start in range(0, len(ids), batch):
+        good, dropped = _good_norms(source.vectors_for(ids[start : start + batch]))
+        n_dropped += dropped
+        if good.size:
+            stats.update(good)
+            global_min = min(global_min, float(good.min()))
+            global_max = max(global_max, float(good.max()))
+    return stats, global_min, global_max, n_dropped
+
+
+def _stream_histogram(
+    source: EmbeddingSource,
+    ids: Sequence[Hashable],
+    batch: int,
+    lo: float,
+    hi: float,
+    n_bins: int,
+) -> OnlineHistogram:
+    """Second pass: fill a fixed-range norm histogram (``O(batch * dim)`` memory)."""
+    hist = OnlineHistogram(lo, hi, n_bins)
+    for start in range(0, len(ids), batch):
+        good, _ = _good_norms(source.vectors_for(ids[start : start + batch]))
+        if good.size:
+            hist.update(good)
+    return hist
+
+
+def _is_degenerate_norms(n_vectors: int, lo: float, hi: float, pre_normalized: bool) -> bool:
+    """Whether a norm distribution has nothing to plot (render the caveat instead).
+
+    Degenerate when there are no usable vectors, the source is flagged
+    pre-normalized (a cosine store -- norms are ~1.0 by construction), or the norm
+    range is negligible. The relative-spread floor (``1e-6``) catches
+    float32-rounding noise around a constant norm (a pre-normalized store that was
+    *not* flagged), while leaving a genuinely narrow-but-real distribution intact.
+    """
+    if n_vectors == 0 or pre_normalized:
+        return True
+    if not (hi > lo):
+        return True
+    scale = max(abs(hi), abs(lo), 1.0)
+    return (hi - lo) <= 1e-6 * scale
+
+
+def _median_from_hist(
+    counts: list[float], edges: list[float], underflow: int, overflow: int
+) -> float | None:
+    """Approximate the median from in-range bin counts (linear within the bin).
+
+    Returns ``None`` when there is no mass, or when the under/overflow tails hold
+    the majority (the median then falls outside the histogram range and cannot be
+    located from it -- honest ``n/a`` beats a wrong number).
+    """
+    total = underflow + overflow + sum(counts)
+    if total <= 0:
+        return None
+    if (underflow + overflow) * 2 > total:
+        return None
+    half = total / 2.0
+    cumulative = float(underflow)
+    for i, count in enumerate(counts):
+        if cumulative + count >= half:
+            lo, hi = edges[i], edges[i + 1]
+            fraction = (half - cumulative) / count if count > 0 else 0.0
+            return float(lo + fraction * (hi - lo))
+        cumulative += count
+    # Unreachable given the tail-majority guard above (the in-range mass then
+    # holds at least half the total, so the loop always returns first).
+    return float(edges[-1])  # pragma: no cover
+
+
+# ----------------------------------------------------------------- single section
+class EmbeddingSection(ProfileSection):
+    """The L2-norm distribution of one embedding model over a corpus.
+
+    Attributes:
+        source_name: The model label the vectors came from.
+        dim: Embedding dimensionality.
+        n_vectors: Usable rows profiled (finite, strictly-positive norm).
+        n_dropped: Rows dropped as zero-norm or non-finite.
+        n_truncated: Ids dropped by an explicit ``cap``.
+        mean_norm / std_norm: Norm mean and population std (``nan`` when empty).
+        median_norm: Histogram-approximate median (``None`` when unavailable).
+        min_norm / max_norm: Global norm extremes (``None`` when empty).
+        pre_normalized: The vectors are already unit-norm (a cosine store); the
+            norm chart is then replaced by a caveat.
+        degenerate: No usable vectors, or all norms equal -- render the caveat,
+            not a chart.
+        hist_edges / hist_counts: In-range histogram edges and counts (empty when
+            degenerate).
+    """
+
+    kind: str = "embedding"
+    source_name: str
+    dim: int
+    n_vectors: int
+    n_dropped: int
+    n_truncated: int = 0
+    mean_norm: float
+    std_norm: float
+    median_norm: float | None
+    min_norm: float | None
+    max_norm: float | None
+    pre_normalized: bool = False
+    degenerate: bool = False
+    hist_edges: list[float] = Field(default_factory=list)
+    hist_counts: list[float] = Field(default_factory=list)
+
+    # ------------------------------------------------------------- text surfaces
+    def to_markdown(self) -> str:
+        """Markdown heading + a norm summary, with a caveat line when degenerate."""
+        lines = [
+            f"## {self.title}",
+            "",
+            f"- model: `{_report_html._md_cell(self.source_name)}`",
+            f"- dimensionality: {self.dim}",
+            f"- vectors profiled: {self.n_vectors}",
+            f"- mean ‖v‖: {_report_html._num(self.mean_norm)} | "
+            f"median ‖v‖: {_report_html._num(self.median_norm)} | "
+            f"std ‖v‖: {_report_html._num(self.std_norm)}",
+            f"- dropped (zero/non-finite): {self.n_dropped}",
+        ]
+        if self.n_truncated:
+            lines.append(f"- truncated by cap: {self.n_truncated}")
+        caveat = self._caveat_text()
+        if caveat:
+            lines += ["", f"_{caveat}_"]
+        return "\n".join(lines)
+
+    @property
+    def summary(self) -> dict[str, object]:
+        """Headline norm numbers, keyed by model so several sections do not clash."""
+        prefix = f"embedding.{self.source_name}"
+        return {
+            f"{prefix}.dim": self.dim,
+            f"{prefix}.n_vectors": self.n_vectors,
+            f"{prefix}.mean_norm": self.mean_norm,
+            f"{prefix}.median_norm": self.median_norm,
+            f"{prefix}.n_dropped": self.n_dropped,
+            f"{prefix}.pre_normalized": self.pre_normalized,
+        }
+
+    def rows(self) -> list[dict[str, object]]:
+        """One tabular row summarising this model's norm profile."""
+        return [
+            {
+                "model": self.source_name,
+                "dim": self.dim,
+                "n_vectors": self.n_vectors,
+                "mean_norm": self.mean_norm,
+                "median_norm": self.median_norm,
+                "std_norm": self.std_norm,
+                "n_dropped": self.n_dropped,
+                "pre_normalized": self.pre_normalized,
+            }
+        ]
+
+    # -------------------------------------------------------------- html surface
+    def panels(self) -> list[str]:
+        """A norm-histogram panel (or caveat) plus a key/value summary panel."""
+        return [self._panel_histogram(), self._panel_summary()]
+
+    def _caveat_text(self) -> str:
+        """The keep-with-hint note for a degenerate norm distribution (else ``""``)."""
+        if not self.degenerate:
+            return ""
+        if self.n_vectors == 0:
+            return (
+                "No vectors to profile: every requested id was missing, zero-norm, or non-finite."
+            )
+        if self.pre_normalized:
+            return (
+                "Vectors are pre-normalized (a cosine store): every norm is ~1.0, so "
+                "a norm distribution is uninformative -- compare these embeddings by "
+                "direction, not magnitude."
+            )
+        return (
+            f"All {self.n_vectors} vectors share a constant norm "
+            f"(~{_report_html._num(self.mean_norm)}); there is no distribution to plot."
+        )
+
+    def _panel_histogram(self) -> str:
+        heading = f"{self.title} — norm distribution"
+        if self.degenerate or not self.hist_edges:
+            note = f'<p class="empty">{html.escape(self._caveat_text())}</p>'
+            return _report_html.section(heading, note)
+        svg = _svg.bar_chart(
+            self.hist_edges,
+            [("‖v‖", _COLOR_NORM, self.hist_counts)],
+            x_label="L2 norm",
+            y_label="count",
+        )
+        return _report_html.section(heading, svg)
+
+    def _panel_summary(self) -> str:
+        rows = [
+            ("dimensionality", str(self.dim)),
+            ("vectors profiled", str(self.n_vectors)),
+            ("mean ‖v‖", _report_html._num(self.mean_norm)),
+            ("median ‖v‖", _report_html._num(self.median_norm)),
+            ("std ‖v‖", _report_html._num(self.std_norm)),
+            ("dropped (zero/non-finite)", str(self.n_dropped)),
+        ]
+        if self.n_truncated:
+            rows.append(("truncated by cap", str(self.n_truncated)))
+        if self.pre_normalized:
+            rows.append(("pre-normalized", "yes (cosine store — norms ~1.0)"))
+        cells = "".join(
+            f"<tr><th>{html.escape(k)}</th><td>{html.escape(v)}</td></tr>" for k, v in rows
+        )
+        return _report_html.section(f"{self.title} — summary", f'<table class="kv">{cells}</table>')
+
+
+def profile_embedding(
+    source: EmbeddingSource,
+    corpus_ids: Sequence[Hashable],
+    *,
+    batch: int = 4096,
+    cap: int | None = None,
+    n_bins: int = _DEFAULT_BINS,
+    title: str | None = None,
+) -> EmbeddingSection:
+    """Profile one model's L2-norm distribution over ``corpus_ids`` (streaming).
+
+    Two streaming passes over ``corpus_ids`` (each ``O(batch * dim)`` memory): the
+    first derives the exact norm range + mean/std/dropped counts, the second fills
+    the histogram over that range. A pre-normalized (cosine) store, or any corpus
+    whose norms are constant, is flagged ``degenerate`` so the section renders a
+    caveat rather than a flat chart.
+
+    Args:
+        source: An :class:`EmbeddingSource` (a bare ndarray raises ``TypeError``).
+        corpus_ids: The record ids to profile (a subset of the source's ids;
+            unknown ones are dropped and logged by the source).
+        batch: Ids per streaming batch (caps the transient vector memory).
+        cap: Optional hard limit on ids streamed; logged when it truncates.
+        n_bins: In-range histogram bins.
+        title: Section title (defaults to ``"Embeddings ({name})"``).
+
+    Returns:
+        An :class:`EmbeddingSection`.
+    """
+    _ensure_source(source)
+    ids, n_truncated = _apply_cap(corpus_ids, cap)
+    stats, global_min, global_max, n_dropped = _stream_stats(source, ids, batch)
+    n_vectors = stats.count
+    pre_normalized = bool(getattr(source, "pre_normalized", False))
+    degenerate = _is_degenerate_norms(n_vectors, global_min, global_max, pre_normalized)
+
+    hist_edges: list[float] = []
+    hist_counts: list[float] = []
+    median: float | None = None
+    if not degenerate:
+        hist = _stream_histogram(source, ids, batch, global_min, global_max, n_bins)
+        hist_edges = [float(edge) for edge in hist.edges]
+        hist_counts = [float(count) for count in hist.bin_counts]
+        median = _median_from_hist(hist_counts, hist_edges, hist.underflow, hist.overflow)
+
+    return EmbeddingSection(
+        title=title or f"Embeddings ({source.name})",
+        source_name=source.name,
+        dim=int(source.dim),
+        n_vectors=n_vectors,
+        n_dropped=n_dropped,
+        n_truncated=n_truncated,
+        mean_norm=stats.mean,
+        std_norm=stats.std,
+        median_norm=median,
+        min_norm=global_min if n_vectors else None,
+        max_norm=global_max if n_vectors else None,
+        pre_normalized=pre_normalized,
+        degenerate=degenerate,
+        hist_edges=hist_edges,
+        hist_counts=hist_counts,
+    )
+
+
+# ----------------------------------------------------------- comparison section
+class EmbeddingModelSummary(BaseModel):
+    """One model's norm profile inside an :class:`EmbeddingComparisonSection`.
+
+    Carries the per-model headline norms plus the histogram counts binned on the
+    comparison's **shared** edges, so every model's mini-chart shares one axis.
+    """
+
+    model_config = ConfigDict(frozen=True)
+
+    name: str
+    dim: int
+    n_vectors: int
+    n_dropped: int
+    mean_norm: float
+    std_norm: float
+    median_norm: float | None
+    min_norm: float | None
+    max_norm: float | None
+    pre_normalized: bool
+    hist_counts: list[float] = Field(default_factory=list)
+
+
+class EmbeddingComparisonSection(ProfileSection):
+    """Norm distributions of several models as shared-axis small multiples.
+
+    Attributes:
+        models: Per-model norm summaries (empty on the placeholder).
+        shared_edges: The bin edges every model's mini-histogram shares (empty
+            when degenerate/placeholder).
+        n_sources: How many sources were passed (drives the placeholder message).
+        n_truncated: Ids dropped by an explicit ``cap``.
+        placeholder: Fewer than two sources -- render a keep-with-hint, not charts.
+        degenerate: No source had norm variance (all pre-normalized/constant/empty)
+            -- render caveats instead of charts.
+        dims_differ: Models have different dimensionalities (norm magnitudes are
+            then not directly comparable -- surfaced as a caveat).
+    """
+
+    kind: str = "embedding_comparison"
+    models: list[EmbeddingModelSummary] = Field(default_factory=list)
+    shared_edges: list[float] = Field(default_factory=list)
+    n_sources: int = 0
+    n_truncated: int = 0
+    placeholder: bool = False
+    degenerate: bool = False
+    dims_differ: bool = False
+
+    # ------------------------------------------------------------- text surfaces
+    def to_markdown(self) -> str:
+        """Markdown table of the compared models (or the placeholder note)."""
+        if self.placeholder:
+            return f"## {self.title}\n\n_{self._placeholder_text()}_"
+        lines = [
+            f"## {self.title}",
+            "",
+            "| model | dim | n_vectors | mean ‖v‖ | median ‖v‖ | std ‖v‖ | dropped | pre-norm |",
+            "|---|---|---|---|---|---|---|---|",
+        ]
+        for model in self.models:
+            lines.append(
+                f"| {_report_html._md_cell(model.name)} | {model.dim} | {model.n_vectors} | "
+                f"{_report_html._num(model.mean_norm)} | {_report_html._num(model.median_norm)} | "
+                f"{_report_html._num(model.std_norm)} | {model.n_dropped} | "
+                f"{'yes' if model.pre_normalized else 'no'} |"
+            )
+        if self.dims_differ:
+            lines += ["", f"_{self._dims_differ_text()}_"]
+        return "\n".join(lines)
+
+    @property
+    def summary(self) -> dict[str, object]:
+        """Headline: how many models, and whether the comparison is renderable."""
+        return {
+            "embedding_comparison.n_models": len(self.models),
+            "embedding_comparison.placeholder": self.placeholder,
+            "embedding_comparison.degenerate": self.degenerate,
+            "embedding_comparison.dims_differ": self.dims_differ,
+        }
+
+    def rows(self) -> list[dict[str, object]]:
+        """One tabular row per compared model."""
+        return [
+            {
+                "model": model.name,
+                "dim": model.dim,
+                "n_vectors": model.n_vectors,
+                "mean_norm": model.mean_norm,
+                "median_norm": model.median_norm,
+                "std_norm": model.std_norm,
+                "n_dropped": model.n_dropped,
+                "pre_normalized": model.pre_normalized,
+            }
+            for model in self.models
+        ]
+
+    # -------------------------------------------------------------- html surface
+    def panels(self) -> list[str]:
+        """A comparison table plus one shared-axis mini-histogram per model."""
+        if self.placeholder:
+            note = f'<p class="empty">{html.escape(self._placeholder_text())}</p>'
+            return [_report_html.section(self.title, note)]
+        panels = [self._panel_table()]
+        for model in self.models:
+            panels.append(self._panel_model(model))
+        return panels
+
+    def _placeholder_text(self) -> str:
+        return (
+            f"Add at least 2 embeddings to compare (only {self.n_sources} given). "
+            "A comparison needs two or more models to place side by side."
+        )
+
+    def _dims_differ_text(self) -> str:
+        return (
+            "Models have different dimensionalities; norm magnitudes are not directly "
+            "comparable across dimensions (higher-dimensional vectors tend to have "
+            "larger norms). Compare shapes, not absolute scales."
+        )
+
+    def _panel_table(self) -> str:
+        head = (
+            "<tr><th>model</th><th>dim</th><th>n</th><th>mean ‖v‖</th>"
+            "<th>median ‖v‖</th><th>std ‖v‖</th><th>dropped</th><th>pre-norm</th></tr>"
+        )
+        body = "".join(
+            f"<tr><td>{html.escape(model.name)}</td><td>{model.dim}</td>"
+            f"<td>{model.n_vectors}</td><td>{_report_html._num(model.mean_norm)}</td>"
+            f"<td>{_report_html._num(model.median_norm)}</td>"
+            f"<td>{_report_html._num(model.std_norm)}</td><td>{model.n_dropped}</td>"
+            f"<td>{'yes' if model.pre_normalized else 'no'}</td></tr>"
+            for model in self.models
+        )
+        note = (
+            f'<p class="empty">{html.escape(self._dims_differ_text())}</p>'
+            if self.dims_differ
+            else ""
+        )
+        return _report_html.section(self.title, f"<table>{head}{body}</table>{note}")
+
+    def _panel_model(self, model: EmbeddingModelSummary) -> str:
+        heading = f"{model.name} — norm distribution"
+        if self.degenerate or not self.shared_edges or not model.hist_counts:
+            reason = (
+                "pre-normalized (norms ~1.0)"
+                if model.pre_normalized
+                else "no norm variance to plot"
+            )
+            note = f'<p class="empty">{html.escape(reason)}</p>'
+            return _report_html.section(heading, note)
+        # Shared edges + per-series max-normalisation => every mini-chart shares
+        # one x-axis and a comparable [0, 1] y-axis despite different corpus sizes.
+        svg = _svg.bar_chart(
+            self.shared_edges,
+            [(model.name, _COLOR_NORM, model.hist_counts)],
+            width=260,
+            height=180,
+            x_label="L2 norm",
+            y_label="rel. count",
+            normalize="max",
+        )
+        return _report_html.section(heading, svg)
+
+
+def profile_embedding_comparison(
+    sources: Sequence[EmbeddingSource],
+    corpus_ids: Sequence[Hashable],
+    *,
+    batch: int = 4096,
+    cap: int | None = None,
+    n_bins: int = _DEFAULT_BINS,
+    title: str = "Embedding comparison",
+) -> EmbeddingComparisonSection:
+    """Compare several models' norm distributions on one shared axis (small multiples).
+
+    Each source is streamed twice (``O(batch * dim)`` memory): a stats pass per
+    source yields the per-model norms and the union norm range; a second pass fills
+    each model's histogram over the **shared** edges of that union range, so the
+    mini-charts are directly comparable. Fewer than two sources yields a
+    keep-with-hint placeholder (never a raise or a vanish).
+
+    Args:
+        sources: Two or more :class:`EmbeddingSource` s (bare ndarrays raise
+            ``TypeError``).
+        corpus_ids: Record ids to profile through every source.
+        batch: Ids per streaming batch.
+        cap: Optional hard limit on ids streamed; logged when it truncates.
+        n_bins: In-range histogram bins (shared across models).
+        title: Section title.
+
+    Returns:
+        An :class:`EmbeddingComparisonSection`.
+    """
+    source_list = list(sources)
+    for source in source_list:
+        _ensure_source(source)
+
+    if len(source_list) < 2:
+        return EmbeddingComparisonSection(title=title, n_sources=len(source_list), placeholder=True)
+
+    ids, n_truncated = _apply_cap(corpus_ids, cap)
+
+    # Pass 1 per source: stats + per-model norm range.
+    profiles: list[tuple[EmbeddingSource, RunningStats, float, float, int]] = []
+    for source in source_list:
+        stats, global_min, global_max, n_dropped = _stream_stats(source, ids, batch)
+        profiles.append((source, stats, global_min, global_max, n_dropped))
+
+    # Shared range = union over the sources that actually have norm variance
+    # (a pre-normalized / constant source contributes no range of its own).
+    varied = [
+        (lo, hi)
+        for source, stats, lo, hi, _ in profiles
+        if not _is_degenerate_norms(
+            stats.count, lo, hi, bool(getattr(source, "pre_normalized", False))
+        )
+    ]
+    degenerate = not varied
+    shared_edges: list[float] = []
+    shared_lo = shared_hi = 0.0
+    if not degenerate:
+        shared_lo = min(lo for lo, _ in varied)
+        shared_hi = max(hi for _, hi in varied)
+        shared_edges = [float(edge) for edge in np.linspace(shared_lo, shared_hi, n_bins + 1)]
+
+    # Pass 2 per source: fill each model's histogram on the shared edges.
+    models: list[EmbeddingModelSummary] = []
+    for source, stats, global_min, global_max, n_dropped in profiles:
+        hist_counts: list[float] = []
+        median: float | None = None
+        if not degenerate:
+            hist = _stream_histogram(source, ids, batch, shared_lo, shared_hi, n_bins)
+            hist_counts = [float(count) for count in hist.bin_counts]
+            median = _median_from_hist(hist_counts, shared_edges, hist.underflow, hist.overflow)
+        n_vectors = stats.count
+        models.append(
+            EmbeddingModelSummary(
+                name=source.name,
+                dim=int(source.dim),
+                n_vectors=n_vectors,
+                n_dropped=n_dropped,
+                mean_norm=stats.mean,
+                std_norm=stats.std,
+                median_norm=median,
+                min_norm=global_min if n_vectors else None,
+                max_norm=global_max if n_vectors else None,
+                pre_normalized=bool(getattr(source, "pre_normalized", False)),
+                hist_counts=hist_counts,
+            )
+        )
+
+    dims_differ = len({model.dim for model in models}) > 1
+    return EmbeddingComparisonSection(
+        title=title,
+        models=models,
+        shared_edges=shared_edges,
+        n_sources=len(source_list),
+        n_truncated=n_truncated,
+        placeholder=False,
+        degenerate=degenerate,
+        dims_differ=dims_differ,
+    )

--- a/src/langres/core/data_profile/embedding_source.py
+++ b/src/langres/core/data_profile/embedding_source.py
@@ -433,6 +433,18 @@ def _locate(root: Path, filename: str) -> Path:
             f"{filename!r} not found in {root} (searched recursively) -- is this a "
             "persisted anchor-store / vector-index artifact with a built index?"
         )
+    if len(matches) > 1:
+        # More than one artifact under the same root: the first (sorted) still
+        # resolves so this stays non-breaking, but we name the choice instead of
+        # picking silently -- matching this module's "never silent" convention.
+        logger.warning(
+            "%r matched %d files under %s; using the first (%s). Point state_dir at a "
+            "single artifact to disambiguate.",
+            filename,
+            len(matches),
+            root,
+            matches[0],
+        )
     return matches[0]
 
 

--- a/src/langres/core/data_profile/embedding_source.py
+++ b/src/langres/core/data_profile/embedding_source.py
@@ -1,0 +1,497 @@
+"""Memory-efficient, read-only access to *precomputed* embedding vectors.
+
+The data-profile report never *produces* embeddings -- it **consumes** vectors a
+pipeline already paid to compute (a ``VectorBlocker``'s corpus, an
+``AnchorStore``'s built index, a bare ``.npy`` a user hands us). This module is
+the seam that exposes those vectors to the embedding sections **without ever
+loading the whole corpus into RAM**: an :class:`EmbeddingSource` resolves a batch
+of record ids to their rows and gathers *only* those rows, so a 30 GB matrix is
+profiled in ``O(batch * dim)`` memory, never ``O(corpus * dim)``.
+
+Three concrete sources, one contract:
+
+- :class:`ArraySource` -- wraps a matrix already in RAM (tests, small corpora).
+- :class:`NpySource` -- memmaps a ``.npy`` (``mmap_mode="r"``) and fancy-indexes
+  the requested rows, so only those pages fault in. The 30 GB-safe default.
+- :meth:`NpySource.from_anchor_store` -- reuses the pipeline's own
+  ``corpus_embeddings.npy`` + the :class:`~langres.core.anchor_store.AnchorStoreManifest`
+  id order, reading the metric from ``corpus.json`` (a cosine index is
+  pre-normalized, so its norms are all ~1.0 -- a caveat the sections surface).
+
+**No heavy imports.** Module scope is pure standard library + numpy -- never
+sentence-transformers / torch / faiss. We read vectors someone else wrote; we do
+not build an embedder. The one langres import (the anchor-store manifest schema)
+is deferred into :meth:`NpySource.from_anchor_store` so importing this module
+stays core-only.
+
+**Guards (a mis-aligned id map corrupts every downstream metric):**
+
+- Unknown ids are **dropped and logged** (a partial miss -- the profile proceeds
+  over the rows that resolve).
+- A **total** id miss (nothing resolves) **raises** -- that is a namespace
+  mismatch (wrong id set entirely), not a profile worth computing.
+- A bare ``ndarray`` passed where a source is expected raises an actionable
+  :class:`TypeError` (wrap it in :class:`ArraySource`).
+- An id-order **fingerprint** guards the vectors<->ids alignment: a length check
+  cannot catch a *same-length permutation*, which silently re-maps every vector.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import logging
+import math
+from collections.abc import Callable, Hashable, Sequence
+from pathlib import Path
+from typing import Protocol, runtime_checkable
+
+import numpy as np
+from numpy.typing import NDArray
+
+logger = logging.getLogger(__name__)
+
+
+@runtime_checkable
+class EmbeddingSource(Protocol):
+    """The read-only contract the embedding sections consume vectors through.
+
+    Any object exposing a model ``name``, an embedding ``dim``, and a
+    memory-bounded :meth:`vectors_for` is a source -- the sections never see the
+    whole matrix, only the rows they ask for. :class:`ArraySource`,
+    :class:`NpySource`, and :meth:`NpySource.from_anchor_store` are the shipped
+    implementations; the protocol lets a caller supply any other backing (a
+    remote store, a lazily-decompressed shard) without this package knowing.
+    """
+
+    name: str
+    dim: int
+
+    def vectors_for(self, ids: Sequence[Hashable]) -> NDArray[np.floating]:
+        """Return the ``(n_resolved, dim)`` rows for ``ids`` in ``O(len(ids) * dim)``.
+
+        Unknown ids are dropped (``n_resolved <= len(ids)``); a total miss (none
+        resolve) raises. Memory MUST be bounded by the request, never the corpus.
+        """
+        ...  # pragma: no cover
+
+
+# Sidecar written next to an anchor store's vectors on first
+# :meth:`NpySource.from_anchor_store`, then compared on every later load: a
+# trust-on-first-use guard that catches a same-length id-order permutation.
+_FINGERPRINT_SIDECAR = "embedding_ids.fingerprint"
+
+# Filenames the pipeline persists (see ``FAISSIndex.save_state`` /
+# ``AnchorStore.save``). Located by name so this module never imports the
+# resolver / faiss to read them.
+_CORPUS_VECTORS = "corpus_embeddings.npy"
+_CORPUS_JSON = "corpus.json"
+_ANCHOR_MANIFEST = "anchor_store.json"
+
+
+def _fingerprint(id_order: Sequence[Hashable]) -> str:
+    """Order-sensitive digest of an id sequence.
+
+    Two id orders collide only if they are element-wise identical, so a
+    same-length permutation (which a length check misses) yields a *different*
+    fingerprint. ``str(id)`` handles any :class:`~collections.abc.Hashable` id
+    (``str``/``int``/tuple); the count and a control-char separator prevent
+    boundary collisions (``["a", "bc"]`` vs ``["ab", "c"]``).
+    """
+    digest = hashlib.sha256()
+    digest.update(str(len(id_order)).encode("utf-8"))
+    for identifier in id_order:
+        digest.update(b"\x1f")
+        digest.update(str(identifier).encode("utf-8"))
+    return digest.hexdigest()
+
+
+class _RowGatherSource:
+    """Shared id->row resolution + memory-safe row gather for both sources.
+
+    Holds an id order (row ``i`` of the matrix belongs to ``id_order[i]``), a
+    ``{id: row}`` lookup, and the backing matrix -- an in-memory ``ndarray``
+    (:class:`ArraySource`) or a read-only ``np.memmap`` (:class:`NpySource`).
+    :meth:`vectors_for` gathers requested rows with a single numpy fancy-index,
+    which materialises **only** those rows (``O(len(ids) * dim)``); a memmap
+    backing never pages the whole corpus in.
+
+    Not constructed directly -- use :class:`ArraySource` / :class:`NpySource`.
+
+    Attributes:
+        name: A short label for the embedding model (shown in the report).
+        pre_normalized: ``True`` when the vectors are already unit-norm (a cosine
+            index normalizes in place), so a norm distribution is degenerate
+            (~1.0) -- the sections render a caveat instead of a flat chart.
+        metric: The source metric string when known (e.g. ``"cosine"`` / ``"L2"``),
+            else ``None``.
+    """
+
+    def __init__(
+        self,
+        name: str,
+        id_order: Sequence[Hashable],
+        matrix: NDArray[np.floating] | np.memmap,
+        *,
+        pre_normalized: bool = False,
+        metric: str | None = None,
+    ) -> None:
+        """Validate the id<->row alignment and build the lookup.
+
+        Raises:
+            ValueError: If ``matrix`` is not 2-D, or its row count does not equal
+                ``len(id_order)`` (a row/id desync would corrupt every metric).
+        """
+        if matrix.ndim != 2:
+            raise ValueError(
+                f"embedding matrix for {name!r} must be 2-D (n_vectors, dim), "
+                f"got shape {matrix.shape!r}"
+            )
+        id_list = list(id_order)
+        if len(id_list) != matrix.shape[0]:
+            raise ValueError(
+                f"id/row desync for source {name!r}: {len(id_list)} ids but "
+                f"{matrix.shape[0]} matrix rows -- every vector would be "
+                "mis-attributed. Pass exactly one id per row, in row order."
+            )
+        self.name = str(name)
+        self.pre_normalized = bool(pre_normalized)
+        self.metric = metric
+        self._matrix = matrix
+        self._id_order = id_list
+        self._row_of: dict[Hashable, int] = {}
+        for row, identifier in enumerate(id_list):
+            # First-wins on a duplicate id (a later dup cannot be addressed, but
+            # dropping it silently beats a corrupt double-mapping).
+            self._row_of.setdefault(identifier, row)
+
+    @property
+    def dim(self) -> int:
+        """Embedding dimensionality (matrix column count)."""
+        return int(self._matrix.shape[1])
+
+    @property
+    def id_order(self) -> list[Hashable]:
+        """A copy of the record ids in row order (row ``i`` -> ``id_order[i]``)."""
+        return list(self._id_order)
+
+    @property
+    def id_fingerprint(self) -> str:
+        """Order-sensitive digest of :attr:`id_order` (see :func:`_fingerprint`)."""
+        return _fingerprint(self._id_order)
+
+    def vectors_for(self, ids: Sequence[Hashable]) -> NDArray[np.floating]:
+        """Gather the vectors for ``ids``, in request order, dropping unknowns.
+
+        Resolves each id to its row and gathers exactly those rows with one
+        fancy-index -- ``O(len(ids) * dim)`` memory, so a memmapped backing pages
+        in only the requested rows and the returned array is an **independent**
+        copy (never a view onto the corpus).
+
+        Args:
+            ids: Record ids to fetch. May be a subset of :attr:`id_order`, in any
+                order, with repeats.
+
+        Returns:
+            An ``(n_resolved, dim)`` float array, where ``n_resolved <= len(ids)``
+            (unknown ids are dropped) and equals ``len(ids)`` when all resolve.
+
+        Raises:
+            KeyError: If ``ids`` is non-empty and **none** resolve -- a total
+                miss, i.e. the wrong id namespace entirely.
+        """
+        rows: list[int] = []
+        n_missing = 0
+        for identifier in ids:
+            row = self._row_of.get(identifier)
+            if row is None:
+                n_missing += 1
+            else:
+                rows.append(row)
+        if n_missing and not rows:
+            raise KeyError(
+                f"none of the {n_missing} requested id(s) exist in source "
+                f"{self.name!r} -- wrong id namespace? (a total miss, not a "
+                "partial one, is raised so a mis-pointed profile fails loudly)"
+            )
+        if n_missing:
+            logger.warning(
+                "EmbeddingSource %r: dropped %d unknown id(s) of %d requested",
+                self.name,
+                n_missing,
+                len(rows) + n_missing,
+            )
+        # Fancy-indexing a memmap materialises only these rows into a fresh,
+        # independent ndarray (owns its data; not an np.memmap, not a view).
+        return np.array(self._matrix[rows])
+
+    def verify_alignment(self, expected_fingerprint: str) -> None:
+        """Raise if this source's id order no longer matches ``expected_fingerprint``.
+
+        The alignment guard a length check cannot provide: a same-length
+        permutation of the ids (with the vectors unchanged) silently re-maps
+        every row, and only a fingerprint comparison catches it.
+
+        Raises:
+            ValueError: On a fingerprint mismatch (the id order changed under the
+                same vectors).
+        """
+        actual = self.id_fingerprint
+        if actual != expected_fingerprint:
+            raise ValueError(
+                f"id-order fingerprint mismatch for source {self.name!r}: the "
+                "recorded vector<->id alignment no longer holds (a permuted id "
+                "order under the same vectors). Rebuild the source from the "
+                "current id order."
+            )
+
+
+class ArraySource(_RowGatherSource):
+    """An :class:`EmbeddingSource` over a matrix already in memory.
+
+    For tests and small corpora where the vectors comfortably fit in RAM. The
+    row/id length check is enforced at construction because a desync corrupts
+    every downstream metric.
+
+    Example::
+
+        src = ArraySource("minilm", ["r1", "r2"], np.array([[0.1, 0.2], [0.3, 0.4]]))
+        src.vectors_for(["r2"])          # -> shape (1, 2)
+    """
+
+    def __init__(
+        self,
+        name: str,
+        ids: Sequence[Hashable],
+        matrix: NDArray[np.floating],
+        *,
+        pre_normalized: bool = False,
+        metric: str | None = None,
+    ) -> None:
+        """Wrap ``matrix`` (rows aligned to ``ids``).
+
+        Args:
+            name: Short model label.
+            ids: One id per matrix row, in row order.
+            matrix: An ``(n_vectors, dim)`` float array.
+            pre_normalized: Mark the vectors as already unit-norm.
+            metric: Optional metric string (e.g. ``"cosine"``).
+
+        Raises:
+            ValueError: If ``matrix`` is not 2-D or ``len(ids) != matrix.shape[0]``.
+        """
+        super().__init__(
+            name, ids, np.asarray(matrix), pre_normalized=pre_normalized, metric=metric
+        )
+
+
+class NpySource(_RowGatherSource):
+    """An :class:`EmbeddingSource` over a memmapped ``.npy`` (the 30 GB-safe default).
+
+    Loads the array with ``mmap_mode="r"`` -- the file is **not** read into RAM;
+    :meth:`vectors_for` fancy-indexes the requested rows so only those pages
+    fault in. The memmap is preserved as the backing store (dropping
+    ``mmap_mode`` would silently re-introduce the ``O(corpus)`` load this class
+    exists to avoid).
+
+    The id order can be passed explicitly or discovered from a companion JSON
+    sidecar (``<stem>.ids.json`` or ``ids.json``) next to the ``.npy``, so a
+    saved ``(vectors, ids)`` pair self-aligns.
+    """
+
+    def __init__(
+        self,
+        name: str,
+        path: str | Path,
+        id_order: Sequence[Hashable] | None = None,
+        *,
+        pre_normalized: bool = False,
+        metric: str | None = None,
+    ) -> None:
+        """Memmap ``path`` and align it to ``id_order`` (or a sidecar).
+
+        Args:
+            name: Short model label.
+            path: Path to a ``.npy`` holding an ``(n_vectors, dim)`` float matrix.
+            id_order: One id per row, in row order. When ``None``, an adjacent
+                ``<stem>.ids.json`` or ``ids.json`` (a JSON list) is loaded.
+            pre_normalized: Mark the vectors as already unit-norm.
+            metric: Optional metric string.
+
+        Raises:
+            ValueError: If ``id_order`` is ``None`` and no sidecar is found, or if
+                the matrix is not 2-D / the id count does not match the rows.
+        """
+        matrix = np.load(Path(path), mmap_mode="r")
+        if id_order is None:
+            id_order = self._load_sidecar_ids(Path(path))
+        super().__init__(name, id_order, matrix, pre_normalized=pre_normalized, metric=metric)
+
+    @staticmethod
+    def _load_sidecar_ids(path: Path) -> list[Hashable]:
+        """Load a companion ids JSON next to ``path`` (``<stem>.ids.json`` / ``ids.json``).
+
+        Raises:
+            ValueError: If neither sidecar exists.
+        """
+        candidates = [path.with_name(f"{path.stem}.ids.json"), path.with_name("ids.json")]
+        for candidate in candidates:
+            if candidate.exists():
+                loaded = json.loads(candidate.read_text())
+                logger.info("NpySource: loaded %d ids from sidecar %s", len(loaded), candidate)
+                return list(loaded)
+        raise ValueError(
+            f"NpySource for {path} needs an id_order: pass one, or place a "
+            f"companion ids file ({candidates[0].name} or ids.json) next to the .npy."
+        )
+
+    @classmethod
+    def from_anchor_store(cls, state_dir: str | Path, name: str) -> NpySource:
+        """Build a source from a persisted ``AnchorStore`` / vector-index artifact.
+
+        Reuses the pipeline's own ``corpus_embeddings.npy`` (row order == corpus
+        order) and the :class:`~langres.core.anchor_store.AnchorStoreManifest`
+        ``anchor_ids`` (the record-id <-> row order), reading ``metric`` from
+        ``corpus.json``. A cosine index L2-normalizes its vectors in place, so the
+        source is marked :attr:`~_RowGatherSource.pre_normalized` and the sections
+        render the "norms are all ~1.0" caveat rather than a flat chart.
+
+        An id-order fingerprint is persisted next to the artifact on first call
+        and compared on every later call, so a same-length permutation of the
+        anchor ids (which a length check misses) fails loudly.
+
+        Args:
+            state_dir: The persisted artifact directory (an ``AnchorStore.save``
+                output, or any dir containing the three sidecar files, possibly
+                nested).
+            name: Short model label for the source.
+
+        Returns:
+            An :class:`NpySource` memmapping the artifact's vectors, aligned to the
+            manifest's anchor id order.
+
+        Raises:
+            FileNotFoundError: If the vectors or the manifest cannot be located.
+            ValueError: On an id-order fingerprint mismatch (a permuted id order).
+        """
+        # Deferred import keeps this module core-only at import time; the manifest
+        # schema itself is import-light (pydantic + core.models, no faiss).
+        from langres.core.anchor_store import AnchorStoreManifest
+
+        root = Path(state_dir)
+        vectors_path = _locate(root, _CORPUS_VECTORS)
+        manifest_path = _locate(root, _ANCHOR_MANIFEST)
+        manifest = AnchorStoreManifest.model_validate_json(manifest_path.read_text())
+        anchor_ids: list[Hashable] = list(manifest.anchor_ids)
+
+        metric: str | None = None
+        corpus_json = vectors_path.with_name(_CORPUS_JSON)
+        if corpus_json.exists():
+            metric = json.loads(corpus_json.read_text()).get("metric")
+
+        # Trust-on-first-use alignment guard: persist the fingerprint beside the
+        # artifact, then compare it on every later load.
+        fingerprint = _fingerprint(anchor_ids)
+        fp_path = root / _FINGERPRINT_SIDECAR
+        if fp_path.exists():
+            previous = fp_path.read_text().strip()
+            if previous != fingerprint:
+                raise ValueError(
+                    f"anchor-store id order changed under the same vectors in "
+                    f"{root} -- a same-length permutation would silently re-map "
+                    "every embedding. Delete "
+                    f"{_FINGERPRINT_SIDECAR} to re-baseline if this is intentional."
+                )
+        else:
+            fp_path.write_text(fingerprint)
+
+        return cls(
+            name,
+            vectors_path,
+            anchor_ids,
+            pre_normalized=(metric == "cosine"),
+            metric=metric,
+        )
+
+
+def _locate(root: Path, filename: str) -> Path:
+    """Find ``filename`` at ``root`` or anywhere beneath it (deterministically).
+
+    ``AnchorStore.save`` nests the vector-index sidecars under a ``resolver/``
+    subtree, so a plain ``root / filename`` is not enough; a name search that
+    tolerates the nesting (without importing the resolver to learn its layout) is.
+
+    Raises:
+        FileNotFoundError: If no file with that name exists under ``root``.
+    """
+    direct = root / filename
+    if direct.exists():
+        return direct
+    matches = sorted(root.rglob(filename))
+    if not matches:
+        raise FileNotFoundError(
+            f"{filename!r} not found in {root} (searched recursively) -- is this a "
+            "persisted anchor-store / vector-index artifact with a built index?"
+        )
+    return matches[0]
+
+
+def _ensure_source(obj: object) -> None:
+    """Reject a value that is not an :class:`EmbeddingSource` with a clear message.
+
+    The most likely mistake is passing the raw vector matrix where a *source* is
+    expected; that would type-check as an ``ndarray`` and then fail obscurely, so
+    it earns a targeted, actionable error.
+
+    Raises:
+        TypeError: If ``obj`` is an ``ndarray`` (or otherwise lacks
+            ``vectors_for``).
+    """
+    if isinstance(obj, np.ndarray):
+        raise TypeError(
+            "expected an EmbeddingSource (ArraySource / NpySource / ...), got a "
+            "bare numpy ndarray -- wrap it: ArraySource(name, ids, matrix)."
+        )
+    if not callable(getattr(obj, "vectors_for", None)):
+        raise TypeError(
+            f"expected an EmbeddingSource with a vectors_for(ids) method, got {type(obj).__name__}."
+        )
+
+
+def cosine_signal(source: EmbeddingSource) -> Callable[[Hashable, Hashable], float | None]:
+    """A pairwise cosine-similarity callable backed by ``source`` (the A<->B bridge).
+
+    Returns ``signal(id_a, id_b) -> float | None`` with the same shape as the
+    separability section's similarity signal: it looks up both ids' vectors via
+    ``source``, L2-normalizes them, and returns their cosine similarity -- or
+    ``None`` when either id is missing or its vector is degenerate (zero-norm or
+    non-finite), so a caller can score a stream of pairs without guarding each
+    lookup.
+
+    Args:
+        source: Any :class:`EmbeddingSource`. A bare ndarray raises a
+            :class:`TypeError` (see :func:`_ensure_source`).
+
+    Returns:
+        A ``(id_a, id_b) -> float | None`` similarity function.
+    """
+    _ensure_source(source)
+
+    def signal(id_a: Hashable, id_b: Hashable) -> float | None:
+        try:
+            pair = source.vectors_for([id_a, id_b])
+        except KeyError:
+            return None  # neither id resolved (total miss)
+        if pair.shape[0] != 2:
+            return None  # exactly one resolved -- cannot form a pair
+        vec_a = np.asarray(pair[0], dtype=np.float64)
+        vec_b = np.asarray(pair[1], dtype=np.float64)
+        norm_a = float(np.linalg.norm(vec_a))
+        norm_b = float(np.linalg.norm(vec_b))
+        if not math.isfinite(norm_a) or not math.isfinite(norm_b) or norm_a == 0.0 or norm_b == 0.0:
+            return None  # degenerate vector -- cosine undefined
+        # Both norms are finite and non-zero, so by Cauchy-Schwarz the dot product
+        # is bounded by their product and the ratio is a finite value in [-1, 1].
+        return float(np.dot(vec_a, vec_b) / (norm_a * norm_b))
+
+    return signal

--- a/src/langres/core/data_profile/hero.py
+++ b/src/langres/core/data_profile/hero.py
@@ -36,14 +36,17 @@ def _fmt_count(value: int | None) -> str:
 
 
 def _fmt_prevalence(value: float | None) -> str:
-    """A small probability with ``%g`` sig-figs; ``None``/NaN/Inf -> ``"n/a"``.
+    """Positive-pair prevalence as a scannable percentage (2 sig figs).
 
-    Prevalence is often tiny (``3e-04`` under ER imbalance); ``%g`` keeps the
-    significant digits a fixed-decimal format would round to ``0.000``.
+    The hero card trades the raw float (``0.00638742``) for the percentage a
+    reader actually scans (``0.64%``). ``None``/NaN/Inf and an exactly-zero
+    prevalence (a degenerate gold with no positive pairs) render as ``"n/a"`` --
+    the report's honest-degradation contract -- never a crash. The Label-structure
+    table keeps full ``%g`` precision (its own ``_fmt_g``); only the hero abridges.
     """
-    if value is None or not math.isfinite(value):
+    if value is None or not math.isfinite(value) or value == 0:
         return "n/a"
-    return f"{value:g}"
+    return f"{value * 100:.2g}%"
 
 
 def _fmt_imbalance(value: float | None) -> str:
@@ -128,13 +131,17 @@ class HeroSection(ProfileSection):
     def panels(self) -> list[str]:
         """A single ``<section>``: a big-number KPI card grid (inline styles only).
 
-        The cards are a flex grid built with inline styles that ride on the shared
-        :mod:`langres.core._report_html` CSS variables (``--line``/``--muted``/
-        ``--fg``), so the hero inherits the report's light/dark palette without a
-        new stylesheet.
+        The cards sit in a CSS grid of ``auto-fill`` tracks
+        (``repeat(auto-fill, minmax(150px, 1fr))``): ``auto-fill`` keeps the empty
+        trailing tracks, so a lone last card stays one cell wide and left-aligned
+        instead of stretching across the row (as ``auto-fit`` or a flex row would).
+        It rides on the shared :mod:`langres.core._report_html` CSS variables
+        (``--line``/``--muted``/``--fg``), inheriting the report's light/dark
+        palette without a new stylesheet, and reflows to fewer columns on narrow
+        widths.
         """
         cards = "".join(
-            f'<div style="flex:1 1 130px;min-width:120px;border:1px solid var(--line);'
+            f'<div style="border:1px solid var(--line);'
             f'border-radius:8px;padding:12px 14px;">'
             f'<div style="font-size:0.78rem;color:var(--muted);">{html.escape(label)}</div>'
             f'<div style="font-size:1.6rem;font-weight:600;font-variant-numeric:tabular-nums;">'
@@ -142,7 +149,11 @@ class HeroSection(ProfileSection):
             f"</div>"
             for label, value in self._cards()
         )
-        grid = f'<div style="display:flex;flex-wrap:wrap;gap:12px;">{cards}</div>'
+        grid = (
+            '<div style="display:grid;'
+            'grid-template-columns:repeat(auto-fill,minmax(150px,1fr));gap:12px;">'
+            f"{cards}</div>"
+        )
         return [_report_html.section(self.title, grid)]
 
 

--- a/src/langres/core/data_profile/hero.py
+++ b/src/langres/core/data_profile/hero.py
@@ -1,0 +1,182 @@
+"""Hero (KPI) profile section: the at-a-glance headline of the whole tearsheet.
+
+The first block a reader sees. It is *derivative* -- it computes nothing from raw
+data; it distils the numbers the other sections already produced into a compact
+row of big-number KPI cards: how many records and clusters, how rare a true match
+is (positive-pair prevalence + the ``1:N`` class-imbalance ratio), and how cleanly
+*some* signal separates matches from non-matches (separability AUC). Those five
+numbers frame every downstream ER decision, so they belong at the top.
+
+Built with :func:`build_hero`, which reads the headline numbers off a
+:class:`~langres.core.data_profile.label_structure.LabelStructureSection` and a
+:class:`~langres.core.data_profile.separability.SeparabilitySection` when present.
+Every KPI is optional: a missing source section leaves that card as an honest
+``"n/a"`` (via :func:`~langres.core._report_html._num`), never a raise -- the same
+graceful-degradation contract the rest of the report keeps.
+"""
+
+from __future__ import annotations
+
+import html
+import math
+from collections.abc import Sequence
+from typing import Any, Literal
+
+from langres.core import _report_html
+from langres.core.data_profile.base import ProfileSection
+from langres.core.data_profile.label_structure import LabelStructureSection
+from langres.core.data_profile.separability import SeparabilitySection
+
+
+def _fmt_count(value: int | None) -> str:
+    """Thousands-separated integer, or ``"n/a"`` when the count is undefined."""
+    if value is None:
+        return "n/a"
+    return f"{value:,}"
+
+
+def _fmt_prevalence(value: float | None) -> str:
+    """A small probability with ``%g`` sig-figs; ``None``/NaN/Inf -> ``"n/a"``.
+
+    Prevalence is often tiny (``3e-04`` under ER imbalance); ``%g`` keeps the
+    significant digits a fixed-decimal format would round to ``0.000``.
+    """
+    if value is None or not math.isfinite(value):
+        return "n/a"
+    return f"{value:g}"
+
+
+def _fmt_imbalance(value: float | None) -> str:
+    """The class-imbalance ratio as ``"1:N"``; ``None``/NaN/Inf -> ``"n/a"``."""
+    if value is None or not math.isfinite(value):
+        return "n/a"
+    return f"1:{value:,.0f}"
+
+
+class HeroSection(ProfileSection):
+    """The KPI-card headline: records, clusters, prevalence, imbalance, AUC.
+
+    A frozen :class:`ProfileSection` holding five optional headline numbers lifted
+    from the other sections. Every field is ``| None`` so a report missing a source
+    section (no gold, no separability signal) still renders a valid hero with
+    ``"n/a"`` cards. Build it with :func:`build_hero`.
+
+    Attributes:
+        n_records: Total records profiled (from the label-structure section).
+        n_clusters: Number of gold clusters (from the label-structure section).
+        prevalence: Positive-pair prevalence -- the share of all candidate pairs
+            that are true matches (from the label-structure section).
+        imbalance_ratio: Negatives per positive, the ``N`` in ``1:N`` (from the
+            label-structure section).
+        separability_auc: How cleanly the (first) separability signal ranks
+            positives above negatives (from the separability section).
+    """
+
+    kind: Literal["hero"] = "hero"
+
+    n_records: int | None
+    n_clusters: int | None
+    prevalence: float | None
+    imbalance_ratio: float | None
+    separability_auc: float | None
+
+    # ------------------------------------------------------------- shared render
+    def _cards(self) -> list[tuple[str, str]]:
+        """The KPI cards as ``(label, display)`` pairs (markdown + HTML share this)."""
+        return [
+            ("records", _fmt_count(self.n_records)),
+            ("clusters", _fmt_count(self.n_clusters)),
+            ("positive-pair prevalence", _fmt_prevalence(self.prevalence)),
+            ("class imbalance (pos:neg)", _fmt_imbalance(self.imbalance_ratio)),
+            ("separability AUC", _report_html._num(self.separability_auc)),
+        ]
+
+    # ------------------------------------------------------------ text surfaces
+    def to_markdown(self) -> str:
+        """Markdown: a compact metric table of the five KPIs."""
+        lines = [f"## {self.title}", "", "| metric | value |", "|---|---|"]
+        lines += [
+            f"| {_report_html._md_cell(label)} | {_report_html._md_cell(value)} |"
+            for label, value in self._cards()
+        ]
+        return "\n".join(lines)
+
+    @property
+    def summary(self) -> dict[str, Any]:
+        """Headline numbers as a flat, title-namespaced dict (log it, assert on it)."""
+        return {
+            f"{self.title}.n_records": self.n_records,
+            f"{self.title}.n_clusters": self.n_clusters,
+            f"{self.title}.prevalence": self.prevalence,
+            f"{self.title}.imbalance_ratio": self.imbalance_ratio,
+            f"{self.title}.separability_auc": self.separability_auc,
+        }
+
+    def rows(self) -> list[dict[str, Any]]:
+        """A single row of the raw KPI values -- ``pd.DataFrame(section.rows())``-ready."""
+        return [
+            {
+                "n_records": self.n_records,
+                "n_clusters": self.n_clusters,
+                "prevalence": self.prevalence,
+                "imbalance_ratio": self.imbalance_ratio,
+                "separability_auc": self.separability_auc,
+            }
+        ]
+
+    # -------------------------------------------------------------- html panel
+    def panels(self) -> list[str]:
+        """A single ``<section>``: a big-number KPI card grid (inline styles only).
+
+        The cards are a flex grid built with inline styles that ride on the shared
+        :mod:`langres.core._report_html` CSS variables (``--line``/``--muted``/
+        ``--fg``), so the hero inherits the report's light/dark palette without a
+        new stylesheet.
+        """
+        cards = "".join(
+            f'<div style="flex:1 1 130px;min-width:120px;border:1px solid var(--line);'
+            f'border-radius:8px;padding:12px 14px;">'
+            f'<div style="font-size:0.78rem;color:var(--muted);">{html.escape(label)}</div>'
+            f'<div style="font-size:1.6rem;font-weight:600;font-variant-numeric:tabular-nums;">'
+            f"{html.escape(value)}</div>"
+            f"</div>"
+            for label, value in self._cards()
+        )
+        grid = f'<div style="display:flex;flex-wrap:wrap;gap:12px;">{cards}</div>'
+        return [_report_html.section(self.title, grid)]
+
+
+def build_hero(
+    sections: Sequence[ProfileSection], *, title: str = "Overview"
+) -> HeroSection | None:
+    """Distil a hero KPI section from already-built profile sections.
+
+    Reads the headline numbers off the first
+    :class:`~langres.core.data_profile.label_structure.LabelStructureSection`
+    (records / clusters / prevalence / imbalance) and the first
+    :class:`~langres.core.data_profile.separability.SeparabilitySection` (AUC) in
+    ``sections``. A KPI whose source section is absent stays ``None`` and renders
+    as ``"n/a"``.
+
+    Args:
+        sections: The other report sections to summarise (any order; unrelated
+            kinds are ignored).
+        title: Section heading; also namespaces this section's :attr:`summary` keys.
+
+    Returns:
+        A :class:`HeroSection`, or ``None`` when *neither* a label-structure nor a
+        separability section is present (there is nothing to headline, so the hero
+        is simply omitted -- graceful degradation).
+    """
+    label = next((s for s in sections if isinstance(s, LabelStructureSection)), None)
+    sep = next((s for s in sections if isinstance(s, SeparabilitySection)), None)
+    if label is None and sep is None:
+        return None
+    return HeroSection(
+        title=title,
+        n_records=label.n_records if label is not None else None,
+        n_clusters=label.n_clusters if label is not None else None,
+        prevalence=label.prevalence if label is not None else None,
+        imbalance_ratio=label.imbalance_ratio if label is not None else None,
+        separability_auc=sep.auc if sep is not None else None,
+    )

--- a/src/langres/core/data_profile/label_structure.py
+++ b/src/langres/core/data_profile/label_structure.py
@@ -1,0 +1,283 @@
+"""Label-structure profile section: what the gold clustering *looks like*.
+
+The first tabular block of the data-profile report. Given a gold clustering (an
+equivalence partition of record ids into match-clusters), it reports the shape
+that governs every downstream ER decision: how many records and clusters, how
+lopsided the cluster sizes are, and -- the number that sets the whole difficulty
+of the task -- the **positive-pair prevalence** / class-imbalance ratio. A
+handful of large clusters vs a long tail of singletons is a very different
+problem from uniform pairs, and this section makes that visible before a single
+matcher runs.
+
+Generic by construction: :func:`profile_label_structure` takes a plain
+``Sequence`` of clusters (each a ``Collection`` of hashable record ids), never a
+benchmark-coupled type -- Wave 2 adapts benchmark gold into this shape. A
+``None`` clustering means "no gold available", and the profiler returns ``None``
+so the section is simply absent from the report (graceful degradation).
+"""
+
+from __future__ import annotations
+
+import html
+import math
+from collections import Counter
+from collections.abc import Collection, Hashable, Sequence
+from typing import Any, Literal
+
+from langres.core import _report_html, _svg
+from langres.core.data_profile.base import ProfileSection
+
+#: Cap on the number of bars in the cluster-size histogram. Sizes at or above the
+#: cap fold into a single overflow bin so a pathological dedup dataset (one
+#: 10k-member cluster) cannot emit 10k bars.
+_MAX_SIZE_BINS = 20
+
+#: Single-series bar color for the cluster-size histogram (explicit, not
+#: ``currentColor``, so it reads in light and dark themes -- matches the
+#: eval_report palette).
+_COLOR_CLUSTERS = "#4361ee"
+
+
+def _shannon_entropy_bits(size_distribution: Sequence[tuple[int, int]], n_records: int) -> float | None:
+    """Shannon entropy (bits) of the cluster-size distribution, with a log(0) guard.
+
+    Treats a record's cluster membership as the random variable: a cluster of
+    size ``s`` carries probability ``p = s / n_records``, and there are ``count``
+    such clusters. Entropy is ``-sum(count * p * log2(p))``.
+
+    The **explicit log(0) guard** is the ``p > 0`` test: a probability of zero
+    (an empty cluster, or the empty-corpus case) contributes ``0`` to the sum by
+    the ``0 * log(0) = 0`` convention, never ``log2(0) = -inf``. A single cluster
+    yields ``p = 1`` and ``log2(1) = 0``, so entropy is exactly ``0.0`` (a fully
+    predictable partition), not a crash.
+
+    Returns:
+        Entropy in bits, or ``None`` when there are no records (undefined).
+    """
+    if n_records <= 0:
+        return None
+    entropy = 0.0
+    for size, count in size_distribution:
+        p = size / n_records
+        # log(0) guard: a zero-probability term (a degenerate empty cluster, or
+        # the empty corpus) contributes 0 by the ``0 * log(0) == 0`` convention,
+        # never ``log2(0) == -inf``.
+        if p > 0.0:
+            entropy -= count * p * math.log2(p)
+    return entropy
+
+
+def _size_histogram(size_distribution: Sequence[tuple[int, int]]) -> tuple[list[float], list[float]]:
+    """Build ``(edges, counts)`` for the cluster-size bar chart from a size map.
+
+    One bar per integer cluster size ``1..max_size``; when ``max_size`` exceeds
+    :data:`_MAX_SIZE_BINS`, sizes at or above the cap fold into a single overflow
+    bar. Returns two empty lists for an empty distribution (the chart then draws
+    bare axes rather than raising).
+    """
+    counts_by_size = dict(size_distribution)
+    if not counts_by_size:
+        return [], []
+    max_size = max(counts_by_size)
+    if max_size <= _MAX_SIZE_BINS:
+        edges = [float(i) for i in range(1, max_size + 2)]
+        counts = [float(counts_by_size.get(i, 0)) for i in range(1, max_size + 1)]
+        return edges, counts
+    # Overflow: bars for sizes 1..cap-1, then one bar for everything >= cap.
+    edges = [float(i) for i in range(1, _MAX_SIZE_BINS + 1)]
+    edges.append(float(max_size + 1))
+    counts = [float(counts_by_size.get(i, 0)) for i in range(1, _MAX_SIZE_BINS)]
+    counts.append(float(sum(c for s, c in counts_by_size.items() if s >= _MAX_SIZE_BINS)))
+    return edges, counts
+
+
+class LabelStructureSection(ProfileSection):
+    """Cluster-shape + class-imbalance metrics of a gold clustering.
+
+    A frozen :class:`ProfileSection` holding the headline label-structure numbers
+    plus the exact cluster-size distribution (so :meth:`rows` and the histogram
+    both derive from one stored field). Build it with
+    :func:`profile_label_structure`.
+
+    Attributes:
+        n_records: Total records covered by the clustering (clustered ids plus any
+            implied singletons declared via ``n_records=``).
+        n_clusters: Number of equivalence classes (implied singletons included).
+        n_singletons: Clusters of size 1.
+        n_multi: Clusters of size >= 2.
+        max_cluster_size: Largest cluster size (``0`` for an empty clustering).
+        mean_cluster_size: ``n_records / n_clusters``; ``None`` when empty.
+        positive_pairs: In-cluster pairs -- ``sum(C(size, 2))`` (the ER positives).
+        total_pairs: All candidate pairs -- ``C(n_records, 2)``.
+        prevalence: ``positive_pairs / total_pairs``; ``None`` when no pairs exist.
+        imbalance_ratio: Negatives per positive (the ``N`` in ``1:N``); ``None``
+            when there are no positive pairs.
+        entropy_bits: Shannon entropy (bits) of the cluster-size distribution;
+            ``None`` when empty.
+        size_distribution: Sorted ``(cluster_size, n_clusters)`` pairs -- the exact
+            distribution the histogram and :meth:`rows` render from.
+    """
+
+    kind: Literal["label_structure"] = "label_structure"
+
+    n_records: int
+    n_clusters: int
+    n_singletons: int
+    n_multi: int
+    max_cluster_size: int
+    mean_cluster_size: float | None
+    positive_pairs: int
+    total_pairs: int
+    prevalence: float | None
+    imbalance_ratio: float | None
+    entropy_bits: float | None
+    size_distribution: list[tuple[int, int]]
+
+    # ------------------------------------------------------------- shared render
+    def _metrics_kv(self) -> list[tuple[str, str]]:
+        """The headline metrics as ``(label, display)`` pairs (markdown + HTML share this)."""
+        imbalance = (
+            f"1:{self.imbalance_ratio:,.0f}" if self.imbalance_ratio is not None else "n/a"
+        )
+        return [
+            ("records", f"{self.n_records:,}"),
+            ("clusters", f"{self.n_clusters:,}"),
+            ("singletons", f"{self.n_singletons:,}"),
+            ("multi-record clusters", f"{self.n_multi:,}"),
+            ("max cluster size", f"{self.max_cluster_size:,}"),
+            ("mean cluster size", _report_html._num(self.mean_cluster_size)),
+            ("positive pairs", f"{self.positive_pairs:,}"),
+            ("total pairs", f"{self.total_pairs:,}"),
+            ("positive-pair prevalence", _fmt_g(self.prevalence)),
+            ("class imbalance (pos:neg)", imbalance),
+            ("cluster-size entropy (bits)", _report_html._num(self.entropy_bits)),
+        ]
+
+    # ------------------------------------------------------------ text surfaces
+    def to_markdown(self) -> str:
+        """Markdown: a metrics table plus the cluster-size distribution table."""
+        lines = [f"## {self.title}", "", "| metric | value |", "|---|---|"]
+        lines += [f"| {_report_html._md_cell(k)} | {_report_html._md_cell(v)} |" for k, v in self._metrics_kv()]
+        lines += ["", "### Cluster-size distribution", "", "| cluster size | clusters |", "|---|---|"]
+        if self.size_distribution:
+            lines += [f"| {size} | {count} |" for size, count in self.size_distribution]
+        else:
+            lines.append("| _(none)_ | 0 |")
+        return "\n".join(lines)
+
+    @property
+    def summary(self) -> dict[str, Any]:
+        """Headline numbers as a flat, title-namespaced dict (collision-free per report)."""
+        return {
+            f"{self.title}.n_records": self.n_records,
+            f"{self.title}.n_clusters": self.n_clusters,
+            f"{self.title}.n_singletons": self.n_singletons,
+            f"{self.title}.prevalence": self.prevalence,
+            f"{self.title}.imbalance_ratio": self.imbalance_ratio,
+            f"{self.title}.entropy_bits": self.entropy_bits,
+        }
+
+    def rows(self) -> list[dict[str, Any]]:
+        """One row per distinct cluster size -- ``pd.DataFrame(section.rows())``-ready."""
+        return [
+            {"cluster_size": size, "n_clusters": count} for size, count in self.size_distribution
+        ]
+
+    # -------------------------------------------------------------- html panel
+    def panels(self) -> list[str]:
+        """A single ``<section>``: the metrics KV table above the size histogram."""
+        kv = "".join(
+            f"<tr><th>{html.escape(k)}</th><td>{html.escape(v)}</td></tr>"
+            for k, v in self._metrics_kv()
+        )
+        edges, counts = _size_histogram(self.size_distribution)
+        chart = _svg.bar_chart(
+            edges,
+            [("clusters", _COLOR_CLUSTERS, counts)],
+            x_label="cluster size",
+            y_label="count",
+        )
+        body = f'<table class="kv">{kv}</table>{chart}'
+        return [_report_html.section(self.title, body)]
+
+
+def profile_label_structure(
+    clusters: Sequence[Collection[Hashable]] | None,
+    *,
+    n_records: int | None = None,
+    title: str = "Label structure",
+) -> LabelStructureSection | None:
+    """Profile a gold clustering into a :class:`LabelStructureSection`.
+
+    Args:
+        clusters: The gold equivalence partition -- a sequence of clusters, each a
+            collection of record ids. ``None`` means no gold is available, and the
+            profiler returns ``None`` (the section is omitted). An empty sequence
+            is a valid, degenerate clustering and renders (all-zero metrics).
+        n_records: Optional total record count. Cross-source ER gold often lists
+            only the matched clusters and omits singletons; passing the true
+            record count folds the ``n_records - clustered`` unmatched records in
+            as size-1 clusters, so prevalence and the imbalance ratio use the
+            honest denominator. Ignored when smaller than the ids already covered
+            by ``clusters`` (the clustering always wins -- we never report fewer
+            records than it contains).
+        title: Section heading; also the key the report looks it up by. Namespaces
+            this section's :attr:`summary` keys, so distinct titles never collide.
+
+    Returns:
+        A :class:`LabelStructureSection`, or ``None`` when ``clusters is None``.
+    """
+    if clusters is None:
+        return None
+
+    sizes = [len(cluster) for cluster in clusters]
+    clustered = sum(sizes)
+    total_records = clustered if n_records is None else max(int(n_records), clustered)
+    extra_singletons = total_records - clustered
+
+    size_counts: Counter[int] = Counter(sizes)
+    if extra_singletons:
+        size_counts[1] += extra_singletons
+
+    n_clusters = sum(size_counts.values())
+    n_singletons = size_counts.get(1, 0)
+    n_multi = sum(count for size, count in size_counts.items() if size >= 2)
+    max_cluster_size = max(size_counts) if size_counts else 0
+    mean_cluster_size = total_records / n_clusters if n_clusters else None
+
+    positive_pairs = sum(math.comb(size, 2) * count for size, count in size_counts.items())
+    total_pairs = math.comb(total_records, 2)
+    prevalence = positive_pairs / total_pairs if total_pairs else None
+    negatives = total_pairs - positive_pairs
+    imbalance_ratio = negatives / positive_pairs if positive_pairs else None
+
+    size_distribution = sorted(size_counts.items())
+    entropy_bits = _shannon_entropy_bits(size_distribution, total_records)
+
+    return LabelStructureSection(
+        title=title,
+        n_records=total_records,
+        n_clusters=n_clusters,
+        n_singletons=n_singletons,
+        n_multi=n_multi,
+        max_cluster_size=max_cluster_size,
+        mean_cluster_size=mean_cluster_size,
+        positive_pairs=positive_pairs,
+        total_pairs=total_pairs,
+        prevalence=prevalence,
+        imbalance_ratio=imbalance_ratio,
+        entropy_bits=entropy_bits,
+        size_distribution=size_distribution,
+    )
+
+
+def _fmt_g(value: float | None) -> str:
+    """Format a small ratio/probability with ``%g`` sig-figs; ``None``/NaN/Inf -> ``"n/a"``.
+
+    Prevalence is often tiny (``3e-04`` under ER imbalance); ``%g`` keeps the
+    significant digits that :func:`_report_html._num`'s fixed 3 decimals would
+    round to ``0.000``.
+    """
+    if value is None or not math.isfinite(value):
+        return "n/a"
+    return f"{value:g}"

--- a/src/langres/core/data_profile/label_structure.py
+++ b/src/langres/core/data_profile/label_structure.py
@@ -38,7 +38,9 @@ _MAX_SIZE_BINS = 20
 _COLOR_CLUSTERS = "#4361ee"
 
 
-def _shannon_entropy_bits(size_distribution: Sequence[tuple[int, int]], n_records: int) -> float | None:
+def _shannon_entropy_bits(
+    size_distribution: Sequence[tuple[int, int]], n_records: int
+) -> float | None:
     """Shannon entropy (bits) of the cluster-size distribution, with a log(0) guard.
 
     Treats a record's cluster membership as the random variable: a cluster of
@@ -67,7 +69,9 @@ def _shannon_entropy_bits(size_distribution: Sequence[tuple[int, int]], n_record
     return entropy
 
 
-def _size_histogram(size_distribution: Sequence[tuple[int, int]]) -> tuple[list[float], list[float]]:
+def _size_histogram(
+    size_distribution: Sequence[tuple[int, int]],
+) -> tuple[list[float], list[float]]:
     """Build ``(edges, counts)`` for the cluster-size bar chart from a size map.
 
     One bar per integer cluster size ``1..max_size``; when ``max_size`` exceeds
@@ -136,9 +140,7 @@ class LabelStructureSection(ProfileSection):
     # ------------------------------------------------------------- shared render
     def _metrics_kv(self) -> list[tuple[str, str]]:
         """The headline metrics as ``(label, display)`` pairs (markdown + HTML share this)."""
-        imbalance = (
-            f"1:{self.imbalance_ratio:,.0f}" if self.imbalance_ratio is not None else "n/a"
-        )
+        imbalance = f"1:{self.imbalance_ratio:,.0f}" if self.imbalance_ratio is not None else "n/a"
         return [
             ("records", f"{self.n_records:,}"),
             ("clusters", f"{self.n_clusters:,}"),
@@ -157,8 +159,17 @@ class LabelStructureSection(ProfileSection):
     def to_markdown(self) -> str:
         """Markdown: a metrics table plus the cluster-size distribution table."""
         lines = [f"## {self.title}", "", "| metric | value |", "|---|---|"]
-        lines += [f"| {_report_html._md_cell(k)} | {_report_html._md_cell(v)} |" for k, v in self._metrics_kv()]
-        lines += ["", "### Cluster-size distribution", "", "| cluster size | clusters |", "|---|---|"]
+        lines += [
+            f"| {_report_html._md_cell(k)} | {_report_html._md_cell(v)} |"
+            for k, v in self._metrics_kv()
+        ]
+        lines += [
+            "",
+            "### Cluster-size distribution",
+            "",
+            "| cluster size | clusters |",
+            "|---|---|",
+        ]
         if self.size_distribution:
             lines += [f"| {size} | {count} |" for size, count in self.size_distribution]
         else:

--- a/src/langres/core/data_profile/separability.py
+++ b/src/langres/core/data_profile/separability.py
@@ -1,0 +1,303 @@
+"""Separability profile section: the chart that justifies the whole tearsheet.
+
+Every ER pipeline lives or dies on one question: does *some* signal separate the
+matching pairs from the non-matching ones? This section answers it directly.
+Given labeled positive and negative pairs and a :data:`SimilaritySignal` that
+scores a pair of record ids, it builds the overlaid similarity histogram of the
+two classes and a **separability AUC** -- the single number saying how cleanly
+the signal ranks positives above negatives.
+
+Two design choices make it honest under real ER class imbalance (positives are
+often 1:1000+ of the negatives):
+
+- the histogram is **density-normalized** (each class scaled to sum 1), so the
+  tiny positive class stays legible instead of being flattened by the negatives;
+- a **capped sample** per class keeps the scan bounded on a huge negative set,
+  and any truncation is logged, never silent.
+
+The A<->B bridge is the :data:`SimilaritySignal` alias: a plain callable over two
+record ids. :func:`string_signal` is the default (rapidfuzz string similarity);
+Unit B supplies a cosine variant of the *same shape*, so the profiler never
+depends on which signal it is handed.
+"""
+
+from __future__ import annotations
+
+import html
+import logging
+import math
+import random
+from collections.abc import Callable, Hashable, Mapping, Sequence
+from types import SimpleNamespace
+from typing import Any, Literal
+
+from pydantic import BaseModel
+
+from langres.core import _report_html, _svg
+from langres.core.comparator import StringComparator
+from langres.core.data_profile.base import ProfileSection
+from langres.core.feature import combine_present
+
+logger = logging.getLogger(__name__)
+
+#: A pair-similarity signal: score two record ids, or ``None`` if unscorable
+#: (an id is absent, or the pair shares no comparable evidence). This is the
+#: A<->B bridge the separability profiler consumes -- :func:`string_signal` is the
+#: default; a cosine-embedding variant of the same shape lives in Unit B.
+SimilaritySignal = Callable[[Hashable, Hashable], float | None]
+
+#: Seed for the deterministic per-class sample when capping (reproducible profiles).
+_SAMPLE_SEED = 0
+
+#: Positive / negative series colors (explicit for light+dark; the eval_report palette).
+_COLOR_POSITIVE = "#2a9d8f"
+_COLOR_NEGATIVE = "#e76f51"
+
+
+class SeparabilitySection(ProfileSection):
+    """Positives-vs-negatives similarity separation for one signal.
+
+    A frozen :class:`ProfileSection` holding the two raw class histograms (density
+    normalization happens at render time) and the separability AUC. Build it with
+    :func:`profile_separability`.
+
+    Attributes:
+        signal_name: Human label of the scoring signal (e.g. ``"string"``).
+        n_positive: Positive pairs that yielded a usable (finite, non-``None``)
+            score.
+        n_negative: Negative pairs that yielded a usable score.
+        auc: Separability AUC (positives labeled ``True``); ``None`` when
+            undefined (a class has no usable scores).
+        hist_edges: Shared bin edges of the two histograms (``B + 1`` values).
+        pos_counts: Raw positive-class counts per bin (``B`` values).
+        neg_counts: Raw negative-class counts per bin.
+        note: An honest one-line hint when the result is degenerate (a class is
+            empty, or AUC is undefined); ``""`` when both classes scored.
+    """
+
+    kind: Literal["separability"] = "separability"
+
+    signal_name: str
+    n_positive: int
+    n_negative: int
+    auc: float | None
+    hist_edges: list[float]
+    pos_counts: list[float]
+    neg_counts: list[float]
+    note: str
+
+    # ------------------------------------------------------------ text surfaces
+    def to_markdown(self) -> str:
+        """Markdown: the AUC + class counts, and the hint when degenerate."""
+        lines = [
+            f"## {self.title}",
+            "",
+            f"- separability AUC: {_report_html._num(self.auc)}",
+            f"- positives scored: {self.n_positive:,}",
+            f"- negatives scored: {self.n_negative:,}",
+        ]
+        if self.note:
+            lines += ["", f"_{_report_html._md_cell(self.note)}_"]
+        return "\n".join(lines)
+
+    @property
+    def summary(self) -> dict[str, Any]:
+        """Headline numbers as a flat, title-namespaced dict."""
+        return {
+            f"{self.title}.auc": self.auc,
+            f"{self.title}.n_positive": self.n_positive,
+            f"{self.title}.n_negative": self.n_negative,
+        }
+
+    def rows(self) -> list[dict[str, Any]]:
+        """One row per histogram bin -- the two class distributions side by side."""
+        rows: list[dict[str, Any]] = []
+        for i in range(len(self.pos_counts)):
+            rows.append(
+                {
+                    "bin_lo": self.hist_edges[i],
+                    "bin_hi": self.hist_edges[i + 1],
+                    "positives": self.pos_counts[i],
+                    "negatives": self.neg_counts[i],
+                }
+            )
+        return rows
+
+    # -------------------------------------------------------------- html panel
+    def panels(self) -> list[str]:
+        """A single ``<section>``: the density-overlaid histogram + AUC line + hint."""
+        chart = _svg.bar_chart(
+            self.hist_edges,
+            [
+                ("positives", _COLOR_POSITIVE, self.pos_counts),
+                ("negatives", _COLOR_NEGATIVE, self.neg_counts),
+            ],
+            x_label=f"{self.signal_name} similarity",
+            y_label="density",
+            normalize="density",
+        )
+        auc_line = f"<p>separability AUC <b>{_report_html._num(self.auc)}</b></p>"
+        note = f'<p class="empty">{html.escape(self.note)}</p>' if self.note else ""
+        return [_report_html.section(self.title, chart + auc_line + note)]
+
+
+def _edges(scores: Sequence[float], n_bins: int) -> list[float]:
+    """``n_bins + 1`` ascending edges spanning the observed score range.
+
+    A degenerate range (all scores equal) is widened to unit width so the bars
+    have real pixel extent rather than collapsing onto one line.
+    """
+    lo, hi = min(scores), max(scores)
+    if hi <= lo:
+        hi = lo + 1.0
+    return [lo + (hi - lo) * i / n_bins for i in range(n_bins + 1)]
+
+
+def _sampled_scores(
+    pairs: Sequence[tuple[Hashable, Hashable]],
+    signal: SimilaritySignal,
+    cap: int | None,
+    label: str,
+) -> list[float]:
+    """Score a (capped) sample of ``pairs``, dropping ``None`` / non-finite results.
+
+    Sampling is a seeded, deterministic draw so a profile is reproducible; any
+    truncation is logged. ``label`` names the class only for that log line.
+    """
+    sample: Sequence[tuple[Hashable, Hashable]] = pairs
+    if cap is not None and len(pairs) > cap:
+        logger.warning(
+            "profile_separability: sampled %d of %d %s pairs (cap=%d)",
+            cap,
+            len(pairs),
+            label,
+            cap,
+        )
+        sample = random.Random(_SAMPLE_SEED).sample(list(pairs), cap)
+    scores: list[float] = []
+    for left, right in sample:
+        value = signal(left, right)
+        if value is not None and math.isfinite(value):
+            scores.append(float(value))
+    return scores
+
+
+def profile_separability(
+    positive_pairs: Sequence[tuple[Hashable, Hashable]],
+    negative_pairs: Sequence[tuple[Hashable, Hashable]],
+    signal: SimilaritySignal,
+    *,
+    name: str,
+    n_bins: int = 20,
+    cap: int | None = None,
+) -> SeparabilitySection | None:
+    """Profile how well ``signal`` separates positive from negative pairs.
+
+    Args:
+        positive_pairs: Matching id-pairs (the positive class).
+        negative_pairs: Non-matching id-pairs (the negative class).
+        signal: The :data:`SimilaritySignal` to score each pair with. ``None`` /
+            non-finite scores are dropped as unscorable.
+        name: Human label of the signal (e.g. ``"string"``), shown on the chart
+            axis and used to build the section title.
+        n_bins: Number of histogram bins over the observed score range.
+        cap: Optional per-class sample cap. When a class has more than ``cap``
+            pairs, a seeded sample of ``cap`` is scored and the truncation is
+            logged (never silent). ``None`` scores every pair.
+
+    Returns:
+        A :class:`SeparabilitySection`, or ``None`` when *no* pair in either class
+        produced a usable score (nothing to plot). A one-sided result (only one
+        class scored) is kept with an honest ``note`` and an ``n/a`` AUC rather
+        than dropped.
+    """
+    pos_scores = _sampled_scores(positive_pairs, signal, cap, "positive")
+    neg_scores = _sampled_scores(negative_pairs, signal, cap, "negative")
+
+    if not pos_scores and not neg_scores:
+        return None
+
+    edges = _edges(pos_scores + neg_scores, n_bins)
+    pos_counts = _report_html._histogram(pos_scores, edges)
+    neg_counts = _report_html._histogram(neg_scores, edges)
+
+    auc = _report_html.safe_auc(
+        [True] * len(pos_scores) + [False] * len(neg_scores),
+        pos_scores + neg_scores,
+    )
+    # safe_auc returns the underlying metric's NaN for a single-class vector;
+    # normalize that to None so no panel/summary ever carries a NaN.
+    if auc is not None and not math.isfinite(auc):
+        auc = None
+
+    note = _degenerate_note(pos_scores, neg_scores)
+
+    return SeparabilitySection(
+        title=f"Separability ({name})",
+        signal_name=name,
+        n_positive=len(pos_scores),
+        n_negative=len(neg_scores),
+        auc=auc,
+        hist_edges=edges,
+        pos_counts=pos_counts,
+        neg_counts=neg_counts,
+        note=note,
+    )
+
+
+def _degenerate_note(pos_scores: Sequence[float], neg_scores: Sequence[float]) -> str:
+    """Honest one-line hint for a one-sided result (``""`` when both classes scored).
+
+    Reached only after the both-empty case has already returned ``None``, so
+    exactly one of these branches fires for a one-sided result; with both classes
+    present the AUC is always defined (never single-class), so no hint is needed.
+    """
+    if not neg_scores:
+        return "No usable negative-pair scores: AUC is undefined; only the positive class is shown."
+    if not pos_scores:
+        return "No usable positive-pair scores: AUC is undefined; only the negative class is shown."
+    return ""
+
+
+def string_signal(
+    records: Mapping[Hashable, Mapping[str, Any]],
+    schema: type[BaseModel],
+) -> SimilaritySignal:
+    """Build the default rapidfuzz string-similarity :data:`SimilaritySignal`.
+
+    Closes over a :class:`~langres.core.comparator.StringComparator` derived from
+    ``schema`` and the :func:`~langres.core.feature.combine_present` evidence
+    floor: the returned callable looks each id up in ``records``, compares the two
+    field dicts feature-by-feature, and combines the present-feature similarities
+    into one score.
+
+    Args:
+        records: ``id -> field mapping`` for every record the pairs reference.
+        schema: The Pydantic entity schema; its ``str | None`` fields become the
+            comparable features (via
+            :meth:`StringComparator.from_schema <langres.core.comparator.StringComparator.from_schema>`).
+
+    Returns:
+        A :data:`SimilaritySignal` returning the combined similarity, or ``None``
+        when either id is absent or the pair shares no comparable (present)
+        feature.
+    """
+    # ``StringComparator[Any]``: ``from_schema``'s TypeVar is unbound at this call
+    # site, and ``compare`` is fed attribute-shim objects (``SimpleNamespace``),
+    # not the schema type -- ``Any`` keeps the missing-aware ``getattr`` path honest
+    # without forcing a concrete model on the shim.
+    comparator: StringComparator[Any] = StringComparator.from_schema(schema)
+    weights = {spec.name: spec.weight for spec in comparator.feature_specs}
+
+    def signal(left_id: Hashable, right_id: Hashable) -> float | None:
+        left = records.get(left_id)
+        right = records.get(right_id)
+        if left is None or right is None:
+            return None
+        vector = comparator.compare(SimpleNamespace(**left), SimpleNamespace(**right))
+        if not vector.similarities:
+            # No feature present on both sides -> the pair is unscorable, not 0.
+            return None
+        return combine_present(vector.similarities, weights)
+
+    return signal

--- a/src/langres/eval.py
+++ b/src/langres/eval.py
@@ -33,7 +33,7 @@ if TYPE_CHECKING:
         evaluate,
         gold_pairs_from_clusters,
     )
-    from langres.core.data_profile import DataProfileReport
+    from langres.core.data_profile import DataProfileReport, from_embedder
     from langres.core.eval_report import EvalReport
     from langres.core.metrics import (
         average_precision_score,
@@ -63,6 +63,7 @@ __all__ = [
     "evaluate",
     "EvalReport",
     "ExternalBenchmarkError",
+    "from_embedder",
     "generalized_merge_distance",
     "get_benchmark",
     "gold_pairs_from_clusters",
@@ -80,6 +81,7 @@ _LAZY: dict[str, str] = {
     "evaluate": "langres.core.benchmark",
     "EvalReport": "langres.core.eval_report",
     "DataProfileReport": "langres.core.data_profile",
+    "from_embedder": "langres.core.data_profile",
     "DEFAULT_PAIR_GRID": "langres.core.benchmark",
     "gold_pairs_from_clusters": "langres.core.benchmark",
     "list_benchmarks": "langres.data.registry",

--- a/src/langres/eval.py
+++ b/src/langres/eval.py
@@ -33,6 +33,7 @@ if TYPE_CHECKING:
         evaluate,
         gold_pairs_from_clusters,
     )
+    from langres.core.data_profile import DataProfileReport
     from langres.core.eval_report import EvalReport
     from langres.core.metrics import (
         average_precision_score,
@@ -57,6 +58,7 @@ __all__ = [
     "calculate_pairwise_metrics",
     "candidates_for",
     "classify_pairs",
+    "DataProfileReport",
     "DEFAULT_PAIR_GRID",
     "evaluate",
     "EvalReport",
@@ -77,6 +79,7 @@ __all__ = [
 _LAZY: dict[str, str] = {
     "evaluate": "langres.core.benchmark",
     "EvalReport": "langres.core.eval_report",
+    "DataProfileReport": "langres.core.data_profile",
     "DEFAULT_PAIR_GRID": "langres.core.benchmark",
     "gold_pairs_from_clusters": "langres.core.benchmark",
     "list_benchmarks": "langres.data.registry",

--- a/tests/core/data_profile/test_accumulators.py
+++ b/tests/core/data_profile/test_accumulators.py
@@ -1,0 +1,181 @@
+"""Tests for the streaming accumulators (``OnlineHistogram`` / ``RunningStats``).
+
+Every claim is checked against a direct ``numpy`` reference over the same finite
+values, so the accumulators are pinned to exact behaviour (not just internal
+consistency). Non-finite handling, under/overflow bins, and mergeability are
+covered explicitly.
+"""
+
+from __future__ import annotations
+
+import math
+
+import numpy as np
+import pytest
+
+from langres.core.data_profile.accumulators import OnlineHistogram, RunningStats
+
+
+class TestOnlineHistogramConstruction:
+    def test_rejects_non_positive_bins(self) -> None:
+        with pytest.raises(ValueError, match="n_bins"):
+            OnlineHistogram(0.0, 1.0, 0)
+
+    def test_rejects_degenerate_range(self) -> None:
+        with pytest.raises(ValueError, match="lo < hi"):
+            OnlineHistogram(1.0, 1.0, 4)
+        with pytest.raises(ValueError, match="lo < hi"):
+            OnlineHistogram(2.0, 1.0, 4)
+
+    def test_rejects_non_finite_bounds(self) -> None:
+        with pytest.raises(ValueError, match="lo < hi"):
+            OnlineHistogram(0.0, float("inf"), 4)
+
+    def test_edges_are_linspace(self) -> None:
+        hist = OnlineHistogram(0.0, 1.0, 4)
+        np.testing.assert_allclose(hist.edges, np.linspace(0.0, 1.0, 5))
+
+    def test_starts_empty(self) -> None:
+        hist = OnlineHistogram(0.0, 1.0, 4)
+        assert hist.counts.tolist() == [0] * 6  # 4 bins + under + over
+        assert hist.bin_counts.tolist() == [0, 0, 0, 0]
+        assert hist.underflow == 0 and hist.overflow == 0
+
+
+class TestOnlineHistogramUpdate:
+    def test_in_range_matches_numpy(self) -> None:
+        values = [0.05, 0.15, 0.25, 0.25, 0.95]
+        hist = OnlineHistogram(0.0, 1.0, 10).update(values)
+        expected, _ = np.histogram(values, bins=hist.edges)
+        assert hist.bin_counts.tolist() == expected.tolist()
+        assert hist.underflow == 0 and hist.overflow == 0
+
+    def test_value_equal_hi_lands_in_last_bin(self) -> None:
+        hist = OnlineHistogram(0.0, 1.0, 4).update([1.0])
+        assert hist.bin_counts.tolist() == [0, 0, 0, 1]
+        assert hist.overflow == 0
+
+    def test_underflow_and_overflow_counted(self) -> None:
+        hist = OnlineHistogram(0.0, 1.0, 4).update([-3.0, -0.1, 0.5, 1.5, 9.0])
+        assert hist.underflow == 2
+        assert hist.overflow == 2
+        assert int(hist.bin_counts.sum()) == 1
+
+    def test_non_finite_dropped(self) -> None:
+        hist = OnlineHistogram(0.0, 1.0, 4).update([0.5, float("nan"), float("inf"), float("-inf")])
+        assert int(hist.counts.sum()) == 1
+
+    def test_accepts_ndarray_and_accumulates_across_batches(self) -> None:
+        hist = OnlineHistogram(0.0, 1.0, 2)
+        hist.update(np.array([0.1, 0.2])).update([0.9])
+        assert hist.bin_counts.tolist() == [2, 1]
+
+    def test_empty_batch_is_noop(self) -> None:
+        hist = OnlineHistogram(0.0, 1.0, 2).update([])
+        assert int(hist.counts.sum()) == 0
+
+    def test_update_returns_self(self) -> None:
+        hist = OnlineHistogram(0.0, 1.0, 2)
+        assert hist.update([0.5]) is hist
+
+    def test_counts_property_is_a_copy(self) -> None:
+        hist = OnlineHistogram(0.0, 1.0, 2).update([0.5])
+        snapshot = hist.counts
+        snapshot[1] = 999
+        assert hist.counts.tolist() != snapshot.tolist()
+
+
+class TestOnlineHistogramMerge:
+    def test_merge_sums_without_mutating_operands(self) -> None:
+        a = OnlineHistogram(0.0, 1.0, 4).update([0.1, 0.9])
+        b = OnlineHistogram(0.0, 1.0, 4).update([0.1, -1.0, 2.0])
+        before_a = a.counts.tolist()
+        before_b = b.counts.tolist()
+        merged = a.merge(b)
+        assert merged.counts.tolist() == (a.counts + b.counts).tolist()
+        # Operands untouched.
+        assert a.counts.tolist() == before_a
+        assert b.counts.tolist() == before_b
+
+    def test_merge_equivalent_to_single_pass(self) -> None:
+        batch1 = [0.1, 0.2, 0.9]
+        batch2 = [0.15, 0.95, 1.0]
+        a = OnlineHistogram(0.0, 1.0, 5).update(batch1)
+        b = OnlineHistogram(0.0, 1.0, 5).update(batch2)
+        single = OnlineHistogram(0.0, 1.0, 5).update(batch1 + batch2)
+        assert a.merge(b).counts.tolist() == single.counts.tolist()
+
+    def test_merge_rejects_mismatched_binning(self) -> None:
+        a = OnlineHistogram(0.0, 1.0, 4)
+        with pytest.raises(ValueError, match="different binning"):
+            a.merge(OnlineHistogram(0.0, 2.0, 4))
+        with pytest.raises(ValueError, match="different binning"):
+            a.merge(OnlineHistogram(0.0, 1.0, 5))
+
+
+class TestRunningStats:
+    def test_empty_is_nan(self) -> None:
+        stats = RunningStats()
+        assert stats.count == 0
+        assert math.isnan(stats.mean)
+        assert math.isnan(stats.variance)
+        assert math.isnan(stats.std)
+
+    def test_matches_numpy_population_moments(self) -> None:
+        values = [1.0, 2.0, 3.0, 4.0, 10.0]
+        stats = RunningStats().update(values)
+        assert stats.count == 5
+        assert stats.mean == pytest.approx(float(np.mean(values)))
+        assert stats.variance == pytest.approx(float(np.var(values)))  # ddof=0
+        assert stats.std == pytest.approx(float(np.std(values)))  # ddof=0
+
+    def test_non_finite_dropped(self) -> None:
+        values = [1.0, float("nan"), 2.0, float("inf"), 3.0]
+        finite = [1.0, 2.0, 3.0]
+        stats = RunningStats().update(values)
+        assert stats.count == 3
+        assert stats.mean == pytest.approx(float(np.mean(finite)))
+        assert stats.std == pytest.approx(float(np.std(finite)))
+
+    def test_accumulates_across_batches(self) -> None:
+        stats = RunningStats().update([1.0, 2.0]).update([3.0, 4.0])
+        assert stats.count == 4
+        assert stats.mean == pytest.approx(2.5)
+
+    def test_update_returns_self(self) -> None:
+        stats = RunningStats()
+        assert stats.update([1.0]) is stats
+
+    def test_empty_batch_is_noop(self) -> None:
+        # An empty (or all-non-finite) batch leaves the accumulator untouched:
+        # exercises the ``if arr.size`` false branch of update().
+        stats = RunningStats().update([]).update([float("nan")])
+        assert stats.count == 0
+        assert math.isnan(stats.mean)
+
+    def test_ndarray_batch(self) -> None:
+        stats = RunningStats().update(np.array([2.0, 4.0, 6.0]))
+        assert stats.mean == pytest.approx(4.0)
+
+    def test_merge_equivalent_to_single_pass(self) -> None:
+        batch1 = [1.0, 2.0, 3.0]
+        batch2 = [10.0, 20.0]
+        a = RunningStats().update(batch1)
+        b = RunningStats().update(batch2)
+        merged = a.merge(b)
+        single = RunningStats().update(batch1 + batch2)
+        assert merged.count == single.count
+        assert merged.mean == pytest.approx(single.mean)
+        assert merged.variance == pytest.approx(single.variance)
+
+    def test_merge_does_not_mutate_operands(self) -> None:
+        a = RunningStats().update([1.0, 2.0])
+        b = RunningStats().update([3.0])
+        a.merge(b)
+        assert a.count == 2 and b.count == 1
+
+    def test_variance_non_negative_on_constant_input(self) -> None:
+        # E[x^2] - E[x]^2 can go slightly negative from float error; must clamp.
+        stats = RunningStats().update([1e8, 1e8, 1e8])
+        assert stats.variance >= 0.0
+        assert stats.variance == pytest.approx(0.0)

--- a/tests/core/data_profile/test_base.py
+++ b/tests/core/data_profile/test_base.py
@@ -1,0 +1,232 @@
+"""Tests for the composable seam: ``ProfileSection`` + ``DataProfileReport``.
+
+Structure-based render asserts (doctype prefix, ``<svg>`` counts, escaping, no
+literal ``NaN``/``Infinity``), plus the container contract (positional build,
+graceful empty render, subset by title, ``SerializeAsAny`` keeping subclass
+fields, thin delegation of the convenience constructors). No concrete profiler
+section exists yet (Wave 2), so a tiny in-test subclass stands in for one.
+"""
+
+from __future__ import annotations
+
+import sys
+import types
+from typing import Any, Literal
+
+import pytest
+
+from langres.core import _report_html, _svg
+from langres.core.data_profile import DataProfileReport, ProfileSection
+
+
+class _FakeSection(ProfileSection):
+    """A minimal concrete section for exercising the container in Wave 0.
+
+    Carries an ``extra`` field the base does not know about, so the
+    ``SerializeAsAny`` round-trip can be observed.
+    """
+
+    kind: Literal["fake"] = "fake"
+    value: float = 0.0
+    extra: str = "subclass-only"
+
+    def to_markdown(self) -> str:
+        return f"## {self.title}\n\nvalue = {self.value:g}"
+
+    @property
+    def summary(self) -> dict[str, Any]:
+        return {f"{self.title}.value": self.value}
+
+    def rows(self) -> list[dict[str, Any]]:
+        return [{"title": self.title, "value": self.value}]
+
+    def panels(self) -> list[str]:
+        chart = _svg.bar_chart([0.0, 1.0], [("v", "#0a0", [self.value])])
+        return [_report_html.section(self.title, chart)]
+
+
+class TestProfileSectionABC:
+    def test_base_is_abstract_cannot_instantiate(self) -> None:
+        with pytest.raises(TypeError):
+            ProfileSection(title="x", kind="base")  # type: ignore[abstract]
+
+    def test_is_frozen(self) -> None:
+        section = _FakeSection(title="s")
+        with pytest.raises(Exception):  # noqa: B017 - pydantic ValidationError on frozen set
+            section.value = 1.0  # type: ignore[misc]
+
+    def test_to_dict_is_model_dump_and_keeps_subclass_fields(self) -> None:
+        section = _FakeSection(title="s", value=0.5)
+        dumped = section.to_dict()
+        assert dumped["title"] == "s"
+        assert dumped["kind"] == "fake"
+        assert dumped["value"] == 0.5
+        assert dumped["extra"] == "subclass-only"
+
+    def test_repr_is_markdown(self) -> None:
+        section = _FakeSection(title="s", value=2.0)
+        assert repr(section) == section.to_markdown()
+        assert repr(section).startswith("## s")
+
+    def test_summary_and_rows(self) -> None:
+        section = _FakeSection(title="s", value=3.0)
+        assert section.summary == {"s.value": 3.0}
+        assert section.rows() == [{"title": "s", "value": 3.0}]
+
+    def test_panels_are_section_html(self) -> None:
+        panels = _FakeSection(title="s", value=1.0).panels()
+        assert len(panels) == 1
+        assert panels[0].startswith("<section><h2>s</h2>")
+        assert "<svg" in panels[0]
+
+
+class TestContainerConstruction:
+    def test_positional_list_of_sections(self) -> None:
+        report = DataProfileReport([_FakeSection(title="a"), _FakeSection(title="b")])
+        assert len(report.sections) == 2
+
+    def test_keyword_sections_still_work(self) -> None:
+        report = DataProfileReport(sections=[_FakeSection(title="a")])
+        assert len(report.sections) == 1
+
+    def test_empty_report_is_valid(self) -> None:
+        report = DataProfileReport([])
+        assert report.sections == []
+
+    def test_no_args_raises_validation_error(self) -> None:
+        # ``sections`` is required (pass ``[]`` for an empty report): omitting it
+        # entirely leaves the field unset -> pydantic validation error. Exercises
+        # the ``sections is None`` branch of the positional-friendly __init__.
+        from pydantic import ValidationError
+
+        with pytest.raises(ValidationError):
+            DataProfileReport()
+
+    def test_is_frozen(self) -> None:
+        report = DataProfileReport([])
+        with pytest.raises(Exception):  # noqa: B017 - frozen model
+            report.sections = [_FakeSection(title="a")]  # type: ignore[misc]
+
+
+class TestContainerTextSurfaces:
+    def test_to_markdown_concatenates_sections_under_heading(self) -> None:
+        report = DataProfileReport([_FakeSection(title="a", value=1.0), _FakeSection(title="b")])
+        md = report.to_markdown()
+        assert md.startswith("# Data profile")
+        assert "## a" in md
+        assert "## b" in md
+        assert "NaN" not in md
+
+    def test_to_markdown_empty_report(self) -> None:
+        md = DataProfileReport([]).to_markdown()
+        assert md.startswith("# Data profile")
+        assert "_No sections._" in md
+
+    def test_repr_is_markdown(self) -> None:
+        report = DataProfileReport([_FakeSection(title="a")])
+        assert repr(report) == report.to_markdown()
+
+    def test_summary_flattens_section_summaries(self) -> None:
+        report = DataProfileReport(
+            [_FakeSection(title="a", value=1.0), _FakeSection(title="b", value=2.0)]
+        )
+        assert report.summary == {"a.value": 1.0, "b.value": 2.0}
+
+    def test_summary_empty_report(self) -> None:
+        assert DataProfileReport([]).summary == {}
+
+    def test_getitem_pulls_section_by_title(self) -> None:
+        wanted = _FakeSection(title="b", value=9.0)
+        report = DataProfileReport([_FakeSection(title="a"), wanted])
+        assert report["b"] is wanted
+
+    def test_getitem_missing_raises_keyerror(self) -> None:
+        report = DataProfileReport([_FakeSection(title="a")])
+        with pytest.raises(KeyError):
+            report["nope"]
+
+
+class TestContainerToDict:
+    def test_model_dump_keeps_subclass_only_fields(self) -> None:
+        # SerializeAsAny: the container declares list[ProfileSection], but the
+        # dump must retain each concrete subclass's own fields (value/extra),
+        # not narrow to the base.
+        report = DataProfileReport([_FakeSection(title="a", value=0.7)])
+        dumped = report.to_dict()
+        section = dumped["sections"][0]
+        assert section["value"] == 0.7
+        assert section["extra"] == "subclass-only"
+        assert section["kind"] == "fake"
+
+    def test_to_dict_is_model_dump(self) -> None:
+        report = DataProfileReport([_FakeSection(title="a")])
+        assert report.to_dict() == report.model_dump()
+
+
+class TestContainerHtml:
+    def test_empty_report_renders_valid_doctype(self) -> None:
+        out = DataProfileReport([]).to_html()
+        assert out.startswith("<!doctype html>")
+        assert out.rstrip().endswith("</html>")
+        assert out.count("<svg") == 0
+
+    def test_renders_one_svg_per_section_panel(self) -> None:
+        report = DataProfileReport([_FakeSection(title="a"), _FakeSection(title="b")])
+        out = report.to_html()
+        assert out.startswith("<!doctype html>")
+        assert out.count("<svg") == 2
+        assert out.count("<section") == 2
+        assert "NaN" not in out and "Infinity" not in out
+
+    def test_custom_title_is_escaped(self) -> None:
+        out = DataProfileReport([]).to_html(title="a & <b>")
+        assert "a &amp; &lt;b&gt;" in out
+        assert "<title>a &amp; &lt;b&gt;</title>" in out
+
+    def test_section_title_escaped_in_panel(self) -> None:
+        out = DataProfileReport([_FakeSection(title="x & <y>")]).to_html()
+        assert "x &amp; &lt;y&gt;" in out
+        assert "<y>" not in out
+
+
+class TestConvenienceConstructorsDelegate:
+    """``from_benchmark`` / ``from_records`` are thin delegators to Wave 2 ``builders``.
+
+    ``builders`` does not exist yet, so a fake module is injected to observe the
+    delegation without pinning the (Wave 2) signature.
+    """
+
+    def _install_fake_builders(
+        self, monkeypatch: pytest.MonkeyPatch, sentinel: DataProfileReport
+    ) -> dict[str, Any]:
+        calls: dict[str, Any] = {}
+        fake = types.ModuleType("langres.core.data_profile.builders")
+
+        def _from_benchmark(*args: Any, **kwargs: Any) -> DataProfileReport:
+            calls["benchmark"] = (args, kwargs)
+            return sentinel
+
+        def _from_records(*args: Any, **kwargs: Any) -> DataProfileReport:
+            calls["records"] = (args, kwargs)
+            return sentinel
+
+        fake.from_benchmark = _from_benchmark  # type: ignore[attr-defined]
+        fake.from_records = _from_records  # type: ignore[attr-defined]
+        # The delegators resolve builders dynamically (importlib.import_module),
+        # which consults sys.modules first -- so injecting the fake here is enough.
+        monkeypatch.setitem(sys.modules, "langres.core.data_profile.builders", fake)
+        return calls
+
+    def test_from_benchmark_delegates(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        sentinel = DataProfileReport([])
+        calls = self._install_fake_builders(monkeypatch, sentinel)
+        result = DataProfileReport.from_benchmark("bench", include={"labels"})
+        assert result is sentinel
+        assert calls["benchmark"] == (("bench",), {"include": {"labels"}})
+
+    def test_from_records_delegates(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        sentinel = DataProfileReport([])
+        calls = self._install_fake_builders(monkeypatch, sentinel)
+        result = DataProfileReport.from_records([{"id": "1"}], gold_pairs=None)
+        assert result is sentinel
+        assert calls["records"] == (([{"id": "1"}],), {"gold_pairs": None})

--- a/tests/core/data_profile/test_builders.py
+++ b/tests/core/data_profile/test_builders.py
@@ -9,6 +9,7 @@ sampling / helper functions.
 
 from __future__ import annotations
 
+import logging
 import sys
 import types
 from collections.abc import Hashable
@@ -22,6 +23,8 @@ from langres.core.data_profile import ArraySource, NpySource
 from langres.core.data_profile.builders import (
     _build_separability,
     _embed_text,
+    _index_by_id,
+    _member_cluster_index,
     _positive_pairs,
     _sample_negative_pairs,
     _validate_include,
@@ -183,26 +186,59 @@ class TestInternalHelpers:
         pairs = {frozenset(pair) for pair in _positive_pairs([{"1", "2", "3"}, {"4"}])}
         assert pairs == {frozenset({"1", "2"}), frozenset({"1", "3"}), frozenset({"2", "3"})}
 
-    def test_sample_negatives_excludes_positives_and_repeats(self) -> None:
-        positives = {frozenset({"1", "2"})}
-        negatives = _sample_negative_pairs(["1", "2", "3", "4"], positives, cap=100, seed=0)
+    def test_positive_pairs_bounded_and_logs_on_huge_cluster(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        # A 500-member gold cluster already yields 124,750 within-cluster pairs; a
+        # 5000-member bad-merge "default entity" would materialise ~12.5M. The
+        # generator must reservoir-sample that down to `cap` (O(cap) memory), not
+        # enumerate the whole O(size**2) set into a list.
+        big = {str(i) for i in range(500)}
+        with caplog.at_level(logging.WARNING):
+            pairs = _positive_pairs([big], cap=200, seed=0)
+        assert len(pairs) == 200  # bounded to cap, not 124,750
+        assert all(a != b and a in big and b in big for a, b in pairs)
+        assert "positive pairs" in caplog.text  # truncation logged (never silent)
+
+    def test_positive_pairs_small_cluster_is_full_set_no_log(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        with caplog.at_level(logging.WARNING):
+            pairs = _positive_pairs([{"1", "2", "3"}, {"4"}], cap=1000, seed=0)
+        # Under the cap: the exact same full within-cluster pair set as an un-capped
+        # enumeration -- the cap only bites on pathologically large clusters.
+        assert {frozenset(p) for p in pairs} == {
+            frozenset({"1", "2"}),
+            frozenset({"1", "3"}),
+            frozenset({"2", "3"}),
+        }
+        assert "positive pairs" not in caplog.text  # no truncation, no log
+
+    def test_member_cluster_index_maps_ids_to_their_cluster(self) -> None:
+        index = _member_cluster_index([{"a", "b"}, {"c"}])
+        assert index["a"] == index["b"]  # same cluster
+        assert index["c"] != index["a"]  # different cluster
+
+    def test_sample_negatives_excludes_same_cluster_and_repeats(self) -> None:
+        member_cluster = {"1": 0, "2": 0}  # 1 and 2 share a gold cluster (a positive)
+        negatives = _sample_negative_pairs(["1", "2", "3", "4"], member_cluster, cap=100, seed=0)
         keys = [frozenset(pair) for pair in negatives]
-        assert frozenset({"1", "2"}) not in keys  # positive excluded
+        assert frozenset({"1", "2"}) not in keys  # same-cluster positive excluded
         assert len(keys) == len(set(keys))  # no repeats
         assert all(len(k) == 2 for k in keys)  # no self-pairs
 
     def test_sample_negatives_respects_cap(self) -> None:
-        negatives = _sample_negative_pairs(list("abcdefgh"), set(), cap=3, seed=0)
+        negatives = _sample_negative_pairs(list("abcdefgh"), {}, cap=3, seed=0)
         assert len(negatives) <= 3
 
     def test_sample_negatives_degenerate_inputs(self) -> None:
-        assert _sample_negative_pairs(["only"], set(), cap=10, seed=0) == []
-        assert _sample_negative_pairs(["a", "b"], set(), cap=0, seed=0) == []
+        assert _sample_negative_pairs(["only"], {}, cap=10, seed=0) == []
+        assert _sample_negative_pairs(["a", "b"], {}, cap=0, seed=0) == []
 
     def test_sample_negatives_is_deterministic(self) -> None:
         ids: list[Hashable] = list("abcdef")
-        first = _sample_negative_pairs(ids, set(), cap=4, seed=7)
-        second = _sample_negative_pairs(ids, set(), cap=4, seed=7)
+        first = _sample_negative_pairs(ids, {}, cap=4, seed=7)
+        second = _sample_negative_pairs(ids, {}, cap=4, seed=7)
         assert first == second
 
     def test_embed_text_joins_string_fields_except_id(self) -> None:
@@ -220,6 +256,30 @@ class TestInternalHelpers:
         _validate_include({"hero", "embedding"})  # no raise
         with pytest.raises(ValueError, match=r"unknown section kind\(s\) \['nope'\]"):
             _validate_include({"nope"})
+
+
+class TestIndexById:
+    def test_first_wins_and_logs_duplicate_count(self, caplog: pytest.LogCaptureFixture) -> None:
+        records = [
+            {"id": "1", "name": "first"},
+            {"id": "1", "name": "second"},  # duplicate id -> dropped (first-wins)
+            {"id": "2", "name": "other"},
+        ]
+        with caplog.at_level(logging.WARNING):
+            id_map = _index_by_id(records, "id")
+        assert id_map["1"]["name"] == "first"  # first-wins, not last ("second")
+        assert list(id_map) == ["1", "2"]
+        assert "dropped 1 duplicate" in caplog.text  # the count is surfaced
+
+    def test_no_duplicates_is_silent(self, caplog: pytest.LogCaptureFixture) -> None:
+        with caplog.at_level(logging.WARNING):
+            id_map = _index_by_id([{"id": "1"}, {"id": "2"}], "id")
+        assert list(id_map) == ["1", "2"]
+        assert caplog.text == ""  # no duplicates -> no warning
+
+    def test_skips_records_missing_id_key(self) -> None:
+        id_map = _index_by_id([{"id": "1"}, {"name": "no-id"}], "id")
+        assert list(id_map) == ["1"]  # the id-less record is skipped, not raised
 
 
 class TestBuildSeparabilityBranches:

--- a/tests/core/data_profile/test_builders.py
+++ b/tests/core/data_profile/test_builders.py
@@ -59,8 +59,10 @@ class _FakeBenchmark:
         self,
     ) -> tuple[list[CompanySchema], list[set[str]], set[frozenset[str]]]:
         corpus = [CompanySchema(**record) for record in _RECORDS]
-        return corpus, [set(cluster) for cluster in _CLUSTERS], gold_pairs_from_clusters(
-            [set(cluster) for cluster in _CLUSTERS]
+        return (
+            corpus,
+            [set(cluster) for cluster in _CLUSTERS],
+            gold_pairs_from_clusters([set(cluster) for cluster in _CLUSTERS]),
         )
 
 
@@ -204,7 +206,9 @@ class TestInternalHelpers:
         assert first == second
 
     def test_embed_text_joins_string_fields_except_id(self) -> None:
-        text = _embed_text({"id": "1", "name": "Acme", "n": 3, "note": "  "}, id_key="id", text_key=None)
+        text = _embed_text(
+            {"id": "1", "name": "Acme", "n": 3, "note": "  "}, id_key="id", text_key=None
+        )
         assert text == "Acme"  # id skipped, non-str skipped, blank skipped
 
     def test_embed_text_uses_explicit_key(self) -> None:

--- a/tests/core/data_profile/test_builders.py
+++ b/tests/core/data_profile/test_builders.py
@@ -1,0 +1,321 @@
+"""Tests for the Wave 2 convenience builders (``from_benchmark`` / ``from_records``).
+
+Covers the happy paths (default pinned section set), the ``include=`` kind
+selector (unknown key -> ``ValueError``), graceful degradation (no gold / no
+schema / no embeddings / empty -> the section is simply absent, never a raise),
+embedding wiring (single source + a >=2-source comparison), and the internal
+sampling / helper functions.
+"""
+
+from __future__ import annotations
+
+import sys
+import types
+from collections.abc import Hashable
+
+import numpy as np
+import pytest
+
+import langres.data.registry as registry
+from langres.core.benchmark import gold_pairs_from_clusters
+from langres.core.data_profile import ArraySource, NpySource
+from langres.core.data_profile.builders import (
+    _build_separability,
+    _embed_text,
+    _positive_pairs,
+    _sample_negative_pairs,
+    _validate_include,
+    from_benchmark,
+    from_embedder,
+    from_records,
+)
+from langres.core.models import CompanySchema
+
+# Shared toy corpus + gold used across the builder tests.
+_RECORDS = [
+    {"id": "1", "name": "Acme Corporation"},
+    {"id": "2", "name": "Acme Corp"},
+    {"id": "3", "name": "Globex Inc"},
+    {"id": "4", "name": "Globex Incorporated"},
+    {"id": "5", "name": "Initech"},
+]
+_CLUSTERS = [{"1", "2"}, {"3", "4"}, {"5"}]
+_IDS = [record["id"] for record in _RECORDS]
+
+
+def _matrix(dim: int, seed: int) -> np.ndarray:
+    """A row-per-id matrix with deliberately varying norms (non-degenerate)."""
+    rng = np.random.default_rng(seed)
+    return np.asarray([rng.normal(size=dim) * (1.0 + i) for i in range(len(_IDS))])
+
+
+class _FakeBenchmark:
+    """A minimal core-only ``Benchmark`` stand-in (no [semantic], no registry)."""
+
+    name = "fake"
+    schema = CompanySchema
+
+    def load(
+        self,
+    ) -> tuple[list[CompanySchema], list[set[str]], set[frozenset[str]]]:
+        corpus = [CompanySchema(**record) for record in _RECORDS]
+        return corpus, [set(cluster) for cluster in _CLUSTERS], gold_pairs_from_clusters(
+            [set(cluster) for cluster in _CLUSTERS]
+        )
+
+
+class TestFromBenchmark:
+    def test_object_builds_default_section_set(self) -> None:
+        report = from_benchmark(_FakeBenchmark())
+        assert [section.kind for section in report.sections] == [
+            "hero",
+            "label_structure",
+            "separability",
+            "corpus_field",
+        ]
+        # The hero distilled the label-structure headline numbers.
+        hero = report.sections[0]
+        assert hero.summary["Overview.n_records"] == 5  # type: ignore[index]
+
+    def test_name_resolves_via_registry(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        calls: list[str] = []
+
+        def _fake_get(name: str) -> _FakeBenchmark:
+            calls.append(name)
+            return _FakeBenchmark()
+
+        # from_benchmark does a LOCAL `from langres.data.registry import get_benchmark`,
+        # so patching the attribute on the module is picked up at call time.
+        monkeypatch.setattr(registry, "get_benchmark", _fake_get)
+        report = from_benchmark("abt_buy")
+        assert calls == ["abt_buy"]
+        assert report.sections[0].kind == "hero"
+
+    def test_include_narrows_sections(self) -> None:
+        report = from_benchmark(_FakeBenchmark(), include={"hero", "corpus_field"})
+        assert [section.kind for section in report.sections] == ["hero", "corpus_field"]
+
+
+class TestFromRecords:
+    def test_happy_path_default_sections(self) -> None:
+        report = from_records(_RECORDS, gold=_CLUSTERS, schema=CompanySchema)
+        assert [section.kind for section in report.sections] == [
+            "hero",
+            "label_structure",
+            "separability",
+            "corpus_field",
+        ]
+
+    def test_no_gold_drops_label_and_separability_and_hero(self) -> None:
+        report = from_records(_RECORDS)  # no gold, no schema, no embeddings
+        assert [section.kind for section in report.sections] == ["corpus_field"]
+
+    def test_gold_without_schema_keeps_label_no_separability(self) -> None:
+        report = from_records(_RECORDS, gold=_CLUSTERS)  # gold but no signal
+        assert [section.kind for section in report.sections] == [
+            "hero",
+            "label_structure",
+            "corpus_field",
+        ]
+
+    def test_empty_records_yields_empty_report_no_raise(self) -> None:
+        report = from_records([])
+        assert report.sections == []
+
+    def test_include_unknown_kind_raises(self) -> None:
+        with pytest.raises(ValueError, match="unknown section kind"):
+            from_records(_RECORDS, gold=_CLUSTERS, schema=CompanySchema, include={"labels"})
+
+    def test_include_selects_by_kind(self) -> None:
+        report = from_records(
+            _RECORDS, gold=_CLUSTERS, schema=CompanySchema, include={"corpus_field"}
+        )
+        assert [section.kind for section in report.sections] == ["corpus_field"]
+
+
+class TestEmbeddingWiring:
+    def test_single_source_adds_embedding_and_cosine_separability(self) -> None:
+        src = ArraySource("m1", _IDS, _matrix(dim=8, seed=1))
+        report = from_records(_RECORDS, gold=_CLUSTERS, schema=CompanySchema, embeddings=[src])
+        assert [section.kind for section in report.sections] == [
+            "hero",
+            "label_structure",
+            "separability",  # string
+            "separability",  # cosine · m1
+            "corpus_field",
+            "embedding",
+        ]
+        titles = [section.title for section in report.sections]
+        assert "Separability (string)" in titles
+        assert "Separability (cosine · m1)" in titles
+
+    def test_two_sources_add_comparison(self) -> None:
+        src_a = ArraySource("m1", _IDS, _matrix(dim=8, seed=1))
+        src_b = ArraySource("m2", _IDS, _matrix(dim=16, seed=2))
+        report = from_records(
+            _RECORDS, gold=_CLUSTERS, schema=CompanySchema, embeddings=[src_a, src_b]
+        )
+        assert [section.kind for section in report.sections] == [
+            "hero",
+            "label_structure",
+            "separability",  # string
+            "separability",  # cosine · m1
+            "separability",  # cosine · m2
+            "corpus_field",
+            "embedding",
+            "embedding",
+            "embedding_comparison",
+        ]
+
+    def test_embeddings_without_schema_still_add_cosine_separability(self) -> None:
+        src = ArraySource("m1", _IDS, _matrix(dim=8, seed=1))
+        report = from_records(_RECORDS, gold=_CLUSTERS, embeddings=[src])
+        kinds = [section.kind for section in report.sections]
+        # No schema -> no string separability, but the cosine one still lands.
+        assert kinds.count("separability") == 1
+        assert "Separability (cosine · m1)" in [s.title for s in report.sections]
+
+
+class TestInternalHelpers:
+    def test_positive_pairs_are_within_cluster_only(self) -> None:
+        pairs = {frozenset(pair) for pair in _positive_pairs([{"1", "2", "3"}, {"4"}])}
+        assert pairs == {frozenset({"1", "2"}), frozenset({"1", "3"}), frozenset({"2", "3"})}
+
+    def test_sample_negatives_excludes_positives_and_repeats(self) -> None:
+        positives = {frozenset({"1", "2"})}
+        negatives = _sample_negative_pairs(["1", "2", "3", "4"], positives, cap=100, seed=0)
+        keys = [frozenset(pair) for pair in negatives]
+        assert frozenset({"1", "2"}) not in keys  # positive excluded
+        assert len(keys) == len(set(keys))  # no repeats
+        assert all(len(k) == 2 for k in keys)  # no self-pairs
+
+    def test_sample_negatives_respects_cap(self) -> None:
+        negatives = _sample_negative_pairs(list("abcdefgh"), set(), cap=3, seed=0)
+        assert len(negatives) <= 3
+
+    def test_sample_negatives_degenerate_inputs(self) -> None:
+        assert _sample_negative_pairs(["only"], set(), cap=10, seed=0) == []
+        assert _sample_negative_pairs(["a", "b"], set(), cap=0, seed=0) == []
+
+    def test_sample_negatives_is_deterministic(self) -> None:
+        ids: list[Hashable] = list("abcdef")
+        first = _sample_negative_pairs(ids, set(), cap=4, seed=7)
+        second = _sample_negative_pairs(ids, set(), cap=4, seed=7)
+        assert first == second
+
+    def test_embed_text_joins_string_fields_except_id(self) -> None:
+        text = _embed_text({"id": "1", "name": "Acme", "n": 3, "note": "  "}, id_key="id", text_key=None)
+        assert text == "Acme"  # id skipped, non-str skipped, blank skipped
+
+    def test_embed_text_uses_explicit_key(self) -> None:
+        text = _embed_text({"id": "1", "blob": "hello"}, id_key="id", text_key="blob")
+        assert text == "hello"
+        assert _embed_text({"id": "1"}, id_key="id", text_key="blob") == ""
+
+    def test_validate_include_accepts_known_and_rejects_unknown(self) -> None:
+        _validate_include({"hero", "embedding"})  # no raise
+        with pytest.raises(ValueError, match=r"unknown section kind\(s\) \['nope'\]"):
+            _validate_include({"nope"})
+
+
+class TestBuildSeparabilityBranches:
+    """Direct tests for the separability assembler's degenerate branches."""
+
+    def test_singleton_gold_yields_no_separability(self) -> None:
+        # No within-cluster pairs and (with one id) no negatives -> [] (no raise).
+        sections = _build_separability(
+            id_map={"1": {"id": "1", "name": "Acme"}},
+            schema=None,
+            clusters=[{"1"}],
+            sources=[],
+            negatives_cap=10,
+            seed=0,
+        )
+        assert sections == []
+
+    def test_string_signal_unscorable_drops_the_section(self) -> None:
+        # Records carry no comparable schema field -> string_signal returns None
+        # for every pair -> profile_separability returns None -> section skipped.
+        sections = _build_separability(
+            id_map={"1": {"id": "1"}, "2": {"id": "2"}},
+            schema=CompanySchema,
+            clusters=[{"1", "2"}],
+            sources=[],
+            negatives_cap=10,
+            seed=0,
+        )
+        assert sections == []
+
+    def test_cosine_signal_total_miss_drops_the_section(self) -> None:
+        # Source ids don't overlap the corpus -> cosine returns None for all pairs
+        # -> the cosine separability section is dropped (not raised).
+        mismatched = ArraySource("m", ["x", "y"], np.array([[1.0, 0.0], [0.0, 1.0]]))
+        sections = _build_separability(
+            id_map={"1": {"id": "1"}, "2": {"id": "2"}},
+            schema=None,
+            clusters=[{"1", "2"}],
+            sources=[mismatched],
+            negatives_cap=10,
+            seed=0,
+        )
+        assert sections == []
+
+
+class _FakeSentenceTransformer:
+    """A stand-in encoder: deterministic vectors, no torch/sentence-transformers."""
+
+    def __init__(self, model: str) -> None:
+        self.model = model
+
+    def encode(
+        self,
+        texts: list[str],
+        *,
+        batch_size: int,
+        normalize_embeddings: bool,
+        convert_to_numpy: bool,
+    ) -> np.ndarray:
+        base = np.arange(len(texts) * 3, dtype=float).reshape(len(texts), 3) + 1.0
+        if normalize_embeddings:
+            base /= np.linalg.norm(base, axis=1, keepdims=True)
+        return base
+
+
+class TestFromEmbedder:
+    def _install_fake_st(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        fake_mod = types.ModuleType("sentence_transformers")
+        fake_mod.SentenceTransformer = _FakeSentenceTransformer  # type: ignore[attr-defined]
+        monkeypatch.setitem(sys.modules, "sentence_transformers", fake_mod)
+
+    def test_embeds_and_persists_npy_source(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path
+    ) -> None:
+        self._install_fake_st(monkeypatch)
+        out = tmp_path / "vecs"  # no .npy suffix -> exercises the suffix-enforce branch
+        src = from_embedder(
+            [{"id": "1", "name": "Acme"}, {"id": "2", "name": "Globex"}],
+            "fake-model",
+            out_path=out,
+        )
+        assert isinstance(src, NpySource)
+        assert src.name == "fake-model"
+        assert src.dim == 3
+        assert (tmp_path / "vecs.npy").exists()
+        assert (tmp_path / "vecs.ids.json").exists()
+        # Rows are aligned to the record ids.
+        assert src.vectors_for(["2"]).shape == (1, 3)
+
+    def test_normalize_marks_cosine_and_keeps_npy_suffix(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path
+    ) -> None:
+        self._install_fake_st(monkeypatch)
+        out = tmp_path / "vecs.npy"  # already .npy -> the suffix branch is skipped
+        src = from_embedder(
+            [{"id": "1", "name": "Acme"}],
+            "fake-model",
+            out_path=out,
+            normalize=True,
+        )
+        assert src.pre_normalized is True
+        assert src.metric == "cosine"
+        assert (tmp_path / "vecs.npy").exists()

--- a/tests/core/data_profile/test_corpus_field.py
+++ b/tests/core/data_profile/test_corpus_field.py
@@ -1,0 +1,214 @@
+"""Tests for the corpus-field profile section.
+
+Behavior + edges: no records -> absent section, per-field completeness /
+cardinality / length, the most-missing-first ordering, all-null fields
+flagged-not-dropped, non-string presence, the top-N truncation (logged, never
+silent), the length sparkline (including degenerate + all-null), and the render
+invariants (no ``NaN``/``Infinity`` in HTML, Markdown/HTML escaping of field
+names).
+"""
+
+from __future__ import annotations
+
+import logging
+
+import pytest
+
+from langres.core.data_profile import ProfileSection
+from langres.core.data_profile.corpus_field import (
+    CorpusFieldSection,
+    FieldStat,
+    profile_corpus_fields,
+)
+
+
+def _fields_by_name(section: CorpusFieldSection) -> dict[str, FieldStat]:
+    return {f.name: f for f in section.fields}
+
+
+class TestGracefulDegradation:
+    def test_none_records_returns_none(self) -> None:
+        assert profile_corpus_fields(None) is None
+
+    def test_empty_records_returns_none(self) -> None:
+        assert profile_corpus_fields([]) is None
+
+    def test_records_with_no_fields_render_empty_table(self) -> None:
+        # Non-empty records but zero field keys: the section renders an empty
+        # table rather than raising or returning None.
+        section = profile_corpus_fields([{}, {}])
+        assert section is not None
+        assert section.n_records == 2
+        assert section.n_fields_total == 0
+        assert section.fields == []
+        assert "no fields" in section.to_markdown()
+        html = "".join(section.panels())
+        assert "<table" in html
+        assert "NaN" not in html and "Infinity" not in html
+
+
+class TestFieldMetrics:
+    def _section(self) -> CorpusFieldSection:
+        records = [
+            {"id": "1", "name": "Acme Corp", "city": "NYC", "note": None},
+            {"id": "2", "name": "acme corporation", "city": "", "note": None},
+            {"id": "3", "name": "Beta LLC", "note": None},  # missing 'city' key
+        ]
+        section = profile_corpus_fields(records)
+        assert section is not None
+        return section
+
+    def test_non_null_rate(self) -> None:
+        fields = _fields_by_name(self._section())
+        assert fields["id"].non_null_rate == 1.0
+        assert fields["name"].non_null_rate == 1.0
+        # 'city' present only in record 1 (record 2 is "", record 3 missing key).
+        assert fields["city"].non_null_rate == 1 / 3
+        assert fields["note"].non_null_rate == 0.0
+
+    def test_cardinality(self) -> None:
+        fields = _fields_by_name(self._section())
+        assert fields["name"].n_distinct == 3
+        assert fields["name"].uniqueness == 1.0
+        assert fields["city"].n_distinct == 1
+
+    def test_value_lengths(self) -> None:
+        fields = _fields_by_name(self._section())
+        # names: len("Acme Corp")=9, len("acme corporation")=16, len("Beta LLC")=8.
+        assert fields["name"].mean_len == pytest.approx((9 + 16 + 8) / 3)
+        assert fields["name"].median_len == 9.0
+
+    def test_most_missing_first_ordering(self) -> None:
+        # note (0.0) < city (0.33) < id/name (1.0); id before name on the name
+        # tie-break -> deterministic order.
+        section = self._section()
+        assert [f.name for f in section.fields] == ["note", "city", "id", "name"]
+
+    def test_all_null_field_flagged_not_dropped(self) -> None:
+        fields = _fields_by_name(self._section())
+        note = fields["note"]
+        assert note.all_null is True
+        assert note.n_present == 0
+        assert note.uniqueness is None
+        assert note.mean_len is None
+        assert note.median_len is None
+        assert note.len_hist == []
+        # Flagged in both render surfaces, not dropped.
+        assert "all-null" in self._section().to_markdown()
+        assert "all-null" in "".join(self._section().panels())
+
+    def test_non_string_values_are_present(self) -> None:
+        # ints / bools are populated values (not null); length is their str form.
+        records = [{"count": 10, "ok": True}, {"count": 200, "ok": False}]
+        section = profile_corpus_fields(records)
+        assert section is not None
+        fields = _fields_by_name(section)
+        assert fields["count"].non_null_rate == 1.0
+        assert fields["count"].n_distinct == 2
+        assert fields["count"].mean_len == pytest.approx((2 + 3) / 2)  # "10", "200"
+
+    def test_whitespace_only_string_is_null(self) -> None:
+        records = [{"x": "   "}, {"x": "value"}]
+        section = profile_corpus_fields(records)
+        assert section is not None
+        assert _fields_by_name(section)["x"].non_null_rate == 0.5
+
+
+class TestTruncation:
+    def test_top_n_truncates_and_logs(self, caplog: pytest.LogCaptureFixture) -> None:
+        records = [{"a": "1", "b": "2", "c": "3", "d": "4", "e": "5"}]
+        with caplog.at_level(logging.WARNING):
+            section = profile_corpus_fields(records, top_n=2)
+        assert section is not None
+        assert section.n_fields_total == 5
+        assert len(section.fields) == 2
+        # The truncation is logged (never silent) and surfaced in the render.
+        assert any("truncated" in r.message.lower() for r in caplog.records)
+        assert "truncated" in section.to_markdown().lower()
+        assert "truncated" in "".join(section.panels()).lower()
+
+    def test_no_truncation_below_cap(self, caplog: pytest.LogCaptureFixture) -> None:
+        records = [{"a": "1", "b": "2"}]
+        with caplog.at_level(logging.WARNING):
+            section = profile_corpus_fields(records, top_n=10)
+        assert section is not None
+        assert len(section.fields) == 2
+        assert "truncated" not in section.to_markdown().lower()
+        assert not any("truncated" in r.message.lower() for r in caplog.records)
+
+
+class TestSparkline:
+    def test_varied_lengths_produce_blocks(self) -> None:
+        # Values of differing length -> a non-empty unicode sparkline.
+        records = [{"x": "a"}, {"x": "abcd"}, {"x": "abcdefghij"}]
+        section = profile_corpus_fields(records)
+        assert section is not None
+        field = _fields_by_name(section)["x"]
+        assert field.len_hist != []
+        assert sum(field.len_hist) == 3
+        # The sparkline is rendered (any block glyph present).
+        md = section.to_markdown()
+        assert any(block in md for block in "▁▂▃▄▅▆▇█")
+
+    def test_uniform_length_is_a_single_spike(self) -> None:
+        records = [{"x": "abc"}, {"x": "xyz"}]  # both length 3
+        section = profile_corpus_fields(records)
+        assert section is not None
+        field = _fields_by_name(section)["x"]
+        # Degenerate min==max: all mass in the first bucket.
+        assert field.len_hist[0] == 2
+        assert sum(field.len_hist) == 2
+
+
+class TestRenderInvariants:
+    def test_html_has_no_nan_or_infinity(self) -> None:
+        records = [{"a": "x", "b": None}, {"a": "y", "b": None}]
+        section = profile_corpus_fields(records)
+        assert section is not None
+        html = "".join(section.panels())
+        assert "NaN" not in html and "Infinity" not in html
+
+    def test_field_name_escaped_in_html(self) -> None:
+        section = profile_corpus_fields([{"a<b> & 'c'": "v"}])
+        assert section is not None
+        html = "".join(section.panels())
+        assert "a&lt;b&gt;" in html
+        assert "<b>" not in html
+
+    def test_field_name_pipe_escaped_in_markdown(self) -> None:
+        # A '|' in a field name must not corrupt the Markdown table.
+        section = profile_corpus_fields([{"a|b": "v"}])
+        assert section is not None
+        md = section.to_markdown()
+        assert "a\\|b" in md
+
+
+class TestContract:
+    def test_kind_and_type(self) -> None:
+        section = profile_corpus_fields([{"a": "1"}])
+        assert isinstance(section, CorpusFieldSection)
+        assert isinstance(section, ProfileSection)
+        assert section.kind == "corpus_field"
+
+    def test_summary_is_title_namespaced(self) -> None:
+        section = profile_corpus_fields(
+            [{"a": "1", "b": None}, {"a": "2", "b": None}], title="Fields"
+        )
+        assert section is not None
+        summary = section.summary
+        assert summary["Fields.n_records"] == 2
+        assert summary["Fields.n_fields"] == 2
+        assert summary["Fields.n_all_null_fields"] == 1
+
+    def test_rows_exclude_len_hist(self) -> None:
+        section = profile_corpus_fields([{"a": "abc"}])
+        assert section is not None
+        rows = section.rows()
+        assert rows[0]["field"] == "a"
+        assert "len_hist" not in rows[0]
+
+    def test_fieldstat_is_frozen(self) -> None:
+        section = profile_corpus_fields([{"a": "1"}])
+        assert section is not None
+        with pytest.raises(Exception):  # noqa: B017 - frozen model
+            section.fields[0].n_present = 5  # type: ignore[misc]

--- a/tests/core/data_profile/test_embedding_memory.py
+++ b/tests/core/data_profile/test_embedding_memory.py
@@ -1,0 +1,113 @@
+"""Memory-behaviour test for ``NpySource``: profiling a big matrix stays O(batch).
+
+The whole point of the memmap-backed source is that a 30 GB corpus is never
+loaded to gather a handful of rows. This pins that: a ~512 MB ``.npy`` is written
+to ``$TMPDIR``, wrapped in an ``NpySource``, and ``vectors_for`` on a 100-row
+subset is measured -- in a **subprocess**, so ``tracemalloc``'s heap peak isolates
+the gather -- to be a tiny fraction of the file. It also guards the two
+regressions that would silently reintroduce the O(corpus) load: dropping
+``mmap_mode`` (the backing must stay an ``np.memmap``) and returning a view onto
+the corpus instead of an independent O(batch) copy.
+
+Marked ``slow`` (writes ~512 MB); run explicitly with ``-m slow`` or by path.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+import tempfile
+
+import numpy as np
+import pytest
+
+from langres.core.data_profile.embedding_source import NpySource
+
+_N_ROWS = 500_000
+_DIM = 256
+_SUBSET = 100
+
+# Runs in a fresh interpreter so the tracemalloc peak reflects ONLY the
+# vectors_for gather -- not the fixture write, the memmap open, or the id map
+# (all allocated before tracemalloc.start()).
+_SUBPROCESS = r"""
+import json, sys, tracemalloc
+import numpy as np
+from langres.core.data_profile.embedding_source import NpySource
+
+path, n_rows, dim, subset_n = sys.argv[1], int(sys.argv[2]), int(sys.argv[3]), int(sys.argv[4])
+src = NpySource("big", path, list(range(n_rows)))
+step = max(n_rows // subset_n, 1)
+subset = list(range(0, n_rows, step))[:subset_n]
+
+tracemalloc.start()
+out = src.vectors_for(subset)
+_, peak = tracemalloc.get_traced_memory()
+tracemalloc.stop()
+
+print(json.dumps({
+    "peak": peak,
+    "backing_is_memmap": isinstance(src._matrix, np.memmap),
+    "out_is_memmap": isinstance(out, np.memmap),
+    "out_base_is_none": out.base is None,
+    "out_shape": list(out.shape),
+    "out_nbytes": int(out.nbytes),
+}))
+"""
+
+
+def _write_big_npy(path: str) -> int:
+    """Write an ``(_N_ROWS, _DIM)`` float32 ``.npy`` in chunks (writer stays O(chunk))."""
+    matrix = np.lib.format.open_memmap(path, mode="w+", dtype=np.float32, shape=(_N_ROWS, _DIM))
+    rng = np.random.default_rng(0)
+    chunk = 50_000
+    for start in range(0, _N_ROWS, chunk):
+        end = min(start + chunk, _N_ROWS)
+        matrix[start:end] = rng.standard_normal((end - start, _DIM)).astype(np.float32)
+    matrix.flush()
+    del matrix
+    return os.path.getsize(path)
+
+
+@pytest.mark.slow
+def test_npysource_gather_is_o_batch_not_o_corpus() -> None:
+    # $TMPDIR-backed temp dir; auto-removed on exit (cleans up the ~512 MB file).
+    with tempfile.TemporaryDirectory() as tmpdir:
+        path = os.path.join(tmpdir, "big.npy")
+        file_size = _write_big_npy(path)
+        assert file_size > 400 * 1024 * 1024  # ~512 MB on disk
+
+        # In-process contract: backing stays a memmap; the gather is an
+        # independent, batch-sized array (not a view onto the corpus).
+        src = NpySource("big", path, list(range(_N_ROWS)))
+        assert isinstance(src._matrix, np.memmap), "mmap_mode dropped -> O(corpus) load"
+        out = src.vectors_for(list(range(0, _N_ROWS, _N_ROWS // _SUBSET))[:_SUBSET])
+        assert out.shape == (_SUBSET, _DIM)
+        assert not isinstance(out, np.memmap)
+        assert out.base is None  # owns its data; independent of the memmap
+        out[0, 0] = 12345.0  # mutating the copy must not touch the file
+        assert np.load(path, mmap_mode="r")[0, 0] != 12345.0
+        del src, out
+
+        # Subprocess: isolate the heap peak of vectors_for on a 100-row subset.
+        proc = subprocess.run(
+            [sys.executable, "-c", _SUBPROCESS, path, str(_N_ROWS), str(_DIM), str(_SUBSET)],
+            capture_output=True,
+            text=True,
+            timeout=300,
+        )
+        assert proc.returncode == 0, proc.stderr
+        result = json.loads(proc.stdout.strip().splitlines()[-1])
+
+        assert result["backing_is_memmap"] is True
+        assert result["out_is_memmap"] is False
+        assert result["out_base_is_none"] is True
+        assert result["out_shape"] == [_SUBSET, _DIM]
+
+        # The gather touches ~100*256*4 ~= 100 KB; the file is ~512 MB. The heap
+        # peak must be a tiny fraction of the file (never an O(corpus) load).
+        batch_bytes = _SUBSET * _DIM * 4
+        assert result["peak"] < 0.05 * file_size
+        assert result["peak"] < batch_bytes + 20 * 1024 * 1024  # generous headroom

--- a/tests/core/data_profile/test_embedding_section.py
+++ b/tests/core/data_profile/test_embedding_section.py
@@ -1,0 +1,335 @@
+"""Tests for the embedding profile sections (norm distribution + comparison).
+
+Vectors are synthesised in-memory (no ML stack); sections are exercised through
+their full render ladder (markdown / summary / rows / panels), the degenerate
+keep-with-hint paths (empty, pre-normalized, constant norm), the drop counting
+(zero-norm / non-finite), the ``cap`` truncation, and the comparison's
+small-multiples / <2-source placeholder / dim-mismatch caveat. Every render is
+asserted to contain no literal ``NaN`` / ``Infinity``.
+"""
+
+from __future__ import annotations
+
+import logging
+
+import numpy as np
+import pytest
+
+from langres.core.data_profile.base import ProfileSection
+from langres.core.data_profile.embedding_section import (
+    EmbeddingComparisonSection,
+    EmbeddingSection,
+    _good_norms,
+    _median_from_hist,
+    profile_embedding,
+    profile_embedding_comparison,
+)
+from langres.core.data_profile.embedding_source import ArraySource
+
+
+def _spread_source(name: str = "m", n: int = 200, dim: int = 8) -> ArraySource:
+    """A source whose row norms vary over a real range (norms grow with the row)."""
+    rng = np.random.default_rng(0)
+    base = rng.standard_normal((n, dim)).astype(np.float32)
+    scales = np.linspace(0.5, 5.0, n, dtype=np.float32).reshape(-1, 1)
+    unit = base / np.linalg.norm(base, axis=1, keepdims=True)
+    return ArraySource(name, [f"r{i}" for i in range(n)], unit * scales)
+
+
+def _ids(n: int) -> list[str]:
+    return [f"r{i}" for i in range(n)]
+
+
+# ------------------------------------------------------------------ single section
+class TestProfileEmbedding:
+    def test_returns_embedding_section(self) -> None:
+        section = profile_embedding(_spread_source(), _ids(200))
+        assert isinstance(section, EmbeddingSection)
+        assert isinstance(section, ProfileSection)
+        assert section.kind == "embedding"
+
+    def test_basic_stats_and_histogram(self) -> None:
+        section = profile_embedding(_spread_source(n=200, dim=8), _ids(200))
+        assert section.dim == 8
+        assert section.n_vectors == 200
+        assert section.n_dropped == 0
+        assert not section.degenerate
+        assert len(section.hist_counts) == len(section.hist_edges) - 1
+        assert sum(section.hist_counts) == pytest.approx(200)
+        # Mean norm sits inside the [0.5, 5.0] scale band.
+        assert 0.5 < section.mean_norm < 5.0
+        assert section.median_norm is not None
+        assert section.min_norm is not None and section.max_norm is not None
+
+    def test_median_matches_numpy_reference_roughly(self) -> None:
+        src = _spread_source(n=400, dim=8)
+        section = profile_embedding(src, _ids(400))
+        true_norms = np.linalg.norm(src.vectors_for(_ids(400)).astype(np.float64), axis=1)
+        assert section.median_norm == pytest.approx(float(np.median(true_norms)), abs=0.15)
+
+    def test_batching_matches_single_batch(self) -> None:
+        src = _spread_source(n=200, dim=8)
+        big = profile_embedding(src, _ids(200), batch=10_000)
+        small = profile_embedding(src, _ids(200), batch=7)
+        assert big.n_vectors == small.n_vectors
+        assert big.mean_norm == pytest.approx(small.mean_norm)
+        assert big.hist_counts == small.hist_counts
+
+    def test_zero_norm_and_non_finite_rows_dropped_and_counted(self) -> None:
+        matrix = np.array(
+            [[3.0, 4.0], [0.0, 0.0], [np.nan, 1.0], [1.0, 0.0], [np.inf, 0.0]],
+            dtype=np.float32,
+        )
+        src = ArraySource("m", _ids(5), matrix)
+        section = profile_embedding(src, _ids(5))
+        assert section.n_vectors == 2  # rows 0 and 3
+        assert section.n_dropped == 3  # zero, nan, inf
+
+    def test_cap_truncates_and_logs(self, caplog: pytest.LogCaptureFixture) -> None:
+        src = _spread_source(n=200, dim=8)
+        with caplog.at_level(logging.INFO):
+            section = profile_embedding(src, _ids(200), cap=50)
+        assert section.n_vectors == 50
+        assert section.n_truncated == 150
+        assert "cap=50" in caplog.text
+
+    def test_empty_corpus_is_degenerate(self) -> None:
+        src = ArraySource("m", [], np.zeros((0, 4), dtype=np.float32))
+        section = profile_embedding(src, [])
+        assert section.degenerate
+        assert section.n_vectors == 0
+        assert section.median_norm is None
+        assert section.hist_counts == []
+
+    def test_pre_normalized_is_degenerate_with_caveat(self) -> None:
+        rng = np.random.default_rng(1)
+        base = rng.standard_normal((50, 16)).astype(np.float32)
+        unit = base / np.linalg.norm(base, axis=1, keepdims=True)
+        src = ArraySource("cos", _ids(50), unit, pre_normalized=True, metric="cosine")
+        section = profile_embedding(src, _ids(50))
+        assert section.degenerate  # all norms ~1.0
+        assert section.pre_normalized
+        assert "pre-normalized" in section.to_markdown()
+
+    def test_constant_norm_is_degenerate(self) -> None:
+        matrix = np.array([[2.0, 0.0], [0.0, 2.0], [2.0, 0.0]], dtype=np.float32)
+        src = ArraySource("m", _ids(3), matrix)  # all norms == 2.0
+        section = profile_embedding(src, _ids(3))
+        assert section.degenerate
+        assert not section.pre_normalized
+        assert "constant norm" in section.to_markdown()
+
+    def test_custom_title(self) -> None:
+        section = profile_embedding(_spread_source(), _ids(200), title="My embeddings")
+        assert section.title == "My embeddings"
+
+    def test_rejects_bare_ndarray(self) -> None:
+        with pytest.raises(TypeError, match="bare numpy ndarray"):
+            profile_embedding(np.zeros((3, 4)), _ids(3))  # type: ignore[arg-type]
+
+
+class TestEmbeddingSectionRender:
+    def test_markdown_has_no_nan_literal(self) -> None:
+        # An empty section has nan mean/std -> must render as n/a, never "NaN".
+        src = ArraySource("m", [], np.zeros((0, 4), dtype=np.float32))
+        md = profile_embedding(src, []).to_markdown()
+        assert "NaN" not in md and "Infinity" not in md
+        assert "n/a" in md
+
+    def test_panels_render_section_html(self) -> None:
+        section = profile_embedding(_spread_source(), _ids(200))
+        panels = section.panels()
+        assert len(panels) == 2
+        assert all(panel.startswith("<section>") for panel in panels)
+        assert "<svg" in panels[0]  # histogram
+        assert 'class="kv"' in panels[1]
+
+    def test_degenerate_panel_is_caveat_not_chart(self) -> None:
+        src = ArraySource("m", [], np.zeros((0, 4), dtype=np.float32))
+        panels = profile_embedding(src, []).panels()
+        assert "<svg" not in panels[0]  # no broken chart
+        assert 'class="empty"' in panels[0]
+
+    def test_summary_keyed_by_model(self) -> None:
+        section = profile_embedding(_spread_source("minilm"), _ids(200))
+        summary = section.summary
+        assert summary["embedding.minilm.n_vectors"] == 200
+        assert "embedding.minilm.mean_norm" in summary
+
+    def test_rows_single_row(self) -> None:
+        section = profile_embedding(_spread_source("m"), _ids(200))
+        rows = section.rows()
+        assert len(rows) == 1
+        assert rows[0]["model"] == "m"
+        assert rows[0]["n_vectors"] == 200
+
+    def test_html_render_via_container_has_no_nan(self) -> None:
+        from langres.core.data_profile.base import DataProfileReport
+
+        section = profile_embedding(_spread_source(), _ids(200))
+        out = DataProfileReport([section]).to_html()
+        assert out.startswith("<!doctype html>")
+        assert "NaN" not in out and "Infinity" not in out
+        assert out.count("<svg") == 1
+
+
+# ------------------------------------------------------------------ comparison
+class TestProfileEmbeddingComparison:
+    def test_two_models_small_multiples(self) -> None:
+        a = _spread_source("a", n=150, dim=8)
+        b = _spread_source("b", n=150, dim=8)
+        section = profile_embedding_comparison([a, b], _ids(150))
+        assert isinstance(section, EmbeddingComparisonSection)
+        assert section.kind == "embedding_comparison"
+        assert not section.placeholder
+        assert not section.degenerate
+        assert len(section.models) == 2
+        assert section.shared_edges  # shared axis exists
+        panels = section.panels()
+        assert len(panels) == 3  # table + 2 minis
+        assert panels[1].count("<svg") == 1 and panels[2].count("<svg") == 1
+
+    def test_shared_edges_are_identical_axis(self) -> None:
+        a = _spread_source("a", n=150, dim=8)
+        b = _spread_source("b", n=150, dim=8)
+        section = profile_embedding_comparison([a, b], _ids(150))
+        # Both minis are drawn against section.shared_edges (one shared x-axis);
+        # the per-model counts align to those edges.
+        for model in section.models:
+            assert len(model.hist_counts) == len(section.shared_edges) - 1
+
+    def test_fewer_than_two_is_placeholder_not_raise(self) -> None:
+        section = profile_embedding_comparison([_spread_source("only")], _ids(200))
+        assert section.placeholder
+        assert section.n_sources == 1
+        panels = section.panels()
+        assert len(panels) == 1
+        assert "at least 2" in panels[0]
+        assert "<svg" not in panels[0]
+
+    def test_zero_sources_is_placeholder(self) -> None:
+        section = profile_embedding_comparison([], _ids(200))
+        assert section.placeholder
+        assert section.models == []
+
+    def test_dim_mismatch_still_renders_with_caveat(self) -> None:
+        a = _spread_source("a8", n=100, dim=8)
+        b = _spread_source("b16", n=100, dim=16)
+        section = profile_embedding_comparison([a, b], _ids(100))
+        assert section.dims_differ
+        assert not section.placeholder
+        assert "different dimensionalities" in section.to_markdown()
+        assert "different dimensionalities" in section._panel_table()
+
+    def test_all_pre_normalized_is_degenerate(self) -> None:
+        rng = np.random.default_rng(3)
+
+        def _unit(name: str) -> ArraySource:
+            base = rng.standard_normal((40, 12)).astype(np.float32)
+            unit = base / np.linalg.norm(base, axis=1, keepdims=True)
+            return ArraySource(name, _ids(40), unit, pre_normalized=True, metric="cosine")
+
+        section = profile_embedding_comparison([_unit("a"), _unit("b")], _ids(40))
+        assert section.degenerate
+        assert section.shared_edges == []
+        panels = section.panels()
+        # Table + per-model caveats, no charts.
+        assert all("<svg" not in panel for panel in panels)
+
+    def test_mixed_variance_uses_varied_range(self) -> None:
+        varied = _spread_source("varied", n=100, dim=8)
+        rng = np.random.default_rng(4)
+        base = rng.standard_normal((100, 8)).astype(np.float32)
+        flat = ArraySource(
+            "flat",
+            _ids(100),
+            base / np.linalg.norm(base, axis=1, keepdims=True),  # norms ~1.0
+            pre_normalized=True,
+        )
+        section = profile_embedding_comparison([varied, flat], _ids(100))
+        assert not section.degenerate  # 'varied' anchors the shared range
+        # The pre-normalized model still gets a spike histogram on the shared axis.
+        flat_model = next(m for m in section.models if m.name == "flat")
+        assert sum(flat_model.hist_counts) > 0
+
+    def test_summary_and_rows(self) -> None:
+        a = _spread_source("a", n=100, dim=8)
+        b = _spread_source("b", n=100, dim=8)
+        section = profile_embedding_comparison([a, b], _ids(100))
+        assert section.summary["embedding_comparison.n_models"] == 2
+        assert len(section.rows()) == 2
+
+    def test_cap_applies_to_comparison(self, caplog: pytest.LogCaptureFixture) -> None:
+        a = _spread_source("a", n=200, dim=8)
+        b = _spread_source("b", n=200, dim=8)
+        with caplog.at_level(logging.INFO):
+            section = profile_embedding_comparison([a, b], _ids(200), cap=40)
+        assert section.n_truncated == 160
+        assert all(model.n_vectors == 40 for model in section.models)
+
+    def test_render_via_container_has_no_nan(self) -> None:
+        from langres.core.data_profile.base import DataProfileReport
+
+        a = _spread_source("a", n=100, dim=8)
+        b = _spread_source("b", n=100, dim=8)
+        section = profile_embedding_comparison([a, b], _ids(100))
+        out = DataProfileReport([section]).to_html()
+        assert "NaN" not in out and "Infinity" not in out
+
+    def test_rejects_bare_ndarray(self) -> None:
+        good = _spread_source("a")
+        with pytest.raises(TypeError, match="bare numpy ndarray"):
+            profile_embedding_comparison([good, np.zeros((3, 4))], _ids(200))  # type: ignore[list-item]
+
+    def test_markdown_placeholder(self) -> None:
+        section = profile_embedding_comparison([_spread_source("only")], _ids(50))
+        assert "at least 2" in section.to_markdown()
+
+    def test_markdown_same_dim_has_no_caveat(self) -> None:
+        a = _spread_source("a", n=80, dim=8)
+        b = _spread_source("b", n=80, dim=8)
+        md = profile_embedding_comparison([a, b], _ids(80)).to_markdown()
+        assert "different dimensionalities" not in md
+        assert "| a |" in md and "| b |" in md
+
+
+# --------------------------------------------------------------------- internals
+class TestSectionInternals:
+    def test_good_norms_empty_matrix(self) -> None:
+        norms, dropped = _good_norms(np.zeros((0, 4), dtype=np.float32))
+        assert norms.shape == (0,)
+        assert dropped == 0
+
+    def test_all_dropped_batch_via_batch_one(self) -> None:
+        # batch=1 makes each zero/nan/inf row its own fully-dropped batch,
+        # exercising the good.size == 0 path in both streaming passes.
+        matrix = np.array([[3, 4], [0, 0], [np.nan, 1], [1, 0], [np.inf, 0]], dtype=np.float32)
+        section = profile_embedding(ArraySource("m", _ids(5), matrix), _ids(5), batch=1)
+        assert section.n_vectors == 2  # norms 5 and 1
+        assert section.n_dropped == 3
+        assert not section.degenerate
+
+    def test_median_from_hist_no_mass(self) -> None:
+        assert _median_from_hist([0.0, 0.0], [0.0, 0.5, 1.0], 0, 0) is None
+
+    def test_median_from_hist_tails_majority(self) -> None:
+        assert _median_from_hist([1.0], [0.0, 1.0], 10, 0) is None
+
+    def test_median_from_hist_underflow_at_half_zero_first_bin(self) -> None:
+        # underflow == half with a zero first bin -> the count==0 fraction path,
+        # returns the bin's lower edge.
+        assert _median_from_hist([0.0, 2.0], [0.0, 1.0, 2.0], 2, 0) == pytest.approx(0.0)
+
+    def test_markdown_non_degenerate_shows_cap_row(self) -> None:
+        section = profile_embedding(_spread_source(n=200, dim=8), _ids(200), cap=50)
+        md = section.to_markdown()
+        assert "truncated by cap: 150" in md  # non-degenerate + capped
+
+    def test_panels_show_cap_and_pre_normalized_rows(self) -> None:
+        capped = profile_embedding(_spread_source(n=200, dim=8), _ids(200), cap=50)
+        assert "truncated by cap" in capped.panels()[1]
+        rng = np.random.default_rng(2)
+        base = rng.standard_normal((30, 8)).astype(np.float32)
+        unit = base / np.linalg.norm(base, axis=1, keepdims=True)
+        pn = profile_embedding(ArraySource("cos", _ids(30), unit, pre_normalized=True), _ids(30))
+        assert "pre-normalized" in pn.panels()[1]

--- a/tests/core/data_profile/test_embedding_source.py
+++ b/tests/core/data_profile/test_embedding_source.py
@@ -1,0 +1,311 @@
+"""Tests for the memory-efficient ``EmbeddingSource`` family.
+
+Consumes *precomputed* vectors only -- fixtures are synthesised with
+``numpy.save`` / in-memory arrays; nothing here imports sentence-transformers,
+torch, or faiss. Covers the id<->row alignment guards (length desync, unknown
+partial vs total miss, same-length permutation via fingerprint), the sidecar id
+auto-load, the ``from_anchor_store`` reuse path (metric-driven pre-normalized
+caveat), and the ``cosine_signal`` A<->B bridge (degenerate/missing -> ``None``).
+The ``O(batch)`` memory behaviour of ``NpySource`` lives in
+``test_embedding_memory.py``.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+from langres.core.data_profile.embedding_source import (
+    ArraySource,
+    EmbeddingSource,
+    NpySource,
+    _fingerprint,
+    cosine_signal,
+)
+
+
+def _matrix(rows: list[list[float]]) -> np.ndarray:
+    return np.asarray(rows, dtype=np.float32)
+
+
+# --------------------------------------------------------------------- ArraySource
+class TestArraySource:
+    def test_basic_lookup_returns_requested_rows_in_order(self) -> None:
+        src = ArraySource("m", ["a", "b", "c"], _matrix([[1, 0], [0, 1], [1, 1]]))
+        out = src.vectors_for(["c", "a"])
+        assert out.shape == (2, 2)
+        np.testing.assert_allclose(out, [[1, 1], [1, 0]])
+
+    def test_is_instance_of_protocol(self) -> None:
+        src = ArraySource("m", ["a"], _matrix([[1, 0]]))
+        assert isinstance(src, EmbeddingSource)
+
+    def test_name_dim_and_id_order(self) -> None:
+        src = ArraySource("minilm", ["a", "b"], _matrix([[1, 0, 0], [0, 1, 0]]))
+        assert src.name == "minilm"
+        assert src.dim == 3
+        assert src.id_order == ["a", "b"]
+
+    def test_id_order_is_a_copy(self) -> None:
+        src = ArraySource("m", ["a", "b"], _matrix([[1, 0], [0, 1]]))
+        src.id_order.append("mutate")
+        assert src.id_order == ["a", "b"]
+
+    def test_row_id_desync_raises(self) -> None:
+        with pytest.raises(ValueError, match="desync"):
+            ArraySource("m", ["a", "b"], _matrix([[1, 0]]))
+
+    def test_non_2d_matrix_raises(self) -> None:
+        with pytest.raises(ValueError, match="2-D"):
+            ArraySource("m", ["a"], np.asarray([1.0, 2.0], dtype=np.float32))
+
+    def test_empty_source_is_valid(self) -> None:
+        src = ArraySource("m", [], np.zeros((0, 4), dtype=np.float32))
+        assert src.dim == 4
+        assert src.vectors_for([]).shape == (0, 4)
+
+    def test_duplicate_ids_first_wins(self) -> None:
+        src = ArraySource("m", ["a", "a"], _matrix([[1, 0], [0, 9]]))
+        np.testing.assert_allclose(src.vectors_for(["a"]), [[1, 0]])
+
+    def test_returned_array_is_independent_copy(self) -> None:
+        matrix = _matrix([[1, 0], [0, 1]])
+        src = ArraySource("m", ["a", "b"], matrix)
+        out = src.vectors_for(["a"])
+        out[0, 0] = 999.0
+        np.testing.assert_allclose(matrix[0], [1, 0])  # backing untouched
+
+
+# ------------------------------------------------------------------- id guards
+class TestIdGuards:
+    def test_unknown_ids_partial_miss_dropped_and_logged(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        src = ArraySource("m", ["a", "b"], _matrix([[1, 0], [0, 1]]))
+        with caplog.at_level(logging.WARNING):
+            out = src.vectors_for(["a", "ghost", "b"])
+        assert out.shape == (2, 2)  # ghost dropped
+        assert "dropped 1 unknown id" in caplog.text
+
+    def test_total_miss_raises(self) -> None:
+        src = ArraySource("m", ["a", "b"], _matrix([[1, 0], [0, 1]]))
+        with pytest.raises(KeyError, match="wrong id namespace"):
+            src.vectors_for(["ghost1", "ghost2"])
+
+    def test_empty_request_is_not_a_miss(self) -> None:
+        src = ArraySource("m", ["a"], _matrix([[1, 0]]))
+        assert src.vectors_for([]).shape == (0, 2)
+
+
+# ------------------------------------------------------------------ fingerprint
+class TestFingerprint:
+    def test_permutation_changes_fingerprint(self) -> None:
+        assert _fingerprint(["a", "b", "c"]) != _fingerprint(["a", "c", "b"])
+
+    def test_same_order_same_fingerprint(self) -> None:
+        assert _fingerprint(["a", "b"]) == _fingerprint(["a", "b"])
+
+    def test_boundary_collision_avoided(self) -> None:
+        assert _fingerprint(["a", "bc"]) != _fingerprint(["ab", "c"])
+
+    def test_source_fingerprint_matches_helper(self) -> None:
+        src = ArraySource("m", ["a", "b"], _matrix([[1, 0], [0, 1]]))
+        assert src.id_fingerprint == _fingerprint(["a", "b"])
+
+    def test_verify_alignment_passes_on_match(self) -> None:
+        src = ArraySource("m", ["a", "b"], _matrix([[1, 0], [0, 1]]))
+        src.verify_alignment(_fingerprint(["a", "b"]))  # no raise
+
+    def test_verify_alignment_raises_on_permutation(self) -> None:
+        src = ArraySource("m", ["a", "b"], _matrix([[1, 0], [0, 1]]))
+        with pytest.raises(ValueError, match="fingerprint mismatch"):
+            src.verify_alignment(_fingerprint(["b", "a"]))
+
+
+# --------------------------------------------------------------------- NpySource
+class TestNpySource:
+    def _write_npy(self, tmp_path: Path, rows: list[list[float]], name: str = "vecs.npy") -> Path:
+        path = tmp_path / name
+        np.save(path, _matrix(rows))
+        return path
+
+    def test_memmap_lookup(self, tmp_path: Path) -> None:
+        path = self._write_npy(tmp_path, [[1, 0], [0, 1], [2, 2]])
+        src = NpySource("m", path, ["a", "b", "c"])
+        np.testing.assert_allclose(src.vectors_for(["b", "c"]), [[0, 1], [2, 2]])
+
+    def test_backing_is_memmap(self, tmp_path: Path) -> None:
+        path = self._write_npy(tmp_path, [[1, 0], [0, 1]])
+        src = NpySource("m", path, ["a", "b"])
+        assert isinstance(src._matrix, np.memmap)
+
+    def test_returned_array_is_not_a_memmap(self, tmp_path: Path) -> None:
+        path = self._write_npy(tmp_path, [[1, 0], [0, 1]])
+        src = NpySource("m", path, ["a", "b"])
+        out = src.vectors_for(["a"])
+        assert not isinstance(out, np.memmap)
+        assert out.base is None  # independent, owns its data
+
+    def test_sidecar_stem_ids_json_auto_load(self, tmp_path: Path) -> None:
+        path = self._write_npy(tmp_path, [[1, 0], [0, 1]], name="vecs.npy")
+        (tmp_path / "vecs.ids.json").write_text(json.dumps(["a", "b"]))
+        src = NpySource("m", path)  # no id_order -> sidecar
+        assert src.id_order == ["a", "b"]
+
+    def test_sidecar_plain_ids_json_auto_load(self, tmp_path: Path) -> None:
+        path = self._write_npy(tmp_path, [[1, 0], [0, 1]], name="vecs.npy")
+        (tmp_path / "ids.json").write_text(json.dumps(["x", "y"]))
+        src = NpySource("m", path)
+        assert src.id_order == ["x", "y"]
+
+    def test_missing_sidecar_raises(self, tmp_path: Path) -> None:
+        path = self._write_npy(tmp_path, [[1, 0]])
+        with pytest.raises(ValueError, match="needs an id_order"):
+            NpySource("m", path)
+
+
+# ------------------------------------------------------------- from_anchor_store
+class TestFromAnchorStore:
+    def _make_artifact(
+        self,
+        root: Path,
+        anchor_ids: list[str],
+        vectors: list[list[float]],
+        metric: str,
+        *,
+        nested: bool = True,
+    ) -> None:
+        """Synthesise an AnchorStore.save-shaped artifact (no faiss / resolver)."""
+        root.mkdir(parents=True, exist_ok=True)
+        # Manifest at the top (AnchorStoreManifest-shaped).
+        manifest = {
+            "store_version": "1",
+            "entity_prefix": "e",
+            "next_ordinal": len(anchor_ids),
+            "anchor_ids": anchor_ids,
+            "records": {rid: {"id": rid} for rid in anchor_ids},
+            "assignments": {rid: f"e{i}" for i, rid in enumerate(anchor_ids)},
+        }
+        (root / "anchor_store.json").write_text(json.dumps(manifest))
+        # Vectors + corpus.json nested under resolver/ (as AnchorStore.save does).
+        index_dir = root / "resolver" / "index" if nested else root
+        index_dir.mkdir(parents=True, exist_ok=True)
+        np.save(index_dir / "corpus_embeddings.npy", _matrix(vectors))
+        (index_dir / "corpus.json").write_text(
+            json.dumps({"corpus_texts": anchor_ids, "metric": metric})
+        )
+
+    def test_cosine_sets_pre_normalized(self, tmp_path: Path) -> None:
+        self._make_artifact(tmp_path, ["a", "b"], [[1, 0], [0, 1]], "cosine")
+        src = NpySource.from_anchor_store(tmp_path, "idx")
+        assert src.pre_normalized is True
+        assert src.metric == "cosine"
+        assert src.id_order == ["a", "b"]
+        np.testing.assert_allclose(src.vectors_for(["b"]), [[0, 1]])
+
+    def test_l2_not_pre_normalized(self, tmp_path: Path) -> None:
+        self._make_artifact(tmp_path, ["a", "b"], [[3, 4], [0, 2]], "L2")
+        src = NpySource.from_anchor_store(tmp_path, "idx")
+        assert src.pre_normalized is False
+        assert src.metric == "L2"
+
+    def test_fingerprint_persisted_then_permutation_raises(self, tmp_path: Path) -> None:
+        self._make_artifact(tmp_path, ["a", "b", "c"], [[1, 0], [0, 1], [1, 1]], "L2")
+        NpySource.from_anchor_store(tmp_path, "idx")  # persists fingerprint
+        assert (tmp_path / "embedding_ids.fingerprint").exists()
+        # Same vectors, permuted anchor ids -> a length check would miss it.
+        manifest = json.loads((tmp_path / "anchor_store.json").read_text())
+        manifest["anchor_ids"] = ["a", "c", "b"]
+        (tmp_path / "anchor_store.json").write_text(json.dumps(manifest))
+        with pytest.raises(ValueError, match="changed under the same vectors"):
+            NpySource.from_anchor_store(tmp_path, "idx")
+
+    def test_reload_same_order_is_stable(self, tmp_path: Path) -> None:
+        self._make_artifact(tmp_path, ["a", "b"], [[1, 0], [0, 1]], "L2")
+        NpySource.from_anchor_store(tmp_path, "idx")
+        src = NpySource.from_anchor_store(tmp_path, "idx")  # fingerprint matches
+        assert src.id_order == ["a", "b"]
+
+    def test_missing_metric_json_defaults_none(self, tmp_path: Path) -> None:
+        self._make_artifact(tmp_path, ["a"], [[1, 0]], "L2")
+        # Remove corpus.json to exercise the "no metric" branch.
+        next(tmp_path.rglob("corpus.json")).unlink()
+        src = NpySource.from_anchor_store(tmp_path, "idx")
+        assert src.metric is None
+        assert src.pre_normalized is False
+
+    def test_missing_vectors_raises(self, tmp_path: Path) -> None:
+        (tmp_path / "anchor_store.json").write_text(
+            json.dumps(
+                {
+                    "store_version": "1",
+                    "entity_prefix": "e",
+                    "next_ordinal": 0,
+                    "anchor_ids": [],
+                    "records": {},
+                    "assignments": {},
+                }
+            )
+        )
+        with pytest.raises(FileNotFoundError, match="corpus_embeddings.npy"):
+            NpySource.from_anchor_store(tmp_path, "idx")
+
+    def test_flat_layout_supported(self, tmp_path: Path) -> None:
+        self._make_artifact(tmp_path, ["a", "b"], [[1, 0], [0, 1]], "cosine", nested=False)
+        src = NpySource.from_anchor_store(tmp_path, "idx")
+        assert src.id_order == ["a", "b"]
+        assert src.pre_normalized is True
+
+
+# ------------------------------------------------------------------ cosine_signal
+class TestCosineSignal:
+    def test_orthogonal_is_zero(self) -> None:
+        src = ArraySource("m", ["a", "b"], _matrix([[1, 0], [0, 1]]))
+        signal = cosine_signal(src)
+        assert signal("a", "b") == pytest.approx(0.0)
+
+    def test_identical_direction_is_one(self) -> None:
+        src = ArraySource("m", ["a", "b"], _matrix([[1, 0], [3, 0]]))
+        signal = cosine_signal(src)
+        assert signal("a", "b") == pytest.approx(1.0)
+
+    def test_opposite_is_minus_one(self) -> None:
+        src = ArraySource("m", ["a", "b"], _matrix([[1, 0], [-1, 0]]))
+        assert cosine_signal(src)("a", "b") == pytest.approx(-1.0)
+
+    def test_missing_id_returns_none(self) -> None:
+        src = ArraySource("m", ["a", "b"], _matrix([[1, 0], [0, 1]]))
+        signal = cosine_signal(src)
+        assert signal("a", "ghost") is None
+        assert signal("ghost", "b") is None
+
+    def test_both_missing_returns_none(self) -> None:
+        src = ArraySource("m", ["a", "b"], _matrix([[1, 0], [0, 1]]))
+        assert cosine_signal(src)("g1", "g2") is None
+
+    def test_zero_norm_vector_returns_none(self) -> None:
+        src = ArraySource("m", ["a", "z"], _matrix([[1, 0], [0, 0]]))
+        assert cosine_signal(src)("a", "z") is None
+
+    def test_non_finite_vector_returns_none(self) -> None:
+        src = ArraySource("m", ["a", "n"], _matrix([[1, 0], [np.nan, 0]]))
+        assert cosine_signal(src)("a", "n") is None
+
+    def test_same_id_twice_is_one(self) -> None:
+        src = ArraySource("m", ["a"], _matrix([[2, 1]]))
+        assert cosine_signal(src)("a", "a") == pytest.approx(1.0)
+
+
+# --------------------------------------------------------------- bare-ndarray guard
+class TestBareNdarrayGuard:
+    def test_cosine_signal_rejects_ndarray(self) -> None:
+        with pytest.raises(TypeError, match="bare numpy ndarray"):
+            cosine_signal(np.zeros((2, 3)))  # type: ignore[arg-type]
+
+    def test_cosine_signal_rejects_non_source(self) -> None:
+        with pytest.raises(TypeError, match="vectors_for"):
+            cosine_signal(object())  # type: ignore[arg-type]

--- a/tests/core/data_profile/test_embedding_source.py
+++ b/tests/core/data_profile/test_embedding_source.py
@@ -24,6 +24,7 @@ from langres.core.data_profile.embedding_source import (
     EmbeddingSource,
     NpySource,
     _fingerprint,
+    _locate,
     cosine_signal,
 )
 
@@ -259,6 +260,35 @@ class TestFromAnchorStore:
         src = NpySource.from_anchor_store(tmp_path, "idx")
         assert src.id_order == ["a", "b"]
         assert src.pre_normalized is True
+
+
+# ------------------------------------------------------------------------ _locate
+class TestLocate:
+    def test_single_match_resolves_without_warning(
+        self, tmp_path: Path, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        nested = tmp_path / "resolver" / "index"
+        nested.mkdir(parents=True)
+        (nested / "corpus_embeddings.npy").write_bytes(b"x")
+        with caplog.at_level(logging.WARNING):
+            found = _locate(tmp_path, "corpus_embeddings.npy")
+        assert found == nested / "corpus_embeddings.npy"
+        assert caplog.text == ""  # unambiguous -> silent
+
+    def test_ambiguous_match_warns_and_still_resolves(
+        self, tmp_path: Path, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        (tmp_path / "a").mkdir()
+        (tmp_path / "b").mkdir()
+        (tmp_path / "a" / "corpus_embeddings.npy").write_bytes(b"x")
+        (tmp_path / "b" / "corpus_embeddings.npy").write_bytes(b"x")
+        with caplog.at_level(logging.WARNING):
+            found = _locate(tmp_path, "corpus_embeddings.npy")
+        # Still resolves (non-breaking: first of the sorted matches) ...
+        assert found == tmp_path / "a" / "corpus_embeddings.npy"
+        # ... but names the ambiguity instead of silently picking one.
+        assert "matched 2 files" in caplog.text
+        assert str(found) in caplog.text
 
 
 # ------------------------------------------------------------------ cosine_signal

--- a/tests/core/data_profile/test_end_to_end.py
+++ b/tests/core/data_profile/test_end_to_end.py
@@ -1,0 +1,119 @@
+"""End-to-end tests: a full multi-section report rendered to HTML/markdown.
+
+Exercises the whole Wave 2 assembly through ``from_records`` with gold, a schema,
+and two embedding sources -- then asserts the render contracts the plan pins:
+valid doctype, one ``<svg>`` per present chart panel, no literal ``NaN``/
+``Infinity``, the pinned section order, and HTML/Markdown escaping.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+
+from langres.core.data_profile import ArraySource, DataProfileReport
+from langres.core.data_profile.builders import from_records
+from langres.core.models import CompanySchema
+
+_RECORDS = [
+    {"id": "1", "name": "Acme Corporation"},
+    {"id": "2", "name": "Acme Corp"},
+    {"id": "3", "name": "Globex Inc"},
+    {"id": "4", "name": "Globex Incorporated"},
+    {"id": "5", "name": "Initech"},
+    {"id": "6", "name": "Initech LLC"},
+    {"id": "7", "name": "Unrelated Bakery"},
+]
+_CLUSTERS = [{"1", "2"}, {"3", "4"}, {"5", "6"}, {"7"}]
+_IDS = [record["id"] for record in _RECORDS]
+
+
+def _cluster_structured_matrix(dim: int, scale: float, seed: int) -> np.ndarray:
+    """Per-cluster base direction + noise, so within-cluster cosine runs high."""
+    rng = np.random.default_rng(seed)
+    cluster_of = {rid: ci for ci, cluster in enumerate(_CLUSTERS) for rid in cluster}
+    bases = {ci: rng.normal(size=dim) for ci in range(len(_CLUSTERS))}
+    return np.asarray(
+        [(bases[cluster_of[rid]] + rng.normal(scale=0.3, size=dim)) * scale for rid in _IDS]
+    )
+
+
+def _full_report() -> DataProfileReport:
+    embeddings = [
+        ArraySource("mini-8d", _IDS, _cluster_structured_matrix(dim=8, scale=1.0, seed=1)),
+        ArraySource("large-16d", _IDS, _cluster_structured_matrix(dim=16, scale=2.5, seed=2)),
+    ]
+    return from_records(_RECORDS, gold=_CLUSTERS, schema=CompanySchema, embeddings=embeddings)
+
+
+class TestEndToEndHtml:
+    def test_pinned_section_order(self) -> None:
+        report = _full_report()
+        assert [section.kind for section in report.sections] == [
+            "hero",
+            "label_structure",
+            "separability",  # string
+            "separability",  # cosine · mini-8d
+            "separability",  # cosine · large-16d
+            "corpus_field",
+            "embedding",
+            "embedding",
+            "embedding_comparison",
+        ]
+
+    def test_to_html_is_valid_self_contained_document(self) -> None:
+        out = _full_report().to_html()
+        assert out.startswith("<!doctype html>")
+        assert out.rstrip().endswith("</html>")
+        # Self-contained: inline styles, no external stylesheet/script/CDN. (An
+        # inline SVG's xmlns="http://www.w3.org/2000/svg" is not an external asset.)
+        assert "<style>" in out
+        assert "<link" not in out
+        assert "<script" not in out
+
+    def test_svg_count_matches_present_panels(self) -> None:
+        report = _full_report()
+        out = report.to_html()
+        expected_svg = sum(
+            panel.count("<svg") for section in report.sections for panel in section.panels()
+        )
+        assert expected_svg > 0
+        assert out.count("<svg") == expected_svg
+
+    def test_section_count_matches_present_panels(self) -> None:
+        report = _full_report()
+        out = report.to_html()
+        expected_sections = sum(len(section.panels()) for section in report.sections)
+        assert out.count("<section") == expected_sections
+
+    def test_no_literal_nan_or_infinity(self) -> None:
+        report = _full_report()
+        assert "NaN" not in report.to_html()
+        assert "Infinity" not in report.to_html()
+        assert "NaN" not in report.to_markdown()
+
+    def test_markdown_has_report_heading_and_all_sections(self) -> None:
+        report = _full_report()
+        md = report.to_markdown()
+        assert md.startswith("# Data profile")
+        assert "## Overview" in md  # hero
+        assert "## Label structure" in md
+        assert "## Corpus fields" in md
+
+    def test_summary_flattens_every_section(self) -> None:
+        report = _full_report()
+        summary = report.summary
+        assert "Overview.n_records" in summary
+        assert summary["Overview.n_records"] == 7
+        assert "Label structure.prevalence" in summary
+
+
+class TestEscaping:
+    def test_html_and_markdown_escape_field_names(self) -> None:
+        # A hostile field name must be HTML-escaped and pipe-safe in markdown.
+        records = [{"id": "1", "na<me|x>": "v"}, {"id": "2", "na<me|x>": "w"}]
+        report = DataProfileReport.from_records(records)
+        html_out = report.to_html()
+        assert "na&lt;me|x&gt;" in html_out  # < and > escaped
+        assert "<me|x>" not in html_out  # never a raw tag-like sequence
+        md = report.to_markdown()
+        assert "na<me\\|x>" in md  # pipe escaped so the table stays aligned

--- a/tests/core/data_profile/test_hero.py
+++ b/tests/core/data_profile/test_hero.py
@@ -22,9 +22,7 @@ def _perfect_signal(left: Hashable, right: Hashable) -> float | None:
 
 def _label_and_sep() -> tuple[object, object]:
     label = profile_label_structure([{"1", "2"}, {"3"}], n_records=3)
-    sep = profile_separability(
-        [("1", "2")], [("1", "3")], _perfect_signal, name="string"
-    )
+    sep = profile_separability([("1", "2")], [("1", "3")], _perfect_signal, name="string")
     return label, sep
 
 

--- a/tests/core/data_profile/test_hero.py
+++ b/tests/core/data_profile/test_hero.py
@@ -41,9 +41,32 @@ class TestHeroSectionRender:
         labels = dict(hero._cards())
         assert labels["records"] == "1,000"
         assert labels["clusters"] == "400"
-        assert labels["positive-pair prevalence"] == "0.0003"
+        # Hero abridges prevalence to a scannable percentage (2 sig figs).
+        assert labels["positive-pair prevalence"] == "0.03%"
         assert labels["class imbalance (pos:neg)"] == "1:2,940"
         assert labels["separability AUC"] == "0.812"
+
+    def test_prevalence_rendered_as_percentage(self) -> None:
+        hero = HeroSection(
+            title="Overview",
+            n_records=None,
+            n_clusters=None,
+            prevalence=0.00638742,
+            imbalance_ratio=None,
+            separability_auc=None,
+        )
+        assert dict(hero._cards())["positive-pair prevalence"] == "0.64%"
+
+    def test_zero_prevalence_is_na_not_zero_percent(self) -> None:
+        hero = HeroSection(
+            title="Overview",
+            n_records=None,
+            n_clusters=None,
+            prevalence=0.0,
+            imbalance_ratio=None,
+            separability_auc=None,
+        )
+        assert dict(hero._cards())["positive-pair prevalence"] == "n/a"
 
     def test_markdown_has_all_kpis(self) -> None:
         hero = HeroSection(

--- a/tests/core/data_profile/test_hero.py
+++ b/tests/core/data_profile/test_hero.py
@@ -1,0 +1,170 @@
+"""Tests for the KPI ``HeroSection`` + ``build_hero``.
+
+Covers the render ladder (markdown / summary / rows / panels), the degenerate
+all-``None`` case (``"n/a"`` cards, never a raise, no literal NaN/Infinity), and
+``build_hero``'s extraction from the label-structure + separability sections
+(including the graceful ``None`` when neither is present).
+"""
+
+from __future__ import annotations
+
+from collections.abc import Hashable
+
+from langres.core.data_profile.hero import HeroSection, build_hero
+from langres.core.data_profile.label_structure import profile_label_structure
+from langres.core.data_profile.separability import profile_separability
+
+
+def _perfect_signal(left: Hashable, right: Hashable) -> float | None:
+    """Score the one positive pair high, everything else low (AUC == 1.0)."""
+    return 1.0 if frozenset((left, right)) == frozenset(("1", "2")) else 0.0
+
+
+def _label_and_sep() -> tuple[object, object]:
+    label = profile_label_structure([{"1", "2"}, {"3"}], n_records=3)
+    sep = profile_separability(
+        [("1", "2")], [("1", "3")], _perfect_signal, name="string"
+    )
+    return label, sep
+
+
+class TestHeroSectionRender:
+    def test_full_cards(self) -> None:
+        hero = HeroSection(
+            title="Overview",
+            n_records=1000,
+            n_clusters=400,
+            prevalence=0.0003,
+            imbalance_ratio=2940.0,
+            separability_auc=0.812,
+        )
+        labels = dict(hero._cards())
+        assert labels["records"] == "1,000"
+        assert labels["clusters"] == "400"
+        assert labels["positive-pair prevalence"] == "0.0003"
+        assert labels["class imbalance (pos:neg)"] == "1:2,940"
+        assert labels["separability AUC"] == "0.812"
+
+    def test_markdown_has_all_kpis(self) -> None:
+        hero = HeroSection(
+            title="Overview",
+            n_records=10,
+            n_clusters=4,
+            prevalence=0.1,
+            imbalance_ratio=9.0,
+            separability_auc=0.75,
+        )
+        md = hero.to_markdown()
+        assert md.startswith("## Overview")
+        assert "separability AUC" in md
+        assert "1:9" in md
+        assert "NaN" not in md
+
+    def test_summary_is_title_namespaced(self) -> None:
+        hero = HeroSection(
+            title="Overview",
+            n_records=10,
+            n_clusters=4,
+            prevalence=0.1,
+            imbalance_ratio=9.0,
+            separability_auc=0.75,
+        )
+        assert hero.summary == {
+            "Overview.n_records": 10,
+            "Overview.n_clusters": 4,
+            "Overview.prevalence": 0.1,
+            "Overview.imbalance_ratio": 9.0,
+            "Overview.separability_auc": 0.75,
+        }
+
+    def test_rows_single_raw_row(self) -> None:
+        hero = HeroSection(
+            title="Overview",
+            n_records=10,
+            n_clusters=4,
+            prevalence=0.1,
+            imbalance_ratio=9.0,
+            separability_auc=0.75,
+        )
+        rows = hero.rows()
+        assert rows == [
+            {
+                "n_records": 10,
+                "n_clusters": 4,
+                "prevalence": 0.1,
+                "imbalance_ratio": 9.0,
+                "separability_auc": 0.75,
+            }
+        ]
+
+    def test_panels_render_card_grid(self) -> None:
+        hero = HeroSection(
+            title="Overview",
+            n_records=10,
+            n_clusters=4,
+            prevalence=0.1,
+            imbalance_ratio=9.0,
+            separability_auc=0.75,
+        )
+        panels = hero.panels()
+        assert len(panels) == 1
+        panel = panels[0]
+        assert panel.startswith("<section><h2>Overview</h2>")
+        # Rides on the shared CSS vocabulary (no new external stylesheet).
+        assert "var(--line)" in panel
+        assert "var(--muted)" in panel
+        assert "<svg" not in panel  # KPI cards, not a chart
+
+    def test_degenerate_all_none_renders_na_never_raises(self) -> None:
+        hero = HeroSection(
+            title="Overview",
+            n_records=None,
+            n_clusters=None,
+            prevalence=None,
+            imbalance_ratio=None,
+            separability_auc=None,
+        )
+        assert [value for _, value in hero._cards()] == ["n/a"] * 5
+        panel = hero.panels()[0]
+        assert "n/a" in panel
+        assert "NaN" not in panel and "Infinity" not in panel
+        md = hero.to_markdown()
+        assert "n/a" in md and "NaN" not in md
+
+
+class TestBuildHero:
+    def test_extracts_from_label_and_separability(self) -> None:
+        label, sep = _label_and_sep()
+        hero = build_hero([label, sep])  # type: ignore[list-item]
+        assert hero is not None
+        assert hero.n_records == 3
+        assert hero.n_clusters == 2
+        assert hero.separability_auc == 1.0
+        # prevalence / imbalance flow from the label section unchanged.
+        assert hero.prevalence == label.prevalence  # type: ignore[attr-defined]
+        assert hero.imbalance_ratio == label.imbalance_ratio  # type: ignore[attr-defined]
+
+    def test_label_only_leaves_auc_none(self) -> None:
+        label, _ = _label_and_sep()
+        hero = build_hero([label])  # type: ignore[list-item]
+        assert hero is not None
+        assert hero.n_records == 3
+        assert hero.separability_auc is None
+
+    def test_separability_only_leaves_counts_none(self) -> None:
+        _, sep = _label_and_sep()
+        hero = build_hero([sep])  # type: ignore[list-item]
+        assert hero is not None
+        assert hero.separability_auc == 1.0
+        assert hero.n_records is None
+        assert hero.prevalence is None
+
+    def test_none_when_no_source_sections(self) -> None:
+        assert build_hero([]) is None
+
+    def test_custom_title_namespaces_summary(self) -> None:
+        label, sep = _label_and_sep()
+        hero = build_hero([label, sep], title="KPIs")  # type: ignore[list-item]
+        assert hero is not None
+        assert hero.title == "KPIs"
+        assert "KPIs.n_records" in hero.summary

--- a/tests/core/data_profile/test_label_structure.py
+++ b/tests/core/data_profile/test_label_structure.py
@@ -1,0 +1,200 @@
+"""Tests for the label-structure profile section.
+
+Behavior + edges: None gold -> absent section, empty / single-record inputs
+render without raising, the single-cluster entropy log(0) guard, cluster-size
+distribution + histogram (including the overflow-bin path), pair prevalence /
+imbalance with an implied-singleton denominator, and the render invariants (no
+literal ``NaN``/``Infinity`` in HTML, title escaping).
+"""
+
+from __future__ import annotations
+
+import math
+
+import pytest
+
+from langres.core.data_profile import ProfileSection
+from langres.core.data_profile.label_structure import (
+    LabelStructureSection,
+    profile_label_structure,
+)
+
+
+class TestGracefulDegradation:
+    def test_none_clusters_returns_none(self) -> None:
+        # No gold available -> the section is simply absent from the report.
+        assert profile_label_structure(None) is None
+
+    def test_empty_clusters_render_without_raising(self) -> None:
+        section = profile_label_structure([])
+        assert section is not None
+        assert section.n_records == 0
+        assert section.n_clusters == 0
+        assert section.mean_cluster_size is None
+        assert section.prevalence is None
+        assert section.imbalance_ratio is None
+        assert section.entropy_bits is None
+        # Every surface renders on the degenerate input.
+        assert section.to_markdown().startswith("## Label structure")
+        assert section.rows() == []
+        html = "".join(section.panels())
+        assert "<svg" in html
+        assert "NaN" not in html and "Infinity" not in html
+
+    def test_single_record_renders(self) -> None:
+        section = profile_label_structure([{"a"}])
+        assert section is not None
+        assert section.n_records == 1
+        assert section.n_clusters == 1
+        assert section.n_singletons == 1
+        assert section.positive_pairs == 0
+        assert section.total_pairs == 0
+        assert section.prevalence is None  # C(1, 2) == 0 -> undefined
+        assert section.imbalance_ratio is None
+        assert "NaN" not in "".join(section.panels())
+
+
+class TestClusterMetrics:
+    def test_basic_counts_and_pairs(self) -> None:
+        section = profile_label_structure([{"a", "b"}, {"c"}, {"d", "e", "f"}])
+        assert section is not None
+        assert section.n_records == 6
+        assert section.n_clusters == 3
+        assert section.n_singletons == 1
+        assert section.n_multi == 2
+        assert section.max_cluster_size == 3
+        assert section.mean_cluster_size == 6 / 3
+        # positives = C(2,2) + C(1,2) + C(3,2) = 1 + 0 + 3 = 4; total = C(6,2) = 15.
+        assert section.positive_pairs == 4
+        assert section.total_pairs == 15
+        assert math.isclose(section.prevalence, 4 / 15)  # type: ignore[arg-type]
+        # negatives = 15 - 4 = 11; imbalance N = 11 / 4.
+        assert math.isclose(section.imbalance_ratio, 11 / 4)  # type: ignore[arg-type]
+
+    def test_size_distribution_and_rows(self) -> None:
+        section = profile_label_structure([{"a", "b"}, {"c"}, {"d"}, {"e", "f", "g"}])
+        assert section is not None
+        assert section.size_distribution == [(1, 2), (2, 1), (3, 1)]
+        assert section.rows() == [
+            {"cluster_size": 1, "n_clusters": 2},
+            {"cluster_size": 2, "n_clusters": 1},
+            {"cluster_size": 3, "n_clusters": 1},
+        ]
+        # The non-empty distribution renders as a Markdown table.
+        md = section.to_markdown()
+        assert "### Cluster-size distribution" in md
+        assert "| 3 | 1 |" in md
+
+    def test_n_records_folds_implied_singletons(self) -> None:
+        # Gold lists only the matched clusters; the true corpus has 100 records.
+        section = profile_label_structure([{"a", "b"}, {"c", "d"}], n_records=100)
+        assert section is not None
+        # 4 clustered records + 96 implied singletons.
+        assert section.n_records == 100
+        assert section.n_singletons == 96
+        assert section.n_clusters == 2 + 96
+        # positives = 2 * C(2,2) = 2; total = C(100, 2) = 4950.
+        assert section.positive_pairs == 2
+        assert section.total_pairs == math.comb(100, 2)
+        assert section.prevalence == 2 / math.comb(100, 2)
+
+    def test_n_records_smaller_than_clustered_is_ignored(self) -> None:
+        # A too-small n_records never shrinks the corpus below what the clusters
+        # already contain (the clustering always wins).
+        section = profile_label_structure([{"a", "b", "c"}], n_records=1)
+        assert section is not None
+        assert section.n_records == 3
+        assert section.n_singletons == 0
+
+    def test_large_imbalance_ratio(self) -> None:
+        # One match-pair in a 1000-record corpus: extreme ER class imbalance.
+        section = profile_label_structure([{"a", "b"}], n_records=1000)
+        assert section is not None
+        # positives = 1; negatives = C(1000,2) - 1; imbalance ~ 499499.
+        assert section.positive_pairs == 1
+        assert section.imbalance_ratio == math.comb(1000, 2) - 1
+        # KV render shows a grouped 1:N ratio, not a raw float / NaN.
+        html = "".join(section.panels())
+        assert "1:499,499" in html
+        assert "NaN" not in html and "Infinity" not in html
+
+
+class TestEntropy:
+    def test_single_cluster_entropy_is_zero(self) -> None:
+        # The log(0) guard: a single cluster has p == 1, log2(1) == 0 -> entropy
+        # exactly 0.0 (a fully predictable partition), never a crash.
+        section = profile_label_structure([{"a", "b", "c"}])
+        assert section is not None
+        assert section.entropy_bits == 0.0
+        assert section.prevalence == 1.0
+
+    def test_uniform_clusters_entropy_is_log2_k(self) -> None:
+        # k equal-size clusters -> maximal entropy log2(k).
+        section = profile_label_structure([{"a", "b"}, {"c", "d"}, {"e", "f"}, {"g", "h"}])
+        assert section is not None
+        assert math.isclose(section.entropy_bits, math.log2(4))  # type: ignore[arg-type]
+
+    def test_empty_cluster_is_skipped_by_log_guard(self) -> None:
+        # A degenerate size-0 cluster must not crash the entropy sum (size <= 0
+        # skip branch) and leaves a finite, defined entropy.
+        section = profile_label_structure([set(), {"a", "b"}])
+        assert section is not None
+        assert section.entropy_bits is not None
+        assert math.isfinite(section.entropy_bits)
+
+
+class TestHistogramRendering:
+    def test_overflow_bin_folds_large_sizes(self) -> None:
+        # A cluster larger than the bar cap must not emit one bar per member; it
+        # folds into a single overflow bar (exercised via the panel not raising).
+        big = set(range(30))
+        section = profile_label_structure([big, {100, 101}, {102}])
+        assert section is not None
+        assert section.max_cluster_size == 30
+        html = "".join(section.panels())
+        assert "<svg" in html
+        assert "NaN" not in html and "Infinity" not in html
+
+    def test_panels_contain_kv_table_and_chart(self) -> None:
+        section = profile_label_structure([{"a", "b"}, {"c"}])
+        assert section is not None
+        panels = section.panels()
+        assert len(panels) == 1
+        html = panels[0]
+        assert html.startswith("<section><h2>Label structure</h2>")
+        assert '<table class="kv">' in html
+        assert "<svg" in html
+
+    def test_title_is_escaped_in_html(self) -> None:
+        section = profile_label_structure([{"a", "b"}], title="Gold & <labels>")
+        assert section is not None
+        html = "".join(section.panels())
+        assert "Gold &amp; &lt;labels&gt;" in html
+        assert "<labels>" not in html
+
+
+class TestContract:
+    def test_kind_and_type(self) -> None:
+        section = profile_label_structure([{"a", "b"}])
+        assert isinstance(section, LabelStructureSection)
+        assert isinstance(section, ProfileSection)
+        assert section.kind == "label_structure"
+
+    def test_summary_is_title_namespaced(self) -> None:
+        section = profile_label_structure([{"a", "b"}, {"c"}], title="Labels")
+        assert section is not None
+        summary = section.summary
+        assert summary["Labels.n_records"] == 3
+        assert summary["Labels.n_clusters"] == 2
+        assert "Labels.prevalence" in summary
+
+    def test_is_frozen(self) -> None:
+        section = profile_label_structure([{"a", "b"}])
+        assert section is not None
+        with pytest.raises(Exception):  # noqa: B017 - pydantic ValidationError on frozen set
+            section.n_records = 99  # type: ignore[misc]
+
+    def test_markdown_has_no_nan(self) -> None:
+        section = profile_label_structure([])
+        assert section is not None
+        assert "NaN" not in section.to_markdown()

--- a/tests/core/data_profile/test_separability.py
+++ b/tests/core/data_profile/test_separability.py
@@ -95,9 +95,7 @@ class TestProfileSeparability:
         def none_signal(a: Hashable, b: Hashable) -> float | None:
             return None
 
-        assert (
-            profile_separability([("1", "2")], [("3", "4")], none_signal, name="string") is None
-        )
+        assert profile_separability([("1", "2")], [("3", "4")], none_signal, name="string") is None
 
     def test_one_sided_negative_empty_keeps_with_hint(self) -> None:
         signal = string_signal(_RECORDS, _Schema)
@@ -141,9 +139,7 @@ class TestProfileSeparability:
         def constant(a: Hashable, b: Hashable) -> float | None:
             return 0.5
 
-        section = profile_separability(
-            [("1", "2")], [("3", "4")], constant, name="const", n_bins=5
-        )
+        section = profile_separability([("1", "2")], [("3", "4")], constant, name="const", n_bins=5)
         assert section is not None
         assert section.hist_edges[0] < section.hist_edges[-1]
         html = "".join(section.panels())

--- a/tests/core/data_profile/test_separability.py
+++ b/tests/core/data_profile/test_separability.py
@@ -1,0 +1,252 @@
+"""Tests for the separability profile section + the string signal.
+
+Behavior + edges: the ``SimilaritySignal`` bridge, ``string_signal`` (absent id
+and no-shared-feature -> ``None``, real similarity otherwise), the density-
+normalized overlaid histogram staying legible under 1:1000 class imbalance, the
+capped-sample truncation (logged), ``None``/non-finite score dropping, the
+no-usable-scores -> absent section path, the one-sided keep-with-hint path
+(never a NaN panel), and the render invariants (no ``NaN``/``Infinity``, name
+escaping).
+"""
+
+from __future__ import annotations
+
+import logging
+import math
+import re
+from collections.abc import Hashable
+
+import pytest
+from pydantic import BaseModel
+
+from langres.core.data_profile import ProfileSection
+from langres.core.data_profile.separability import (
+    SeparabilitySection,
+    SimilaritySignal,
+    profile_separability,
+    string_signal,
+)
+
+
+class _Schema(BaseModel):
+    id: str
+    name: str | None = None
+    city: str | None = None
+
+
+_RECORDS = {
+    "1": {"name": "Acme Corporation", "city": "New York"},
+    "2": {"name": "Acme Corp", "city": "New York City"},
+    "3": {"name": "Zeta Foods Ltd", "city": "Los Angeles"},
+    "4": {"name": "Omega Holdings", "city": "San Francisco"},
+}
+
+
+def _rect_heights_by_fill(svg: str, fill: str) -> list[float]:
+    """Extract every ``<rect>`` height for a given fill color from an SVG string."""
+    heights: list[float] = []
+    for rect in re.findall(r"<rect [^>]*/>", svg):
+        if f'fill="{fill}"' in rect:
+            match = re.search(r'height="([0-9.]+)"', rect)
+            if match:
+                heights.append(float(match.group(1)))
+    return heights
+
+
+class TestStringSignal:
+    def test_returns_similarity_for_present_ids(self) -> None:
+        signal = string_signal(_RECORDS, _Schema)
+        score = signal("1", "2")
+        assert score is not None
+        assert 0.0 <= score <= 1.0
+        # Near-duplicate scores higher than an unrelated pair.
+        assert signal("1", "2") > signal("1", "3")  # type: ignore[operator]
+
+    def test_absent_id_returns_none(self) -> None:
+        signal = string_signal(_RECORDS, _Schema)
+        assert signal("1", "missing") is None
+        assert signal("missing", "1") is None
+
+    def test_no_shared_feature_returns_none(self) -> None:
+        # Two records with no populated comparable field -> unscorable (not 0.0).
+        records: dict[Hashable, dict[str, object]] = {"a": {}, "b": {}}
+        signal = string_signal(records, _Schema)
+        assert signal("a", "b") is None
+
+    def test_matches_similaritysignal_shape(self) -> None:
+        signal: SimilaritySignal = string_signal(_RECORDS, _Schema)
+        assert callable(signal)
+
+
+class TestProfileSeparability:
+    def test_both_classes_scored_yield_auc(self) -> None:
+        signal = string_signal(_RECORDS, _Schema)
+        section = profile_separability(
+            [("1", "2")], [("1", "3"), ("1", "4"), ("3", "4")], signal, name="string"
+        )
+        assert section is not None
+        assert section.n_positive == 1
+        assert section.n_negative == 3
+        assert section.auc == 1.0  # the match pair outscores every non-match
+        assert section.note == ""
+
+    def test_no_usable_scores_returns_none(self) -> None:
+        # An all-None signal (every pair unscorable) -> the section is absent.
+        def none_signal(a: Hashable, b: Hashable) -> float | None:
+            return None
+
+        assert (
+            profile_separability([("1", "2")], [("3", "4")], none_signal, name="string") is None
+        )
+
+    def test_one_sided_negative_empty_keeps_with_hint(self) -> None:
+        signal = string_signal(_RECORDS, _Schema)
+        section = profile_separability([("1", "2")], [], signal, name="string")
+        assert section is not None
+        assert section.n_positive == 1
+        assert section.n_negative == 0
+        assert section.auc is None  # single-class -> undefined, normalized to None
+        assert "negative" in section.note.lower()
+        # The hint surfaces in Markdown too, and the AUC reads "n/a" (never NaN).
+        md = section.to_markdown()
+        assert "negative" in md.lower()
+        assert "n/a" in md
+        # Never a NaN panel.
+        html = "".join(section.panels())
+        assert "NaN" not in html and "Infinity" not in html
+
+    def test_one_sided_positive_empty_keeps_with_hint(self) -> None:
+        signal = string_signal(_RECORDS, _Schema)
+        section = profile_separability([], [("3", "4")], signal, name="string")
+        assert section is not None
+        assert section.auc is None
+        assert "positive" in section.note.lower()
+
+    def test_none_and_nonfinite_scores_dropped(self) -> None:
+        # A signal emitting None / inf / nan -> those pairs are dropped as unscorable.
+        scores = {("1", "2"): 0.9, ("1", "3"): None, ("1", "4"): float("inf")}
+
+        def flaky(a: Hashable, b: Hashable) -> float | None:
+            return scores.get((a, b), 0.1)  # type: ignore[return-value]
+
+        section = profile_separability(
+            [("1", "2"), ("1", "3")], [("1", "4"), ("3", "4")], flaky, name="flaky"
+        )
+        assert section is not None
+        assert section.n_positive == 1  # ("1","3") dropped (None)
+        assert section.n_negative == 1  # ("1","4") dropped (inf)
+
+    def test_degenerate_equal_scores_do_not_crash(self) -> None:
+        # All scores identical -> the edge range is widened so bars still render.
+        def constant(a: Hashable, b: Hashable) -> float | None:
+            return 0.5
+
+        section = profile_separability(
+            [("1", "2")], [("3", "4")], constant, name="const", n_bins=5
+        )
+        assert section is not None
+        assert section.hist_edges[0] < section.hist_edges[-1]
+        html = "".join(section.panels())
+        assert "NaN" not in html and "Infinity" not in html
+
+
+class TestCapping:
+    def test_cap_truncates_and_logs(self, caplog: pytest.LogCaptureFixture) -> None:
+        signal = string_signal(_RECORDS, _Schema)
+        negatives = [("1", "3"), ("1", "4"), ("3", "4"), ("2", "3"), ("2", "4")]
+        with caplog.at_level(logging.WARNING):
+            section = profile_separability([("1", "2")], negatives, signal, name="string", cap=2)
+        assert section is not None
+        assert section.n_negative == 2  # capped
+        assert any("sampled" in r.message.lower() for r in caplog.records)
+
+    def test_no_cap_scores_everything(self) -> None:
+        signal = string_signal(_RECORDS, _Schema)
+        negatives = [("1", "3"), ("1", "4"), ("3", "4")]
+        section = profile_separability([("1", "2")], negatives, signal, name="string", cap=None)
+        assert section is not None
+        assert section.n_negative == 3
+
+
+class TestDensityLegibility:
+    def test_tiny_positive_class_stays_visible_under_imbalance(self) -> None:
+        # 3 positives vs 3000 negatives: without density normalization the
+        # positive bars would be < 1px; with it, both classes are comparable.
+        pos_pairs = [(f"p{i}a", f"p{i}b") for i in range(3)]
+        neg_pairs = [(f"n{i}a", f"n{i}b") for i in range(3000)]
+        pos_set = set(pos_pairs)
+
+        def signal(a: Hashable, b: Hashable) -> float | None:
+            return 0.95 if (a, b) in pos_set else 0.05
+
+        section = profile_separability(pos_pairs, neg_pairs, signal, name="string", n_bins=10)
+        assert section is not None
+        assert section.n_positive == 3
+        assert section.n_negative == 3000
+        assert section.auc == 1.0
+
+        svg = "".join(section.panels())
+        pos_heights = _rect_heights_by_fill(svg, "#2a9d8f")
+        neg_heights = _rect_heights_by_fill(svg, "#e76f51")
+        assert pos_heights and neg_heights
+        # Density-normalized: the tiny positive class reaches a comparable height,
+        # not a sub-pixel sliver dwarfed by the 3000 negatives.
+        assert max(pos_heights) > 0.1 * max(neg_heights)
+
+
+class TestRenderSurfaces:
+    def _section(self) -> SeparabilitySection:
+        signal = string_signal(_RECORDS, _Schema)
+        section = profile_separability(
+            [("1", "2")], [("1", "3"), ("3", "4")], signal, name="string"
+        )
+        assert section is not None
+        return section
+
+    def test_rows_are_per_bin_distributions(self) -> None:
+        section = self._section()
+        rows = section.rows()
+        assert len(rows) == len(section.pos_counts)
+        assert set(rows[0]) == {"bin_lo", "bin_hi", "positives", "negatives"}
+
+    def test_summary_is_title_namespaced(self) -> None:
+        section = self._section()
+        summary = section.summary
+        assert "Separability (string).auc" in summary
+        assert summary["Separability (string).n_positive"] == 1
+
+    def test_markdown_and_panels_render(self) -> None:
+        section = self._section()
+        md = section.to_markdown()
+        assert md.startswith("## Separability (string)")
+        assert "AUC" in md
+        panels = section.panels()
+        assert len(panels) == 1
+        assert "<svg" in panels[0]
+
+    def test_name_escaped_in_html(self) -> None:
+        signal = string_signal(_RECORDS, _Schema)
+        section = profile_separability([("1", "2")], [("3", "4")], signal, name="a & <b>")
+        assert section is not None
+        html = "".join(section.panels())
+        assert "a &amp; &lt;b&gt;" in html
+        # The raw, unescaped name must not leak into the markup.
+        assert "a & <b>" not in html
+
+
+class TestContract:
+    def test_kind_and_type(self) -> None:
+        section = profile_separability(
+            [("1", "2")], [("3", "4")], string_signal(_RECORDS, _Schema), name="string"
+        )
+        assert isinstance(section, SeparabilitySection)
+        assert isinstance(section, ProfileSection)
+        assert section.kind == "separability"
+
+    def test_is_frozen(self) -> None:
+        section = profile_separability(
+            [("1", "2")], [("3", "4")], string_signal(_RECORDS, _Schema), name="string"
+        )
+        assert section is not None
+        with pytest.raises(Exception):  # noqa: B017 - frozen model
+            section.auc = 0.0  # type: ignore[misc]

--- a/tests/core/test_report_html.py
+++ b/tests/core/test_report_html.py
@@ -1,0 +1,137 @@
+"""Tests for the shared render scaffold ``langres.core._report_html``.
+
+Structure-based asserts (doctype prefix, escaping, ``"n/a"`` sentinel, absence
+of literal ``NaN``/``Infinity``), never byte-for-byte equality, so cosmetic
+tweaks don't churn the suite. The AUC/AP guards are checked against the
+underlying ``core.metrics`` primitives on the finite-scored subset.
+"""
+
+from __future__ import annotations
+
+import math
+
+from langres.core import _report_html
+from langres.core.metrics import average_precision_score, roc_auc_score
+
+
+class TestDocument:
+    def test_is_a_self_contained_html_document(self) -> None:
+        out = _report_html.document("My title", "<section>body</section>")
+        assert out.startswith("<!doctype html>")
+        assert out.rstrip().endswith("</html>")
+        # Inline style, no external asset.
+        assert "<style>" in out
+        assert "http://" not in out.replace('xmlns="http://www.w3.org/2000/svg"', "")
+        # Title lands in both <title> and <h1>.
+        assert "<title>My title</title>" in out
+        assert "<h1>My title</h1>" in out
+        # Body is emitted verbatim.
+        assert "<section>body</section>" in out
+
+    def test_title_is_html_escaped_in_head_and_heading(self) -> None:
+        out = _report_html.document("a & b <x>", "")
+        assert "a &amp; b &lt;x&gt;" in out
+        assert "<x>" not in out
+
+    def test_summary_html_absent_by_default(self) -> None:
+        out = _report_html.document("t", "<p>b</p>")
+        assert 'class="summary"' not in out
+
+    def test_summary_html_is_emitted_verbatim_when_given(self) -> None:
+        out = _report_html.document("t", "<p>b</p>", summary_html="P=<b>0.9</b>")
+        assert '<p class="summary">P=<b>0.9</b></p>' in out
+
+    def test_empty_body_still_valid_document(self) -> None:
+        out = _report_html.document("t", "")
+        assert out.startswith("<!doctype html>")
+        assert out.rstrip().endswith("</html>")
+
+
+class TestSection:
+    def test_wraps_body_in_a_section_with_escaped_heading(self) -> None:
+        out = _report_html.section("Fields & <stuff>", "<table></table>")
+        assert out.startswith("<section><h2>")
+        assert out.endswith("</section>")
+        assert "Fields &amp; &lt;stuff&gt;" in out
+        assert "<stuff>" not in out
+        # Body HTML passes through unescaped.
+        assert "<table></table>" in out
+
+
+class TestNum:
+    def test_formats_to_requested_digits(self) -> None:
+        assert _report_html._num(0.12345) == "0.123"
+        assert _report_html._num(0.12345, digits=1) == "0.1"
+
+    def test_none_and_nonfinite_map_to_na(self) -> None:
+        assert _report_html._num(None) == "n/a"
+        assert _report_html._num(float("nan")) == "n/a"
+        assert _report_html._num(float("inf")) == "n/a"
+        assert _report_html._num(float("-inf")) == "n/a"
+
+
+class TestMdCell:
+    def test_escapes_pipe_and_flattens_newlines(self) -> None:
+        assert _report_html._md_cell("a|b") == r"a\|b"
+        assert _report_html._md_cell("a\nb\rc") == "a b c"
+
+    def test_coerces_non_str(self) -> None:
+        assert _report_html._md_cell(42) == "42"  # type: ignore[arg-type]
+
+
+class TestHistogram:
+    def test_counts_into_half_open_bins_last_bin_closed(self) -> None:
+        edges = [0.0, 0.5, 1.0]
+        # 0.5 -> second bin; 1.0 (== final edge) counted in the last (closed) bin.
+        assert _report_html._histogram([0.1, 0.5, 1.0], edges) == [1.0, 2.0]
+
+    def test_non_finite_values_ignored(self) -> None:
+        edges = [0.0, 1.0]
+        assert _report_html._histogram([0.5, float("nan"), float("inf")], edges) == [1.0]
+
+    def test_no_bins_when_single_edge(self) -> None:
+        assert _report_html._histogram([0.5], [0.0]) == []
+
+
+class TestSafeAuc:
+    def test_none_on_empty(self) -> None:
+        assert _report_html.safe_auc([], []) is None
+
+    def test_none_when_all_scores_non_finite(self) -> None:
+        assert _report_html.safe_auc([True, False], [float("nan"), float("inf")]) is None
+
+    def test_matches_metric_on_finite_subset(self) -> None:
+        # One non-finite pair is dropped; the guard must equal the metric on the rest.
+        labels = [False, True, False, True]
+        scores = [1.0, 2.0, float("nan"), 4.0]
+        expected = roc_auc_score([False, True, True], [1.0, 2.0, 4.0])
+        got = _report_html.safe_auc(labels, scores)
+        assert got is not None
+        assert got == expected
+
+    def test_perfect_separation(self) -> None:
+        assert _report_html.safe_auc([False, False, True, True], [1.0, 2.0, 3.0, 4.0]) == 1.0
+
+    def test_single_class_returns_underlying_nan_never_raises(self) -> None:
+        got = _report_html.safe_auc([True, True], [0.2, 0.8])
+        assert got is not None and math.isnan(got)
+
+
+class TestSafeAp:
+    def test_none_on_empty(self) -> None:
+        assert _report_html.safe_ap([], []) is None
+
+    def test_none_when_all_scores_non_finite(self) -> None:
+        assert _report_html.safe_ap([True, False], [float("inf"), float("nan")]) is None
+
+    def test_matches_metric_on_finite_subset(self) -> None:
+        labels = [False, True, False, True]
+        scores = [1.0, 2.0, float("inf"), 4.0]
+        expected = average_precision_score([False, True, True], [1.0, 2.0, 4.0])
+        got = _report_html.safe_ap(labels, scores)
+        assert got is not None
+        assert got == expected
+
+    def test_no_positives_returns_underlying_nan_never_raises(self) -> None:
+        got = _report_html.safe_ap([False, False], [0.2, 0.8])
+        assert got is not None and math.isnan(got)

--- a/tests/core/test_svg.py
+++ b/tests/core/test_svg.py
@@ -4,9 +4,12 @@ Tested by STRUCTURE (element counts, parsed attributes, escaped substrings),
 never by full-string equality, so cosmetic tweaks don't churn the suite.
 """
 
+import math
 import re
 
-from langres.core._svg import Series, _scale, bar_chart, line_chart
+import pytest
+
+from langres.core._svg import Series, _rescale_counts, _scale, bar_chart, line_chart
 
 
 def _polyline_points(svg: str) -> list[tuple[float, float]]:
@@ -14,6 +17,11 @@ def _polyline_points(svg: str) -> list[tuple[float, float]]:
     match = re.search(r'<polyline[^>]*points="([^"]*)"', svg)
     assert match is not None, "expected a <polyline> in the output"
     return [(float(x), float(y)) for x, y in (p.split(",") for p in match.group(1).split())]
+
+
+def _rect_heights(svg: str) -> list[float]:
+    """Parse every ``<rect ... height="...">`` height into a float list, in order."""
+    return [float(h) for h in re.findall(r'<rect[^>]*\bheight="([^"]*)"', svg)]
 
 
 class TestScale:
@@ -187,3 +195,70 @@ class TestBarChart:
         out = bar_chart([0.0, 1.0], [("g & <n>", "#0a0", [2.0])])
         assert "g &amp; &lt;n&gt;" in out
         assert "<n>" not in out
+
+
+class TestRescaleCounts:
+    """The per-series scaling behind ``bar_chart(normalize=...)``."""
+
+    def test_none_is_identity(self) -> None:
+        assert _rescale_counts([1.0, 2.0, 3.0], "none") == [1.0, 2.0, 3.0]
+
+    def test_density_sums_to_one(self) -> None:
+        out = _rescale_counts([1.0, 3.0], "density")
+        assert sum(out) == pytest.approx(1.0)
+        assert out == pytest.approx([0.25, 0.75])
+
+    def test_max_peaks_at_one(self) -> None:
+        out = _rescale_counts([2.0, 4.0], "max")
+        assert max(out) == pytest.approx(1.0)
+        assert out == pytest.approx([0.5, 1.0])
+
+    def test_degenerate_all_zero_left_as_is(self) -> None:
+        assert _rescale_counts([0.0, 0.0], "density") == [0.0, 0.0]
+        assert _rescale_counts([], "max") == []
+
+    def test_non_finite_passed_through_and_excluded_from_scale(self) -> None:
+        out = _rescale_counts([2.0, float("nan")], "density")
+        assert out[0] == pytest.approx(1.0)  # only the finite 2.0 sets the total
+        assert math.isnan(out[1])
+
+
+class TestBarChartNormalize:
+    def test_none_matches_the_default(self) -> None:
+        edges = [0.0, 0.5, 1.0]
+        series = [("g", "#0a0", [3.0, 1.0]), ("n", "#a00", [1.0, 4.0])]
+        # Backward compatibility: the explicit "none" is byte-identical to the
+        # pre-existing (normalize-free) call every current caller makes.
+        assert bar_chart(edges, series, normalize="none") == bar_chart(edges, series)
+
+    def test_none_keeps_imbalanced_series_incomparable(self) -> None:
+        # Raw counts: a 1-vs-1000 split renders the small bar ~1/1000 the tall one.
+        out = bar_chart([0.0, 1.0], [("s", "#0a0", [1.0]), ("b", "#a00", [1000.0])])
+        heights = _rect_heights(out)
+        assert len(heights) == 2
+        assert heights[0] < heights[1]
+
+    def test_max_makes_each_series_peak_at_full_height(self) -> None:
+        # Under class imbalance (the whole point): max-normalizing lifts the tiny
+        # series so both peak at the same (full) height and are legible together.
+        out = bar_chart(
+            [0.0, 1.0], [("s", "#0a0", [1.0]), ("b", "#a00", [1000.0])], normalize="max"
+        )
+        heights = _rect_heights(out)
+        assert len(heights) == 2
+        assert heights[0] == pytest.approx(heights[1])
+
+    def test_density_scales_series_to_unit_area(self) -> None:
+        # A two-bin series [2, 2] -> [0.5, 0.5]: both bars equal, and their
+        # heights reflect the density (sums to 1), not the raw counts.
+        out = bar_chart([0.0, 0.5, 1.0], [("a", "#0a0", [2.0, 2.0])], normalize="density")
+        heights = _rect_heights(out)
+        assert len(heights) == 2
+        assert heights[0] == pytest.approx(heights[1])
+
+    def test_normalize_all_zero_series_draws_no_bars(self) -> None:
+        for mode in ("density", "max"):
+            out = bar_chart([0.0, 1.0], [("z", "#0a0", [0.0])], normalize=mode)  # type: ignore[arg-type]
+            assert "<rect" not in out
+            assert out.count("<svg") == 1
+            assert "NaN" not in out and "Infinity" not in out

--- a/tests/test_eval.py
+++ b/tests/test_eval.py
@@ -50,6 +50,7 @@ def test_dir_and_all_list_the_curated_surface() -> None:
         "evaluate",
         "EvalReport",
         "DataProfileReport",
+        "from_embedder",
         "DEFAULT_PAIR_GRID",
         "list_benchmarks",
         "get_benchmark",

--- a/tests/test_eval.py
+++ b/tests/test_eval.py
@@ -49,6 +49,7 @@ def test_dir_and_all_list_the_curated_surface() -> None:
     surface = {
         "evaluate",
         "EvalReport",
+        "DataProfileReport",
         "DEFAULT_PAIR_GRID",
         "list_benchmarks",
         "get_benchmark",

--- a/tests/test_import_budget.py
+++ b/tests/test_import_budget.py
@@ -242,6 +242,40 @@ def test_eval_report_stays_import_light() -> None:
     )
 
 
+# The data-profile report (``langres.core.data_profile``) and its shared render
+# scaffold (``langres.core._report_html``) render entirely from stdlib + numpy (a
+# core dep) + the import-light ``core.metrics``. Like the EvalReport tearsheet
+# they must NEVER pull the heavy/optional stack -- the plan's load-bearing
+# guarantee that a ``$0`` data profile is buildable on a bare core-only install
+# (no torch, no sentence-transformers, no matplotlib). The report *consumes*
+# precomputed embeddings; it never generates them, so it carries no [semantic]
+# dep. Same fresh-process subprocess pattern as the eval_report check above.
+_DATA_PROFILE_IMPORT_LIGHT_SCRIPT = (
+    "import sys; import langres.core.data_profile; import langres.core._report_html; "
+    "leaked = [m for m in {modules!r} if m in sys.modules]; "
+    "assert not leaked, f'data_profile/_report_html leaked heavy modules: {{leaked}}'; "
+    "print('OK')"
+).format(modules=_EVAL_REPORT_HEAVY_DEPS)
+
+
+def test_data_profile_stays_import_light() -> None:
+    """``import langres.core.data_profile`` (+ ``_report_html``) must not pull a heavy dep.
+
+    The data profile is dependency-free by construction: inline SVG, no
+    matplotlib, no ML stack, no embedding generation (embeddings are consumed
+    precomputed). This locks it so a future edit can never regress the $0,
+    core-only path.
+    """
+    result = subprocess.run(
+        [sys.executable, "-c", _DATA_PROFILE_IMPORT_LIGHT_SCRIPT],
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode == 0, (
+        f"data_profile import-budget check failed.\nSTDOUT:\n{result.stdout}\nSTDERR:\n{result.stderr}"
+    )
+
+
 # ``langres.data.registry.list_methods`` is a public, import-light discovery API
 # (exported from ``langres.data``): it must return the method NAMES without
 # pulling ``langres.methods`` — which imports VectorBlocker / RandomForestMatcher /
@@ -314,6 +348,7 @@ _ROOT_LAZY_MODULES = [
     "langres.core.eval_report",
     "langres.core.benchmark",
     "langres.core.calibration",
+    "langres.core.data_profile",
 ]
 
 _ROOT_LAZY_SCRIPT = (


### PR DESCRIPTION
## What

Adds `langres.DataProfileReport` — a **composable, memory-efficient data-profiling report** for entity-resolution datasets. The existing reports (`EvalReport`, `ScoreInspectionReport`, blocker metrics) all profile *pipeline output* or *gold-vs-prediction*; nothing profiled the **data itself**. This does: class balance, gold cluster shape, per-field stats, positives-vs-negatives separability, and precomputed embedding distributions — a "QuantStats tearsheet, but for ER data."

This is **PR-1 (the report)**. The AnyMatch-style mining seam (`mine_misclassified` / `sample_negatives` / `denoise_pairs` + a mining-readiness section) is a fast-follow **PR-2**; the report renders fully without it.

## Design

- **Composable, not monolithic.** `ProfileSection` (frozen Pydantic ABC, `kind` discriminator) → `DataProfileReport`, a pure container over `list[SerializeAsAny[ProfileSection]]` that renders exactly the sections present. Each metric family is an independent profiler function; a missing input (no gold / no embeddings / no blocker) → that section is simply absent, **never a raise**. New metric family = new subclass + function; the container is untouched (open/closed).
- **Text-first, HTML optional.** `print(report)` / `to_markdown()` / `to_dict()` / `.summary` / `section.rows()` (pandas interop without a pandas dep) are the primary surfaces; `to_html()` is a self-contained `$0` inline-SVG tearsheet (no CDN/JS/matplotlib), reusing the `eval_report` leaf pattern via a new shared `core/_report_html` scaffold (`EvalReport` left untouched — one transient CSS copy, migration tracked separately).
- **Embeddings precomputed & consumed-only.** The report never generates embeddings. `EmbeddingSource` protocol (`name`, `dim`, `vectors_for(ids)`), with `ArraySource` (in-memory), `NpySource` (memmap `.npy` — the 30GB-safe default), and `NpySource.from_anchor_store` (reuses the pipeline's existing `corpus_embeddings.npy` + anchor manifest). Multiple models are first-class → N sections + a shared-axis comparison.
- **Memory-efficient by construction.** Norm/cosine distributions stream corpus ids in fixed batches through online accumulators → **O(batch·dim) regardless of corpus size**. A `tracemalloc` test proves peak heap < 5% of a 512 MB `.npy`.

## Sections (pinned order)

KPI hero → label-structure (class balance, cluster-size distribution, entropy) → separability (density-normalized positives-vs-negatives similarity histogram + AUC; string-signal by default, cosine per embedding) → corpus-field (null-rate / cardinality / length, in-cell sparklines, all-null flag) → per-model embeddings (norm distribution) → embedding comparison (fixed-axis small-multiples). `include=` selects a subset; an unknown key raises.

## Entry points

`DataProfileReport.from_benchmark(name)`, `.from_records(records, gold=, schema=, embeddings=)`, and a `[semantic]`-gated `langres.eval.from_embedder(...)` on-ramp (embeds once → `.npy` → `NpySource`; the report itself still never generates embeddings).

## Verification

- **Full suite green** on the integrated branch: fast subset **3203 passed / 4 skipped** @ 98.5% coverage; the `data_profile` package **233/233** including the slow 512 MB memory test; **100% coverage** on every `data_profile` module + `_report_html`.
- **mypy** strict clean (118 files); **ruff** clean; the **import-budget** test confirms `import langres` stays light (no torch/faiss/sklearn/sentence-transformers/litellm/dspy pulled at import).
- **Visual QA**: tearsheet reviewed in-browser in light + dark on a rich synthetic dataset (1:156 class imbalance, 3 embedding models of differing quality) — KPI hero, density-normalized separability histograms, and shared-axis small-multiples all confirmed legible under class imbalance.

## Docs & examples

`docs/reference/data-profile.md` + mkdocs nav; offline `examples/quickstart_profile.py`; full design record in `docs/plans/20260715_data_layer_plan.md`.

Built via staged parallel worktree agents (Wave 0 foundation → {tabular ∥ embeddings+memory} → integration → polish), TDD throughout, then hardened against a review pass (safe-AUC never-raise guards, density-normalized imbalance charts, `tracemalloc` memory gate).

## Summary by Sourcery

Introduce a composable, import-light DataProfileReport with embedding, separability, corpus-field, and label-structure profiling plus shared HTML rendering, and wire it into the public eval and docs surfaces.

New Features:
- Add DataProfileReport and ProfileSection abstractions with multiple concrete sections (hero, label structure, corpus fields, separability, embedding norms, and embedding comparison) for profiling ER datasets.
- Introduce EmbeddingSource protocol with ArraySource and NpySource implementations, including anchor-store integration and cosine similarity signal helpers.
- Provide high-level builders (from_benchmark, from_records, from_embedder) to assemble default report layouts from benchmarks or raw records, with optional precomputed embeddings and schema.
- Add a shared _report_html scaffold and extended SVG bar_chart normalization to support density- and max-normalized inline SVG charts in reports.

Enhancements:
- Extend eval and langres top-level API surfaces to expose DataProfileReport and from_embedder alongside existing evaluation utilities.
- Enforce import-budget guarantees via new tests to keep data_profile and _report_html free of heavy ML and visualization dependencies.

Documentation:
- Add user-facing documentation for DataProfileReport, including design plan and reference docs, and a quickstart example script demonstrating report generation from records and precomputed embeddings.
- Update MkDocs navigation to link the new data-profile reference page.

Tests:
- Add extensive unit and end-to-end tests for data_profile sections, builders, embedding sources, accumulators, HTML scaffold, and memory behavior, including large-matrix memmap checks and NaN/Infinity rendering guards.
- Augment SVG tests to cover new bar_chart normalization behavior and rectangle extraction helpers.

Chores:
- Update import-budget and lazy-import tests to account for new data_profile modules and ensure they remain import-light.