### PR TITLE
fix: OpenMP guard for faiss/torch + correct stale VectorBlocker docstrings

### DIFF
--- a/src/langres/core/blocker.py
+++ b/src/langres/core/blocker.py
@@ -244,7 +244,7 @@ class Blocker(ABC, Generic[SchemaT]):
             See BlockerEvaluationReport documentation for full details.
 
         Example:
-            >>> blocker = VectorBlocker(embedding_model, k_neighbors=10)
+            >>> blocker = VectorBlocker(...)
             >>> candidates = list(blocker.stream(data))
             >>> report = blocker.evaluate(candidates, gold_clusters)
             >>> print(f"Blocking recall: {report.candidates.recall:.2%}")

--- a/src/langres/core/indexes/vector_index.py
+++ b/src/langres/core/indexes/vector_index.py
@@ -13,8 +13,15 @@ Key design principles:
 
 import json
 import logging
+import os
 from pathlib import Path
 from typing import ClassVar, Literal, Protocol, cast
+
+# faiss and torch each vendor their own libomp; on macOS loading both in one
+# process can abort with a duplicate-OpenMP-runtime error (exit 139). Opting
+# into the documented workaround before faiss loads keeps the dev/test flow
+# (parallel pytest) stable. No effect once an OpenMP runtime is already loaded.
+os.environ.setdefault("KMP_DUPLICATE_LIB_OK", "TRUE")
 
 import faiss
 import numpy as np

--- a/src/langres/core/optimizers/blocker_optimizer.py
+++ b/src/langres/core/optimizers/blocker_optimizer.py
@@ -25,8 +25,10 @@ class BlockerOptimizer:
     Example:
         # Define objective function
         def objective(trial: optuna.Trial, params: dict) -> dict:
+            embedder = SentenceTransformerEmbedder(params["embedding_model"])
+            index = FAISSIndex(embedder=embedder, metric="cosine")
             blocker = VectorBlocker(
-                embedding_model=params["embedding_model"],
+                vector_index=index,
                 k_neighbors=params["k_neighbors"],
                 ...
             )
@@ -146,8 +148,10 @@ class BlockerOptimizer:
             # Returns: {"embedding_model": "all-mpnet-base-v2", "k_neighbors": 35}
 
             # Use best params to create final blocker
+            embedder = SentenceTransformerEmbedder(best_params["embedding_model"])
+            index = FAISSIndex(embedder=embedder, metric="cosine")
             blocker = VectorBlocker(
-                embedding_model=best_params["embedding_model"],
+                vector_index=index,
                 k_neighbors=best_params["k_neighbors"],
                 ...
             )


### PR DESCRIPTION
## Summary

Two independent, small fixes bundled together (epic #145, autoresearch M1 g-stack). This is the **first PR in the g-stack** — it de-risks embedding-test segfaults for downstream PRs by landing the OpenMP guard early.

**G3 — OpenMP duplicate-lib segfault guard (macOS dev-flow fix)**
- `src/langres/core/indexes/vector_index.py`: set `os.environ.setdefault("KMP_DUPLICATE_LIB_OK", "TRUE")` immediately before the eager `import faiss`. faiss and torch each vendor their own libomp; loading both in one process can abort with exit 139 on macOS, which bites parallel pytest runs (`pytest -n`) that mix embedding and faiss tests.
- Verified `faiss` is imported nowhere else in `src/` — this single guard site covers every path. `src/langres/core/embeddings.py` (eager `sentence_transformers`→torch import) does **not** get a duplicate guard: since KMP's duplicate-runtime check fires on whichever OpenMP-linked library initializes *second*, and the guard is set before faiss's own `import` statement regardless of import order, one guard site is sufficient — adding a second would just scatter the workaround per CLAUDE.md's "surgical changes" rule.
- This is a **dev-flow** mitigation (matches the project's existing `.env.example` / friction-log workaround, made in-process so it also protects a bare `uv run pytest` without `--env-file .env`), not a correctness guarantee.

**G4 — stale VectorBlocker docstrings (docs-only)**
`VectorBlocker` takes `vector_index=` (wrapping an injected embedder), not `embedding_model=`. Read `src/langres/core/blockers/vector.py` to confirm the real constructor, then fixed the two stale call-site docstrings:
- `src/langres/core/optimizers/blocker_optimizer.py` (two `Example:` blocks): now build `SentenceTransformerEmbedder` + `FAISSIndex` and pass `vector_index=index`, matching the real construction pattern used in `core/presets.py`/`core/resolver.py`.
- `src/langres/core/blocker.py` (`Blocker.evaluate` doctest): simplified `VectorBlocker(embedding_model, k_neighbors=10)` to the `VectorBlocker(...)` ellipsis convention already used consistently in `core/metrics.py`'s docstrings.

No behavior changes — docstring/comment-only for G4, a single `os.environ.setdefault` (no-op if already set) for G3.

## Test plan
- [x] `uv sync --all-extras --no-extra finetune`
- [x] `uv run ruff check .` — all checks passed
- [x] `uv run ruff format --check .` — all files formatted
- [x] `uv run mypy src` — no issues, 108 source files
- [x] `uv run --with pytest-xdist pytest tests -k "vector or faiss or embed or index or blocker" -n auto -q` — 553 passed, 1 skipped, 16 pre-existing/unrelated failures in `tests/plotting/test_blockers.py` (confirmed via `git stash` to pre-exist on `feat/autoresearch` before this change, and confirmed order-dependent/flaky — a `mock.patch("matplotlib.pyplot", ...)` timing issue, unrelated to faiss/torch/OpenMP). No exit-139 segfault, with or without the G3 guard applied (see PR discussion for the before/after comparison run).

## Summary by Sourcery

Guard FAISS index imports with an OpenMP duplicate-runtime workaround and refresh VectorBlocker usage examples to match the current API.

Bug Fixes:
- Prevent macOS dev/test segfaults from FAISS and Torch loading conflicting OpenMP runtimes by setting KMP_DUPLICATE_LIB_OK before importing faiss.

Enhancements:
- Update VectorBlocker-related docstrings and examples to construct a SentenceTransformerEmbedder and FAISSIndex and pass them via vector_index instead of the outdated embedding_model parameter.
- Simplify the Blocker.evaluate doctest to use an ellipsis-style VectorBlocker(...) example consistent with other documentation.