### PR TITLE
feat(autoresearch): pluggable Objective + log_loss steering signal

### DIFF
--- a/src/langres/core/autoresearch/objective.py
+++ b/src/langres/core/autoresearch/objective.py
@@ -46,8 +46,7 @@ def _require(metrics: Mapping[str, float], name: str) -> float:
         return metrics[name]
     except KeyError:
         raise ValueError(
-            f"metric {name!r} is missing from the metrics mapping "
-            f"(available: {sorted(metrics)})"
+            f"metric {name!r} is missing from the metrics mapping (available: {sorted(metrics)})"
         ) from None
 
 
@@ -259,4 +258,6 @@ def _to_constraints(triples: Iterable[tuple[str, str, float]]) -> tuple[Constrai
     :meth:`Constraint.__post_init__` is the real runtime guard that rejects an
     unknown operator with a clear ``ValueError``.
     """
-    return tuple(Constraint(metric, cast(ConstraintOp, op), threshold) for metric, op, threshold in triples)
+    return tuple(
+        Constraint(metric, cast(ConstraintOp, op), threshold) for metric, op, threshold in triples
+    )

--- a/src/langres/core/autoresearch/objective.py
+++ b/src/langres/core/autoresearch/objective.py
@@ -1,0 +1,262 @@
+"""The immutable Objective the autoresearch loop steers on.
+
+The autoresearch loop is ``propose → run → evaluate → keep-if-better`` (epic
+#145). The :class:`Objective` is the *immutable scorer* that decides the last
+step: given a candidate config's metrics and the incumbent's, is the candidate
+**better**? ER F1 saturates near 99%, so the loop steers on loss-like / Pareto
+signals (``recall@budget``, ``log_loss``, quality×cost) instead of a thresholded
+F1, and the Objective supports both a single goal with feasibility constraints
+*and* multi-objective Pareto dominance.
+
+**Metric-source-agnostic by design.** The Objective operates on a plain
+``Mapping[str, float]`` of already-computed metrics; it never computes a metric
+itself (the run/evaluate stage does that and hands the numbers over). It imports
+nothing heavy — pure stdlib + typing — so a bare ``import langres`` stays
+import-light (see ``tests/test_import_budget.py``).
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable, Iterable, Mapping
+from dataclasses import dataclass
+from typing import Literal, cast, get_args
+
+Direction = Literal["maximize", "minimize"]
+"""Optimization sense of a goal metric: higher-is-better or lower-is-better."""
+
+ConstraintOp = Literal[">=", "<=", ">", "<"]
+"""Comparison operator for a feasibility constraint (``metric <op> threshold``)."""
+
+_DIRECTIONS: tuple[Direction, ...] = get_args(Direction)
+_OPS: dict[ConstraintOp, Callable[[float, float], bool]] = {
+    ">=": lambda a, b: a >= b,
+    "<=": lambda a, b: a <= b,
+    ">": lambda a, b: a > b,
+    "<": lambda a, b: a < b,
+}
+
+
+def _require(metrics: Mapping[str, float], name: str) -> float:
+    """Return ``metrics[name]`` or raise a clear error naming what is available.
+
+    Missing metrics fail loud rather than defaulting to 0.0: a silently-absent
+    metric would corrupt every feasibility and dominance decision downstream.
+    """
+    try:
+        return metrics[name]
+    except KeyError:
+        raise ValueError(
+            f"metric {name!r} is missing from the metrics mapping "
+            f"(available: {sorted(metrics)})"
+        ) from None
+
+
+@dataclass(frozen=True, slots=True)
+class Goal:
+    """A single optimization goal: one metric plus the direction to push it.
+
+    Attributes:
+        metric: The metric key looked up in a metrics mapping.
+        direction: ``"maximize"`` (higher is better) or ``"minimize"`` (lower is
+            better).
+    """
+
+    metric: str
+    direction: Direction
+
+    def __post_init__(self) -> None:
+        if self.direction not in _DIRECTIONS:
+            raise ValueError(
+                f"direction must be one of {list(_DIRECTIONS)}, got {self.direction!r}"
+            )
+
+
+@dataclass(frozen=True, slots=True)
+class Constraint:
+    """A feasibility constraint: ``metrics[metric] <op> threshold`` must hold.
+
+    Attributes:
+        metric: The metric key looked up in a metrics mapping.
+        op: One of ``">="``, ``"<="``, ``">"``, ``"<"``.
+        threshold: The value the metric is compared against.
+    """
+
+    metric: str
+    op: ConstraintOp
+    threshold: float
+
+    def __post_init__(self) -> None:
+        if self.op not in _OPS:
+            raise ValueError(f"constraint op must be one of {list(_OPS)}, got {self.op!r}")
+
+    def satisfied(self, metrics: Mapping[str, float]) -> bool:
+        """Whether ``metrics`` satisfies this constraint.
+
+        Raises:
+            ValueError: If ``metric`` is absent from ``metrics``.
+        """
+        return _OPS[self.op](_require(metrics, self.metric), self.threshold)
+
+
+@dataclass(frozen=True, slots=True)
+class Objective:
+    """The immutable keep-if-better scorer for the autoresearch loop.
+
+    An Objective bundles one or more :class:`Goal` s (the optimization targets)
+    with zero or more :class:`Constraint` s (feasibility gates). It scores a
+    candidate config's metrics against the incumbent's and answers the loop's
+    single question via :meth:`is_better`.
+
+    Prefer the ergonomic constructors :meth:`maximize`, :meth:`minimize`, and
+    :meth:`pareto` over the raw tuple form.
+
+    Attributes:
+        goals: The optimization goals (at least one). Multiple goals are treated
+            as a Pareto front — never scalarized.
+        constraints: Feasibility gates; a candidate violating any is infeasible.
+    """
+
+    goals: tuple[Goal, ...]
+    constraints: tuple[Constraint, ...] = ()
+
+    def __post_init__(self) -> None:
+        if not self.goals:
+            raise ValueError("an Objective needs at least one goal")
+
+    def is_feasible(self, metrics: Mapping[str, float]) -> bool:
+        """True iff every constraint holds (vacuously true with no constraints).
+
+        Raises:
+            ValueError: If a constrained metric is absent from ``metrics``.
+        """
+        return all(c.satisfied(metrics) for c in self.constraints)
+
+    def value(self, metrics: Mapping[str, float]) -> tuple[float, ...]:
+        """The goal metrics as a tuple, each normalized to higher-is-better.
+
+        A ``minimize`` goal is negated so a larger normalized value is always
+        better; this makes Pareto dominance uniform across goals (see
+        :meth:`dominates`). The tuple is ordered to match ``goals``.
+
+        Raises:
+            ValueError: If a goal metric is absent from ``metrics``.
+        """
+        out: list[float] = []
+        for g in self.goals:
+            v = _require(metrics, g.metric)
+            out.append(v if g.direction == "maximize" else -v)
+        return tuple(out)
+
+    def dominates(self, a: Mapping[str, float], b: Mapping[str, float]) -> bool:
+        """Pareto dominance: ``a`` dominates ``b`` over the goal metrics.
+
+        Compares the higher-is-better normalized value tuples (see
+        :meth:`value`): ``a`` dominates ``b`` iff it is ``>=`` on *every* goal
+        and strictly ``>`` on *at least one*. For a single goal this collapses
+        to a strict scalar improvement (``a > b``). Feasibility is not
+        considered here — :meth:`is_better` gates on that first.
+
+        Raises:
+            ValueError: If a goal metric is absent from ``a`` or ``b``.
+        """
+        va = self.value(a)
+        vb = self.value(b)
+        no_worse = all(x >= y for x, y in zip(va, vb, strict=True))
+        strictly_better = any(x > y for x, y in zip(va, vb, strict=True))
+        return no_worse and strictly_better
+
+    def is_better(
+        self,
+        candidate: Mapping[str, float],
+        incumbent: Mapping[str, float] | None,
+    ) -> bool:
+        """The loop's keep-if-better decision for ``candidate`` vs ``incumbent``.
+
+        Semantics, in order:
+
+        1. **Feasibility gates first.** An infeasible candidate is never better
+           (returns ``False``), whatever the incumbent. A feasible candidate
+           beats a ``None`` incumbent (the first feasible config seen) or an
+           infeasible incumbent.
+        2. **Pareto improvement.** With both feasible, the candidate is better
+           iff it *dominates* the incumbent (see :meth:`dominates`) — ``>=`` on
+           every goal and ``>`` on at least one. For a single goal this is a
+           strict scalar improvement.
+
+        When neither dominates the other — a tie, or an incomparable
+        multi-objective trade-off (better on one goal, worse on another) — the
+        candidate is **not** better and the loop keeps the incumbent. This makes
+        the decision deterministic and monotone for M1: trade-offs are never
+        scalarized, so the incumbent is displaced only by a strict Pareto win.
+
+        Raises:
+            ValueError: If a referenced goal metric is absent from ``candidate``,
+                or from ``incumbent`` when the comparison reaches it, or a
+                constrained metric is absent from a mapping it is checked against.
+        """
+        if not self.is_feasible(candidate):
+            return False
+        if incumbent is None or not self.is_feasible(incumbent):
+            return True
+        return self.dominates(candidate, incumbent)
+
+    @classmethod
+    def maximize(
+        cls,
+        metric: str,
+        *,
+        subject_to: Iterable[tuple[str, str, float]] = (),
+    ) -> Objective:
+        """A single maximize goal, optionally subject to constraints.
+
+        Args:
+            metric: The metric to maximize (higher is better).
+            subject_to: Constraints as ``(metric, op, threshold)`` triples, e.g.
+                ``[("precision", ">=", 0.9)]``.
+        """
+        return cls(goals=(Goal(metric, "maximize"),), constraints=_to_constraints(subject_to))
+
+    @classmethod
+    def minimize(
+        cls,
+        metric: str,
+        *,
+        subject_to: Iterable[tuple[str, str, float]] = (),
+    ) -> Objective:
+        """A single minimize goal (e.g. ``log_loss``, cost), optionally constrained.
+
+        Args:
+            metric: The metric to minimize (lower is better).
+            subject_to: Constraints as ``(metric, op, threshold)`` triples.
+        """
+        return cls(goals=(Goal(metric, "minimize"),), constraints=_to_constraints(subject_to))
+
+    @classmethod
+    def pareto(
+        cls,
+        goals: Iterable[tuple[str, str]],
+        *,
+        subject_to: Iterable[tuple[str, str, float]] = (),
+    ) -> Objective:
+        """A multi-objective Pareto goal set.
+
+        Args:
+            goals: ``(metric, direction)`` pairs where direction is
+                ``"maximize"`` or ``"minimize"``, e.g.
+                ``[("recall", "maximize"), ("cost", "minimize")]``.
+            subject_to: Constraints as ``(metric, op, threshold)`` triples.
+        """
+        return cls(
+            goals=tuple(Goal(m, cast(Direction, d)) for m, d in goals),
+            constraints=_to_constraints(subject_to),
+        )
+
+
+def _to_constraints(triples: Iterable[tuple[str, str, float]]) -> tuple[Constraint, ...]:
+    """Build validated :class:`Constraint` s from ``(metric, op, threshold)`` triples.
+
+    The ``op`` is cast to :data:`ConstraintOp` to satisfy the type checker;
+    :meth:`Constraint.__post_init__` is the real runtime guard that rejects an
+    unknown operator with a clear ``ValueError``.
+    """
+    return tuple(Constraint(metric, cast(ConstraintOp, op), threshold) for metric, op, threshold in triples)

--- a/src/langres/core/metrics.py
+++ b/src/langres/core/metrics.py
@@ -5,8 +5,8 @@ This module provides metrics for evaluating different pipeline stages:
 - Clustering stage: evaluate_clustering(), calculate_bcubed_metrics(), calculate_pairwise_metrics()
 - Agreement (rater-vs-rater): cohens_kappa(), matthews_corrcoef()
 - Ranking (score-vs-label): roc_auc_score(), average_precision_score()
-- Calibration (confidence-vs-outcome): brier_score(), expected_calibration_error(),
-  reliability_bins()
+- Calibration (confidence-vs-outcome): brier_score(), log_loss(),
+  expected_calibration_error(), reliability_bins()
 
 References:
     Amigó, E., Gonzalo, J., Artiles, J., & Verdejo, F. (2009).
@@ -1282,6 +1282,53 @@ def brier_score(confidences: list[float], outcomes: list[bool]) -> float:
     return sum(
         (p - (1.0 if y else 0.0)) ** 2 for p, y in zip(confidences, outcomes, strict=True)
     ) / len(confidences)
+
+
+# Epsilon that clamps predicted probabilities away from 0 and 1 before taking
+# their log, so a confident-and-wrong prediction yields a large *finite* loss
+# instead of ``log(0) = -inf``. 1e-15 matches the scikit-learn default and caps
+# the per-item penalty near ``-log(1e-15) ~= 34.5``.
+_LOG_LOSS_EPS = 1e-15
+
+
+def log_loss(confidences: list[float], outcomes: list[bool]) -> float:
+    """Binary cross-entropy (log loss): the loss-like proper scoring rule.
+
+    ``log_loss = -mean( y*log(p) + (1 - y)*log(1 - p) )`` over aligned predicted
+    probabilities ``p`` and boolean outcomes ``y``. Like :func:`brier_score` it
+    is a strictly proper scoring rule (minimized only by honest probabilities)
+    and needs no binning, but it penalizes confident mistakes far more harshly.
+    That heavy tail makes it the natural loss-like steering signal for the
+    autoresearch loop, which optimizes a loss rather than a saturated F1.
+
+    Each probability is clamped to ``[eps, 1 - eps]`` (``eps = _LOG_LOSS_EPS =
+    1e-15``) before the log, so a confident-and-wrong ``p = 0`` / ``p = 1`` gives
+    a large finite loss instead of ``+inf``; the per-item penalty is therefore
+    capped near ``-log(eps) ~= 34.5``.
+
+    Args:
+        confidences: Predicted probabilities in ``[0, 1]``.
+        outcomes: Realized boolean outcomes, aligned with ``confidences``.
+
+    Returns:
+        Mean binary cross-entropy in nats; ``>= 0.0``, lower is better.
+        Approaches ``0.0`` only for confident, correct predictions (up to the
+        ``eps`` clamp). A constant ``0.5`` forecaster scores ``log(2) ~= 0.693``.
+
+    Raises:
+        ValueError: If inputs differ in length, are empty, or any confidence is
+            outside ``[0, 1]``.
+
+    Example:
+        >>> log_loss([0.9, 0.1], [True, False])
+        0.10536051565782628
+    """
+    _validate_calibration(confidences, outcomes)
+    total = 0.0
+    for p, y in zip(confidences, outcomes, strict=True):
+        clamped = min(max(p, _LOG_LOSS_EPS), 1.0 - _LOG_LOSS_EPS)
+        total += math.log(clamped) if y else math.log(1.0 - clamped)
+    return -total / len(confidences)
 
 
 def _bin_indices(confidences: list[float], n_bins: int, strategy: BinStrategy) -> list[list[int]]:

--- a/src/langres/core/metrics.py
+++ b/src/langres/core/metrics.py
@@ -1301,10 +1301,14 @@ def log_loss(confidences: list[float], outcomes: list[bool]) -> float:
     That heavy tail makes it the natural loss-like steering signal for the
     autoresearch loop, which optimizes a loss rather than a saturated F1.
 
-    Each probability is clamped to ``[eps, 1 - eps]`` (``eps = _LOG_LOSS_EPS =
-    1e-15``) before the log, so a confident-and-wrong ``p = 0`` / ``p = 1`` gives
-    a large finite loss instead of ``+inf``; the per-item penalty is therefore
-    capped near ``-log(eps) ~= 34.5``.
+    Numerically, the probability the forecaster assigned to the *realized*
+    outcome (``p`` for a ``True``, ``1 - p`` for a ``False``) is clamped to
+    ``[eps, 1 - eps]`` (``eps = _LOG_LOSS_EPS = 1e-15``) before the log. Clamping
+    that realized-class probability directly -- rather than clamping ``p`` and
+    subtracting -- keeps a confident-and-wrong ``p = 0`` / ``p = 1`` exact:
+    ``1 - 1.0`` is ``0.0`` before the clamp, avoiding the float cancellation of
+    ``1 - (1 - eps)``. So a confident mistake gives a large *finite* loss (the
+    per-item penalty is capped near ``-log(eps) ~= 34.5``) instead of ``+inf``.
 
     Args:
         confidences: Predicted probabilities in ``[0, 1]``.
@@ -1326,8 +1330,8 @@ def log_loss(confidences: list[float], outcomes: list[bool]) -> float:
     _validate_calibration(confidences, outcomes)
     total = 0.0
     for p, y in zip(confidences, outcomes, strict=True):
-        clamped = min(max(p, _LOG_LOSS_EPS), 1.0 - _LOG_LOSS_EPS)
-        total += math.log(clamped) if y else math.log(1.0 - clamped)
+        realized = p if y else 1.0 - p
+        total += math.log(min(max(realized, _LOG_LOSS_EPS), 1.0 - _LOG_LOSS_EPS))
     return -total / len(confidences)
 
 

--- a/tests/core/test_autoresearch_objective.py
+++ b/tests/core/test_autoresearch_objective.py
@@ -1,0 +1,262 @@
+"""Tests for the autoresearch :class:`Objective` (the keep-if-better scorer).
+
+Core contract code -> high coverage tier. Covers feasibility gating, goal
+normalization, Pareto dominance (dominating / dominated / incomparable / tie),
+the ``is_better`` decision against ``None`` and feasible/infeasible incumbents,
+the ergonomic constructors, and every fail-loud validation branch.
+"""
+
+import pytest
+
+from langres.core.autoresearch.objective import (
+    Constraint,
+    Goal,
+    Objective,
+)
+
+# ---------------------------------------------------------------------------
+# Goal
+# ---------------------------------------------------------------------------
+
+
+def test_goal_is_frozen() -> None:
+    g = Goal("recall", "maximize")
+    with pytest.raises((AttributeError, TypeError)):
+        g.metric = "precision"  # type: ignore[misc]
+
+
+def test_goal_bad_direction_raises() -> None:
+    with pytest.raises(ValueError, match="direction must be one of"):
+        Goal("recall", "maximise")  # type: ignore[arg-type]
+
+
+# ---------------------------------------------------------------------------
+# Constraint
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    ("op", "threshold", "value", "expected"),
+    [
+        (">=", 0.9, 0.9, True),
+        (">=", 0.9, 0.89, False),
+        ("<=", 0.1, 0.1, True),
+        ("<=", 0.1, 0.11, False),
+        (">", 0.5, 0.6, True),
+        (">", 0.5, 0.5, False),
+        ("<", 0.5, 0.4, True),
+        ("<", 0.5, 0.5, False),
+    ],
+)
+def test_constraint_satisfied_each_op(
+    op: str, threshold: float, value: float, expected: bool
+) -> None:
+    c = Constraint("m", op, threshold)  # type: ignore[arg-type]
+    assert c.satisfied({"m": value}) is expected
+
+
+def test_constraint_bad_op_raises() -> None:
+    with pytest.raises(ValueError, match="constraint op must be one of"):
+        Constraint("m", ">>", 0.5)  # type: ignore[arg-type]
+
+
+def test_constraint_missing_metric_raises() -> None:
+    c = Constraint("precision", ">=", 0.9)
+    with pytest.raises(ValueError, match="metric 'precision' is missing"):
+        c.satisfied({"recall": 0.9})
+
+
+# ---------------------------------------------------------------------------
+# Objective construction / value normalization
+# ---------------------------------------------------------------------------
+
+
+def test_objective_requires_a_goal() -> None:
+    with pytest.raises(ValueError, match="at least one goal"):
+        Objective(goals=())
+
+
+def test_value_maximize_passthrough() -> None:
+    obj = Objective.maximize("recall")
+    assert obj.value({"recall": 0.8}) == (0.8,)
+
+
+def test_value_minimize_is_negated() -> None:
+    obj = Objective.minimize("log_loss")
+    # Normalized to higher-is-better: a minimize goal is negated.
+    assert obj.value({"log_loss": 0.3}) == (-0.3,)
+
+
+def test_value_orders_by_goals() -> None:
+    obj = Objective.pareto([("recall", "maximize"), ("cost", "minimize")])
+    assert obj.value({"recall": 0.9, "cost": 2.0}) == (0.9, -2.0)
+
+
+def test_value_missing_metric_raises() -> None:
+    obj = Objective.maximize("recall")
+    with pytest.raises(ValueError, match="metric 'recall' is missing"):
+        obj.value({"precision": 0.9})
+
+
+# ---------------------------------------------------------------------------
+# Feasibility
+# ---------------------------------------------------------------------------
+
+
+def test_is_feasible_no_constraints_is_vacuously_true() -> None:
+    obj = Objective.maximize("recall")
+    assert obj.is_feasible({"recall": 0.1}) is True
+
+
+def test_is_feasible_all_satisfied() -> None:
+    obj = Objective.maximize("recall", subject_to=[("precision", ">=", 0.9)])
+    assert obj.is_feasible({"recall": 0.8, "precision": 0.95}) is True
+
+
+def test_is_feasible_one_violated() -> None:
+    obj = Objective.maximize("recall", subject_to=[("precision", ">=", 0.9)])
+    assert obj.is_feasible({"recall": 0.8, "precision": 0.85}) is False
+
+
+def test_is_feasible_missing_constraint_metric_raises() -> None:
+    obj = Objective.maximize("recall", subject_to=[("precision", ">=", 0.9)])
+    with pytest.raises(ValueError, match="metric 'precision' is missing"):
+        obj.is_feasible({"recall": 0.8})
+
+
+# ---------------------------------------------------------------------------
+# Pareto dominance
+# ---------------------------------------------------------------------------
+
+
+def test_dominates_strictly_better_on_all() -> None:
+    obj = Objective.pareto([("recall", "maximize"), ("precision", "maximize")])
+    a = {"recall": 0.9, "precision": 0.9}
+    b = {"recall": 0.8, "precision": 0.8}
+    assert obj.dominates(a, b) is True
+    assert obj.dominates(b, a) is False
+
+
+def test_dominates_equal_on_one_better_on_other() -> None:
+    obj = Objective.pareto([("recall", "maximize"), ("precision", "maximize")])
+    a = {"recall": 0.9, "precision": 0.8}
+    b = {"recall": 0.8, "precision": 0.8}  # a is >= on both and > on recall
+    assert obj.dominates(a, b) is True
+
+
+def test_dominates_incomparable_tradeoff() -> None:
+    obj = Objective.pareto([("recall", "maximize"), ("precision", "maximize")])
+    a = {"recall": 0.9, "precision": 0.7}
+    b = {"recall": 0.8, "precision": 0.8}  # a better on recall, worse on precision
+    assert obj.dominates(a, b) is False
+    assert obj.dominates(b, a) is False
+
+
+def test_dominates_tie_is_not_dominance() -> None:
+    obj = Objective.pareto([("recall", "maximize"), ("precision", "maximize")])
+    m = {"recall": 0.9, "precision": 0.9}
+    assert obj.dominates(m, dict(m)) is False
+
+
+def test_dominates_respects_minimize_direction() -> None:
+    obj = Objective.pareto([("recall", "maximize"), ("cost", "minimize")])
+    a = {"recall": 0.9, "cost": 1.0}
+    b = {"recall": 0.9, "cost": 2.0}  # same recall, lower cost -> a dominates
+    assert obj.dominates(a, b) is True
+    assert obj.dominates(b, a) is False
+
+
+# ---------------------------------------------------------------------------
+# is_better — the loop's keep/revert decision
+# ---------------------------------------------------------------------------
+
+
+def test_is_better_feasible_beats_none_incumbent() -> None:
+    obj = Objective.maximize("recall")
+    assert obj.is_better({"recall": 0.5}, None) is True
+
+
+def test_is_better_infeasible_candidate_never_better_even_vs_none() -> None:
+    obj = Objective.maximize("recall", subject_to=[("precision", ">=", 0.9)])
+    assert obj.is_better({"recall": 0.99, "precision": 0.5}, None) is False
+
+
+def test_is_better_feasible_beats_infeasible_incumbent() -> None:
+    obj = Objective.maximize("recall", subject_to=[("precision", ">=", 0.9)])
+    candidate = {"recall": 0.5, "precision": 0.95}  # feasible
+    incumbent = {"recall": 0.99, "precision": 0.5}  # infeasible
+    assert obj.is_better(candidate, incumbent) is True
+
+
+def test_is_better_single_goal_strict_improvement() -> None:
+    obj = Objective.maximize("recall")
+    assert obj.is_better({"recall": 0.9}, {"recall": 0.8}) is True
+    assert obj.is_better({"recall": 0.8}, {"recall": 0.9}) is False
+
+
+def test_is_better_single_goal_tie_keeps_incumbent() -> None:
+    obj = Objective.maximize("recall")
+    assert obj.is_better({"recall": 0.8}, {"recall": 0.8}) is False
+
+
+def test_is_better_minimize_single_goal() -> None:
+    obj = Objective.minimize("log_loss")
+    assert obj.is_better({"log_loss": 0.2}, {"log_loss": 0.3}) is True
+    assert obj.is_better({"log_loss": 0.4}, {"log_loss": 0.3}) is False
+
+
+def test_is_better_multi_goal_dominating() -> None:
+    obj = Objective.pareto([("recall", "maximize"), ("precision", "maximize")])
+    assert obj.is_better(
+        {"recall": 0.9, "precision": 0.9}, {"recall": 0.8, "precision": 0.8}
+    ) is True
+
+
+def test_is_better_multi_goal_incomparable_keeps_incumbent() -> None:
+    obj = Objective.pareto([("recall", "maximize"), ("precision", "maximize")])
+    # Better on recall, worse on precision: incomparable -> not better.
+    assert obj.is_better(
+        {"recall": 0.9, "precision": 0.7}, {"recall": 0.8, "precision": 0.8}
+    ) is False
+
+
+def test_is_better_missing_metric_raises() -> None:
+    obj = Objective.maximize("recall")
+    with pytest.raises(ValueError, match="metric 'recall' is missing"):
+        obj.is_better({"precision": 0.9}, {"recall": 0.8})
+
+
+# ---------------------------------------------------------------------------
+# Ergonomic constructors
+# ---------------------------------------------------------------------------
+
+
+def test_maximize_builds_single_goal_and_constraints() -> None:
+    obj = Objective.maximize("recall", subject_to=[("precision", ">=", 0.9)])
+    assert obj.goals == (Goal("recall", "maximize"),)
+    assert obj.constraints == (Constraint("precision", ">=", 0.9),)
+
+
+def test_minimize_builds_single_minimize_goal() -> None:
+    obj = Objective.minimize("log_loss")
+    assert obj.goals == (Goal("log_loss", "minimize"),)
+    assert obj.constraints == ()
+
+
+def test_pareto_builds_multiple_goals_with_mixed_directions() -> None:
+    obj = Objective.pareto(
+        [("recall", "maximize"), ("cost", "minimize")],
+        subject_to=[("precision", ">=", 0.8)],
+    )
+    assert obj.goals == (Goal("recall", "maximize"), Goal("cost", "minimize"))
+    assert obj.constraints == (Constraint("precision", ">=", 0.8),)
+
+
+def test_pareto_bad_direction_raises() -> None:
+    with pytest.raises(ValueError, match="direction must be one of"):
+        Objective.pareto([("recall", "up")])
+
+
+def test_constructor_bad_constraint_op_raises() -> None:
+    with pytest.raises(ValueError, match="constraint op must be one of"):
+        Objective.maximize("recall", subject_to=[("precision", "=>", 0.9)])

--- a/tests/core/test_autoresearch_objective.py
+++ b/tests/core/test_autoresearch_objective.py
@@ -207,17 +207,17 @@ def test_is_better_minimize_single_goal() -> None:
 
 def test_is_better_multi_goal_dominating() -> None:
     obj = Objective.pareto([("recall", "maximize"), ("precision", "maximize")])
-    assert obj.is_better(
-        {"recall": 0.9, "precision": 0.9}, {"recall": 0.8, "precision": 0.8}
-    ) is True
+    assert (
+        obj.is_better({"recall": 0.9, "precision": 0.9}, {"recall": 0.8, "precision": 0.8}) is True
+    )
 
 
 def test_is_better_multi_goal_incomparable_keeps_incumbent() -> None:
     obj = Objective.pareto([("recall", "maximize"), ("precision", "maximize")])
     # Better on recall, worse on precision: incomparable -> not better.
-    assert obj.is_better(
-        {"recall": 0.9, "precision": 0.7}, {"recall": 0.8, "precision": 0.8}
-    ) is False
+    assert (
+        obj.is_better({"recall": 0.9, "precision": 0.7}, {"recall": 0.8, "precision": 0.8}) is False
+    )
 
 
 def test_is_better_missing_metric_raises() -> None:

--- a/tests/core/test_metrics_calibration.py
+++ b/tests/core/test_metrics_calibration.py
@@ -10,9 +10,11 @@ import pytest
 
 from langres.core.metrics import (
     _bin_indices,
+    _LOG_LOSS_EPS,
     brier_score,
     cohens_kappa,
     expected_calibration_error,
+    log_loss,
     matthews_corrcoef,
     reliability_bins,
 )
@@ -144,6 +146,73 @@ def test_brier_confidence_out_of_range_raises() -> None:
 def test_brier_confidence_negative_raises() -> None:
     with pytest.raises(ValueError, match=r"\[0, 1\]"):
         brier_score([-0.1], [True])
+
+
+# ---------------------------------------------------------------------------
+# Log loss (binary cross-entropy)
+# ---------------------------------------------------------------------------
+
+
+def test_log_loss_hand_computed() -> None:
+    # -(log(0.9) + log(1-0.1)) / 2 = -log(0.9).
+    assert log_loss([0.9, 0.1], [True, False]) == pytest.approx(-math.log(0.9))
+
+
+def test_log_loss_perfect_is_near_zero() -> None:
+    # Clamped to [eps, 1-eps]; the residual is ~eps, i.e. effectively 0.
+    assert log_loss([1.0, 0.0], [True, False]) == pytest.approx(0.0, abs=1e-12)
+
+
+def test_log_loss_confident_and_wrong_is_large_but_finite() -> None:
+    # p=0 for a True and p=1 for a False both clamp to the eps bound.
+    worst = log_loss([0.0, 1.0], [True, False])
+    assert worst == pytest.approx(-math.log(_LOG_LOSS_EPS))
+    assert math.isfinite(worst)
+
+
+def test_log_loss_constant_half_is_log_two() -> None:
+    assert log_loss([0.5, 0.5], [True, False]) == pytest.approx(math.log(2.0))
+
+
+def test_log_loss_is_symmetric_under_label_flip() -> None:
+    # Flipping every (p, y) to (1-p, not y) leaves the loss unchanged.
+    assert log_loss([0.9, 0.1], [True, False]) == pytest.approx(
+        log_loss([0.1, 0.9], [False, True])
+    )
+
+
+def test_log_loss_small_vector() -> None:
+    conf = [0.8, 0.6, 0.3]
+    out = [True, True, False]
+    expected = -(math.log(0.8) + math.log(0.6) + math.log(1 - 0.3)) / 3
+    assert log_loss(conf, out) == pytest.approx(expected)
+
+
+def test_log_loss_epsilon_clamp_at_zero() -> None:
+    # p=0: correct-False stays ~0, wrong-True clamps to the eps penalty (finite).
+    assert log_loss([0.0], [False]) == pytest.approx(0.0, abs=1e-12)
+    assert log_loss([0.0], [True]) == pytest.approx(-math.log(_LOG_LOSS_EPS))
+
+
+def test_log_loss_epsilon_clamp_at_one() -> None:
+    # p=1: correct-True stays ~0, wrong-False clamps to the eps penalty (finite).
+    assert log_loss([1.0], [True]) == pytest.approx(0.0, abs=1e-12)
+    assert log_loss([1.0], [False]) == pytest.approx(-math.log(_LOG_LOSS_EPS))
+
+
+def test_log_loss_length_mismatch_raises() -> None:
+    with pytest.raises(ValueError, match="equal length"):
+        log_loss([0.5], [True, False])
+
+
+def test_log_loss_empty_raises() -> None:
+    with pytest.raises(ValueError, match="non-empty"):
+        log_loss([], [])
+
+
+def test_log_loss_confidence_out_of_range_raises() -> None:
+    with pytest.raises(ValueError, match=r"\[0, 1\]"):
+        log_loss([1.5], [True])
 
 
 # ---------------------------------------------------------------------------

--- a/tests/core/test_metrics_calibration.py
+++ b/tests/core/test_metrics_calibration.py
@@ -176,9 +176,7 @@ def test_log_loss_constant_half_is_log_two() -> None:
 
 def test_log_loss_is_symmetric_under_label_flip() -> None:
     # Flipping every (p, y) to (1-p, not y) leaves the loss unchanged.
-    assert log_loss([0.9, 0.1], [True, False]) == pytest.approx(
-        log_loss([0.1, 0.9], [False, True])
-    )
+    assert log_loss([0.9, 0.1], [True, False]) == pytest.approx(log_loss([0.1, 0.9], [False, True]))
 
 
 def test_log_loss_small_vector() -> None:


### PR DESCRIPTION
## What (epic #145 M1, PR P-A)

Adds the immutable **Objective** the autoresearch loop (`propose → run → evaluate → keep-if-better`) steers on, plus **`log_loss`** as the loss-like steering signal for the matching vertical.

### `src/langres/core/autoresearch/objective.py` (new)

Frozen dataclasses, pure stdlib + typing. **Metric-source-agnostic**: operates on a plain `Mapping[str, float]` of already-computed metrics and imports nothing heavy, so a bare `import langres` stays import-light (`tests/test_import_budget.py` still green).

Public API:
- `Direction = Literal["maximize", "minimize"]`, `ConstraintOp = Literal[">=","<=",">","<"]`
- `Goal(metric, direction)` — frozen; validates direction.
- `Constraint(metric, op, threshold)` — frozen; validates op; `.satisfied(metrics) -> bool`.
- `Objective(goals, constraints=())` — frozen. Methods:
  - `is_feasible(metrics) -> bool` — all constraints satisfied (vacuously true with none).
  - `value(metrics) -> tuple[float, ...]` — goal metrics normalized to higher-is-better (minimize goals negated) so dominance is uniform.
  - `dominates(a, b) -> bool` — Pareto: `>=` on every goal, `>` on at least one.
  - `is_better(candidate, incumbent | None) -> bool` — the keep/revert decision.
- Constructors: `Objective.maximize(metric, *, subject_to=…)`, `.minimize(...)`, `.pareto(goals, *, subject_to=…)` (constraints as `(metric, op, threshold)` triples; pareto goals as `(metric, "maximize"|"minimize")` pairs).

**Semantics of `is_better`:** feasibility gates first — an infeasible candidate is never better; a feasible candidate beats a `None`/infeasible incumbent. With both feasible, the candidate is better iff it Pareto-**dominates** the incumbent. **Incomparable multi-objective trade-offs (better on one goal, worse on another) and ties → not better → keep the incumbent.** Trade-offs are never scalarized in M1, so the incumbent is displaced only by a strict Pareto win (deterministic, monotone). Single-goal dominance collapses to a strict scalar improvement.

**Fail loud:** a referenced goal/constraint metric absent from the mapping raises `ValueError` (never treated as 0).

### `src/langres/core/metrics.py`

Adds `log_loss(confidences, outcomes) -> float` — binary cross-entropy, pure stdlib `math` (no sklearn/new deps), sibling of the existing `brier_score`. Probabilities clamped with `_LOG_LOSS_EPS = 1e-15` (matches scikit-learn) to keep a confident-and-wrong `p=0`/`p=1` a large *finite* loss (`-log(eps) ≈ 34.5`) instead of `+inf`. Clamps the realized-class probability (`p` for True, `1-p` for False) directly rather than clamping `p` and subtracting, so the eps floor is exact (no `1-(1-eps)` cancellation).

## Tests

- `tests/core/test_autoresearch_objective.py` (new) — 40 tests: feasibility gating, single maximize/minimize, each constraint op, Pareto dominance (dominating/dominated/incomparable/tie), `is_better` vs None + feasible/infeasible incumbent, minimize normalization, all fail-loud branches, ergonomic constructors. **objective.py = 100% line+branch coverage.**
- `tests/core/test_metrics_calibration.py` — added a `log_loss` section (hand-computed values, perfect ≈ 0, worst = `-log(eps)`, `0.5` → `log 2`, label-flip symmetry, eps clamp at p=0 and p=1, validation branches).

## Verification (all green locally)
`uv sync --all-extras --no-extra finetune` · `ruff check .` · `ruff format --check .` · `mypy src` (no issues) · new test files 88 passed · `tests/test_import_budget.py` 37 passed / 4 skipped.

## Summary by Sourcery

Introduce an immutable, metrics-agnostic Objective abstraction for steering the autoresearch loop and add log_loss as a binary cross-entropy calibration metric.

New Features:
- Add Goal, Constraint, and Objective abstractions to represent optimization goals, feasibility constraints, and Pareto-based keep-if-better decisions in the autoresearch loop.
- Expose ergonomic constructors for common objective configurations, including single-goal maximize/minimize and multi-goal Pareto setups.
- Add a log_loss binary cross-entropy metric as a loss-like calibration signal for model evaluation.

Enhancements:
- Ensure the autoresearch Objective operates on a lightweight metrics mapping without introducing heavy dependencies, preserving import-time performance.
- Normalize multi-objective comparisons via higher-is-better value transformation to support consistent Pareto dominance checks.

Tests:
- Add high-coverage tests for the Objective, Goal, and Constraint behavior, including feasibility gating, Pareto dominance, is_better semantics, and constructor validation.
- Extend calibration metric tests with coverage for log_loss behavior, numerical stability via epsilon clamping, and input validation edge cases.