### PR TITLE
feat(autoresearch): declarative SearchSpace + config→blocker factory

### DIFF
--- a/src/langres/core/autoresearch/factory.py
+++ b/src/langres/core/autoresearch/factory.py
@@ -1,0 +1,118 @@
+"""Turn one autoresearch config dict into a runnable blocker.
+
+Companion to ``search_space``: :class:`SearchSpace` enumerates config dicts and
+this module builds the blocker each one describes. Two pure functions, no global
+mutable state — index reuse across ``k`` values is the *caller's* job (it builds
+one index and threads it into :func:`build_blocker_from_config`; see the
+k-innermost ordering contract on ``SearchSpace.configs``), not a cache here.
+
+**NOT import-light.** This module imports the [semantic] stack
+(faiss/sentence-transformers, via the vector index + embedder) at module top, so
+it must only ever be imported **lazily** — on demand when a search actually runs,
+never from a bare ``import langres`` (unlike the sibling ``search_space``, which
+stays pure so it can live on the public API surface). The autoresearch package
+``__init__`` intentionally exports nothing, so importing ``langres`` does not
+reach this module.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping, Sequence
+from typing import Any, Literal, cast
+
+from langres.core.blocker import Blocker
+from langres.core.blockers.all_pairs import AllPairsBlocker
+from langres.core.blockers.vector import VectorBlocker
+from langres.core.embeddings import EmbeddingProvider, SentenceTransformerEmbedder
+from langres.core.indexes.vector_index import FAISSIndex, VectorIndex
+
+
+def build_index(
+    embedding_model: str,
+    metric: str,
+    texts: Sequence[str],
+    *,
+    embedder: EmbeddingProvider | None = None,
+) -> VectorIndex:
+    """Build a FAISS index over ``texts``, ready for search.
+
+    Mirrors the canonical VectorBlocker build path used across the codebase
+    (embedder → ``FAISSIndex(embedder=..., metric=...)`` → ``create_index``;
+    see ``core/presets.py:_build_vector_blocker`` and
+    ``data/_benchmark_utils.py:sweep_blocking_k``). ``create_index`` is called
+    here, so the returned index is immediately usable by a ``VectorBlocker`` —
+    an un-built index raises when streamed.
+
+    Args:
+        embedding_model: sentence-transformers model name. Used to construct a
+            :class:`SentenceTransformerEmbedder` unless ``embedder`` is injected.
+        metric: FAISS metric, ``"L2"`` or ``"cosine"``. Passed to ``FAISSIndex``;
+            an unknown value raises ``ValueError`` inside ``create_index``.
+        texts: Corpus texts to embed and index, in the same order as the records
+            the resulting blocker will stream.
+        embedder: Optional pre-built embedder that overrides constructing one
+            from ``embedding_model``. Tests inject a ``FakeEmbedder`` here to skip
+            the model download; production leaves it ``None``.
+
+    Returns:
+        A ready-to-search :class:`FAISSIndex` (``create_index`` already called).
+    """
+    if embedder is None:
+        embedder = SentenceTransformerEmbedder(embedding_model)
+    index = FAISSIndex(embedder=embedder, metric=cast(Literal["L2", "cosine"], metric))
+    index.create_index(list(texts))
+    return index
+
+
+def build_blocker_from_config(
+    config: Mapping[str, Any],
+    *,
+    schema: type[Any],
+    index: VectorIndex | None = None,
+) -> Blocker[Any]:
+    """Construct the blocker a config describes, dispatching on ``config["blocker"]``.
+
+    Named ``build_blocker_from_config`` (not ``build_blocker``) to avoid colliding
+    with ``Benchmark.build_blocker`` in the data layer.
+
+    Dispatch:
+
+    - ``"vector"`` — builds a :class:`VectorBlocker` over a **prebuilt** ``index``
+      (from :func:`build_index`), mirroring the canonical declarative wiring
+      (``schema=`` + ``text_field=`` keeps the blocker config-serializable).
+      Raises ``ValueError`` if ``index is None``.
+    - ``"all_pairs"`` — builds an :class:`AllPairsBlocker`; ``index`` is unused.
+
+    Args:
+        config: A config dict as yielded by ``SearchSpace.configs()``. For the
+            vector path it must carry ``text_field`` and ``k_neighbors``.
+        schema: The Pydantic record schema, passed declaratively so the blocker
+            stays config-serializable.
+        index: A prebuilt vector index. **Required** for ``blocker == "vector"``;
+            ignored for ``"all_pairs"``.
+
+    Returns:
+        A ready-to-stream :class:`Blocker`.
+
+    Raises:
+        ValueError: If ``blocker == "vector"`` and ``index is None``, or if
+            ``config["blocker"]`` names an unknown blocker kind.
+    """
+    blocker_kind = config["blocker"]
+    if blocker_kind == "vector":
+        if index is None:
+            raise ValueError(
+                "build_blocker_from_config requires a prebuilt 'index' for "
+                "blocker='vector' (build one with build_index(...) first)."
+            )
+        return VectorBlocker(
+            vector_index=index,
+            schema=schema,
+            text_field=config["text_field"],
+            k_neighbors=config["k_neighbors"],
+        )
+    if blocker_kind == "all_pairs":
+        return AllPairsBlocker(schema=schema)
+    raise ValueError(
+        f"unknown blocker {blocker_kind!r} in config (expected 'vector' or 'all_pairs')"
+    )

--- a/src/langres/core/autoresearch/factory.py
+++ b/src/langres/core/autoresearch/factory.py
@@ -46,8 +46,9 @@ def build_index(
     Args:
         embedding_model: sentence-transformers model name. Used to construct a
             :class:`SentenceTransformerEmbedder` unless ``embedder`` is injected.
-        metric: FAISS metric, ``"L2"`` or ``"cosine"``. Passed to ``FAISSIndex``;
-            an unknown value raises ``ValueError`` inside ``create_index``.
+        metric: FAISS metric, ``"L2"`` or ``"cosine"``. Validated here, so an
+            unknown value fails fast with a clear ``ValueError`` before any
+            embedding work — rather than deferring to the FAISS internals.
         texts: Corpus texts to embed and index, in the same order as the records
             the resulting blocker will stream.
         embedder: Optional pre-built embedder that overrides constructing one
@@ -57,8 +58,11 @@ def build_index(
     Returns:
         A ready-to-search :class:`FAISSIndex` (``create_index`` already called).
     """
+    if metric not in ("L2", "cosine"):
+        raise ValueError(f"metric must be 'L2' or 'cosine', got {metric!r}")
     if embedder is None:
         embedder = SentenceTransformerEmbedder(embedding_model)
+    # metric is validated just above, so narrowing str -> Literal is sound.
     index = FAISSIndex(embedder=embedder, metric=cast(Literal["L2", "cosine"], metric))
     index.create_index(list(texts))
     return index

--- a/src/langres/core/autoresearch/search_space.py
+++ b/src/langres/core/autoresearch/search_space.py
@@ -1,0 +1,101 @@
+"""The declarative search space the autoresearch loop enumerates.
+
+The autoresearch loop is ``propose → run → evaluate → keep-if-better`` (epic
+#145). A :class:`SearchSpace` is the *proposal substrate*: it names the candidate
+values per pipeline parameter and enumerates their Cartesian product as plain
+config dicts (``dict[str, Any]``) that the loop turns into runnable blockers via
+``core.autoresearch.factory``.
+
+**Import-light by design.** This module is pure stdlib + typing (``itertools`` /
+``dataclasses``) — it constructs no blocker and imports no
+faiss/torch/sentence-transformers, so it can sit on the public API surface (users
+build a ``SearchSpace`` to call ``langres.optimize``) without pulling the heavy
+[semantic] stack into a bare ``import langres`` (see ``tests/test_import_budget.py``).
+The heavy construction lives in the sibling ``factory`` module, which this one
+never imports.
+"""
+
+from __future__ import annotations
+
+import itertools
+from collections.abc import Iterator
+from dataclasses import dataclass, fields
+from typing import Any
+
+
+@dataclass(frozen=True, slots=True)
+class SearchSpace:
+    """A declarative Cartesian grid of blocker configs for the autoresearch loop.
+
+    Each field holds the candidate values for one pipeline parameter as a tuple;
+    :meth:`configs` yields their Cartesian product as config dicts. The defaults
+    describe a small vector-blocker ``k`` sweep (the one axis usually swept) with
+    a MiniLM + cosine baseline.
+
+    Attributes:
+        blocker: Blocker kinds to try (``"vector"`` and/or ``"all_pairs"``). The
+            vector-specific axes below are ignored by ``"all_pairs"``.
+        embedding_model: sentence-transformers model names for the vector index.
+        metric: FAISS distance metrics (``"L2"`` / ``"cosine"``).
+        text_field: Record attribute names holding each record's blocking text.
+            Dataset-specific — override the default to match your schema's field.
+        k_neighbors: Nearest-neighbour counts to sweep. The **innermost** axis of
+            :meth:`configs` (see its ordering contract).
+    """
+
+    blocker: tuple[str, ...] = ("vector",)
+    embedding_model: tuple[str, ...] = ("all-MiniLM-L6-v2",)
+    metric: tuple[str, ...] = ("cosine",)
+    text_field: tuple[str, ...] = ("name",)
+    k_neighbors: tuple[int, ...] = (5, 10, 20)
+
+    def __post_init__(self) -> None:
+        # Fail loud: an empty axis would silently collapse the whole product to
+        # zero configs, so the loop would run nothing without ever erroring.
+        for f in fields(self):
+            if not getattr(self, f.name):
+                raise ValueError(f"SearchSpace.{f.name} must be a non-empty tuple")
+
+    def configs(self) -> Iterator[dict[str, Any]]:
+        """Yield the Cartesian product of the axes as config dicts.
+
+        **Ordering contract (relied on by the loop):** ``k_neighbors`` is the
+        **innermost** varying dimension, so consecutive configs hold
+        ``(blocker, embedding_model, metric, text_field)`` fixed while ``k``
+        varies across its full range before any outer axis advances. This lets
+        the downstream loop build **one** vector index per
+        ``(embedding_model, metric, text_field)`` and reuse it across every
+        ``k`` value (``k`` lives on the blocker, not the index), instead of
+        re-embedding the corpus for each ``k``.
+
+        Yields:
+            One ``dict[str, Any]`` per grid point, with keys ``blocker``,
+            ``embedding_model``, ``metric``, ``text_field``, ``k_neighbors`` (in
+            that order).
+        """
+        # itertools.product varies its LAST argument fastest, so listing
+        # k_neighbors last makes it the innermost dimension (the contract above).
+        for blocker, embedding_model, metric, text_field, k in itertools.product(
+            self.blocker,
+            self.embedding_model,
+            self.metric,
+            self.text_field,
+            self.k_neighbors,
+        ):
+            yield {
+                "blocker": blocker,
+                "embedding_model": embedding_model,
+                "metric": metric,
+                "text_field": text_field,
+                "k_neighbors": k,
+            }
+
+    def __len__(self) -> int:
+        """The number of configs :meth:`configs` yields (the product of axis sizes)."""
+        return (
+            len(self.blocker)
+            * len(self.embedding_model)
+            * len(self.metric)
+            * len(self.text_field)
+            * len(self.k_neighbors)
+        )

--- a/tests/core/test_autoresearch_factory.py
+++ b/tests/core/test_autoresearch_factory.py
@@ -1,0 +1,135 @@
+"""Tests for the autoresearch config->blocker :mod:`factory`.
+
+Core contract code -> high coverage tier. The fast tests inject a ``FakeEmbedder``
+via the ``embedder=`` seam so no model is downloaded; one ``@pytest.mark.slow``
+smoke exercises the real ``SentenceTransformerEmbedder`` path. Covers a usable
+built index, the metric pass-through, VectorBlocker streaming from a config, the
+prebuilt-index requirement, the AllPairsBlocker path, and unknown-blocker
+fail-loud.
+"""
+
+import pytest
+
+from langres.core.autoresearch.factory import build_blocker_from_config, build_index
+from langres.core.blockers.all_pairs import AllPairsBlocker
+from langres.core.blockers.vector import VectorBlocker
+from langres.core.embeddings import FakeEmbedder
+from langres.core.indexes.vector_index import FAISSIndex
+from langres.core.models import CompanySchema
+
+# A tiny, offline dataset. build_index() must be fed texts in the same order as
+# the records the resulting blocker streams.
+_DATA = [
+    {"id": "c1", "name": "Acme Corporation"},
+    {"id": "c2", "name": "Acme Corp"},
+    {"id": "c3", "name": "Globex Inc"},
+    {"id": "c4", "name": "Globex Incorporated"},
+]
+_TEXTS = [r["name"] for r in _DATA]
+
+
+def _fake_index(metric: str = "cosine") -> FAISSIndex:
+    """Build a ready index over ``_TEXTS`` using a FakeEmbedder (no download)."""
+    index = build_index(
+        embedding_model="unused-with-fake",
+        metric=metric,
+        texts=_TEXTS,
+        embedder=FakeEmbedder(embedding_dim=16),
+    )
+    assert isinstance(index, FAISSIndex)
+    return index
+
+
+# ---------------------------------------------------------------------------
+# build_index
+# ---------------------------------------------------------------------------
+
+
+def test_build_index_returns_a_usable_built_index() -> None:
+    index = _fake_index()
+    # create_index() was called -> the FAISS index object exists and is searchable.
+    assert index._index is not None
+    distances, indices = index.search_all(k=2)
+    assert distances.shape == (len(_TEXTS), 2)
+    assert indices.shape == (len(_TEXTS), 2)
+
+
+def test_build_index_passes_metric_through() -> None:
+    assert _fake_index(metric="cosine").metric == "cosine"
+    assert _fake_index(metric="L2").metric == "L2"
+
+
+# ---------------------------------------------------------------------------
+# build_blocker_from_config -- vector
+# ---------------------------------------------------------------------------
+
+
+def test_vector_config_builds_streaming_vector_blocker() -> None:
+    index = _fake_index()
+    config = {
+        "blocker": "vector",
+        "embedding_model": "unused-with-fake",
+        "metric": "cosine",
+        "text_field": "name",
+        "k_neighbors": 2,
+    }
+    blocker = build_blocker_from_config(config, schema=CompanySchema, index=index)
+
+    assert isinstance(blocker, VectorBlocker)
+    assert blocker.k_neighbors == 2
+    assert blocker.vector_index is index  # index is reused, not rebuilt
+
+    candidates = list(blocker.stream(_DATA))
+    assert candidates, "vector blocker should stream at least one candidate pair"
+    ids = {frozenset((c.left.id, c.right.id)) for c in candidates}
+    assert all(len(pair) == 2 for pair in ids)  # no self-pairs
+
+
+def test_vector_config_without_index_raises() -> None:
+    config = {"blocker": "vector", "text_field": "name", "k_neighbors": 2}
+    with pytest.raises(ValueError, match="requires a prebuilt 'index'"):
+        build_blocker_from_config(config, schema=CompanySchema, index=None)
+
+
+# ---------------------------------------------------------------------------
+# build_blocker_from_config -- all_pairs
+# ---------------------------------------------------------------------------
+
+
+def test_all_pairs_config_builds_all_pairs_blocker_ignoring_index() -> None:
+    config = {"blocker": "all_pairs"}
+    blocker = build_blocker_from_config(config, schema=CompanySchema, index=None)
+
+    assert isinstance(blocker, AllPairsBlocker)
+    candidates = list(blocker.stream(_DATA))
+    # All unique unordered pairs of 4 records: C(4, 2) = 6.
+    assert len(candidates) == 6
+
+
+# ---------------------------------------------------------------------------
+# build_blocker_from_config -- errors
+# ---------------------------------------------------------------------------
+
+
+def test_unknown_blocker_raises() -> None:
+    with pytest.raises(ValueError, match="unknown blocker"):
+        build_blocker_from_config({"blocker": "nope"}, schema=CompanySchema)
+
+
+# ---------------------------------------------------------------------------
+# slow: real SentenceTransformerEmbedder path (covers the non-injected branch)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.slow
+def test_build_index_real_sentence_transformer_smoke() -> None:
+    """build_index with no injected embedder loads a real model and still streams.
+
+    Marked slow: downloads/loads all-MiniLM-L6-v2. Runs in the full suite, which
+    is where the coverage gate (and this branch's coverage) is enforced.
+    """
+    index = build_index("all-MiniLM-L6-v2", "cosine", _TEXTS)
+    config = {"blocker": "vector", "text_field": "name", "k_neighbors": 2}
+    blocker = build_blocker_from_config(config, schema=CompanySchema, index=index)
+    candidates = list(blocker.stream(_DATA))
+    assert candidates

--- a/tests/core/test_autoresearch_factory.py
+++ b/tests/core/test_autoresearch_factory.py
@@ -59,6 +59,11 @@ def test_build_index_passes_metric_through() -> None:
     assert _fake_index(metric="L2").metric == "L2"
 
 
+def test_build_index_rejects_unknown_metric() -> None:
+    with pytest.raises(ValueError, match="metric must be 'L2' or 'cosine'"):
+        build_index("m", "euclidean", _TEXTS, embedder=FakeEmbedder(embedding_dim=8))
+
+
 # ---------------------------------------------------------------------------
 # build_blocker_from_config -- vector
 # ---------------------------------------------------------------------------

--- a/tests/core/test_autoresearch_search_space.py
+++ b/tests/core/test_autoresearch_search_space.py
@@ -1,0 +1,157 @@
+"""Tests for the autoresearch :class:`SearchSpace` (the proposal substrate).
+
+Core contract code -> high coverage tier. Covers the config Cartesian product,
+its size (``__len__`` vs enumerated count), the **k_neighbors-innermost** ordering
+guarantee the loop depends on for index reuse, fail-loud empty-axis validation,
+frozenness, and import-lightness (no faiss/torch pulled by importing this module).
+"""
+
+import subprocess
+import sys
+
+import pytest
+
+from langres.core.autoresearch.search_space import SearchSpace
+
+
+def test_defaults_are_a_vector_k_sweep() -> None:
+    space = SearchSpace()
+    assert space.blocker == ("vector",)
+    assert space.embedding_model == ("all-MiniLM-L6-v2",)
+    assert space.metric == ("cosine",)
+    assert space.text_field == ("name",)
+    assert space.k_neighbors == (5, 10, 20)
+
+
+def test_is_frozen() -> None:
+    space = SearchSpace()
+    with pytest.raises((AttributeError, TypeError)):
+        space.k_neighbors = (1, 2)  # type: ignore[misc]
+
+
+def test_len_is_product_of_axis_sizes() -> None:
+    space = SearchSpace(
+        blocker=("vector",),
+        embedding_model=("m1", "m2"),
+        metric=("cosine", "L2"),
+        text_field=("a", "b", "c"),
+        k_neighbors=(5, 10),
+    )
+    assert len(space) == 1 * 2 * 2 * 3 * 2 == 24
+
+
+def test_configs_count_matches_len() -> None:
+    space = SearchSpace(
+        embedding_model=("m1", "m2"),
+        metric=("cosine", "L2"),
+        text_field=("a", "b"),
+        k_neighbors=(5, 10, 20),
+    )
+    configs = list(space.configs())
+    assert len(configs) == len(space)
+
+
+def test_configs_default_is_the_k_sweep() -> None:
+    configs = list(SearchSpace().configs())
+    # Only k varies; everything else is the single default value.
+    assert [c["k_neighbors"] for c in configs] == [5, 10, 20]
+    assert {c["blocker"] for c in configs} == {"vector"}
+    assert {c["embedding_model"] for c in configs} == {"all-MiniLM-L6-v2"}
+    assert {c["metric"] for c in configs} == {"cosine"}
+    assert {c["text_field"] for c in configs} == {"name"}
+
+
+def test_config_dict_has_the_expected_keys() -> None:
+    config = next(SearchSpace().configs())
+    assert set(config) == {"blocker", "embedding_model", "metric", "text_field", "k_neighbors"}
+
+
+def test_k_neighbors_is_the_innermost_dimension() -> None:
+    """The load-bearing contract: k varies fastest, outer keys held fixed per k-block.
+
+    Consecutive configs must share ``(blocker, embedding_model, metric,
+    text_field)`` while ``k_neighbors`` cycles through its full range, so the
+    downstream loop can build one index per outer tuple and reuse it across k.
+    """
+    ks = (5, 10, 20)
+    space = SearchSpace(
+        blocker=("vector",),
+        embedding_model=("m1", "m2"),
+        metric=("cosine", "L2"),
+        text_field=("a", "b"),
+        k_neighbors=ks,
+    )
+    configs = list(space.configs())
+    outer_keys = ("blocker", "embedding_model", "metric", "text_field")
+
+    for i, config in enumerate(configs):
+        # k cycles through the full range in order, fastest-varying.
+        assert config["k_neighbors"] == ks[i % len(ks)]
+
+    # Within each block of len(ks) configs the outer tuple is constant; it only
+    # advances at block boundaries.
+    for start in range(0, len(configs), len(ks)):
+        block = configs[start : start + len(ks)]
+        outer_tuples = {tuple(c[k] for k in outer_keys) for c in block}
+        assert len(outer_tuples) == 1, f"outer keys changed within a k-block at {start}"
+
+    # Every outer tuple is distinct across blocks (no block repeats).
+    block_starts = range(0, len(configs), len(ks))
+    outer_per_block = [tuple(configs[s][k] for k in outer_keys) for s in block_starts]
+    assert len(set(outer_per_block)) == len(outer_per_block)
+
+
+def test_consecutive_configs_within_a_block_differ_only_in_k() -> None:
+    ks = (5, 10, 20)
+    space = SearchSpace(embedding_model=("m1", "m2"), k_neighbors=ks)
+    configs = list(space.configs())
+    for i in range(len(configs) - 1):
+        if (i + 1) % len(ks) != 0:  # not a block boundary
+            a, b = configs[i], configs[i + 1]
+            assert {k: v for k, v in a.items() if k != "k_neighbors"} == {
+                k: v for k, v in b.items() if k != "k_neighbors"
+            }
+
+
+def test_all_pairs_in_blocker_axis_still_products() -> None:
+    """The product spans all axes; ``all_pairs`` configs carry the same keys.
+
+    (The factory ignores the vector-only keys for the all_pairs path.)
+    """
+    space = SearchSpace(blocker=("vector", "all_pairs"), k_neighbors=(5,))
+    kinds = [c["blocker"] for c in space.configs()]
+    assert kinds == ["vector", "all_pairs"]
+    assert len(space) == 2
+
+
+@pytest.mark.parametrize(
+    "kwargs",
+    [
+        {"blocker": ()},
+        {"embedding_model": ()},
+        {"metric": ()},
+        {"text_field": ()},
+        {"k_neighbors": ()},
+    ],
+)
+def test_empty_axis_raises(kwargs: dict[str, tuple[object, ...]]) -> None:
+    with pytest.raises(ValueError, match="must be a non-empty tuple"):
+        SearchSpace(**kwargs)  # type: ignore[arg-type]
+
+
+def test_import_is_light() -> None:
+    """Importing search_space must not pull faiss/torch/sentence_transformers.
+
+    Run in a fresh interpreter so no other test's heavy imports contaminate
+    ``sys.modules``. This module lives on the public API surface, so it must
+    stay as import-light as a bare ``import langres`` (see test_import_budget.py).
+    """
+    code = (
+        "import sys\n"
+        "import langres.core.autoresearch.search_space  # noqa: F401\n"
+        "heavy = sorted(m for m in ('faiss', 'torch', 'sentence_transformers') "
+        "if m in sys.modules)\n"
+        "assert not heavy, f'unexpectedly imported: {heavy}'\n"
+    )
+    result = subprocess.run([sys.executable, "-c", code], capture_output=True, text=True)
+    assert result.returncode == 0, result.stderr


### PR DESCRIPTION
## What

The **proposal substrate** for the autoresearch loop (`propose → run → evaluate → keep-if-better`, epic #145 M1, **PR P-B**): a declarative `SearchSpace` the loop enumerates, and a pure `factory` that turns one config dict into a runnable blocker. Builds on the sibling `Objective` (#154); the loop + `langres.optimize` facade land in a later PR.

## `core/autoresearch/search_space.py` — import-light

Frozen dataclass; each field is the candidate-value tuple for one parameter:

```python
SearchSpace(
    blocker=("vector",),
    embedding_model=("all-MiniLM-L6-v2",),
    metric=("cosine",),
    text_field=("name",),
    k_neighbors=(5, 10, 20),
)
```

- `configs() -> Iterator[dict[str, Any]]` yields the Cartesian product as config dicts.
- **Ordering contract (load-bearing):** `k_neighbors` is the **innermost** varying dimension, so consecutive configs hold `(blocker, embedding_model, metric, text_field)` fixed while `k` sweeps its full range. This lets the downstream loop build **one** vector index per `(model, metric, text_field)` and reuse it across every `k` (`k` lives on the blocker, not the index) instead of re-embedding per `k`.
- `__len__` sizes the grid; `__post_init__` fails loud on an empty axis.
- **Pure stdlib + typing** (itertools/dataclasses) — no faiss/torch/sentence-transformers, so it can sit on the public API surface (users build a `SearchSpace` to call `langres.optimize`) without breaking the `import langres` budget. It never imports `factory`.

## `core/autoresearch/factory.py` — lazy leaf

Two pure functions, no global mutable state (index reuse is the caller's job via the k-innermost ordering + passing `index=`, not a cache here):

- `build_index(embedding_model, metric, texts, *, embedder=None) -> VectorIndex` — mirrors the **canonical** VectorBlocker build path (`SentenceTransformerEmbedder` → `FAISSIndex(embedder=, metric=)` → `create_index`) used in `core/presets.py:_build_vector_blocker` and `data/_benchmark_utils.py:sweep_blocking_k`. The optional `embedder=` seam lets tests inject `FakeEmbedder` (no model download).
- `build_blocker_from_config(config, *, schema, index=None) -> Blocker` — dispatches on `config["blocker"]`: `"vector"` requires a prebuilt `index` (clear `ValueError` if `None`) and builds `VectorBlocker(vector_index=index, schema=schema, text_field=…, k_neighbors=…)`; `"all_pairs"` builds `AllPairsBlocker` (index unused). Named `build_blocker_from_config` to avoid colliding with `Benchmark.build_blocker`.
- **Not import-light** by design — imports the [semantic] stack at module top, so it must only ever be imported lazily (never reached by a bare `import langres`, since the package `__init__` exports nothing).

## Scope

Adds only `search_space.py`, `factory.py`, and their tests. No `__init__.py` / `pyproject.toml` / `test_import_budget.py` edits.

## Verification

`ruff check .`, `ruff format --check .`, `mypy src` (clean), 21 fast + 1 `@slow` new tests pass, `tests/test_import_budget.py` still green. Both new modules are covered 100% by construction (fast tests + the slow real-embedder smoke covers the non-injected branch; the coverage gate runs on the Linux `test-full` job).

## Summary by Sourcery

Introduce a declarative SearchSpace for autoresearch configurations and a factory to build blockers and vector indexes from those configs.

New Features:
- Add a frozen, import-light SearchSpace dataclass that enumerates Cartesian products of blocking configurations with a k-neighbors-innermost ordering contract.
- Provide a factory module with build_index and build_blocker_from_config helpers to construct FAISS-based vector indexes and corresponding Blocker instances from config dicts.

Tests:
- Add high-coverage tests validating SearchSpace defaults, Cartesian product sizing, k-neighbors ordering, empty-axis validation, and import-lightness.
- Add tests for the factory module covering index construction, metric propagation, vector and all-pairs blocker creation, error handling, and a slow smoke test for the real SentenceTransformerEmbedder path.