### PR TITLE
feat(autoresearch): langres.optimize facade + propose→run→eval→keep loop + persistence

### DIFF
--- a/src/langres/__init__.py
+++ b/src/langres/__init__.py
@@ -61,6 +61,7 @@ from langres.core import (
 )
 from langres.core.models import MatcherAbstainedError
 from langres.core.presets import DEFAULT_AUTO_MODEL, NoMatcherAvailableError
+from langres.optimize import optimize, score_blocking
 from langres.verbs import LinkVerdict, dedupe, link
 
 if TYPE_CHECKING:
@@ -103,7 +104,9 @@ __all__ = [
     "gold_pairs_from_clusters",
     "harvest_labeled_pairs",
     "link",
+    "optimize",
     "run_finetune",
+    "score_blocking",
     "select_for_review",
 ]
 

--- a/src/langres/core/autoresearch/loop.py
+++ b/src/langres/core/autoresearch/loop.py
@@ -1,0 +1,205 @@
+"""The ``propose → run → evaluate → keep-if-better`` driver for autoresearch.
+
+This is the integration seam of the autoresearch loop (epic #145): it walks a
+stream of proposed configs, scores each one, and keeps the incumbent that the
+:class:`~langres.core.autoresearch.objective.Objective` says is best — logging
+*every* trial (accepted and rejected) through the existing run-tracking spine
+(``core.runs``) so a run is durable, deduplicated, and lineage-linked.
+
+**Injected-scorer testability seam.** :func:`run_loop` takes the scorer as a
+plain ``Callable[[Mapping], Mapping[str, float]]`` (config → metrics), so its
+keep/revert + logging logic is unit-testable with a canned dict scorer — no
+embeddings, faiss, or benchmark load required. The concrete blocking scorer
+(and its index reuse) lives one layer up in :mod:`langres.optimize`; this module
+knows nothing about blockers.
+
+**Import-light by design.** Only stdlib + :mod:`~langres.core.autoresearch.objective`
++ :mod:`~langres.core.runs` (+ its ``trackers``) — all already on the bare
+``import langres`` path. It imports no factory / data / metrics module, so it
+adds no weight and could sit on the public surface if ever needed.
+"""
+
+from __future__ import annotations
+
+import logging
+from collections.abc import Callable, Iterable, Mapping
+from dataclasses import dataclass
+from typing import Any
+
+from langres.core.autoresearch.objective import Objective
+from langres.core.runs import RunContext, capture_run, compute_recipe_id
+from langres.core.trackers import ExperimentTracker, NoOpTracker
+
+logger = logging.getLogger(__name__)
+
+#: A scorer maps one config dict to a metrics mapping the Objective can read.
+Scorer = Callable[[Mapping[str, Any]], Mapping[str, float]]
+
+
+@dataclass(frozen=True, slots=True)
+class Trial:
+    """One config's outcome in a :func:`run_loop` pass — the audit trail unit.
+
+    Attributes:
+        config: The config dict that was scored (a copy, so mutating the input
+            stream can't retroactively rewrite the trail).
+        metrics: The scorer's metrics for this config, or ``None`` if the scorer
+            raised (a failed trial).
+        accepted: Whether this config displaced the incumbent (``objective.is_better``
+            returned ``True``). Also written to the run record's logged metrics as
+            ``accepted`` so a reader can reconstruct the incumbent timeline from
+            the store alone.
+        recipe_id: The content-addressed dedup key (``core.runs.compute_recipe_id``)
+            for this config's run recipe.
+        attempt_id: The run record PK for this trial (``recipe_id``-``started_at``);
+            the *next* trial's ``parent_run_id`` when this one is the incumbent,
+            giving the store its lineage chain.
+        status: ``"completed"`` (scored) or ``"failed"`` (scorer raised).
+    """
+
+    config: dict[str, Any]
+    metrics: dict[str, float] | None
+    accepted: bool
+    recipe_id: str
+    attempt_id: str
+    status: str
+
+
+@dataclass(frozen=True, slots=True)
+class LoopResult:
+    """The best incumbent found plus the full trial trail.
+
+    Attributes:
+        best_config: The winning config dict, or ``None`` if no config was ever
+            accepted (empty input, or every trial infeasible/failed).
+        best_metrics: The winning config's metrics, or ``None`` (see above).
+        trials: Every trial in evaluation order — accepted, rejected, and failed —
+            for inspection and for reconstructing why the incumbent won.
+    """
+
+    best_config: dict[str, Any] | None
+    best_metrics: dict[str, float] | None
+    trials: tuple[Trial, ...]
+
+
+def run_loop(
+    configs: Iterable[Mapping[str, Any]],
+    scorer: Scorer,
+    objective: Objective,
+    *,
+    experiment: str,
+    dataset_name: str,
+    dataset_fingerprint: str | None = None,
+    split_id: str | None = None,
+    seeds: dict[str, int] | None = None,
+    store: str | Any | None = None,
+    tracker: ExperimentTracker = NoOpTracker(),
+    dedup: bool = True,
+) -> LoopResult:
+    """Run the ``propose → run → evaluate → keep-if-better`` loop over ``configs``.
+
+    For each config, in order:
+
+    1. Build a :class:`~langres.core.runs.RunContext` (``resolver_config`` = the
+       config, ``method`` = ``config["blocker"]``, ``blocking_k`` =
+       ``config["k_neighbors"]``, ``parent_run_id`` = the *current incumbent's*
+       ``attempt_id`` so the store records lineage) and compute its ``recipe_id``.
+    2. **Dedup** (``dedup=True``): skip a config whose ``recipe_id`` was already
+       seen this run — this collapses P-B's redundant degenerate configs (e.g.
+       several ``all_pairs`` configs the caller normalized to one recipe).
+    3. Score it *inside* :func:`~langres.core.runs.capture_run`, so timing and
+       failures are captured. Compute ``better = objective.is_better(metrics,
+       incumbent_metrics)`` and log **every** trial's metrics plus an ``accepted``
+       flag (``1.0``/``0.0``), with the first goal's metric as the headline and
+       ``str(objective)`` as the metric definition.
+    4. If ``better``, the config becomes the incumbent (its ``attempt_id`` becomes
+       the next trial's parent). Otherwise the incumbent is kept.
+
+    A scorer that raises is logged as a ``failed`` run (``capture_run`` writes the
+    ``failed`` terminal line and re-raises; this wraps the ``with`` per-config to
+    swallow it) and the loop continues to the next config — one bad config never
+    aborts the sweep. The result is deterministic given a fixed ``configs`` order.
+
+    Args:
+        configs: The proposed config dicts (e.g. ``SearchSpace.configs()``), in
+            evaluation order. Callers that want degenerate configs deduplicated
+            should normalize them to a canonical shape first (see
+            :mod:`langres.optimize`).
+        scorer: ``config -> metrics``. The one seam under test; the metrics it
+            returns must contain every goal/constraint metric the ``objective``
+            references (a missing one raises inside ``capture_run`` and the trial
+            is recorded ``failed``).
+        objective: The immutable keep-if-better decision.
+        experiment: Experiment label for every run record (organizational, not
+            part of the recipe hash beyond its own field).
+        dataset_name: Dataset label recorded on every run (part of the recipe).
+        dataset_fingerprint: Optional content hash of the loaded data (part of the
+            recipe), so a data change mints fresh ids.
+        split_id: Optional split label recorded on every run (part of the recipe).
+        seeds: Optional seed map recorded on every run (part of the recipe).
+        store: Where to persist run records — a path / ``RunStore`` / ``None``.
+            ``None`` writes **nothing** (the offline path); the loop still returns
+            the same ``LoopResult``.
+        tracker: Experiment tracker forwarded to ``capture_run`` (default no-op).
+        dedup: When ``True`` (default), skip a config whose ``recipe_id`` was
+            already scored this run.
+
+    Returns:
+        A :class:`LoopResult` with the best incumbent and the full trial trail.
+    """
+    best_config: dict[str, Any] | None = None
+    best_metrics: dict[str, float] | None = None
+    best_attempt_id: str | None = None
+    trials: list[Trial] = []
+    seen: set[str] = set()
+    headline_metric = objective.goals[0].metric
+    objective_repr = str(objective)
+
+    for raw_config in configs:
+        config = dict(raw_config)
+        context = RunContext(
+            experiment=experiment,
+            dataset_name=dataset_name,
+            dataset_fingerprint=dataset_fingerprint,
+            split_id=split_id,
+            seeds=dict(seeds) if seeds else {},
+            resolver_config=config,
+            method=config.get("blocker"),
+            blocking_k=config.get("k_neighbors"),
+            parent_run_id=best_attempt_id,
+        )
+        recipe_id = compute_recipe_id(context)
+        if dedup and recipe_id in seen:
+            logger.debug("autoresearch loop: skipping duplicate recipe %s", recipe_id)
+            continue
+        seen.add(recipe_id)
+
+        attempt_id = ""
+        metrics: dict[str, float] | None = None
+        accepted = False
+        try:
+            with capture_run(context, store=store, tracker=tracker) as run:
+                attempt_id = run.attempt_id
+                scored = dict(scorer(config))
+                accepted = objective.is_better(scored, best_metrics)
+                run.log_metrics(
+                    {**scored, "accepted": float(accepted)},
+                    headline_metric=scored[headline_metric],
+                    metric_definition=objective_repr,
+                )
+                metrics = scored
+        except Exception:
+            # capture_run already wrote a status="failed" terminal record and
+            # re-raised; log the config as a failed trial and keep going so one
+            # bad config never aborts the whole sweep.
+            logger.warning("autoresearch loop: scorer failed for config %s", config, exc_info=True)
+            trials.append(Trial(config, None, False, recipe_id, attempt_id, "failed"))
+            continue
+
+        trials.append(Trial(config, metrics, accepted, recipe_id, attempt_id, "completed"))
+        if accepted:
+            best_config = config
+            best_metrics = metrics
+            best_attempt_id = attempt_id
+
+    return LoopResult(best_config, best_metrics, tuple(trials))

--- a/src/langres/core/autoresearch/loop.py
+++ b/src/langres/core/autoresearch/loop.py
@@ -93,7 +93,7 @@ def run_loop(
     split_id: str | None = None,
     seeds: dict[str, int] | None = None,
     store: str | Any | None = None,
-    tracker: ExperimentTracker = NoOpTracker(),
+    tracker: ExperimentTracker | None = None,
     dedup: bool = True,
 ) -> LoopResult:
     """Run the ``propose → run → evaluate → keep-if-better`` loop over ``configs``.
@@ -140,13 +140,16 @@ def run_loop(
         store: Where to persist run records — a path / ``RunStore`` / ``None``.
             ``None`` writes **nothing** (the offline path); the loop still returns
             the same ``LoopResult``.
-        tracker: Experiment tracker forwarded to ``capture_run`` (default no-op).
+        tracker: Experiment tracker forwarded to ``capture_run``; ``None``
+            (default) uses a fresh :class:`~langres.core.trackers.NoOpTracker`
+            rather than a shared instance.
         dedup: When ``True`` (default), skip a config whose ``recipe_id`` was
             already scored this run.
 
     Returns:
         A :class:`LoopResult` with the best incumbent and the full trial trail.
     """
+    tracker = tracker or NoOpTracker()
     best_config: dict[str, Any] | None = None
     best_metrics: dict[str, float] | None = None
     best_attempt_id: str | None = None

--- a/src/langres/optimize.py
+++ b/src/langres/optimize.py
@@ -65,11 +65,11 @@ def _source_sizes(corpus: list[Any]) -> tuple[int, int] | None:
     """
     from collections import Counter
 
-    counts = Counter(getattr(record, "source", None) for record in corpus)
+    counts: Counter[Any] = Counter(getattr(record, "source", None) for record in corpus)
     counts.pop(None, None)
     if len(counts) != 2:
         return None
-    left, right = (counts[key] for key in sorted(counts))
+    left, right = (counts[key] for key in sorted(counts, key=str))
     return (left, right)
 
 

--- a/src/langres/optimize.py
+++ b/src/langres/optimize.py
@@ -1,0 +1,275 @@
+"""``langres.optimize``: the public autoresearch facade (epic #145, M1).
+
+Two entry points compose P-A (:class:`~langres.core.autoresearch.objective.Objective`),
+P-B (:class:`~langres.core.autoresearch.search_space.SearchSpace` + the config→blocker
+``factory``), and P-C (the ``propose → run → evaluate → keep`` loop + ``core.runs``
+persistence) into a one-call blocking search:
+
+- :func:`score_blocking` — the concrete blocking scorer for ONE config: load a
+  benchmark, build the index + blocker the config describes, stream candidates,
+  and return blocking metrics (``candidate_recall`` / ``reduction_ratio`` / …).
+- :func:`optimize` — load a benchmark once, fingerprint it once, wrap an
+  **index-caching** blocking scorer, and drive
+  :func:`~langres.core.autoresearch.loop.run_loop` over ``space.configs()``,
+  keeping the incumbent the ``objective`` prefers and persisting every trial.
+
+**Import-lightness (hard requirement).** This module sits on the eager
+``import langres`` path (the two symbols are root-exported), so its module top is
+stdlib/typing only — every langres import (``factory``, ``langres.data``,
+``core.metrics``, ``core.runs``, ``core.autoresearch.loop``, ``core.trackers``)
+is **lazy, inside a function body**. A bare ``import langres`` therefore never
+pulls faiss / sentence-transformers / torch through here (see
+``tests/test_import_budget.py``).
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from collections.abc import Mapping
+
+    from langres.core.autoresearch.loop import LoopResult
+    from langres.core.autoresearch.objective import Objective
+    from langres.core.autoresearch.search_space import SearchSpace
+    from langres.core.benchmark import Benchmark
+    from langres.core.embeddings import EmbeddingProvider
+    from langres.core.indexes.vector_index import VectorIndex
+    from langres.core.runs import RunStore
+    from langres.core.trackers import ExperimentTracker
+
+
+def _resolve_benchmark(benchmark: str | Benchmark[Any]) -> Benchmark[Any]:
+    """Accept a registered benchmark **name** or an already-built benchmark object.
+
+    The public DX is a name string (``optimize(space, obj, "amazon_google")``);
+    tests (and advanced callers) may pass a hand-built in-memory benchmark object
+    directly to stay offline.
+    """
+    if isinstance(benchmark, str):
+        from langres.data.registry import get_benchmark
+
+        return get_benchmark(benchmark)
+    return benchmark
+
+
+def _source_sizes(corpus: list[Any]) -> tuple[int, int] | None:
+    """``(n_left, n_right)`` for a two-source linkage corpus, else ``None`` (dedup).
+
+    Groups records by their ``source`` attribute. Exactly two distinct sources is
+    the cross-source (linkage) case — the sizes feed ``evaluate_blocking``'s
+    ``n_left``/``n_right`` so the reduction ratio uses ``|A| * |B|`` — and every
+    other shape (no ``source``, one source, three+) falls back to the dedup
+    ``num_records`` reduction ratio.
+    """
+    from collections import Counter
+
+    counts = Counter(getattr(record, "source", None) for record in corpus)
+    counts.pop(None, None)
+    if len(counts) != 2:
+        return None
+    left, right = (counts[key] for key in sorted(counts))
+    return (left, right)
+
+
+def _index_for_config(
+    config: Mapping[str, Any],
+    corpus: list[Any],
+    embedder: EmbeddingProvider | None,
+) -> VectorIndex:
+    """Build the FAISS index a vector config describes over the corpus texts.
+
+    Texts are extracted in corpus order (``config["text_field"]``) so the index
+    positions align with the records the blocker streams — mirroring
+    ``data/_benchmark_utils.sweep_blocking_k``.
+    """
+    from langres.core.autoresearch.factory import build_index
+
+    texts = [getattr(record, config["text_field"]) for record in corpus]
+    return build_index(config["embedding_model"], config["metric"], texts, embedder=embedder)
+
+
+def _score_loaded(
+    config: Mapping[str, Any],
+    corpus: list[Any],
+    gold_clusters: list[set[str]],
+    schema: type[Any],
+    source_sizes: tuple[int, int] | None,
+    *,
+    index: VectorIndex | None = None,
+) -> dict[str, float]:
+    """Score ONE config against already-loaded data — the shared scoring core.
+
+    Builds the blocker the config describes (a prebuilt ``index`` is required for
+    ``blocker == "vector"``; ignored for ``"all_pairs"``), streams the corpus to
+    candidates, and evaluates blocking. For a two-source corpus the candidates are
+    filtered to cross-source pairs (all gold matches are cross-source) and RR is
+    computed with ``n_left``/``n_right``; otherwise RR uses ``num_records``.
+    """
+    from langres.core.autoresearch.factory import build_blocker_from_config
+    from langres.core.metrics import evaluate_blocking
+
+    blocker = build_blocker_from_config(config, schema=schema, index=index)
+    candidates = list(blocker.stream([record.model_dump() for record in corpus]))
+
+    if source_sizes is not None:
+        # Cross-source linkage: keep only inter-source pairs (all gold matches
+        # are cross-source, so recall is unchanged) and use |A|*|B| for RR.
+        candidates = [c for c in candidates if c.left.source != c.right.source]
+        n_left, n_right = source_sizes
+        stats = evaluate_blocking(candidates, gold_clusters, n_left=n_left, n_right=n_right)
+    else:
+        stats = evaluate_blocking(candidates, gold_clusters, num_records=len(corpus))
+
+    return {
+        "candidate_recall": stats.candidate_recall,
+        "candidate_precision": stats.candidate_precision,
+        "reduction_ratio": stats.reduction_ratio,
+        "total_candidates": float(stats.total_candidates),
+    }
+
+
+def score_blocking(
+    config: Mapping[str, Any],
+    benchmark: str | Benchmark[Any],
+    *,
+    embedder: EmbeddingProvider | None = None,
+    index: VectorIndex | None = None,
+) -> dict[str, float]:
+    """Blocking metrics for ONE config on ``benchmark`` (the concrete scorer).
+
+    Loads the benchmark, builds the index + blocker the config describes (mirroring
+    ``sweep_blocking_k``), streams the full corpus to candidates, and returns a
+    plain metrics dict — ``candidate_recall``, ``candidate_precision``,
+    ``reduction_ratio``, ``total_candidates`` — ready for an
+    :class:`~langres.core.autoresearch.objective.Objective`.
+
+    Args:
+        config: A config dict as yielded by ``SearchSpace.configs()`` (keys
+            ``blocker``, and for ``"vector"`` also ``embedding_model`` / ``metric``
+            / ``text_field`` / ``k_neighbors``).
+        benchmark: A registered benchmark **name** (loaded via the data registry)
+            or an already-built benchmark object (offline / test path).
+        embedder: Optional pre-built embedder (a ``FakeEmbedder`` in tests) passed
+            to ``build_index``; production leaves it ``None`` to load the real
+            SentenceTransformer. Ignored when ``index`` is supplied or the blocker
+            is ``"all_pairs"``.
+        index: Optional prebuilt vector index to reuse instead of building one
+            (the ``optimize`` closure threads a cached index in through here).
+
+    Returns:
+        The blocking metrics mapping (all values ``float``).
+    """
+    bench = _resolve_benchmark(benchmark)
+    corpus, gold_clusters, _gold_pairs = bench.load()
+    if not corpus:
+        raise ValueError(f"benchmark {getattr(bench, 'name', bench)!r} loaded an empty corpus")
+    schema = type(corpus[0])
+    if index is None and config.get("blocker") == "vector":
+        index = _index_for_config(config, corpus, embedder)
+    return _score_loaded(config, corpus, gold_clusters, schema, _source_sizes(corpus), index=index)
+
+
+def _canonical_config(config: Mapping[str, Any]) -> dict[str, Any]:
+    """Collapse a config to its recipe-relevant shape (for correct dedup).
+
+    ``all_pairs`` ignores every vector axis (``embedding_model`` / ``metric`` /
+    ``text_field`` / ``k_neighbors``), so P-B's grid can yield several
+    *semantically identical* ``all_pairs`` configs differing only in those unused
+    keys. Reducing each to ``{"blocker": "all_pairs"}`` makes them hash to one
+    ``recipe_id`` so the loop's in-run dedup skips the redundant repeats. A
+    ``vector`` config is recipe-relevant in full and passes through unchanged.
+    """
+    if config.get("blocker") == "all_pairs":
+        return {"blocker": "all_pairs"}
+    return dict(config)
+
+
+def optimize(
+    space: SearchSpace,
+    objective: Objective,
+    benchmark: str | Benchmark[Any],
+    *,
+    seed: int | None = None,
+    store: str | Path | RunStore | None = None,
+    dedup: bool = True,
+    split: str = "full",
+    embedder: EmbeddingProvider | None = None,
+    tracker: ExperimentTracker | None = None,
+) -> LoopResult:
+    """Search ``space`` for the blocking config ``objective`` prefers on ``benchmark``.
+
+    Loads the benchmark **once**, fingerprints it **once**, and wraps an
+    index-caching blocking scorer: because ``SearchSpace.configs()`` varies
+    ``k_neighbors`` innermost, one vector index is built per
+    ``(embedding_model, metric, text_field)`` group and reused across every ``k``
+    (``k`` lives on the blocker, not the index). It then drives
+    :func:`~langres.core.autoresearch.loop.run_loop`, which keeps the incumbent
+    ``objective.is_better`` selects and persists **every** trial (accepted and
+    rejected) to ``store`` — ``store=None`` persists nothing.
+
+    Args:
+        space: The declarative config grid to enumerate.
+        objective: The immutable keep-if-better decision.
+        benchmark: A registered benchmark **name** or an already-built benchmark
+            object (offline / test path).
+        seed: Optional seed recorded on every run for provenance/identity (blocking
+            itself is deterministic, so this only labels the run). Recorded under
+            ``seeds["optimize"]`` when given.
+        store: Where to persist run records (path / ``RunStore`` / ``None``);
+            ``None`` writes nothing.
+        dedup: Skip a config whose ``recipe_id`` was already scored this run
+            (default ``True``); the degenerate ``all_pairs`` repeats are collapsed
+            first via :func:`_canonical_config`.
+        split: Split label recorded on every run (``RunContext.split_id``). Default
+            ``"full"`` — M1 measures blocking over the whole loaded corpus.
+        embedder: Optional pre-built embedder for the vector index (a
+            ``FakeEmbedder`` keeps tests offline); production leaves it ``None``.
+        tracker: Optional experiment tracker; defaults to a no-op.
+
+    Returns:
+        The :class:`~langres.core.autoresearch.loop.LoopResult` (best incumbent +
+        full trial trail).
+    """
+    from langres.core.autoresearch.loop import run_loop
+    from langres.core.runs import dataset_fingerprint
+    from langres.core.trackers import NoOpTracker
+
+    bench = _resolve_benchmark(benchmark)
+    dataset_name = benchmark if isinstance(benchmark, str) else bench.name
+    corpus, gold_clusters, _gold_pairs = bench.load()
+    if not corpus:
+        raise ValueError(f"benchmark {dataset_name!r} loaded an empty corpus")
+    schema = type(corpus[0])
+    fingerprint = dataset_fingerprint(corpus, gold_clusters)
+    source_sizes = _source_sizes(corpus)
+
+    # One index per (embedding_model, metric, text_field); reused across all k
+    # (SearchSpace yields k innermost, so the group is contiguous). all_pairs
+    # configs never touch the cache (no index).
+    index_cache: dict[tuple[str, str, str], VectorIndex] = {}
+
+    def scorer(config: Mapping[str, Any]) -> dict[str, float]:
+        index: VectorIndex | None = None
+        if config.get("blocker") == "vector":
+            key = (config["embedding_model"], config["metric"], config["text_field"])
+            index = index_cache.get(key)
+            if index is None:
+                index = _index_for_config(config, corpus, embedder)
+                index_cache[key] = index
+        return _score_loaded(config, corpus, gold_clusters, schema, source_sizes, index=index)
+
+    return run_loop(
+        (_canonical_config(config) for config in space.configs()),
+        scorer,
+        objective,
+        experiment=f"optimize_blocking:{dataset_name}",
+        dataset_name=dataset_name,
+        dataset_fingerprint=fingerprint,
+        split_id=split,
+        seeds={"optimize": seed} if seed is not None else None,
+        store=store,
+        tracker=tracker or NoOpTracker(),
+        dedup=dedup,
+    )

--- a/tests/core/test_autoresearch_loop.py
+++ b/tests/core/test_autoresearch_loop.py
@@ -1,0 +1,224 @@
+"""Tests for the autoresearch keep-if-better :mod:`~langres.core.autoresearch.loop`.
+
+Core contract code -> high coverage tier. Every test injects a **fake dict
+scorer** (config -> canned metrics), so the loop's incumbent tracking, dedup,
+persistence, and failure handling are exercised with zero embeddings / faiss /
+benchmark load -- the point of the injected-scorer seam.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Any
+
+import pytest
+
+from langres.core.autoresearch.loop import LoopResult, Trial, run_loop
+from langres.core.autoresearch.objective import Objective
+from langres.core.runs import RunStore
+
+
+def _scorer(table: dict[str, dict[str, float]]) -> Any:
+    """A fake scorer resolving a config's ``id`` to canned metrics."""
+
+    def scorer(config: Mapping[str, Any]) -> dict[str, float]:
+        return dict(table[config["id"]])
+
+    return scorer
+
+
+def _cfg(cid: str, blocker: str = "vector", **extra: Any) -> dict[str, Any]:
+    """A minimal config dict tagged with an ``id`` the fake scorer keys on."""
+    return {"blocker": blocker, "id": cid, **extra}
+
+
+# ---------------------------------------------------------------------------
+# Incumbent tracking
+# ---------------------------------------------------------------------------
+
+
+def test_strictly_better_config_displaces_the_incumbent() -> None:
+    configs = [_cfg("a"), _cfg("b"), _cfg("c")]
+    scorer = _scorer({"a": {"r": 0.5}, "b": {"r": 0.9}, "c": {"r": 0.7}})
+    result = run_loop(configs, scorer, Objective.maximize("r"), experiment="e", dataset_name="d")
+
+    assert isinstance(result, LoopResult)
+    assert result.best_config == _cfg("b")
+    assert result.best_metrics == {"r": 0.9}
+    assert [t.accepted for t in result.trials] == [True, True, False]
+    assert [t.status for t in result.trials] == ["completed", "completed", "completed"]
+
+
+def test_first_feasible_config_is_accepted_against_a_none_incumbent() -> None:
+    result = run_loop(
+        [_cfg("only")],
+        _scorer({"only": {"r": 0.1}}),
+        Objective.maximize("r"),
+        experiment="e",
+        dataset_name="d",
+    )
+    assert result.best_config == _cfg("only")
+    assert result.trials[0].accepted is True
+
+
+def test_empty_config_stream_yields_no_incumbent() -> None:
+    result = run_loop([], _scorer({}), Objective.maximize("r"), experiment="e", dataset_name="d")
+    assert result.best_config is None
+    assert result.best_metrics is None
+    assert result.trials == ()
+
+
+def test_infeasible_candidate_is_never_accepted() -> None:
+    # A constraint the only config violates -> feasible-gate keeps it out.
+    obj = Objective.maximize("r", subject_to=[("r", ">=", 0.8)])
+    result = run_loop(
+        [_cfg("a")], _scorer({"a": {"r": 0.5}}), obj, experiment="e", dataset_name="d"
+    )
+    assert result.best_config is None
+    assert result.trials[0].accepted is False
+    assert result.trials[0].status == "completed"  # scored fine, just not better
+
+
+def test_incomparable_multiobjective_trade_off_is_kept_out() -> None:
+    # Candidate b is better on recall but worse on cost -> neither dominates ->
+    # the incumbent (a) is kept.
+    obj = Objective.pareto([("recall", "maximize"), ("cost", "minimize")])
+    configs = [_cfg("a"), _cfg("b")]
+    scorer = _scorer({"a": {"recall": 0.5, "cost": 0.2}, "b": {"recall": 0.9, "cost": 0.9}})
+    result = run_loop(configs, scorer, obj, experiment="e", dataset_name="d")
+
+    assert result.best_config == _cfg("a")
+    assert [t.accepted for t in result.trials] == [True, False]
+
+
+# ---------------------------------------------------------------------------
+# Persistence (every trial logged; accepted flag; lineage)
+# ---------------------------------------------------------------------------
+
+
+def test_every_trial_is_logged_with_accepted_flag_and_lineage(tmp_path: Any) -> None:
+    store_path = tmp_path / "runs.jsonl"
+    configs = [_cfg("a"), _cfg("b"), _cfg("c")]
+    scorer = _scorer({"a": {"r": 0.5}, "b": {"r": 0.9}, "c": {"r": 0.7}})
+    obj = Objective.maximize("r")
+    result = run_loop(configs, scorer, obj, experiment="e", dataset_name="d", store=store_path)
+
+    records = RunStore(store_path).read()
+    # One terminal record per attempt (running + completed collapse by attempt_id).
+    assert len(records) == 3
+    by_attempt = {r.attempt_id: r for r in records}
+    assert set(by_attempt) == {t.attempt_id for t in result.trials}
+
+    # Records come back in first-seen (loop) order.
+    assert [r.metrics["accepted"] for r in records] == [1.0, 1.0, 0.0]
+    assert [r.headline_metric for r in records] == [0.5, 0.9, 0.7]
+    assert all(r.metric_definition == str(obj) for r in records)
+    assert all(r.status == "completed" for r in records)
+
+    # Lineage: each accepted incumbent parents the next trial; the rejected c
+    # still points at the incumbent (b) at comparison time.
+    a, b, c = records
+    assert a.context.parent_run_id is None
+    assert b.context.parent_run_id == a.attempt_id
+    assert c.context.parent_run_id == b.attempt_id
+
+
+def test_store_none_writes_nothing(tmp_path: Any) -> None:
+    result = run_loop(
+        [_cfg("a"), _cfg("b")],
+        _scorer({"a": {"r": 0.3}, "b": {"r": 0.6}}),
+        Objective.maximize("r"),
+        experiment="e",
+        dataset_name="d",
+        store=None,
+    )
+    # The loop still ran and tracked an incumbent...
+    assert result.best_metrics == {"r": 0.6}
+    assert all(t.attempt_id for t in result.trials)  # attempt ids exist even unpersisted
+    # ...but nothing was written anywhere.
+    assert list(tmp_path.iterdir()) == []
+
+
+# ---------------------------------------------------------------------------
+# Dedup
+# ---------------------------------------------------------------------------
+
+
+def test_dedup_skips_a_duplicate_recipe(tmp_path: Any) -> None:
+    store_path = tmp_path / "runs.jsonl"
+    # Two byte-identical configs -> one recipe_id -> the second is skipped.
+    dup = _cfg("a", blocker="all_pairs")
+    result = run_loop(
+        [dict(dup), dict(dup)],
+        _scorer({"a": {"r": 0.5}}),
+        Objective.maximize("r"),
+        experiment="e",
+        dataset_name="d",
+        store=store_path,
+    )
+    assert len(result.trials) == 1
+    assert len(RunStore(store_path).read()) == 1
+
+
+def test_dedup_can_be_disabled(tmp_path: Any) -> None:
+    store_path = tmp_path / "runs.jsonl"
+    dup = _cfg("a", blocker="all_pairs")
+    result = run_loop(
+        [dict(dup), dict(dup)],
+        _scorer({"a": {"r": 0.5}}),
+        Objective.maximize("r"),
+        experiment="e",
+        dataset_name="d",
+        store=store_path,
+        dedup=False,
+    )
+    # Both scored; two attempts persisted (distinct attempt_ids, same recipe_id).
+    assert len(result.trials) == 2
+    records = RunStore(store_path).read()
+    assert len(records) == 2
+    assert len({r.recipe_id for r in records}) == 1
+
+
+# ---------------------------------------------------------------------------
+# Failure handling
+# ---------------------------------------------------------------------------
+
+
+def test_scorer_failure_is_logged_failed_and_loop_continues(tmp_path: Any) -> None:
+    store_path = tmp_path / "runs.jsonl"
+
+    def scorer(config: Mapping[str, Any]) -> dict[str, float]:
+        if config["id"] == "boom":
+            raise RuntimeError("scorer blew up")
+        return {"a": {"r": 0.5}, "c": {"r": 0.9}}[config["id"]]
+
+    result = run_loop(
+        [_cfg("a"), _cfg("boom"), _cfg("c")],
+        scorer,
+        Objective.maximize("r"),
+        experiment="e",
+        dataset_name="d",
+        store=store_path,
+    )
+
+    # The failure did not abort the sweep: three trials, the middle one failed.
+    assert [t.status for t in result.trials] == ["completed", "failed", "completed"]
+    failed = result.trials[1]
+    assert failed.metrics is None
+    assert failed.accepted is False
+    assert result.best_config == _cfg("c")  # c still won
+
+    records = {r.attempt_id: r for r in RunStore(store_path).read()}
+    assert records[failed.attempt_id].status == "failed"
+    assert records[failed.attempt_id].error_type == "RuntimeError"
+
+    # Lineage skips the failed trial: c's parent is a's attempt (the incumbent
+    # never advanced through the failure).
+    good_a, _boom, good_c = result.trials
+    assert records[good_c.attempt_id].context.parent_run_id == good_a.attempt_id
+
+
+def test_trial_is_a_frozen_dataclass() -> None:
+    trial = Trial({"blocker": "vector"}, {"r": 1.0}, True, "rid", "aid", "completed")
+    with pytest.raises((AttributeError, TypeError)):
+        trial.accepted = False  # type: ignore[misc]

--- a/tests/test_import_budget.py
+++ b/tests/test_import_budget.py
@@ -81,6 +81,44 @@ def test_import_langres_excludes_heavy_modules_from_sys_modules() -> None:
     )
 
 
+# The autoresearch facade (``langres.optimize`` / ``langres.score_blocking``,
+# PR P-C) is eager-exported from ``langres/__init__.py`` -- so a bare
+# ``import langres`` must expose both as callables WHILE staying import-light:
+# ``langres/optimize.py``'s module top is stdlib/typing only (every factory /
+# data / metrics / faiss import is lazy inside a function body), so pulling the
+# module into the eager graph must not drag torch / faiss / sentence-transformers
+# / litellm / scikit-learn into ``sys.modules``. Fresh-process for an unpolluted
+# import state (same pattern as the checks above).
+_OPTIMIZE_FACADE_HEAVY_DEPS = [
+    "torch",
+    "faiss",
+    "sentence_transformers",
+    "litellm",
+    "sklearn",
+]
+
+_OPTIMIZE_FACADE_SCRIPT = (
+    "import sys; import langres; "
+    "assert callable(langres.optimize), 'langres.optimize missing or not callable'; "
+    "assert callable(langres.score_blocking), 'langres.score_blocking missing or not callable'; "
+    "leaked = [m for m in {modules!r} if m in sys.modules]; "
+    "assert not leaked, f'optimize facade leaked heavy modules on bare import: {{leaked}}'; "
+    "print('OK')"
+).format(modules=_OPTIMIZE_FACADE_HEAVY_DEPS)
+
+
+def test_optimize_facade_is_eager_and_import_light() -> None:
+    """``langres.optimize``/``score_blocking`` are callable on bare import, pulling no heavy dep."""
+    result = subprocess.run(
+        [sys.executable, "-c", _OPTIMIZE_FACADE_SCRIPT],
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode == 0, (
+        f"optimize-facade import-budget check failed.\nSTDOUT:\n{result.stdout}\nSTDERR:\n{result.stderr}"
+    )
+
+
 # The prompt-optimize ``Method`` objects (``Bootstrap`` / ``MIPRO`` / ``GEPA``)
 # are pure config a caller constructs at the fit call site -- constructing one
 # (even ``GEPA(reflection_model=...)``, which names a DSPy optimizer) must never

--- a/tests/test_optimize.py
+++ b/tests/test_optimize.py
@@ -1,0 +1,237 @@
+"""Tests for the public ``langres.optimize`` facade (score_blocking + optimize).
+
+The fast tests use a TINY hand-built in-memory benchmark (a few records + gold),
+passed to the facade as a benchmark *object* (the offline seam alongside the
+public name-string DX). The ``all_pairs`` path needs no embeddings at all; the
+vector path injects a ``FakeEmbedder`` (and is guarded by ``importorskip`` so it
+skips without the [semantic] extra). One ``@pytest.mark.slow`` smoke exercises a
+registered benchmark with the real SentenceTransformer + FAISS stack.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Literal
+
+import pytest
+from pydantic import BaseModel
+
+from langres import optimize, score_blocking
+from langres.core.autoresearch.loop import LoopResult
+from langres.core.autoresearch.objective import Objective
+from langres.core.autoresearch.search_space import SearchSpace
+from langres.core.runs import RunStore
+
+
+class _ProductRec(BaseModel):
+    """A tiny two-source product record (offline test schema)."""
+
+    id: str
+    name: str
+    source: Literal["a", "b"]
+
+
+class _MemoryBenchmark:
+    """A minimal in-memory benchmark: ``name`` + ``load()`` is all the facade needs."""
+
+    name = "memory_products"
+
+    def load(self) -> tuple[list[_ProductRec], list[set[str]], set[frozenset[str]]]:
+        corpus = [
+            _ProductRec(id="a1", name="apple iphone 12", source="a"),
+            _ProductRec(id="a2", name="samsung galaxy s21", source="a"),
+            _ProductRec(id="b1", name="apple iphone 12", source="b"),
+            _ProductRec(id="b2", name="samsung galaxy s21", source="b"),
+        ]
+        gold_clusters = [{"a1", "b1"}, {"a2", "b2"}]
+        gold_pairs = {frozenset({"a1", "b1"}), frozenset({"a2", "b2"})}
+        return corpus, gold_clusters, gold_pairs
+
+
+_VECTOR_CFG = {
+    "blocker": "vector",
+    "embedding_model": "unused-with-fake",
+    "metric": "cosine",
+    "text_field": "name",
+    "k_neighbors": 3,
+}
+
+
+def _fake_embedder() -> Any:
+    pytest.importorskip("faiss", reason="requires the [semantic] extra")
+    from langres.core.embeddings import FakeEmbedder
+
+    return FakeEmbedder(embedding_dim=16)
+
+
+# ---------------------------------------------------------------------------
+# score_blocking
+# ---------------------------------------------------------------------------
+
+
+def test_score_blocking_all_pairs_returns_metrics_offline() -> None:
+    metrics = score_blocking({"blocker": "all_pairs"}, _MemoryBenchmark())
+    assert set(metrics) == {
+        "candidate_recall",
+        "candidate_precision",
+        "reduction_ratio",
+        "total_candidates",
+    }
+    # AllPairs surfaces every cross-source pair -> perfect blocking recall.
+    assert metrics["candidate_recall"] == 1.0
+    # Cross-source filter drops the two intra-source pairs (a1-a2, b1-b2).
+    assert metrics["total_candidates"] == 4.0
+
+
+def test_score_blocking_vector_with_fake_embedder() -> None:
+    embedder = _fake_embedder()
+    metrics = score_blocking(_VECTOR_CFG, _MemoryBenchmark(), embedder=embedder)
+    assert "candidate_recall" in metrics
+    assert 0.0 <= metrics["candidate_recall"] <= 1.0
+    assert isinstance(metrics["total_candidates"], float)
+
+
+def test_score_blocking_accepts_a_prebuilt_index() -> None:
+    embedder = _fake_embedder()
+    from langres.core.autoresearch.factory import build_index
+
+    corpus, _gc, _gp = _MemoryBenchmark().load()
+    index = build_index("x", "cosine", [r.name for r in corpus], embedder=embedder)
+    metrics = score_blocking(_VECTOR_CFG, _MemoryBenchmark(), index=index)
+    assert "candidate_recall" in metrics
+
+
+def test_score_blocking_by_registered_name_offline() -> None:
+    # The public name-string DX: get_benchmark("tiny_fixture") loads offline, and
+    # all_pairs blocking needs no embeddings -> a fully offline name-path check.
+    metrics = score_blocking({"blocker": "all_pairs"}, "tiny_fixture")
+    assert metrics["candidate_recall"] == 1.0
+
+
+def test_score_blocking_empty_corpus_raises() -> None:
+    class _Empty:
+        name = "empty"
+
+        def load(self) -> tuple[list[_ProductRec], list[set[str]], set[frozenset[str]]]:
+            return [], [], set()
+
+    with pytest.raises(ValueError, match="empty corpus"):
+        score_blocking({"blocker": "all_pairs"}, _Empty())
+
+
+# ---------------------------------------------------------------------------
+# optimize
+# ---------------------------------------------------------------------------
+
+
+def test_optimize_all_pairs_returns_loop_result_and_logs_trials(tmp_path: Any) -> None:
+    store_path = tmp_path / "runs.jsonl"
+    space = SearchSpace(blocker=("all_pairs",), text_field=("name",), k_neighbors=(5,))
+    result = optimize(
+        space, Objective.maximize("candidate_recall"), _MemoryBenchmark(), store=store_path
+    )
+
+    assert isinstance(result, LoopResult)
+    assert result.best_metrics is not None
+    assert result.best_metrics["candidate_recall"] == 1.0
+    assert result.best_config == {"blocker": "all_pairs"}  # canonicalized
+
+    records = RunStore(store_path).read()
+    assert len(records) == 1
+    assert records[0].metrics["accepted"] == 1.0
+    assert records[0].context.dataset_name == "memory_products"
+    assert records[0].context.split_id == "full"
+    assert records[0].context.dataset_fingerprint is not None
+
+
+def test_optimize_dedup_collapses_degenerate_all_pairs(tmp_path: Any) -> None:
+    store_path = tmp_path / "runs.jsonl"
+    # Several all_pairs configs differing only in (ignored) vector axes -> after
+    # canonicalization they share one recipe_id and the loop scores just one.
+    space = SearchSpace(
+        blocker=("all_pairs",),
+        embedding_model=("m1", "m2"),
+        metric=("cosine", "L2"),
+        text_field=("name",),
+        k_neighbors=(5, 10),
+    )
+    assert len(space) == 8  # 2 * 2 * 1 * 2 degenerate configs
+    result = optimize(
+        space, Objective.maximize("candidate_recall"), _MemoryBenchmark(), store=store_path
+    )
+    assert len(result.trials) == 1  # all collapsed to one
+    assert len(RunStore(store_path).read()) == 1
+
+
+def test_optimize_vector_reuses_index_across_k() -> None:
+    pytest.importorskip("faiss", reason="requires the [semantic] extra")
+    from langres.core.embeddings import FakeEmbedder
+
+    class _CountingEmbedder(FakeEmbedder):
+        encode_calls = 0
+
+        def encode(self, texts: Any) -> Any:
+            type(self).encode_calls += 1
+            return super().encode(texts)
+
+    space = SearchSpace(
+        blocker=("vector",),
+        embedding_model=("x",),
+        metric=("cosine",),
+        text_field=("name",),
+        k_neighbors=(1, 2, 3),
+    )
+    embedder = _CountingEmbedder(embedding_dim=16)
+    result = optimize(
+        space, Objective.maximize("candidate_recall"), _MemoryBenchmark(), embedder=embedder
+    )
+
+    assert len(result.trials) == 3
+    # One index built (one encode call) for the whole k-sweep, since k varies
+    # innermost within the shared (model, metric, text_field) group.
+    assert _CountingEmbedder.encode_calls == 1
+
+
+def test_optimize_store_none_writes_nothing(tmp_path: Any) -> None:
+    space = SearchSpace(blocker=("all_pairs",), text_field=("name",), k_neighbors=(5,))
+    result = optimize(space, Objective.maximize("candidate_recall"), _MemoryBenchmark(), store=None)
+    assert isinstance(result, LoopResult)
+    assert list(tmp_path.iterdir()) == []
+
+
+def test_optimize_records_seed_when_given(tmp_path: Any) -> None:
+    store_path = tmp_path / "runs.jsonl"
+    space = SearchSpace(blocker=("all_pairs",), text_field=("name",), k_neighbors=(5,))
+    optimize(
+        space,
+        Objective.maximize("candidate_recall"),
+        _MemoryBenchmark(),
+        store=store_path,
+        seed=7,
+    )
+    records = RunStore(store_path).read()
+    assert records[0].context.seeds == {"optimize": 7}
+
+
+# ---------------------------------------------------------------------------
+# Slow: real embedder + FAISS on a registered benchmark
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.slow
+def test_optimize_vector_real_embedder_on_registered_benchmark() -> None:
+    """End-to-end with the real SentenceTransformer + FAISS stack (downloads a model)."""
+    pytest.importorskip("faiss", reason="requires the [semantic] extra")
+    pytest.importorskip("sentence_transformers", reason="requires the [semantic] extra")
+
+    space = SearchSpace(
+        blocker=("vector",),
+        embedding_model=("all-MiniLM-L6-v2",),
+        metric=("cosine",),
+        text_field=("embed_text",),
+        k_neighbors=(3, 5),
+    )
+    result = optimize(space, Objective.maximize("candidate_recall"), "tiny_fixture")
+    assert isinstance(result, LoopResult)
+    assert result.best_metrics is not None
+    assert 0.0 <= result.best_metrics["candidate_recall"] <= 1.0
+    assert len(result.trials) == 2


### PR DESCRIPTION
## PR P-C — the autoresearch integration piece (epic #145, M1)

Composes P-A (`Objective`), P-B (`SearchSpace` + config→blocker `factory`), and the run-tracking spine (`core/runs`) into a one-call blocking search: the `propose → run → evaluate → keep-if-better` loop + the public `langres.optimize` facade + persistence reuse.

### Public API (both eager-exported from `langres`)

```python
score_blocking(config, benchmark, *, embedder=None, index=None) -> dict[str, float]
optimize(space, objective, benchmark, *, seed=None, store=None, dedup=True,
         split="full", embedder=None, tracker=None) -> LoopResult
```

- `benchmark` accepts a **registered name string** (DX) or an already-built benchmark **object** (offline/test seam).
- `score_blocking` metrics: `candidate_recall`, `candidate_precision`, `reduction_ratio`, `total_candidates`. Two-source corpora are cross-source-filtered and RR uses `n_left*n_right`; single-source uses `num_records` (mirrors `sweep_blocking_k`).

### The Driver — `core/autoresearch/loop.py`

```python
run_loop(configs, scorer, objective, *, experiment, dataset_name,
         dataset_fingerprint=None, split_id=None, seeds=None,
         store=None, tracker=NoOpTracker(), dedup=True) -> LoopResult
```

`LoopResult(best_config, best_metrics, trials)`; each `Trial(config, metrics, accepted, recipe_id, attempt_id, status)`.

- **Injected-scorer seam** (`Callable[[Mapping], Mapping[str, float]]`): keep/revert + logging unit-tested with a canned dict scorer — no embeddings/benchmarks. loop.py imports only stdlib + `objective` + `runs` (all import-light).
- **Incumbent vs rejected + lineage**: every trial (accepted, rejected, failed) is logged via `capture_run`; the logged metrics carry an `accepted` flag (`1.0`/`0.0`) so a reader reconstructs the incumbent timeline from the store; `parent_run_id` = the incumbent-at-comparison-time's `attempt_id` gives the lineage chain.
- Scorer raises → logged as a `failed` run and the loop continues (one bad config never aborts the sweep).

### Index reuse

`optimize` loads + fingerprints the benchmark once, then wraps an index-caching scorer keyed on `(embedding_model, metric, text_field)`. Because `SearchSpace` yields `k_neighbors` **innermost**, one FAISS index is built per group and reused across every `k` (`k` lives on the blocker, not the index). Degenerate `all_pairs` configs are canonicalized to `{"blocker": "all_pairs"}` so dedup collapses them to one `recipe_id`.

### Persistence reuse

Reuses `core/runs` verbatim — `RunContext` / `compute_recipe_id` / `capture_run` / `RunStore` / `dataset_fingerprint`. `store=None` writes **nothing** (offline path); every trial is otherwise a durable, deduplicated, lineage-linked record.

### Import-lightness

`optimize.py`'s module top is stdlib/typing only (every heavy import is lazy inside a function body), so `import langres` stays free of torch/faiss/sentence-transformers/litellm/sklearn — locked by a new assertion in `tests/test_import_budget.py`.

### Tests

- `tests/core/test_autoresearch_loop.py` — fake-scorer unit tests: incumbent tracking (strictly-better displaces; worse/incomparable/infeasible kept out), per-trial persistence (count, `accepted` flag, `parent_run_id` lineage), dedup skip + `dedup=False`, `store=None` writes nothing, scorer-raises → failed + continue.
- `tests/test_optimize.py` — tiny in-memory benchmark: `score_blocking` (all_pairs offline, vector via `FakeEmbedder`, prebuilt index, name-string path), `optimize` (LoopResult + all trials logged, degenerate-all_pairs dedup, index-reuse-across-k, `store=None`, seed recording). One `@pytest.mark.slow` real SentenceTransformer+FAISS smoke.

### Notes / deviations

- `score_blocking` omits a `split` param: it measures over the full `.load()` corpus, so a `split` arg would be genuinely unused there. `split` lives on `optimize` (threaded to `RunContext.split_id`, default `"full"`), where it labels the run.
- `optimize` adds an `embedder=` seam (symmetric with `score_blocking`) for offline vector-path testing, and `tracker` defaults to `None`→`NoOpTracker()` internally to keep the module top import-light.

Scope: created `loop.py`, `optimize.py`, and their tests; edited only `src/langres/__init__.py` and `tests/test_import_budget.py`.

## Summary by Sourcery

Add an import-light autoresearch optimization facade with a propose→run→evaluate loop, eager public exports, and comprehensive tests.

New Features:
- Introduce langres.optimize and score_blocking as public APIs for running blocking configuration searches and scoring single configs against benchmarks.
- Implement an autoresearch run_loop driver that iterates candidate configs, evaluates them with an injected scorer, and tracks the best configuration with full trial history.

Enhancements:
- Reuse dataset fingerprints and cached vector indexes across configurations in optimize to avoid redundant work while supporting benchmark-name or object inputs.
- Canonicalize degenerate all_pairs configs for correct recipe-level deduplication in optimization runs.
- Ensure the new optimize facade is eager-exported yet keeps bare langres imports free of heavy ML dependencies via lazy internal imports.

Tests:
- Add unit tests for the autoresearch loop covering incumbent selection, feasibility checks, deduplication behavior, persistence, and failure handling.
- Add tests for score_blocking and optimize, including offline in-memory benchmarks, index reuse across k values, all_pairs deduplication, and a slow end-to-end vector blocking run on a registered benchmark.
- Extend import budget tests to verify langres.optimize and langres.score_blocking are callable on bare import without pulling heavy dependencies into sys.modules.