### PR TITLE
feat(autoresearch): M1 loop — propose→run→eval→keep for ER, proven on blocking recall (#145)

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -4,7 +4,7 @@ on:
   push:
     branches: [main]
   pull_request:
-    branches: [main, feat/m4-foundation, feat/m5-foundation, feat/tracking-observability]
+    branches: [main, feat/m4-foundation, feat/m5-foundation, feat/tracking-observability, feat/autoresearch]
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,49 @@
 
 ## [Unreleased]
 
+### Autoresearch: the self-tuning loop over blocking (epic #145, M1)
+
+A `propose → run → evaluate → keep-if-better` hill-climber that tunes a pipeline
+against a **loss-like** objective instead of a saturated F1. M1 proves the loop on
+the **blocking** vertical; the matching vertical (`log_loss` / AUC-PR steering) and
+small-LM fine-tuning are deferred, as is a durable off-laptop **Trackio + Hugging
+Face** dashboard (an optional `tracker=` hook is wired but no-op by default) and an
+Optuna/LLAMBO proposer swap.
+
+#### Added
+
+- **`langres.optimize(space, objective, benchmark, *, seed=None, store=None,
+  dedup=True, split="full", embedder=None, tracker=None) -> LoopResult`** — the
+  one-call autoresearch facade over blocking search. Loads the benchmark once,
+  wraps an index-caching scorer (one vector index per
+  `(embedding_model, metric, text_field)` group, reused across every `k`), drives
+  the loop over `space.configs()`, keeps the incumbent the `objective` prefers, and
+  persists **every** trial (accepted, over-budget reject, and scorer failure) to a
+  local `RunStore` JSONL at `store=` (`store=None` writes nothing). **Local-only
+  persistence today.**
+- **`langres.score_blocking(config, benchmark, *, embedder=None, index=None) ->
+  dict[str, float]`** — the concrete one-config blocking scorer `optimize` wraps,
+  returning `candidate_recall` / `reduction_ratio` / `candidate_precision` /
+  `total_candidates`. Both `optimize` and `score_blocking` are **root exports and
+  import-light** (heavy imports are lazy inside the call, so a bare `import langres`
+  never pulls faiss; `tests/test_import_budget.py` guards it).
+- **`Objective`** (`langres.core.autoresearch.objective`) — the immutable
+  keep-if-better scorer: `Objective.maximize` / `minimize` / `pareto`, feasibility
+  `subject_to=[(metric, op, threshold), ...]` constraints, feasibility-first then
+  strict-Pareto-dominance `is_better` (ties keep the incumbent). Pure-stdlib,
+  metric-source-agnostic.
+- **`SearchSpace`** (`langres.core.autoresearch.search_space`) — a frozen,
+  declarative Cartesian grid of blocker configs; `configs()` yields config dicts
+  with `k_neighbors` as the **innermost** axis (the index-reuse ordering contract).
+  Pure-stdlib.
+- **`langres.core.metrics.log_loss(confidences, outcomes)`** — binary
+  cross-entropy, the strictly-proper loss-like steering signal for the loop
+  (penalizes confident mistakes far more than `brier_score`; per-item penalty
+  clamped near `-log(1e-15)` so a confident-and-wrong `p=0/1` is large but finite).
+- **`examples/research/blocking_recall_autoresearch.py`** — the E1 proof: the loop
+  hill-climbs blocking recall@budget on amazon_google at **$0, offline** (measured
+  climb + budget-rejection numbers in `docs/EXPERIMENTS.md`).
+
 ### Model identity + one method registry (v0.3 slice, closes #103)
 
 The maintainer complaint this fixes: *"`langres.dedupe` is too simple — you

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -46,6 +46,7 @@ load only when you read/edit a file matching their `paths:`.
 langres/
 ├── src/langres/
 │   ├── verbs.py        # User-facing verbs: link(), dedupe(), LinkVerdict
+│   ├── optimize.py     # langres.optimize / score_blocking: import-light autoresearch facade over blocking search
 │   ├── eval.py         # Curated evaluation facade (lazy): evaluate, list_benchmarks/get_benchmark, ER metrics
 │   ├── cli.py          # langres CLI: review / export-csv / import-csv (labeling loop)
 │   ├── core/           # Low-level primitives + the Resolver
@@ -62,7 +63,8 @@ langres/
 │   │   ├── harvest.py      # Correction/CorrectionLog, harvest_labeled_pairs, derive_threshold_from_pairs
 │   │   ├── calibration.py          # derive_threshold
 │   │   ├── reports.py              # inspection/evaluation report models (ScoreInspectionReport, BlockerEvaluationReport, ...)
-│   │   └── optimizers/             # BlockerOptimizer (Optuna)
+│   │   ├── optimizers/             # BlockerOptimizer (Optuna)
+│   │   └── autoresearch/           # the langres.optimize engine: objective (keep-if-better) / search_space / factory / loop (propose→run→eval→keep)
 │   ├── methods.py      # method registry / _make_module_builder (benchmark path)
 │   ├── clients/        # OpenRouter client, SpendMonitor, pricing
 │   └── data/           # benchmark dataset loaders (FZ, Amazon-Google, ...)

--- a/README.md
+++ b/README.md
@@ -223,6 +223,7 @@ custom pipelines. See [docs/DX_RESOLVER.md](docs/DX_RESOLVER.md) and
 | **Incremental single-record assignment** (`Resolver.build_anchor_store` / `assign`, serializable `AnchorStore`) | ✅ shipped |
 | **Golden records / canonicalization** (`Canonicalizer` survivorship + `enrich`) | ✅ shipped |
 | Evaluation instrument: benchmark registry, `evaluate()`, `EvalReport` tearsheet | ✅ shipped |
+| **Self-tuning blocking search** (`langres.optimize` — `propose→run→eval→keep` over a `SearchSpace`, gated by a loss-like `Objective`) | ✅ shipped (blocking vertical; matching + fine-tuning roadmap) |
 | Cross-source linking (`Resolver.link`, `stream_against`) | 🚧 reserved stubs (raise `NotImplementedError`) — roadmap |
 | Fine-tuning a small LM on harvested labels (the next cost rung) | 🚧 roadmap |
 | Negative constraints (cannot-link clustering) | 🚧 roadmap |

--- a/docs/EXPERIMENTS.md
+++ b/docs/EXPERIMENTS.md
@@ -294,6 +294,117 @@ captures a two-threshold sweep, reads it back, and prints the two-run metric dif
 plus the agent two-liner. Run it:
 `uv run python examples/research/experiment_tracking_demo.py`.
 
+## Self-tuning: the autoresearch loop (`langres.optimize`)
+
+Every surface above measures *one* configuration you chose. The **autoresearch
+loop** closes the outer loop: it **propose**s configs from a search space,
+**run**s and **evaluate**s each into metrics, and **keep**s the one an
+`Objective` prefers — a small, deterministic hill-climber. Because ER F1
+saturates near 99%, the loop steers on a **loss-like signal, not a thresholded
+F1**: `candidate_recall@budget`, `log_loss`, or a quality×cost Pareto front.
+
+`langres.optimize` is the one-call facade; it is **import-light** (`optimize` and
+`score_blocking` are root exports, but every heavy import — faiss, the benchmark
+loader — is lazy inside the call, so a bare `import langres` never pulls the
+[semantic] stack; `tests/test_import_budget.py` guards this).
+
+```python
+from langres import optimize
+from langres.core.autoresearch.objective import Objective
+from langres.core.autoresearch.search_space import SearchSpace
+
+# 1. A SearchSpace is a declarative Cartesian grid of blocker configs. k_neighbors
+#    is the INNERMOST axis, so one vector index is built per
+#    (embedding_model, metric, text_field) group and reused across every k.
+space = SearchSpace(
+    blocker=("vector",),
+    embedding_model=("all-MiniLM-L6-v2",),   # local + free ($0, offline)
+    metric=("cosine", "L2"),
+    text_field=("embed_text", "title"),
+    k_neighbors=(5, 10, 20, 40, 80),         # ascending: recall climbs with k
+)
+
+# 2. An Objective is the immutable keep-if-better rule. Maximize a continuous
+#    recall signal subject to a reduction-ratio floor (>=98.5% of the |A|x|B|
+#    comparisons eliminated) — a real recall@budget tradeoff, not a saturated F1.
+objective = Objective.maximize(
+    "candidate_recall", subject_to=[("reduction_ratio", ">=", 0.985)]
+)
+
+# 3. optimize() loads the benchmark once, drives the loop, and persists EVERY
+#    trial (accepted + rejected) to the local JSONL at store=.
+result = optimize(
+    space, objective, "amazon_google",
+    store="tmp/autoresearch/ag_blocking.jsonl",   # gitignored; store=None writes nothing
+    seed=0,
+)
+print(result.best_config, result.best_metrics)     # the winning feasible config
+```
+
+**Defining the `Objective` — three ergonomic constructors.** An `Objective`
+bundles one or more goals with zero or more feasibility constraints
+(`(metric, op, threshold)` triples, `op` in `>= <= > <`). A candidate that
+violates any constraint is never kept; among feasible candidates the incumbent is
+displaced only by a strict Pareto win (`>=` on every goal, `>` on at least one) —
+ties and incomparable trade-offs keep the incumbent, so the loop is monotone.
+
+```python
+# single maximize goal, optionally constrained
+Objective.maximize("candidate_recall", subject_to=[("reduction_ratio", ">=", 0.985)])
+
+# single minimize goal (e.g. log_loss, cost) — the matching vertical's steering signal
+Objective.minimize("log_loss")
+
+# multi-objective Pareto front — never scalarized (recall up, work down)
+Objective.pareto([("candidate_recall", "maximize"), ("reduction_ratio", "maximize")])
+```
+
+**Where results are stored — local JSONL only, today.** `optimize(store=...)`
+appends **every** trial — accepted, over-budget rejects, and scorer failures — as
+one line to a local `RunStore` JSONL (the same `core.runs` spine as
+`capture_run` above), so the full audit trail is durable off-git. `store=None`
+persists **nothing** (the offline path); the same `LoopResult` is returned either
+way. Read the trail back with `RunStore(path).read()`:
+
+```python
+from langres.core.runs import RunStore
+
+records = RunStore("tmp/autoresearch/ag_blocking.jsonl").read()   # last-wins per attempt
+accepted = [r for r in records if (r.metrics or {}).get("accepted") == 1.0]
+```
+
+This persistence is **local-only for now.** A durable, off-laptop dashboard
+(Trackio + Hugging Face, with the winning artifact pushed to the Hub) is
+**deferred** — an optional `tracker=` hook is wired into `optimize`/`run_loop` but
+defaults to a no-op. Also deferred: swapping the exhaustive grid proposer for an
+Optuna/LLAMBO one, and the **matching vertical** (steering a judge on `log_loss` /
+AUC-PR) plus small-LM fine-tuning. **M1 proves the loop on the blocking vertical
+only** (epic #145).
+
+### Worked proof — climbing blocking recall@budget on amazon_google
+
+`examples/research/blocking_recall_autoresearch.py` runs exactly the loop above
+over the 20-config grid at **$0, offline** (local MiniLM embeddings, no LLM; the
+benchmark is vendored). amazon_google is a genuinely hard, *unsaturated* two-source
+linkage benchmark — blocking recall plateaus ~0.84, never reaching a 0.90 gate —
+which is what makes the climb and the budget tradeoff honest rather than a
+foregone conclusion. A measured run:
+
+- The incumbent `candidate_recall` **climbs** as `k` grows within the winning
+  `(metric, text_field)` group: **0.7568 → 0.8129 → 0.8317 → 0.8388** for
+  `k = 5 → 10 → 20 → 40`.
+- `k = 80` is **rejected as over-budget** — it spends ~2× the comparisons for no
+  extra recall, so its `reduction_ratio` (0.9776) breaches the 0.985 floor. The
+  loop keeps the best *feasible* incumbent. The budget is a real gate, not
+  decoration.
+- **20 trials logged (4 accepted / 16 rejected)** to the gitignored
+  `tmp/autoresearch/` JSONL; ~41 s wall-clock, **$0**.
+
+```bash
+uv run --env-file .env python examples/research/blocking_recall_autoresearch.py
+# needs the [semantic] extra: uv sync --all-extras --no-extra finetune
+```
+
 ## W3 paid smoke — SelectMatcher vs pairwise, measured
 
 `examples/research/w3_paid_smoke.py` is the ≤$10, SpendMonitor-capped operator run
@@ -399,6 +510,8 @@ with `examples/data/flywheel/generate_fixtures.py`.
   scoring walkthrough.
 - `examples/research/portfolio_race.py` — registry-driven race over every loadable
   benchmark (offline by default; optional capped LLM row).
+- `examples/research/blocking_recall_autoresearch.py` — the autoresearch loop
+  (`langres.optimize`) hill-climbing blocking recall@budget on amazon_google, $0/offline.
 - `examples/research/m4_experiment_loop.py` — the runnable zero-spend loop documented here.
 - `examples/research/m4_dspy_judge.py` — DSPyMatcher compile + save/load round-trip.
 - `examples/research/m4_calibration.py` — honest held-out `derive_threshold` lift on AG.

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -380,6 +380,27 @@ model/version registry, production/operability guidance, cannot-link clustering.
 - **Exit:** Person resolver meets **BCubed F1 ≥ 0.85**; documented deploy/rollback
   path; reproducible artifact versioning.
 
+### Autoresearch (epic #145) — the self-tuning loop — M1 LANDED
+The Karpathy-style `propose → run → evaluate → keep-if-better` outer loop, so
+langres *tunes itself* against a **loss-like** objective (`recall@budget`,
+`log_loss`, quality×cost Pareto) instead of a saturated F1. Shipped as the
+import-light `langres.optimize` / `score_blocking` facade over a declarative
+`SearchSpace` + an immutable `Objective`, with every trial (accepted and rejected)
+persisted to a local `RunStore` JSONL.
+
+- **M1 (landed) — proven on the blocking vertical.** The loop hill-climbs blocking
+  recall@budget on the hard, unsaturated amazon_google benchmark at **$0, offline**:
+  incumbent `candidate_recall` climbs `0.7568 → 0.8388` (`k = 5 → 40`) while the
+  over-budget `k = 80` config is correctly rejected — a real recall-vs-cost tradeoff,
+  not a foregone conclusion. See
+  [`docs/EXPERIMENTS.md`](EXPERIMENTS.md#self-tuning-the-autoresearch-loop-langresoptimize)
+  and `examples/research/blocking_recall_autoresearch.py`.
+- **Deferred (do not reference as existing):** the **matching** vertical (steering a
+  judge on `log_loss` / AUC-PR) and small-LM fine-tuning; an Optuna/LLAMBO proposer
+  swap; and a durable off-laptop **Trackio + Hugging Face** dashboard with the
+  winning artifact pushed to the Hub (an optional `tracker=` hook is wired but
+  defaults to a no-op — persistence is **local JSONL only** today).
+
 ---
 
 ## 7. Mapping to the first production consumer

--- a/docs/TECHNICAL_OVERVIEW.md
+++ b/docs/TECHNICAL_OVERVIEW.md
@@ -354,6 +354,10 @@ best_params = optimizer.optimize()   # -> {"embedding_model": ..., "k_neighbors"
 (Optuna lives in the dev dependency group, not a runtime extra — `BlockerOptimizer`
 is an eval-time tool, not part of the `link()`/`dedupe()` path.)
 
+> For a higher-level, self-tuning blocking search — a declarative `SearchSpace`
+> driven by an `Objective` through the `propose → run → evaluate → keep` loop, with
+> every trial persisted — see `langres.optimize` in §10.
+
 ### core.Canonicalizer (`langres.core.canonicalizer`, M5/W2.3) — ✅ ships today
 
 **Definition:** The "last mile" of Master Data Creation (Use Case 4): merge one
@@ -861,3 +865,143 @@ see `examples/research/w1_blocking_algebra_output.md` for the full tables and th
 default-flip decision (kept opt-in; recommended for harder/messier
 entity-resolution problems, not flipped globally on a single hard-dataset
 win).
+
+## 10. Self-tuning: the autoresearch loop (`langres.optimize`)
+
+The autoresearch loop (epic #145, M1) is a small **propose → run → evaluate →
+keep-if-better** hill-climber: it enumerates blocker configs, scores each into
+blocking metrics, and keeps the one an `Objective` prefers. Because ER F1
+saturates near 99%, it steers on a **loss-like** signal (`candidate_recall@budget`,
+`log_loss`, quality×cost Pareto) rather than a thresholded F1.
+
+`optimize` / `score_blocking` are **root exports** (`from langres import optimize`)
+and **import-light**: every heavy import (faiss, the benchmark loader,
+`core.autoresearch.factory`) is lazy inside the call, so a bare `import langres`
+never pulls the `[semantic]` stack (`tests/test_import_budget.py` guards this). The
+proposal/objective types (`SearchSpace`, `Objective`) are pure-stdlib and safe to
+import anywhere; only the concrete blocking scorer touches faiss.
+
+> This is a **blocking-search** facade, distinct from `core.optimizers.BlockerOptimizer`
+> (§5): `BlockerOptimizer` runs an Optuna study returning best params, while
+> `optimize` runs the deterministic keep-if-better loop over a declarative
+> `SearchSpace`, gated by an `Objective`, persisting every trial. A general
+> `Optimizer` over full *pipelines* remains roadmap.
+
+### langres.optimize (the loop facade)
+
+`optimize(space, objective, benchmark, *, seed=None, store=None, dedup=True, split="full", embedder=None, tracker=None) -> LoopResult`
+
+Loads `benchmark` **once**, fingerprints it once, wraps an index-caching blocking
+scorer (one vector index per `(embedding_model, metric, text_field)` group, reused
+across every `k`), and drives the loop over `space.configs()`.
+
+- `space: SearchSpace` — the declarative config grid (below).
+- `objective: Objective` — the immutable keep-if-better decision (below).
+- `benchmark: str | Benchmark` — a registered benchmark **name** (loaded via
+  `langres.data`) or an already-built benchmark object (offline / test path).
+- `seed: int | None` — recorded on every run for provenance under
+  `seeds["optimize"]` (blocking is deterministic, so this only labels the run).
+- `store: str | Path | RunStore | None` — where to persist run records;
+  **`store=None` writes nothing.**
+- `dedup: bool = True` — skip a config whose `recipe_id` was already scored this
+  run (degenerate `all_pairs` repeats are collapsed first).
+- `split: str = "full"` — split label recorded on every run (M1 measures over the
+  whole loaded corpus).
+- `embedder: EmbeddingProvider | None` — optional pre-built embedder (a fake keeps
+  tests offline); production leaves it `None` to load the real SentenceTransformer.
+- `tracker: ExperimentTracker | None` — optional experiment tracker; defaults to a
+  no-op (the deferred Trackio/HF hook).
+
+### score_blocking (the one-config scorer)
+
+`score_blocking(config, benchmark, *, embedder=None, index=None) -> dict[str, float]`
+
+Blocking metrics for **one** config — builds the index + blocker the config
+describes, streams the full corpus to candidates, and evaluates blocking. This is
+the concrete scorer `optimize` wraps; call it directly to score a single config.
+`index=` reuses a prebuilt vector index instead of building one. Returns a plain
+metrics dict (all values `float`):
+
+| Key | Meaning |
+|---|---|
+| `candidate_recall` | Fraction of true match pairs the blocker surfaced (the recall signal the loop maximizes). |
+| `reduction_ratio` | Fraction of the `O(|A|·|B|)` (or `num_records`-choose-2) comparison space eliminated — the budget/cost axis. |
+| `candidate_precision` | Fraction of surfaced candidates that are true matches. |
+| `total_candidates` | Count of candidate pairs emitted (as a float). |
+
+For a two-source (linkage) corpus the candidates are filtered to cross-source
+pairs and `reduction_ratio` uses `|A|·|B|`; otherwise it uses `num_records`.
+
+### SearchSpace (`langres.core.autoresearch.search_space`)
+
+A frozen, declarative Cartesian grid of blocker configs. Each field is a
+non-empty tuple of candidate values for one axis (an empty axis raises).
+
+- `blocker: tuple[str, ...] = ("vector",)` — `"vector"` and/or `"all_pairs"`
+  (the vector axes below are ignored by `"all_pairs"`).
+- `embedding_model: tuple[str, ...] = ("all-MiniLM-L6-v2",)`
+- `metric: tuple[str, ...] = ("cosine",)` — FAISS metric `"L2"` / `"cosine"`.
+- `text_field: tuple[str, ...] = ("name",)` — record attribute holding the
+  blocking text (dataset-specific; override to your schema's field).
+- `k_neighbors: tuple[int, ...] = (5, 10, 20)`
+
+`configs() -> Iterator[dict[str, Any]]` yields the Cartesian product as config
+dicts (keys `blocker`, `embedding_model`, `metric`, `text_field`, `k_neighbors`).
+**Ordering contract (the loop relies on it):** `k_neighbors` is the **innermost**
+varying axis, so consecutive configs hold `(blocker, embedding_model, metric,
+text_field)` fixed while `k` sweeps its full range — letting `optimize` build one
+index per group and reuse it across every `k`. `len(space)` is the product of the
+axis sizes.
+
+### Objective (`langres.core.autoresearch.objective`)
+
+The immutable keep-if-better scorer, metric-source-agnostic (it operates on a
+plain `Mapping[str, float]` and never computes a metric itself). It bundles one or
+more `Goal`s (optimization targets) with zero or more `Constraint`s (feasibility
+gates). Prefer the three ergonomic constructors:
+
+- `Objective.maximize(metric, *, subject_to=())` — one maximize goal.
+- `Objective.minimize(metric, *, subject_to=())` — one minimize goal (e.g.
+  `log_loss`, cost).
+- `Objective.pareto(goals, *, subject_to=())` — a multi-objective Pareto front,
+  `goals` = `(metric, direction)` pairs; **never scalarized**.
+
+`subject_to` is an iterable of `(metric, op, threshold)` triples with `op` in
+`>= <= > <`; a missing metric raises (it never defaults to `0.0`).
+
+**`is_better(candidate, incumbent) -> bool`** — the loop's decision, in order:
+(1) **feasibility first** — an infeasible candidate is never better; a feasible
+candidate beats a `None` or infeasible incumbent; (2) **Pareto improvement** —
+with both feasible, the candidate wins iff it *dominates* the incumbent (`>=` on
+every goal, `>` on at least one; for a single goal, a strict scalar improvement).
+A tie or an incomparable trade-off keeps the incumbent, so the decision is
+deterministic and monotone.
+
+### LoopResult / Trial (`langres.core.autoresearch.loop`)
+
+`run_loop` (the driver `optimize` calls) returns a frozen `LoopResult`:
+
+- `best_config: dict[str, Any] | None` — the winning config, or `None` if no
+  config was ever accepted (empty input, or every trial infeasible/failed).
+- `best_metrics: dict[str, float] | None` — the winning config's metrics (or `None`).
+- `trials: tuple[Trial, ...]` — every trial in evaluation order (accepted,
+  rejected, and failed), for reconstructing why the incumbent won.
+
+Each `Trial` is frozen: `config` (the scored dict), `metrics` (`dict | None` —
+`None` if the scorer raised), `accepted` (whether it displaced the incumbent),
+`recipe_id` (the content-addressed dedup key), `attempt_id` (the run record PK),
+and `status` (`"completed"` or `"failed"` — one bad config is logged and skipped,
+never aborting the sweep).
+
+### Persistence — local JSONL only, today
+
+Every trial (including over-budget rejects and scorer failures) is appended to the
+`store` path's `RunStore` JSONL (the `core.runs` spine, §2). `store=None` writes
+nothing; read a trail back with `RunStore(path).read()` (each `RunRecord`'s
+`metrics["accepted"]` is `1.0`/`0.0`, so the incumbent timeline is reconstructable
+from the store alone). This is **local-only for now**: a durable off-laptop
+dashboard (Trackio + Hugging Face + models-on-Hub) is deferred behind the optional
+`tracker=` hook (a no-op by default), as are an Optuna/LLAMBO proposer and the
+matching vertical (`log_loss` / AUC-PR steering) + fine-tuning. See
+[EXPERIMENTS.md](EXPERIMENTS.md#self-tuning-the-autoresearch-loop-langresoptimize)
+for the worked amazon_google proof and `examples/research/blocking_recall_autoresearch.py`.

--- a/examples/research/README.md
+++ b/examples/research/README.md
@@ -1,0 +1,44 @@
+# Research examples
+
+Experiment-tier scripts (harness code, not the library contract) that reproduce
+langres milestones and probe methods. Run any of them with `uv run python
+examples/research/<script>.py`; the ML-heavy ones want the OpenMP remedy
+(`OMP_NUM_THREADS=1 KMP_DUPLICATE_LIB_OK=TRUE`, or `uv run --env-file .env`).
+
+## Autoresearch: the propose→run→eval→keep loop (epic #145)
+
+**`blocking_recall_autoresearch.py`** — the E1 **proof that the loop closes**.
+
+The autoresearch loop is a small hill-climber: **propose** a config, **run** it,
+**evaluate** it into metrics, and **keep** it iff an `Objective` says it beats the
+incumbent. Because ER F1 saturates near 99%, the loop steers on a *loss-like*
+signal instead — here, continuous **recall@budget**:
+
+```
+maximize candidate_recall  subject_to  reduction_ratio >= 0.985
+```
+
+Point `langres.optimize` at a modest, frozen grid over the **amazon_google**
+benchmark (2 metrics × 2 blocking texts × an ascending `k` sweep) and watch it
+climb:
+
+- **Recall@budget climbs.** `SearchSpace` sweeps `k_neighbors` innermost, so more
+  neighbours surface more true pairs and the *incumbent* candidate_recall ratchets
+  up trial by trial. The script prints the progress curve so the climb is visible.
+- **The budget is a real gate.** The top-of-sweep configs spend ~2× the
+  comparisons for no extra recall, breach the reduction-ratio floor, and are
+  **rejected** — the loop keeps the best *feasible* incumbent. That is the
+  recall-vs-cost tradeoff, made explicit (not a saturated F1 threshold).
+- **Every trial is logged off-git — accepted *and* rejected.** The loop persists
+  each trial to a local, owned `RunStore` JSONL under `tmp/` (gitignored); the
+  script reads it back to prove nothing was dropped.
+- **$0 and offline.** Local `all-MiniLM-L6-v2` embeddings, no LLM; the benchmark
+  is vendored. `k` is innermost, so it is only 4 embedding passes over the corpus.
+
+```bash
+uv run --env-file .env python examples/research/blocking_recall_autoresearch.py
+# needs the [semantic] extra: uv sync --all-extras --no-extra finetune
+```
+
+Nothing generated is committed: the `RunStore` JSONL (and the optional
+incumbent-recall PNG) land in the gitignored `tmp/autoresearch/`.

--- a/examples/research/blocking_recall_autoresearch.py
+++ b/examples/research/blocking_recall_autoresearch.py
@@ -1,0 +1,257 @@
+"""Autoresearch proof (epic #145, M1/E1): the propose→run→eval→keep loop climbs.
+
+This is the runnable *proof that the loop closes*. It points ``langres.optimize``
+at a small, frozen search space over the **amazon_google** benchmark and lets the
+``propose → run → evaluate → keep-if-better`` loop hill-climb — with **$0 spend**
+(local ``all-MiniLM-L6-v2`` embeddings, no LLM) and fully offline (the benchmark
+is vendored).
+
+What it demonstrates
+--------------------
+* **The loop steers on a loss-like objective, not a saturated F1.** ER F1
+  plateaus near 99%, so we optimize a continuous *recall@budget* signal instead:
+  ``maximize candidate_recall subject_to reduction_ratio >= 0.985`` (keep >=98.5%
+  of the O(|A|x|B|) comparisons eliminated). See ``Objective.maximize``.
+* **Recall@budget climbs.** ``SearchSpace`` sweeps ``k_neighbors`` innermost, so
+  within each ``(metric, text_field)`` group more neighbours surface more true
+  pairs and the *incumbent* candidate_recall ratchets up trial by trial — the
+  printed progress curve makes the climb visible.
+* **The budget is a real gate, not decoration.** The highest-``k`` configs buy
+  little-to-no extra recall while spending more comparisons, so they breach the
+  reduction-ratio budget and are **rejected** — the loop keeps the best *feasible*
+  incumbent. This is the recall-vs-cost tradeoff, made explicit.
+* **Every trial is logged off-git — accepted *and* rejected.** The loop persists
+  each trial to a local, owned ``RunStore`` JSONL under ``tmp/`` (gitignored), so
+  the full audit trail (including the over-budget rejects) survives the run. The
+  script reads it back to prove nothing was dropped.
+
+Why amazon_google: it is a genuinely *hard, unsaturated* two-source linkage
+benchmark (blocking recall plateaus ~0.84 with title+manufacturer vector
+blocking — it never reaches a 0.90 gate), which is exactly what makes the climb
+and the budget tradeoff honest rather than a foregone conclusion.
+
+Run:
+    OMP_NUM_THREADS=1 KMP_DUPLICATE_LIB_OK=TRUE \\
+        uv run python examples/research/blocking_recall_autoresearch.py
+
+    # or, with the repo's env file:
+    uv run --env-file .env python examples/research/blocking_recall_autoresearch.py
+"""
+
+from __future__ import annotations
+
+# Force single-threaded / duplicate-safe OpenMP *before* faiss/torch load, so the
+# macOS libomp double-load segfault can't bite (belt to the guard already in
+# core.indexes.vector_index). Harmless elsewhere; mirrors the sibling examples.
+import os
+
+os.environ.setdefault("OMP_NUM_THREADS", "1")
+os.environ.setdefault("KMP_DUPLICATE_LIB_OK", "TRUE")
+
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+from langres import optimize
+from langres.core.autoresearch.objective import Objective
+from langres.core.autoresearch.search_space import SearchSpace
+from langres.core.runs import RunStore
+
+if TYPE_CHECKING:
+    from langres.core.autoresearch.loop import LoopResult
+
+#: Registered, vendored, offline benchmark (two-source Amazon<->Google linkage).
+BENCHMARK = "amazon_google"
+
+#: Reduction-ratio budget the loop must stay within. 0.985 = "eliminate >=98.5%
+#: of the |A|x|B| comparisons". Chosen so the k-sweep can climb to its recall
+#: plateau (k<=40) while the top of the sweep (k=80), which spends ~2x the
+#: comparisons for no recall gain, breaches the budget and is rejected — a real
+#: recall@budget tradeoff rather than a vacuous constraint every config passes.
+RR_BUDGET = 0.985
+
+#: Off-git audit trail (``tmp/`` is gitignored). Every trial — accepted and
+#: rejected — lands here; the loop owns it, and we read it back at the end.
+STORE_PATH = "tmp/autoresearch/amazon_google_blocking.jsonl"
+
+
+def build_space() -> SearchSpace:
+    """The modest, frozen grid the loop proposes over (20 configs, 4 index builds).
+
+    Two metrics x two blocking texts x a 5-point ascending ``k`` sweep. Because
+    ``k_neighbors`` is the innermost axis, ``optimize`` builds **one** vector
+    index per ``(embedding_model, metric, text_field)`` group and reuses it across
+    every ``k`` — so this is only 4 embedding passes over the corpus, not 20.
+    """
+    return SearchSpace(
+        blocker=("vector",),
+        embedding_model=("all-MiniLM-L6-v2",),  # local + free; keep it $0/fast
+        metric=("cosine", "L2"),
+        text_field=("embed_text", "title"),  # title+manufacturer vs title-only
+        k_neighbors=(5, 10, 20, 40, 80),  # ascending: recall climbs with k
+    )
+
+
+def run_search(
+    space: SearchSpace,
+    rr_budget: float,
+    store: str | None,
+    *,
+    seed: int = 0,
+) -> LoopResult:
+    """Drive the autoresearch loop over ``space`` and return its :class:`LoopResult`.
+
+    The objective is the E1 steering signal: maximize the continuous
+    ``candidate_recall`` subject to a reduction-ratio floor. ``optimize`` loads
+    amazon_google once, threads a cached index through the scorer, and persists
+    every trial to ``store`` (``None`` => persist nothing).
+    """
+    objective = Objective.maximize(
+        "candidate_recall", subject_to=[("reduction_ratio", ">=", rr_budget)]
+    )
+    return optimize(space, objective, BENCHMARK, store=store, seed=seed)
+
+
+def _config_label(config: dict[str, object]) -> str:
+    """Compact one-line view of a vector config: ``metric/text_field/k=..``."""
+    return f"{config['metric']:>6}/{config['text_field']:<10}/k={config['k_neighbors']:<3}"
+
+
+def print_progress(result: LoopResult, rr_budget: float) -> list[float]:
+    """Print the recall@budget progress curve; return the incumbent-recall series.
+
+    One row per trial in evaluation order: the config, its ``candidate_recall`` and
+    ``reduction_ratio``, an outcome tag, and the **running incumbent recall** so
+    the climb is visible. The outcome tag distinguishes the two reasons a trial is
+    not accepted — over-budget (``reduction_ratio`` below the floor) vs. simply not
+    better than the incumbent.
+    """
+    print("\n" + "=" * 78)
+    print(
+        f"Recall@budget progress curve  (objective: maximize candidate_recall "
+        f"s.t. reduction_ratio >= {rr_budget})"
+    )
+    print("=" * 78)
+    print(f"{'#':>2}  {'config':<26} {'recall':>7} {'RR':>8}  {'outcome':<18} {'incumbent':>9}")
+    print("-" * 78)
+
+    incumbent = 0.0
+    incumbents: list[float] = []
+    for i, trial in enumerate(result.trials, start=1):
+        metrics = trial.metrics
+        if metrics is None:  # scorer raised — recorded as a failed trial
+            print(
+                f"{i:>2}  {_config_label(trial.config):<26} {'—':>7} {'—':>8}  "
+                f"{'FAILED':<18} {incumbent:>9.4f}"
+            )
+            incumbents.append(incumbent)
+            continue
+        recall = metrics["candidate_recall"]
+        rr = metrics["reduction_ratio"]
+        if trial.accepted:
+            incumbent = recall
+            outcome = "ACCEPT (new best)"
+        elif rr < rr_budget:
+            outcome = "reject: over budget"
+        else:
+            outcome = "reject: no gain"
+        print(
+            f"{i:>2}  {_config_label(trial.config):<26} {recall:>7.4f} {rr:>8.5f}  "
+            f"{outcome:<18} {incumbent:>9.4f}"
+        )
+        incumbents.append(incumbent)
+    print("-" * 78)
+    return incumbents
+
+
+def report_best(result: LoopResult, rr_budget: float) -> None:
+    """Print the winning config and its metrics."""
+    print("\nBest feasible config found:")
+    if result.best_config is None or result.best_metrics is None:
+        print("  (none — no config satisfied the budget)")
+        return
+    cfg = result.best_config
+    m = result.best_metrics
+    print(f"  metric        : {cfg['metric']}")
+    print(f"  text_field    : {cfg['text_field']}")
+    print(f"  k_neighbors   : {cfg['k_neighbors']}")
+    print(f"  candidate_recall : {m['candidate_recall']:.4f}")
+    print(f"  reduction_ratio  : {m['reduction_ratio']:.5f}  (budget >= {rr_budget})")
+    print(f"  candidate_precision : {m['candidate_precision']:.4f}")
+    print(f"  total_candidates    : {int(m['total_candidates'])}")
+
+
+def report_store(store_path: str) -> None:
+    """Read the persisted trail back and prove every trial was logged off-git."""
+    records = RunStore(store_path).read()
+    accepted = sum(1 for r in records if (r.metrics or {}).get("accepted") == 1.0)
+    failed = sum(1 for r in records if r.status == "failed")
+    rejected = len(records) - accepted - failed
+    print("\n" + "-" * 78)
+    print(f"RunStore audit trail: {store_path}")
+    print(
+        f"  {len(records)} trials logged (incl. rejects)  ->  "
+        f"{accepted} accepted / {rejected} rejected / {failed} failed"
+    )
+    print("  (every proposed config is durable off-git — the full propose->eval->keep record)")
+    print("-" * 78)
+
+
+def maybe_plot(incumbents: list[float], out_dir: str) -> None:
+    """Save an incumbent-recall-vs-trial PNG *iff* matplotlib is already installed.
+
+    A nice-to-have — the printed curve is the primary artifact. Never adds a
+    dependency: a missing matplotlib is silently skipped.
+    """
+    try:
+        import matplotlib
+
+        matplotlib.use("Agg")  # headless; no display needed
+        import matplotlib.pyplot as plt
+    except ImportError:
+        print("\n(matplotlib not installed — skipping the PNG; the printed curve is the proof.)")
+        return
+
+    Path(out_dir).mkdir(parents=True, exist_ok=True)
+    out_path = Path(out_dir) / "incumbent_recall_curve.png"
+    trials = range(1, len(incumbents) + 1)
+    fig, ax = plt.subplots(figsize=(7, 4))
+    ax.step(trials, incumbents, where="post", marker="o", color="#2563eb")
+    ax.set_xlabel("trial (proposal order)")
+    ax.set_ylabel("incumbent candidate_recall")
+    ax.set_title("Autoresearch: incumbent recall@budget climbs (amazon_google)")
+    ax.grid(True, alpha=0.3)
+    fig.tight_layout()
+    fig.savefig(out_path, dpi=120)
+    plt.close(fig)
+    print(f"\nSaved incumbent-recall curve -> {out_path}")
+
+
+def main() -> None:
+    """Run the E1 proof: hill-climb blocking recall@budget on amazon_google."""
+    print("=" * 78)
+    print("Autoresearch E1 proof — blocking recall@budget loop on amazon_google")
+    print("$0, offline, local MiniLM embeddings (no LLM). Epic #145, M1.")
+    print("=" * 78)
+
+    space = build_space()
+    print(
+        f"\nSearch space: {len(space)} configs "
+        f"(metrics x text_fields x k-sweep; k innermost -> 4 index builds)."
+    )
+    print(f"Persisting every trial to: {STORE_PATH}  (gitignored)")
+
+    result = run_search(space, RR_BUDGET, STORE_PATH, seed=0)
+
+    incumbents = print_progress(result, RR_BUDGET)
+    report_best(result, RR_BUDGET)
+    report_store(STORE_PATH)
+    maybe_plot(incumbents, os.path.dirname(STORE_PATH))
+
+    print(
+        "\nThe loop closed: incumbent recall@budget climbed and every trial "
+        "(incl. over-budget rejects) is durable off-git."
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/src/langres/__init__.py
+++ b/src/langres/__init__.py
@@ -61,6 +61,7 @@ from langres.core import (
 )
 from langres.core.models import MatcherAbstainedError
 from langres.core.presets import DEFAULT_AUTO_MODEL, NoMatcherAvailableError
+from langres.optimize import optimize, score_blocking
 from langres.verbs import LinkVerdict, dedupe, link
 
 if TYPE_CHECKING:
@@ -103,7 +104,9 @@ __all__ = [
     "gold_pairs_from_clusters",
     "harvest_labeled_pairs",
     "link",
+    "optimize",
     "run_finetune",
+    "score_blocking",
     "select_for_review",
 ]
 

--- a/src/langres/core/autoresearch/__init__.py
+++ b/src/langres/core/autoresearch/__init__.py
@@ -1,0 +1,7 @@
+"""Autoresearch loop for entity resolution: propose → run → evaluate → keep-if-better.
+
+The immutable Objective (the un-gameable scorer) and the pluggable proposer over a
+declarative SearchSpace sit under here; the public entry point is ``langres.optimize``.
+See epic #145. Submodules are imported by dotted path — this package intentionally
+exports nothing until the public facade wires it up.
+"""

--- a/src/langres/core/autoresearch/factory.py
+++ b/src/langres/core/autoresearch/factory.py
@@ -1,0 +1,122 @@
+"""Turn one autoresearch config dict into a runnable blocker.
+
+Companion to ``search_space``: :class:`SearchSpace` enumerates config dicts and
+this module builds the blocker each one describes. Two pure functions, no global
+mutable state — index reuse across ``k`` values is the *caller's* job (it builds
+one index and threads it into :func:`build_blocker_from_config`; see the
+k-innermost ordering contract on ``SearchSpace.configs``), not a cache here.
+
+**NOT import-light.** This module imports the [semantic] stack
+(faiss/sentence-transformers, via the vector index + embedder) at module top, so
+it must only ever be imported **lazily** — on demand when a search actually runs,
+never from a bare ``import langres`` (unlike the sibling ``search_space``, which
+stays pure so it can live on the public API surface). The autoresearch package
+``__init__`` intentionally exports nothing, so importing ``langres`` does not
+reach this module.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping, Sequence
+from typing import Any, Literal, cast
+
+from langres.core.blocker import Blocker
+from langres.core.blockers.all_pairs import AllPairsBlocker
+from langres.core.blockers.vector import VectorBlocker
+from langres.core.embeddings import EmbeddingProvider, SentenceTransformerEmbedder
+from langres.core.indexes.vector_index import FAISSIndex, VectorIndex
+
+
+def build_index(
+    embedding_model: str,
+    metric: str,
+    texts: Sequence[str],
+    *,
+    embedder: EmbeddingProvider | None = None,
+) -> VectorIndex:
+    """Build a FAISS index over ``texts``, ready for search.
+
+    Mirrors the canonical VectorBlocker build path used across the codebase
+    (embedder → ``FAISSIndex(embedder=..., metric=...)`` → ``create_index``;
+    see ``core/presets.py:_build_vector_blocker`` and
+    ``data/_benchmark_utils.py:sweep_blocking_k``). ``create_index`` is called
+    here, so the returned index is immediately usable by a ``VectorBlocker`` —
+    an un-built index raises when streamed.
+
+    Args:
+        embedding_model: sentence-transformers model name. Used to construct a
+            :class:`SentenceTransformerEmbedder` unless ``embedder`` is injected.
+        metric: FAISS metric, ``"L2"`` or ``"cosine"``. Validated here, so an
+            unknown value fails fast with a clear ``ValueError`` before any
+            embedding work — rather than deferring to the FAISS internals.
+        texts: Corpus texts to embed and index, in the same order as the records
+            the resulting blocker will stream.
+        embedder: Optional pre-built embedder that overrides constructing one
+            from ``embedding_model``. Tests inject a ``FakeEmbedder`` here to skip
+            the model download; production leaves it ``None``.
+
+    Returns:
+        A ready-to-search :class:`FAISSIndex` (``create_index`` already called).
+    """
+    if metric not in ("L2", "cosine"):
+        raise ValueError(f"metric must be 'L2' or 'cosine', got {metric!r}")
+    if embedder is None:
+        embedder = SentenceTransformerEmbedder(embedding_model)
+    # metric is validated just above, so narrowing str -> Literal is sound.
+    index = FAISSIndex(embedder=embedder, metric=cast(Literal["L2", "cosine"], metric))
+    index.create_index(list(texts))
+    return index
+
+
+def build_blocker_from_config(
+    config: Mapping[str, Any],
+    *,
+    schema: type[Any],
+    index: VectorIndex | None = None,
+) -> Blocker[Any]:
+    """Construct the blocker a config describes, dispatching on ``config["blocker"]``.
+
+    Named ``build_blocker_from_config`` (not ``build_blocker``) to avoid colliding
+    with ``Benchmark.build_blocker`` in the data layer.
+
+    Dispatch:
+
+    - ``"vector"`` — builds a :class:`VectorBlocker` over a **prebuilt** ``index``
+      (from :func:`build_index`), mirroring the canonical declarative wiring
+      (``schema=`` + ``text_field=`` keeps the blocker config-serializable).
+      Raises ``ValueError`` if ``index is None``.
+    - ``"all_pairs"`` — builds an :class:`AllPairsBlocker`; ``index`` is unused.
+
+    Args:
+        config: A config dict as yielded by ``SearchSpace.configs()``. For the
+            vector path it must carry ``text_field`` and ``k_neighbors``.
+        schema: The Pydantic record schema, passed declaratively so the blocker
+            stays config-serializable.
+        index: A prebuilt vector index. **Required** for ``blocker == "vector"``;
+            ignored for ``"all_pairs"``.
+
+    Returns:
+        A ready-to-stream :class:`Blocker`.
+
+    Raises:
+        ValueError: If ``blocker == "vector"`` and ``index is None``, or if
+            ``config["blocker"]`` names an unknown blocker kind.
+    """
+    blocker_kind = config["blocker"]
+    if blocker_kind == "vector":
+        if index is None:
+            raise ValueError(
+                "build_blocker_from_config requires a prebuilt 'index' for "
+                "blocker='vector' (build one with build_index(...) first)."
+            )
+        return VectorBlocker(
+            vector_index=index,
+            schema=schema,
+            text_field=config["text_field"],
+            k_neighbors=config["k_neighbors"],
+        )
+    if blocker_kind == "all_pairs":
+        return AllPairsBlocker(schema=schema)
+    raise ValueError(
+        f"unknown blocker {blocker_kind!r} in config (expected 'vector' or 'all_pairs')"
+    )

--- a/src/langres/core/autoresearch/loop.py
+++ b/src/langres/core/autoresearch/loop.py
@@ -1,0 +1,208 @@
+"""The ``propose → run → evaluate → keep-if-better`` driver for autoresearch.
+
+This is the integration seam of the autoresearch loop (epic #145): it walks a
+stream of proposed configs, scores each one, and keeps the incumbent that the
+:class:`~langres.core.autoresearch.objective.Objective` says is best — logging
+*every* trial (accepted and rejected) through the existing run-tracking spine
+(``core.runs``) so a run is durable, deduplicated, and lineage-linked.
+
+**Injected-scorer testability seam.** :func:`run_loop` takes the scorer as a
+plain ``Callable[[Mapping], Mapping[str, float]]`` (config → metrics), so its
+keep/revert + logging logic is unit-testable with a canned dict scorer — no
+embeddings, faiss, or benchmark load required. The concrete blocking scorer
+(and its index reuse) lives one layer up in :mod:`langres.optimize`; this module
+knows nothing about blockers.
+
+**Import-light by design.** Only stdlib + :mod:`~langres.core.autoresearch.objective`
++ :mod:`~langres.core.runs` (+ its ``trackers``) — all already on the bare
+``import langres`` path. It imports no factory / data / metrics module, so it
+adds no weight and could sit on the public surface if ever needed.
+"""
+
+from __future__ import annotations
+
+import logging
+from collections.abc import Callable, Iterable, Mapping
+from dataclasses import dataclass
+from typing import Any
+
+from langres.core.autoresearch.objective import Objective
+from langres.core.runs import RunContext, capture_run, compute_recipe_id
+from langres.core.trackers import ExperimentTracker, NoOpTracker
+
+logger = logging.getLogger(__name__)
+
+#: A scorer maps one config dict to a metrics mapping the Objective can read.
+Scorer = Callable[[Mapping[str, Any]], Mapping[str, float]]
+
+
+@dataclass(frozen=True, slots=True)
+class Trial:
+    """One config's outcome in a :func:`run_loop` pass — the audit trail unit.
+
+    Attributes:
+        config: The config dict that was scored (a copy, so mutating the input
+            stream can't retroactively rewrite the trail).
+        metrics: The scorer's metrics for this config, or ``None`` if the scorer
+            raised (a failed trial).
+        accepted: Whether this config displaced the incumbent (``objective.is_better``
+            returned ``True``). Also written to the run record's logged metrics as
+            ``accepted`` so a reader can reconstruct the incumbent timeline from
+            the store alone.
+        recipe_id: The content-addressed dedup key (``core.runs.compute_recipe_id``)
+            for this config's run recipe.
+        attempt_id: The run record PK for this trial (``recipe_id``-``started_at``);
+            the *next* trial's ``parent_run_id`` when this one is the incumbent,
+            giving the store its lineage chain.
+        status: ``"completed"`` (scored) or ``"failed"`` (scorer raised).
+    """
+
+    config: dict[str, Any]
+    metrics: dict[str, float] | None
+    accepted: bool
+    recipe_id: str
+    attempt_id: str
+    status: str
+
+
+@dataclass(frozen=True, slots=True)
+class LoopResult:
+    """The best incumbent found plus the full trial trail.
+
+    Attributes:
+        best_config: The winning config dict, or ``None`` if no config was ever
+            accepted (empty input, or every trial infeasible/failed).
+        best_metrics: The winning config's metrics, or ``None`` (see above).
+        trials: Every trial in evaluation order — accepted, rejected, and failed —
+            for inspection and for reconstructing why the incumbent won.
+    """
+
+    best_config: dict[str, Any] | None
+    best_metrics: dict[str, float] | None
+    trials: tuple[Trial, ...]
+
+
+def run_loop(
+    configs: Iterable[Mapping[str, Any]],
+    scorer: Scorer,
+    objective: Objective,
+    *,
+    experiment: str,
+    dataset_name: str,
+    dataset_fingerprint: str | None = None,
+    split_id: str | None = None,
+    seeds: dict[str, int] | None = None,
+    store: str | Any | None = None,
+    tracker: ExperimentTracker | None = None,
+    dedup: bool = True,
+) -> LoopResult:
+    """Run the ``propose → run → evaluate → keep-if-better`` loop over ``configs``.
+
+    For each config, in order:
+
+    1. Build a :class:`~langres.core.runs.RunContext` (``resolver_config`` = the
+       config, ``method`` = ``config["blocker"]``, ``blocking_k`` =
+       ``config["k_neighbors"]``, ``parent_run_id`` = the *current incumbent's*
+       ``attempt_id`` so the store records lineage) and compute its ``recipe_id``.
+    2. **Dedup** (``dedup=True``): skip a config whose ``recipe_id`` was already
+       seen this run — this collapses P-B's redundant degenerate configs (e.g.
+       several ``all_pairs`` configs the caller normalized to one recipe).
+    3. Score it *inside* :func:`~langres.core.runs.capture_run`, so timing and
+       failures are captured. Compute ``better = objective.is_better(metrics,
+       incumbent_metrics)`` and log **every** trial's metrics plus an ``accepted``
+       flag (``1.0``/``0.0``), with the first goal's metric as the headline and
+       ``str(objective)`` as the metric definition.
+    4. If ``better``, the config becomes the incumbent (its ``attempt_id`` becomes
+       the next trial's parent). Otherwise the incumbent is kept.
+
+    A scorer that raises is logged as a ``failed`` run (``capture_run`` writes the
+    ``failed`` terminal line and re-raises; this wraps the ``with`` per-config to
+    swallow it) and the loop continues to the next config — one bad config never
+    aborts the sweep. The result is deterministic given a fixed ``configs`` order.
+
+    Args:
+        configs: The proposed config dicts (e.g. ``SearchSpace.configs()``), in
+            evaluation order. Callers that want degenerate configs deduplicated
+            should normalize them to a canonical shape first (see
+            :mod:`langres.optimize`).
+        scorer: ``config -> metrics``. The one seam under test; the metrics it
+            returns must contain every goal/constraint metric the ``objective``
+            references (a missing one raises inside ``capture_run`` and the trial
+            is recorded ``failed``).
+        objective: The immutable keep-if-better decision.
+        experiment: Experiment label for every run record (organizational, not
+            part of the recipe hash beyond its own field).
+        dataset_name: Dataset label recorded on every run (part of the recipe).
+        dataset_fingerprint: Optional content hash of the loaded data (part of the
+            recipe), so a data change mints fresh ids.
+        split_id: Optional split label recorded on every run (part of the recipe).
+        seeds: Optional seed map recorded on every run (part of the recipe).
+        store: Where to persist run records — a path / ``RunStore`` / ``None``.
+            ``None`` writes **nothing** (the offline path); the loop still returns
+            the same ``LoopResult``.
+        tracker: Experiment tracker forwarded to ``capture_run``; ``None``
+            (default) uses a fresh :class:`~langres.core.trackers.NoOpTracker`
+            rather than a shared instance.
+        dedup: When ``True`` (default), skip a config whose ``recipe_id`` was
+            already scored this run.
+
+    Returns:
+        A :class:`LoopResult` with the best incumbent and the full trial trail.
+    """
+    tracker = tracker or NoOpTracker()
+    best_config: dict[str, Any] | None = None
+    best_metrics: dict[str, float] | None = None
+    best_attempt_id: str | None = None
+    trials: list[Trial] = []
+    seen: set[str] = set()
+    headline_metric = objective.goals[0].metric
+    objective_repr = str(objective)
+
+    for raw_config in configs:
+        config = dict(raw_config)
+        context = RunContext(
+            experiment=experiment,
+            dataset_name=dataset_name,
+            dataset_fingerprint=dataset_fingerprint,
+            split_id=split_id,
+            seeds=dict(seeds) if seeds else {},
+            resolver_config=config,
+            method=config.get("blocker"),
+            blocking_k=config.get("k_neighbors"),
+            parent_run_id=best_attempt_id,
+        )
+        recipe_id = compute_recipe_id(context)
+        if dedup and recipe_id in seen:
+            logger.debug("autoresearch loop: skipping duplicate recipe %s", recipe_id)
+            continue
+        seen.add(recipe_id)
+
+        attempt_id = ""
+        metrics: dict[str, float] | None = None
+        accepted = False
+        try:
+            with capture_run(context, store=store, tracker=tracker) as run:
+                attempt_id = run.attempt_id
+                scored = dict(scorer(config))
+                accepted = objective.is_better(scored, best_metrics)
+                run.log_metrics(
+                    {**scored, "accepted": float(accepted)},
+                    headline_metric=scored[headline_metric],
+                    metric_definition=objective_repr,
+                )
+                metrics = scored
+        except Exception:
+            # capture_run already wrote a status="failed" terminal record and
+            # re-raised; log the config as a failed trial and keep going so one
+            # bad config never aborts the whole sweep.
+            logger.warning("autoresearch loop: scorer failed for config %s", config, exc_info=True)
+            trials.append(Trial(config, None, False, recipe_id, attempt_id, "failed"))
+            continue
+
+        trials.append(Trial(config, metrics, accepted, recipe_id, attempt_id, "completed"))
+        if accepted:
+            best_config = config
+            best_metrics = metrics
+            best_attempt_id = attempt_id
+
+    return LoopResult(best_config, best_metrics, tuple(trials))

--- a/src/langres/core/autoresearch/objective.py
+++ b/src/langres/core/autoresearch/objective.py
@@ -1,0 +1,263 @@
+"""The immutable Objective the autoresearch loop steers on.
+
+The autoresearch loop is ``propose → run → evaluate → keep-if-better`` (epic
+#145). The :class:`Objective` is the *immutable scorer* that decides the last
+step: given a candidate config's metrics and the incumbent's, is the candidate
+**better**? ER F1 saturates near 99%, so the loop steers on loss-like / Pareto
+signals (``recall@budget``, ``log_loss``, quality×cost) instead of a thresholded
+F1, and the Objective supports both a single goal with feasibility constraints
+*and* multi-objective Pareto dominance.
+
+**Metric-source-agnostic by design.** The Objective operates on a plain
+``Mapping[str, float]`` of already-computed metrics; it never computes a metric
+itself (the run/evaluate stage does that and hands the numbers over). It imports
+nothing heavy — pure stdlib + typing — so a bare ``import langres`` stays
+import-light (see ``tests/test_import_budget.py``).
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable, Iterable, Mapping
+from dataclasses import dataclass
+from typing import Literal, cast, get_args
+
+Direction = Literal["maximize", "minimize"]
+"""Optimization sense of a goal metric: higher-is-better or lower-is-better."""
+
+ConstraintOp = Literal[">=", "<=", ">", "<"]
+"""Comparison operator for a feasibility constraint (``metric <op> threshold``)."""
+
+_DIRECTIONS: tuple[Direction, ...] = get_args(Direction)
+_OPS: dict[ConstraintOp, Callable[[float, float], bool]] = {
+    ">=": lambda a, b: a >= b,
+    "<=": lambda a, b: a <= b,
+    ">": lambda a, b: a > b,
+    "<": lambda a, b: a < b,
+}
+
+
+def _require(metrics: Mapping[str, float], name: str) -> float:
+    """Return ``metrics[name]`` or raise a clear error naming what is available.
+
+    Missing metrics fail loud rather than defaulting to 0.0: a silently-absent
+    metric would corrupt every feasibility and dominance decision downstream.
+    """
+    try:
+        return metrics[name]
+    except KeyError:
+        raise ValueError(
+            f"metric {name!r} is missing from the metrics mapping (available: {sorted(metrics)})"
+        ) from None
+
+
+@dataclass(frozen=True, slots=True)
+class Goal:
+    """A single optimization goal: one metric plus the direction to push it.
+
+    Attributes:
+        metric: The metric key looked up in a metrics mapping.
+        direction: ``"maximize"`` (higher is better) or ``"minimize"`` (lower is
+            better).
+    """
+
+    metric: str
+    direction: Direction
+
+    def __post_init__(self) -> None:
+        if self.direction not in _DIRECTIONS:
+            raise ValueError(
+                f"direction must be one of {list(_DIRECTIONS)}, got {self.direction!r}"
+            )
+
+
+@dataclass(frozen=True, slots=True)
+class Constraint:
+    """A feasibility constraint: ``metrics[metric] <op> threshold`` must hold.
+
+    Attributes:
+        metric: The metric key looked up in a metrics mapping.
+        op: One of ``">="``, ``"<="``, ``">"``, ``"<"``.
+        threshold: The value the metric is compared against.
+    """
+
+    metric: str
+    op: ConstraintOp
+    threshold: float
+
+    def __post_init__(self) -> None:
+        if self.op not in _OPS:
+            raise ValueError(f"constraint op must be one of {list(_OPS)}, got {self.op!r}")
+
+    def satisfied(self, metrics: Mapping[str, float]) -> bool:
+        """Whether ``metrics`` satisfies this constraint.
+
+        Raises:
+            ValueError: If ``metric`` is absent from ``metrics``.
+        """
+        return _OPS[self.op](_require(metrics, self.metric), self.threshold)
+
+
+@dataclass(frozen=True, slots=True)
+class Objective:
+    """The immutable keep-if-better scorer for the autoresearch loop.
+
+    An Objective bundles one or more :class:`Goal` s (the optimization targets)
+    with zero or more :class:`Constraint` s (feasibility gates). It scores a
+    candidate config's metrics against the incumbent's and answers the loop's
+    single question via :meth:`is_better`.
+
+    Prefer the ergonomic constructors :meth:`maximize`, :meth:`minimize`, and
+    :meth:`pareto` over the raw tuple form.
+
+    Attributes:
+        goals: The optimization goals (at least one). Multiple goals are treated
+            as a Pareto front — never scalarized.
+        constraints: Feasibility gates; a candidate violating any is infeasible.
+    """
+
+    goals: tuple[Goal, ...]
+    constraints: tuple[Constraint, ...] = ()
+
+    def __post_init__(self) -> None:
+        if not self.goals:
+            raise ValueError("an Objective needs at least one goal")
+
+    def is_feasible(self, metrics: Mapping[str, float]) -> bool:
+        """True iff every constraint holds (vacuously true with no constraints).
+
+        Raises:
+            ValueError: If a constrained metric is absent from ``metrics``.
+        """
+        return all(c.satisfied(metrics) for c in self.constraints)
+
+    def value(self, metrics: Mapping[str, float]) -> tuple[float, ...]:
+        """The goal metrics as a tuple, each normalized to higher-is-better.
+
+        A ``minimize`` goal is negated so a larger normalized value is always
+        better; this makes Pareto dominance uniform across goals (see
+        :meth:`dominates`). The tuple is ordered to match ``goals``.
+
+        Raises:
+            ValueError: If a goal metric is absent from ``metrics``.
+        """
+        out: list[float] = []
+        for g in self.goals:
+            v = _require(metrics, g.metric)
+            out.append(v if g.direction == "maximize" else -v)
+        return tuple(out)
+
+    def dominates(self, a: Mapping[str, float], b: Mapping[str, float]) -> bool:
+        """Pareto dominance: ``a`` dominates ``b`` over the goal metrics.
+
+        Compares the higher-is-better normalized value tuples (see
+        :meth:`value`): ``a`` dominates ``b`` iff it is ``>=`` on *every* goal
+        and strictly ``>`` on *at least one*. For a single goal this collapses
+        to a strict scalar improvement (``a > b``). Feasibility is not
+        considered here — :meth:`is_better` gates on that first.
+
+        Raises:
+            ValueError: If a goal metric is absent from ``a`` or ``b``.
+        """
+        va = self.value(a)
+        vb = self.value(b)
+        no_worse = all(x >= y for x, y in zip(va, vb, strict=True))
+        strictly_better = any(x > y for x, y in zip(va, vb, strict=True))
+        return no_worse and strictly_better
+
+    def is_better(
+        self,
+        candidate: Mapping[str, float],
+        incumbent: Mapping[str, float] | None,
+    ) -> bool:
+        """The loop's keep-if-better decision for ``candidate`` vs ``incumbent``.
+
+        Semantics, in order:
+
+        1. **Feasibility gates first.** An infeasible candidate is never better
+           (returns ``False``), whatever the incumbent. A feasible candidate
+           beats a ``None`` incumbent (the first feasible config seen) or an
+           infeasible incumbent.
+        2. **Pareto improvement.** With both feasible, the candidate is better
+           iff it *dominates* the incumbent (see :meth:`dominates`) — ``>=`` on
+           every goal and ``>`` on at least one. For a single goal this is a
+           strict scalar improvement.
+
+        When neither dominates the other — a tie, or an incomparable
+        multi-objective trade-off (better on one goal, worse on another) — the
+        candidate is **not** better and the loop keeps the incumbent. This makes
+        the decision deterministic and monotone for M1: trade-offs are never
+        scalarized, so the incumbent is displaced only by a strict Pareto win.
+
+        Raises:
+            ValueError: If a referenced goal metric is absent from ``candidate``,
+                or from ``incumbent`` when the comparison reaches it, or a
+                constrained metric is absent from a mapping it is checked against.
+        """
+        if not self.is_feasible(candidate):
+            return False
+        if incumbent is None or not self.is_feasible(incumbent):
+            return True
+        return self.dominates(candidate, incumbent)
+
+    @classmethod
+    def maximize(
+        cls,
+        metric: str,
+        *,
+        subject_to: Iterable[tuple[str, str, float]] = (),
+    ) -> Objective:
+        """A single maximize goal, optionally subject to constraints.
+
+        Args:
+            metric: The metric to maximize (higher is better).
+            subject_to: Constraints as ``(metric, op, threshold)`` triples, e.g.
+                ``[("precision", ">=", 0.9)]``.
+        """
+        return cls(goals=(Goal(metric, "maximize"),), constraints=_to_constraints(subject_to))
+
+    @classmethod
+    def minimize(
+        cls,
+        metric: str,
+        *,
+        subject_to: Iterable[tuple[str, str, float]] = (),
+    ) -> Objective:
+        """A single minimize goal (e.g. ``log_loss``, cost), optionally constrained.
+
+        Args:
+            metric: The metric to minimize (lower is better).
+            subject_to: Constraints as ``(metric, op, threshold)`` triples.
+        """
+        return cls(goals=(Goal(metric, "minimize"),), constraints=_to_constraints(subject_to))
+
+    @classmethod
+    def pareto(
+        cls,
+        goals: Iterable[tuple[str, str]],
+        *,
+        subject_to: Iterable[tuple[str, str, float]] = (),
+    ) -> Objective:
+        """A multi-objective Pareto goal set.
+
+        Args:
+            goals: ``(metric, direction)`` pairs where direction is
+                ``"maximize"`` or ``"minimize"``, e.g.
+                ``[("recall", "maximize"), ("cost", "minimize")]``.
+            subject_to: Constraints as ``(metric, op, threshold)`` triples.
+        """
+        return cls(
+            goals=tuple(Goal(m, cast(Direction, d)) for m, d in goals),
+            constraints=_to_constraints(subject_to),
+        )
+
+
+def _to_constraints(triples: Iterable[tuple[str, str, float]]) -> tuple[Constraint, ...]:
+    """Build validated :class:`Constraint` s from ``(metric, op, threshold)`` triples.
+
+    The ``op`` is cast to :data:`ConstraintOp` to satisfy the type checker;
+    :meth:`Constraint.__post_init__` is the real runtime guard that rejects an
+    unknown operator with a clear ``ValueError``.
+    """
+    return tuple(
+        Constraint(metric, cast(ConstraintOp, op), threshold) for metric, op, threshold in triples
+    )

--- a/src/langres/core/autoresearch/search_space.py
+++ b/src/langres/core/autoresearch/search_space.py
@@ -1,0 +1,101 @@
+"""The declarative search space the autoresearch loop enumerates.
+
+The autoresearch loop is ``propose → run → evaluate → keep-if-better`` (epic
+#145). A :class:`SearchSpace` is the *proposal substrate*: it names the candidate
+values per pipeline parameter and enumerates their Cartesian product as plain
+config dicts (``dict[str, Any]``) that the loop turns into runnable blockers via
+``core.autoresearch.factory``.
+
+**Import-light by design.** This module is pure stdlib + typing (``itertools`` /
+``dataclasses``) — it constructs no blocker and imports no
+faiss/torch/sentence-transformers, so it can sit on the public API surface (users
+build a ``SearchSpace`` to call ``langres.optimize``) without pulling the heavy
+[semantic] stack into a bare ``import langres`` (see ``tests/test_import_budget.py``).
+The heavy construction lives in the sibling ``factory`` module, which this one
+never imports.
+"""
+
+from __future__ import annotations
+
+import itertools
+from collections.abc import Iterator
+from dataclasses import dataclass, fields
+from typing import Any
+
+
+@dataclass(frozen=True, slots=True)
+class SearchSpace:
+    """A declarative Cartesian grid of blocker configs for the autoresearch loop.
+
+    Each field holds the candidate values for one pipeline parameter as a tuple;
+    :meth:`configs` yields their Cartesian product as config dicts. The defaults
+    describe a small vector-blocker ``k`` sweep (the one axis usually swept) with
+    a MiniLM + cosine baseline.
+
+    Attributes:
+        blocker: Blocker kinds to try (``"vector"`` and/or ``"all_pairs"``). The
+            vector-specific axes below are ignored by ``"all_pairs"``.
+        embedding_model: sentence-transformers model names for the vector index.
+        metric: FAISS distance metrics (``"L2"`` / ``"cosine"``).
+        text_field: Record attribute names holding each record's blocking text.
+            Dataset-specific — override the default to match your schema's field.
+        k_neighbors: Nearest-neighbour counts to sweep. The **innermost** axis of
+            :meth:`configs` (see its ordering contract).
+    """
+
+    blocker: tuple[str, ...] = ("vector",)
+    embedding_model: tuple[str, ...] = ("all-MiniLM-L6-v2",)
+    metric: tuple[str, ...] = ("cosine",)
+    text_field: tuple[str, ...] = ("name",)
+    k_neighbors: tuple[int, ...] = (5, 10, 20)
+
+    def __post_init__(self) -> None:
+        # Fail loud: an empty axis would silently collapse the whole product to
+        # zero configs, so the loop would run nothing without ever erroring.
+        for f in fields(self):
+            if not getattr(self, f.name):
+                raise ValueError(f"SearchSpace.{f.name} must be a non-empty tuple")
+
+    def configs(self) -> Iterator[dict[str, Any]]:
+        """Yield the Cartesian product of the axes as config dicts.
+
+        **Ordering contract (relied on by the loop):** ``k_neighbors`` is the
+        **innermost** varying dimension, so consecutive configs hold
+        ``(blocker, embedding_model, metric, text_field)`` fixed while ``k``
+        varies across its full range before any outer axis advances. This lets
+        the downstream loop build **one** vector index per
+        ``(embedding_model, metric, text_field)`` and reuse it across every
+        ``k`` value (``k`` lives on the blocker, not the index), instead of
+        re-embedding the corpus for each ``k``.
+
+        Yields:
+            One ``dict[str, Any]`` per grid point, with keys ``blocker``,
+            ``embedding_model``, ``metric``, ``text_field``, ``k_neighbors`` (in
+            that order).
+        """
+        # itertools.product varies its LAST argument fastest, so listing
+        # k_neighbors last makes it the innermost dimension (the contract above).
+        for blocker, embedding_model, metric, text_field, k in itertools.product(
+            self.blocker,
+            self.embedding_model,
+            self.metric,
+            self.text_field,
+            self.k_neighbors,
+        ):
+            yield {
+                "blocker": blocker,
+                "embedding_model": embedding_model,
+                "metric": metric,
+                "text_field": text_field,
+                "k_neighbors": k,
+            }
+
+    def __len__(self) -> int:
+        """The number of configs :meth:`configs` yields (the product of axis sizes)."""
+        return (
+            len(self.blocker)
+            * len(self.embedding_model)
+            * len(self.metric)
+            * len(self.text_field)
+            * len(self.k_neighbors)
+        )

--- a/src/langres/core/blocker.py
+++ b/src/langres/core/blocker.py
@@ -244,7 +244,7 @@ class Blocker(ABC, Generic[SchemaT]):
             See BlockerEvaluationReport documentation for full details.
 
         Example:
-            >>> blocker = VectorBlocker(embedding_model, k_neighbors=10)
+            >>> blocker = VectorBlocker(...)
             >>> candidates = list(blocker.stream(data))
             >>> report = blocker.evaluate(candidates, gold_clusters)
             >>> print(f"Blocking recall: {report.candidates.recall:.2%}")

--- a/src/langres/core/indexes/vector_index.py
+++ b/src/langres/core/indexes/vector_index.py
@@ -13,8 +13,15 @@ Key design principles:
 
 import json
 import logging
+import os
 from pathlib import Path
 from typing import ClassVar, Literal, Protocol, cast
+
+# faiss and torch each vendor their own libomp; on macOS loading both in one
+# process can abort with a duplicate-OpenMP-runtime error (exit 139). Opting
+# into the documented workaround before faiss loads keeps the dev/test flow
+# (parallel pytest) stable. No effect once an OpenMP runtime is already loaded.
+os.environ.setdefault("KMP_DUPLICATE_LIB_OK", "TRUE")
 
 import faiss
 import numpy as np

--- a/src/langres/core/metrics.py
+++ b/src/langres/core/metrics.py
@@ -5,8 +5,8 @@ This module provides metrics for evaluating different pipeline stages:
 - Clustering stage: evaluate_clustering(), calculate_bcubed_metrics(), calculate_pairwise_metrics()
 - Agreement (rater-vs-rater): cohens_kappa(), matthews_corrcoef()
 - Ranking (score-vs-label): roc_auc_score(), average_precision_score()
-- Calibration (confidence-vs-outcome): brier_score(), expected_calibration_error(),
-  reliability_bins()
+- Calibration (confidence-vs-outcome): brier_score(), log_loss(),
+  expected_calibration_error(), reliability_bins()
 
 References:
     Amigó, E., Gonzalo, J., Artiles, J., & Verdejo, F. (2009).
@@ -1282,6 +1282,57 @@ def brier_score(confidences: list[float], outcomes: list[bool]) -> float:
     return sum(
         (p - (1.0 if y else 0.0)) ** 2 for p, y in zip(confidences, outcomes, strict=True)
     ) / len(confidences)
+
+
+# Epsilon that clamps predicted probabilities away from 0 and 1 before taking
+# their log, so a confident-and-wrong prediction yields a large *finite* loss
+# instead of ``log(0) = -inf``. 1e-15 matches the scikit-learn default and caps
+# the per-item penalty near ``-log(1e-15) ~= 34.5``.
+_LOG_LOSS_EPS = 1e-15
+
+
+def log_loss(confidences: list[float], outcomes: list[bool]) -> float:
+    """Binary cross-entropy (log loss): the loss-like proper scoring rule.
+
+    ``log_loss = -mean( y*log(p) + (1 - y)*log(1 - p) )`` over aligned predicted
+    probabilities ``p`` and boolean outcomes ``y``. Like :func:`brier_score` it
+    is a strictly proper scoring rule (minimized only by honest probabilities)
+    and needs no binning, but it penalizes confident mistakes far more harshly.
+    That heavy tail makes it the natural loss-like steering signal for the
+    autoresearch loop, which optimizes a loss rather than a saturated F1.
+
+    Numerically, the probability the forecaster assigned to the *realized*
+    outcome (``p`` for a ``True``, ``1 - p`` for a ``False``) is clamped to
+    ``[eps, 1 - eps]`` (``eps = _LOG_LOSS_EPS = 1e-15``) before the log. Clamping
+    that realized-class probability directly -- rather than clamping ``p`` and
+    subtracting -- keeps a confident-and-wrong ``p = 0`` / ``p = 1`` exact:
+    ``1 - 1.0`` is ``0.0`` before the clamp, avoiding the float cancellation of
+    ``1 - (1 - eps)``. So a confident mistake gives a large *finite* loss (the
+    per-item penalty is capped near ``-log(eps) ~= 34.5``) instead of ``+inf``.
+
+    Args:
+        confidences: Predicted probabilities in ``[0, 1]``.
+        outcomes: Realized boolean outcomes, aligned with ``confidences``.
+
+    Returns:
+        Mean binary cross-entropy in nats; ``>= 0.0``, lower is better.
+        Approaches ``0.0`` only for confident, correct predictions (up to the
+        ``eps`` clamp). A constant ``0.5`` forecaster scores ``log(2) ~= 0.693``.
+
+    Raises:
+        ValueError: If inputs differ in length, are empty, or any confidence is
+            outside ``[0, 1]``.
+
+    Example:
+        >>> log_loss([0.9, 0.1], [True, False])
+        0.10536051565782628
+    """
+    _validate_calibration(confidences, outcomes)
+    total = 0.0
+    for p, y in zip(confidences, outcomes, strict=True):
+        realized = p if y else 1.0 - p
+        total += math.log(min(max(realized, _LOG_LOSS_EPS), 1.0 - _LOG_LOSS_EPS))
+    return -total / len(confidences)
 
 
 def _bin_indices(confidences: list[float], n_bins: int, strategy: BinStrategy) -> list[list[int]]:

--- a/src/langres/core/optimizers/blocker_optimizer.py
+++ b/src/langres/core/optimizers/blocker_optimizer.py
@@ -25,8 +25,10 @@ class BlockerOptimizer:
     Example:
         # Define objective function
         def objective(trial: optuna.Trial, params: dict) -> dict:
+            embedder = SentenceTransformerEmbedder(params["embedding_model"])
+            index = FAISSIndex(embedder=embedder, metric="cosine")
             blocker = VectorBlocker(
-                embedding_model=params["embedding_model"],
+                vector_index=index,
                 k_neighbors=params["k_neighbors"],
                 ...
             )
@@ -146,8 +148,10 @@ class BlockerOptimizer:
             # Returns: {"embedding_model": "all-mpnet-base-v2", "k_neighbors": 35}
 
             # Use best params to create final blocker
+            embedder = SentenceTransformerEmbedder(best_params["embedding_model"])
+            index = FAISSIndex(embedder=embedder, metric="cosine")
             blocker = VectorBlocker(
-                embedding_model=best_params["embedding_model"],
+                vector_index=index,
                 k_neighbors=best_params["k_neighbors"],
                 ...
             )

--- a/src/langres/optimize.py
+++ b/src/langres/optimize.py
@@ -1,0 +1,275 @@
+"""``langres.optimize``: the public autoresearch facade (epic #145, M1).
+
+Two entry points compose P-A (:class:`~langres.core.autoresearch.objective.Objective`),
+P-B (:class:`~langres.core.autoresearch.search_space.SearchSpace` + the config→blocker
+``factory``), and P-C (the ``propose → run → evaluate → keep`` loop + ``core.runs``
+persistence) into a one-call blocking search:
+
+- :func:`score_blocking` — the concrete blocking scorer for ONE config: load a
+  benchmark, build the index + blocker the config describes, stream candidates,
+  and return blocking metrics (``candidate_recall`` / ``reduction_ratio`` / …).
+- :func:`optimize` — load a benchmark once, fingerprint it once, wrap an
+  **index-caching** blocking scorer, and drive
+  :func:`~langres.core.autoresearch.loop.run_loop` over ``space.configs()``,
+  keeping the incumbent the ``objective`` prefers and persisting every trial.
+
+**Import-lightness (hard requirement).** This module sits on the eager
+``import langres`` path (the two symbols are root-exported), so its module top is
+stdlib/typing only — every langres import (``factory``, ``langres.data``,
+``core.metrics``, ``core.runs``, ``core.autoresearch.loop``, ``core.trackers``)
+is **lazy, inside a function body**. A bare ``import langres`` therefore never
+pulls faiss / sentence-transformers / torch through here (see
+``tests/test_import_budget.py``).
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from collections.abc import Mapping
+
+    from langres.core.autoresearch.loop import LoopResult
+    from langres.core.autoresearch.objective import Objective
+    from langres.core.autoresearch.search_space import SearchSpace
+    from langres.core.benchmark import Benchmark
+    from langres.core.embeddings import EmbeddingProvider
+    from langres.core.indexes.vector_index import VectorIndex
+    from langres.core.runs import RunStore
+    from langres.core.trackers import ExperimentTracker
+
+
+def _resolve_benchmark(benchmark: str | Benchmark[Any]) -> Benchmark[Any]:
+    """Accept a registered benchmark **name** or an already-built benchmark object.
+
+    The public DX is a name string (``optimize(space, obj, "amazon_google")``);
+    tests (and advanced callers) may pass a hand-built in-memory benchmark object
+    directly to stay offline.
+    """
+    if isinstance(benchmark, str):
+        from langres.data.registry import get_benchmark
+
+        return get_benchmark(benchmark)
+    return benchmark
+
+
+def _source_sizes(corpus: list[Any]) -> tuple[int, int] | None:
+    """``(n_left, n_right)`` for a two-source linkage corpus, else ``None`` (dedup).
+
+    Groups records by their ``source`` attribute. Exactly two distinct sources is
+    the cross-source (linkage) case — the sizes feed ``evaluate_blocking``'s
+    ``n_left``/``n_right`` so the reduction ratio uses ``|A| * |B|`` — and every
+    other shape (no ``source``, one source, three+) falls back to the dedup
+    ``num_records`` reduction ratio.
+    """
+    from collections import Counter
+
+    counts: Counter[Any] = Counter(getattr(record, "source", None) for record in corpus)
+    counts.pop(None, None)
+    if len(counts) != 2:
+        return None
+    left, right = (counts[key] for key in sorted(counts, key=str))
+    return (left, right)
+
+
+def _index_for_config(
+    config: Mapping[str, Any],
+    corpus: list[Any],
+    embedder: EmbeddingProvider | None,
+) -> VectorIndex:
+    """Build the FAISS index a vector config describes over the corpus texts.
+
+    Texts are extracted in corpus order (``config["text_field"]``) so the index
+    positions align with the records the blocker streams — mirroring
+    ``data/_benchmark_utils.sweep_blocking_k``.
+    """
+    from langres.core.autoresearch.factory import build_index
+
+    texts = [getattr(record, config["text_field"]) for record in corpus]
+    return build_index(config["embedding_model"], config["metric"], texts, embedder=embedder)
+
+
+def _score_loaded(
+    config: Mapping[str, Any],
+    corpus: list[Any],
+    gold_clusters: list[set[str]],
+    schema: type[Any],
+    source_sizes: tuple[int, int] | None,
+    *,
+    index: VectorIndex | None = None,
+) -> dict[str, float]:
+    """Score ONE config against already-loaded data — the shared scoring core.
+
+    Builds the blocker the config describes (a prebuilt ``index`` is required for
+    ``blocker == "vector"``; ignored for ``"all_pairs"``), streams the corpus to
+    candidates, and evaluates blocking. For a two-source corpus the candidates are
+    filtered to cross-source pairs (all gold matches are cross-source) and RR is
+    computed with ``n_left``/``n_right``; otherwise RR uses ``num_records``.
+    """
+    from langres.core.autoresearch.factory import build_blocker_from_config
+    from langres.core.metrics import evaluate_blocking
+
+    blocker = build_blocker_from_config(config, schema=schema, index=index)
+    candidates = list(blocker.stream([record.model_dump() for record in corpus]))
+
+    if source_sizes is not None:
+        # Cross-source linkage: keep only inter-source pairs (all gold matches
+        # are cross-source, so recall is unchanged) and use |A|*|B| for RR.
+        candidates = [c for c in candidates if c.left.source != c.right.source]
+        n_left, n_right = source_sizes
+        stats = evaluate_blocking(candidates, gold_clusters, n_left=n_left, n_right=n_right)
+    else:
+        stats = evaluate_blocking(candidates, gold_clusters, num_records=len(corpus))
+
+    return {
+        "candidate_recall": stats.candidate_recall,
+        "candidate_precision": stats.candidate_precision,
+        "reduction_ratio": stats.reduction_ratio,
+        "total_candidates": float(stats.total_candidates),
+    }
+
+
+def score_blocking(
+    config: Mapping[str, Any],
+    benchmark: str | Benchmark[Any],
+    *,
+    embedder: EmbeddingProvider | None = None,
+    index: VectorIndex | None = None,
+) -> dict[str, float]:
+    """Blocking metrics for ONE config on ``benchmark`` (the concrete scorer).
+
+    Loads the benchmark, builds the index + blocker the config describes (mirroring
+    ``sweep_blocking_k``), streams the full corpus to candidates, and returns a
+    plain metrics dict — ``candidate_recall``, ``candidate_precision``,
+    ``reduction_ratio``, ``total_candidates`` — ready for an
+    :class:`~langres.core.autoresearch.objective.Objective`.
+
+    Args:
+        config: A config dict as yielded by ``SearchSpace.configs()`` (keys
+            ``blocker``, and for ``"vector"`` also ``embedding_model`` / ``metric``
+            / ``text_field`` / ``k_neighbors``).
+        benchmark: A registered benchmark **name** (loaded via the data registry)
+            or an already-built benchmark object (offline / test path).
+        embedder: Optional pre-built embedder (a ``FakeEmbedder`` in tests) passed
+            to ``build_index``; production leaves it ``None`` to load the real
+            SentenceTransformer. Ignored when ``index`` is supplied or the blocker
+            is ``"all_pairs"``.
+        index: Optional prebuilt vector index to reuse instead of building one
+            (the ``optimize`` closure threads a cached index in through here).
+
+    Returns:
+        The blocking metrics mapping (all values ``float``).
+    """
+    bench = _resolve_benchmark(benchmark)
+    corpus, gold_clusters, _gold_pairs = bench.load()
+    if not corpus:
+        raise ValueError(f"benchmark {getattr(bench, 'name', bench)!r} loaded an empty corpus")
+    schema = type(corpus[0])
+    if index is None and config.get("blocker") == "vector":
+        index = _index_for_config(config, corpus, embedder)
+    return _score_loaded(config, corpus, gold_clusters, schema, _source_sizes(corpus), index=index)
+
+
+def _canonical_config(config: Mapping[str, Any]) -> dict[str, Any]:
+    """Collapse a config to its recipe-relevant shape (for correct dedup).
+
+    ``all_pairs`` ignores every vector axis (``embedding_model`` / ``metric`` /
+    ``text_field`` / ``k_neighbors``), so P-B's grid can yield several
+    *semantically identical* ``all_pairs`` configs differing only in those unused
+    keys. Reducing each to ``{"blocker": "all_pairs"}`` makes them hash to one
+    ``recipe_id`` so the loop's in-run dedup skips the redundant repeats. A
+    ``vector`` config is recipe-relevant in full and passes through unchanged.
+    """
+    if config.get("blocker") == "all_pairs":
+        return {"blocker": "all_pairs"}
+    return dict(config)
+
+
+def optimize(
+    space: SearchSpace,
+    objective: Objective,
+    benchmark: str | Benchmark[Any],
+    *,
+    seed: int | None = None,
+    store: str | Path | RunStore | None = None,
+    dedup: bool = True,
+    split: str = "full",
+    embedder: EmbeddingProvider | None = None,
+    tracker: ExperimentTracker | None = None,
+) -> LoopResult:
+    """Search ``space`` for the blocking config ``objective`` prefers on ``benchmark``.
+
+    Loads the benchmark **once**, fingerprints it **once**, and wraps an
+    index-caching blocking scorer: because ``SearchSpace.configs()`` varies
+    ``k_neighbors`` innermost, one vector index is built per
+    ``(embedding_model, metric, text_field)`` group and reused across every ``k``
+    (``k`` lives on the blocker, not the index). It then drives
+    :func:`~langres.core.autoresearch.loop.run_loop`, which keeps the incumbent
+    ``objective.is_better`` selects and persists **every** trial (accepted and
+    rejected) to ``store`` — ``store=None`` persists nothing.
+
+    Args:
+        space: The declarative config grid to enumerate.
+        objective: The immutable keep-if-better decision.
+        benchmark: A registered benchmark **name** or an already-built benchmark
+            object (offline / test path).
+        seed: Optional seed recorded on every run for provenance/identity (blocking
+            itself is deterministic, so this only labels the run). Recorded under
+            ``seeds["optimize"]`` when given.
+        store: Where to persist run records (path / ``RunStore`` / ``None``);
+            ``None`` writes nothing.
+        dedup: Skip a config whose ``recipe_id`` was already scored this run
+            (default ``True``); the degenerate ``all_pairs`` repeats are collapsed
+            first via :func:`_canonical_config`.
+        split: Split label recorded on every run (``RunContext.split_id``). Default
+            ``"full"`` — M1 measures blocking over the whole loaded corpus.
+        embedder: Optional pre-built embedder for the vector index (a
+            ``FakeEmbedder`` keeps tests offline); production leaves it ``None``.
+        tracker: Optional experiment tracker; defaults to a no-op.
+
+    Returns:
+        The :class:`~langres.core.autoresearch.loop.LoopResult` (best incumbent +
+        full trial trail).
+    """
+    from langres.core.autoresearch.loop import run_loop
+    from langres.core.runs import dataset_fingerprint
+    from langres.core.trackers import NoOpTracker
+
+    bench = _resolve_benchmark(benchmark)
+    dataset_name = benchmark if isinstance(benchmark, str) else bench.name
+    corpus, gold_clusters, _gold_pairs = bench.load()
+    if not corpus:
+        raise ValueError(f"benchmark {dataset_name!r} loaded an empty corpus")
+    schema = type(corpus[0])
+    fingerprint = dataset_fingerprint(corpus, gold_clusters)
+    source_sizes = _source_sizes(corpus)
+
+    # One index per (embedding_model, metric, text_field); reused across all k
+    # (SearchSpace yields k innermost, so the group is contiguous). all_pairs
+    # configs never touch the cache (no index).
+    index_cache: dict[tuple[str, str, str], VectorIndex] = {}
+
+    def scorer(config: Mapping[str, Any]) -> dict[str, float]:
+        index: VectorIndex | None = None
+        if config.get("blocker") == "vector":
+            key = (config["embedding_model"], config["metric"], config["text_field"])
+            index = index_cache.get(key)
+            if index is None:
+                index = _index_for_config(config, corpus, embedder)
+                index_cache[key] = index
+        return _score_loaded(config, corpus, gold_clusters, schema, source_sizes, index=index)
+
+    return run_loop(
+        (_canonical_config(config) for config in space.configs()),
+        scorer,
+        objective,
+        experiment=f"optimize_blocking:{dataset_name}",
+        dataset_name=dataset_name,
+        dataset_fingerprint=fingerprint,
+        split_id=split,
+        seeds={"optimize": seed} if seed is not None else None,
+        store=store,
+        tracker=tracker or NoOpTracker(),
+        dedup=dedup,
+    )

--- a/tests/core/test_autoresearch_factory.py
+++ b/tests/core/test_autoresearch_factory.py
@@ -1,0 +1,140 @@
+"""Tests for the autoresearch config->blocker :mod:`factory`.
+
+Core contract code -> high coverage tier. The fast tests inject a ``FakeEmbedder``
+via the ``embedder=`` seam so no model is downloaded; one ``@pytest.mark.slow``
+smoke exercises the real ``SentenceTransformerEmbedder`` path. Covers a usable
+built index, the metric pass-through, VectorBlocker streaming from a config, the
+prebuilt-index requirement, the AllPairsBlocker path, and unknown-blocker
+fail-loud.
+"""
+
+import pytest
+
+from langres.core.autoresearch.factory import build_blocker_from_config, build_index
+from langres.core.blockers.all_pairs import AllPairsBlocker
+from langres.core.blockers.vector import VectorBlocker
+from langres.core.embeddings import FakeEmbedder
+from langres.core.indexes.vector_index import FAISSIndex
+from langres.core.models import CompanySchema
+
+# A tiny, offline dataset. build_index() must be fed texts in the same order as
+# the records the resulting blocker streams.
+_DATA = [
+    {"id": "c1", "name": "Acme Corporation"},
+    {"id": "c2", "name": "Acme Corp"},
+    {"id": "c3", "name": "Globex Inc"},
+    {"id": "c4", "name": "Globex Incorporated"},
+]
+_TEXTS = [r["name"] for r in _DATA]
+
+
+def _fake_index(metric: str = "cosine") -> FAISSIndex:
+    """Build a ready index over ``_TEXTS`` using a FakeEmbedder (no download)."""
+    index = build_index(
+        embedding_model="unused-with-fake",
+        metric=metric,
+        texts=_TEXTS,
+        embedder=FakeEmbedder(embedding_dim=16),
+    )
+    assert isinstance(index, FAISSIndex)
+    return index
+
+
+# ---------------------------------------------------------------------------
+# build_index
+# ---------------------------------------------------------------------------
+
+
+def test_build_index_returns_a_usable_built_index() -> None:
+    index = _fake_index()
+    # create_index() was called -> the FAISS index object exists and is searchable.
+    assert index._index is not None
+    distances, indices = index.search_all(k=2)
+    assert distances.shape == (len(_TEXTS), 2)
+    assert indices.shape == (len(_TEXTS), 2)
+
+
+def test_build_index_passes_metric_through() -> None:
+    assert _fake_index(metric="cosine").metric == "cosine"
+    assert _fake_index(metric="L2").metric == "L2"
+
+
+def test_build_index_rejects_unknown_metric() -> None:
+    with pytest.raises(ValueError, match="metric must be 'L2' or 'cosine'"):
+        build_index("m", "euclidean", _TEXTS, embedder=FakeEmbedder(embedding_dim=8))
+
+
+# ---------------------------------------------------------------------------
+# build_blocker_from_config -- vector
+# ---------------------------------------------------------------------------
+
+
+def test_vector_config_builds_streaming_vector_blocker() -> None:
+    index = _fake_index()
+    config = {
+        "blocker": "vector",
+        "embedding_model": "unused-with-fake",
+        "metric": "cosine",
+        "text_field": "name",
+        "k_neighbors": 2,
+    }
+    blocker = build_blocker_from_config(config, schema=CompanySchema, index=index)
+
+    assert isinstance(blocker, VectorBlocker)
+    assert blocker.k_neighbors == 2
+    assert blocker.vector_index is index  # index is reused, not rebuilt
+
+    candidates = list(blocker.stream(_DATA))
+    assert candidates, "vector blocker should stream at least one candidate pair"
+    ids = {frozenset((c.left.id, c.right.id)) for c in candidates}
+    assert all(len(pair) == 2 for pair in ids)  # no self-pairs
+
+
+def test_vector_config_without_index_raises() -> None:
+    config = {"blocker": "vector", "text_field": "name", "k_neighbors": 2}
+    with pytest.raises(ValueError, match="requires a prebuilt 'index'"):
+        build_blocker_from_config(config, schema=CompanySchema, index=None)
+
+
+# ---------------------------------------------------------------------------
+# build_blocker_from_config -- all_pairs
+# ---------------------------------------------------------------------------
+
+
+def test_all_pairs_config_builds_all_pairs_blocker_ignoring_index() -> None:
+    config = {"blocker": "all_pairs"}
+    blocker = build_blocker_from_config(config, schema=CompanySchema, index=None)
+
+    assert isinstance(blocker, AllPairsBlocker)
+    candidates = list(blocker.stream(_DATA))
+    # All unique unordered pairs of 4 records: C(4, 2) = 6.
+    assert len(candidates) == 6
+
+
+# ---------------------------------------------------------------------------
+# build_blocker_from_config -- errors
+# ---------------------------------------------------------------------------
+
+
+def test_unknown_blocker_raises() -> None:
+    with pytest.raises(ValueError, match="unknown blocker"):
+        build_blocker_from_config({"blocker": "nope"}, schema=CompanySchema)
+
+
+# ---------------------------------------------------------------------------
+# slow: real SentenceTransformerEmbedder path (covers the non-injected branch)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.slow
+def test_build_index_real_sentence_transformer_smoke() -> None:
+    """build_index with no injected embedder loads a real model and still streams.
+
+    Marked slow: downloads/loads all-MiniLM-L6-v2. Runs in the full suite, which
+    is where the coverage gate (and this branch's coverage) is enforced.
+    """
+    index = build_index("all-MiniLM-L6-v2", "cosine", _TEXTS)
+    config = {"blocker": "vector", "text_field": "name", "k_neighbors": 2}
+    blocker = build_blocker_from_config(config, schema=CompanySchema, index=index)
+    candidates = list(blocker.stream(_DATA))
+    assert candidates

--- a/tests/core/test_autoresearch_loop.py
+++ b/tests/core/test_autoresearch_loop.py
@@ -1,0 +1,224 @@
+"""Tests for the autoresearch keep-if-better :mod:`~langres.core.autoresearch.loop`.
+
+Core contract code -> high coverage tier. Every test injects a **fake dict
+scorer** (config -> canned metrics), so the loop's incumbent tracking, dedup,
+persistence, and failure handling are exercised with zero embeddings / faiss /
+benchmark load -- the point of the injected-scorer seam.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Any
+
+import pytest
+
+from langres.core.autoresearch.loop import LoopResult, Trial, run_loop
+from langres.core.autoresearch.objective import Objective
+from langres.core.runs import RunStore
+
+
+def _scorer(table: dict[str, dict[str, float]]) -> Any:
+    """A fake scorer resolving a config's ``id`` to canned metrics."""
+
+    def scorer(config: Mapping[str, Any]) -> dict[str, float]:
+        return dict(table[config["id"]])
+
+    return scorer
+
+
+def _cfg(cid: str, blocker: str = "vector", **extra: Any) -> dict[str, Any]:
+    """A minimal config dict tagged with an ``id`` the fake scorer keys on."""
+    return {"blocker": blocker, "id": cid, **extra}
+
+
+# ---------------------------------------------------------------------------
+# Incumbent tracking
+# ---------------------------------------------------------------------------
+
+
+def test_strictly_better_config_displaces_the_incumbent() -> None:
+    configs = [_cfg("a"), _cfg("b"), _cfg("c")]
+    scorer = _scorer({"a": {"r": 0.5}, "b": {"r": 0.9}, "c": {"r": 0.7}})
+    result = run_loop(configs, scorer, Objective.maximize("r"), experiment="e", dataset_name="d")
+
+    assert isinstance(result, LoopResult)
+    assert result.best_config == _cfg("b")
+    assert result.best_metrics == {"r": 0.9}
+    assert [t.accepted for t in result.trials] == [True, True, False]
+    assert [t.status for t in result.trials] == ["completed", "completed", "completed"]
+
+
+def test_first_feasible_config_is_accepted_against_a_none_incumbent() -> None:
+    result = run_loop(
+        [_cfg("only")],
+        _scorer({"only": {"r": 0.1}}),
+        Objective.maximize("r"),
+        experiment="e",
+        dataset_name="d",
+    )
+    assert result.best_config == _cfg("only")
+    assert result.trials[0].accepted is True
+
+
+def test_empty_config_stream_yields_no_incumbent() -> None:
+    result = run_loop([], _scorer({}), Objective.maximize("r"), experiment="e", dataset_name="d")
+    assert result.best_config is None
+    assert result.best_metrics is None
+    assert result.trials == ()
+
+
+def test_infeasible_candidate_is_never_accepted() -> None:
+    # A constraint the only config violates -> feasible-gate keeps it out.
+    obj = Objective.maximize("r", subject_to=[("r", ">=", 0.8)])
+    result = run_loop(
+        [_cfg("a")], _scorer({"a": {"r": 0.5}}), obj, experiment="e", dataset_name="d"
+    )
+    assert result.best_config is None
+    assert result.trials[0].accepted is False
+    assert result.trials[0].status == "completed"  # scored fine, just not better
+
+
+def test_incomparable_multiobjective_trade_off_is_kept_out() -> None:
+    # Candidate b is better on recall but worse on cost -> neither dominates ->
+    # the incumbent (a) is kept.
+    obj = Objective.pareto([("recall", "maximize"), ("cost", "minimize")])
+    configs = [_cfg("a"), _cfg("b")]
+    scorer = _scorer({"a": {"recall": 0.5, "cost": 0.2}, "b": {"recall": 0.9, "cost": 0.9}})
+    result = run_loop(configs, scorer, obj, experiment="e", dataset_name="d")
+
+    assert result.best_config == _cfg("a")
+    assert [t.accepted for t in result.trials] == [True, False]
+
+
+# ---------------------------------------------------------------------------
+# Persistence (every trial logged; accepted flag; lineage)
+# ---------------------------------------------------------------------------
+
+
+def test_every_trial_is_logged_with_accepted_flag_and_lineage(tmp_path: Any) -> None:
+    store_path = tmp_path / "runs.jsonl"
+    configs = [_cfg("a"), _cfg("b"), _cfg("c")]
+    scorer = _scorer({"a": {"r": 0.5}, "b": {"r": 0.9}, "c": {"r": 0.7}})
+    obj = Objective.maximize("r")
+    result = run_loop(configs, scorer, obj, experiment="e", dataset_name="d", store=store_path)
+
+    records = RunStore(store_path).read()
+    # One terminal record per attempt (running + completed collapse by attempt_id).
+    assert len(records) == 3
+    by_attempt = {r.attempt_id: r for r in records}
+    assert set(by_attempt) == {t.attempt_id for t in result.trials}
+
+    # Records come back in first-seen (loop) order.
+    assert [r.metrics["accepted"] for r in records] == [1.0, 1.0, 0.0]
+    assert [r.headline_metric for r in records] == [0.5, 0.9, 0.7]
+    assert all(r.metric_definition == str(obj) for r in records)
+    assert all(r.status == "completed" for r in records)
+
+    # Lineage: each accepted incumbent parents the next trial; the rejected c
+    # still points at the incumbent (b) at comparison time.
+    a, b, c = records
+    assert a.context.parent_run_id is None
+    assert b.context.parent_run_id == a.attempt_id
+    assert c.context.parent_run_id == b.attempt_id
+
+
+def test_store_none_writes_nothing(tmp_path: Any) -> None:
+    result = run_loop(
+        [_cfg("a"), _cfg("b")],
+        _scorer({"a": {"r": 0.3}, "b": {"r": 0.6}}),
+        Objective.maximize("r"),
+        experiment="e",
+        dataset_name="d",
+        store=None,
+    )
+    # The loop still ran and tracked an incumbent...
+    assert result.best_metrics == {"r": 0.6}
+    assert all(t.attempt_id for t in result.trials)  # attempt ids exist even unpersisted
+    # ...but nothing was written anywhere.
+    assert list(tmp_path.iterdir()) == []
+
+
+# ---------------------------------------------------------------------------
+# Dedup
+# ---------------------------------------------------------------------------
+
+
+def test_dedup_skips_a_duplicate_recipe(tmp_path: Any) -> None:
+    store_path = tmp_path / "runs.jsonl"
+    # Two byte-identical configs -> one recipe_id -> the second is skipped.
+    dup = _cfg("a", blocker="all_pairs")
+    result = run_loop(
+        [dict(dup), dict(dup)],
+        _scorer({"a": {"r": 0.5}}),
+        Objective.maximize("r"),
+        experiment="e",
+        dataset_name="d",
+        store=store_path,
+    )
+    assert len(result.trials) == 1
+    assert len(RunStore(store_path).read()) == 1
+
+
+def test_dedup_can_be_disabled(tmp_path: Any) -> None:
+    store_path = tmp_path / "runs.jsonl"
+    dup = _cfg("a", blocker="all_pairs")
+    result = run_loop(
+        [dict(dup), dict(dup)],
+        _scorer({"a": {"r": 0.5}}),
+        Objective.maximize("r"),
+        experiment="e",
+        dataset_name="d",
+        store=store_path,
+        dedup=False,
+    )
+    # Both scored; two attempts persisted (distinct attempt_ids, same recipe_id).
+    assert len(result.trials) == 2
+    records = RunStore(store_path).read()
+    assert len(records) == 2
+    assert len({r.recipe_id for r in records}) == 1
+
+
+# ---------------------------------------------------------------------------
+# Failure handling
+# ---------------------------------------------------------------------------
+
+
+def test_scorer_failure_is_logged_failed_and_loop_continues(tmp_path: Any) -> None:
+    store_path = tmp_path / "runs.jsonl"
+
+    def scorer(config: Mapping[str, Any]) -> dict[str, float]:
+        if config["id"] == "boom":
+            raise RuntimeError("scorer blew up")
+        return {"a": {"r": 0.5}, "c": {"r": 0.9}}[config["id"]]
+
+    result = run_loop(
+        [_cfg("a"), _cfg("boom"), _cfg("c")],
+        scorer,
+        Objective.maximize("r"),
+        experiment="e",
+        dataset_name="d",
+        store=store_path,
+    )
+
+    # The failure did not abort the sweep: three trials, the middle one failed.
+    assert [t.status for t in result.trials] == ["completed", "failed", "completed"]
+    failed = result.trials[1]
+    assert failed.metrics is None
+    assert failed.accepted is False
+    assert result.best_config == _cfg("c")  # c still won
+
+    records = {r.attempt_id: r for r in RunStore(store_path).read()}
+    assert records[failed.attempt_id].status == "failed"
+    assert records[failed.attempt_id].error_type == "RuntimeError"
+
+    # Lineage skips the failed trial: c's parent is a's attempt (the incumbent
+    # never advanced through the failure).
+    good_a, _boom, good_c = result.trials
+    assert records[good_c.attempt_id].context.parent_run_id == good_a.attempt_id
+
+
+def test_trial_is_a_frozen_dataclass() -> None:
+    trial = Trial({"blocker": "vector"}, {"r": 1.0}, True, "rid", "aid", "completed")
+    with pytest.raises((AttributeError, TypeError)):
+        trial.accepted = False  # type: ignore[misc]

--- a/tests/core/test_autoresearch_objective.py
+++ b/tests/core/test_autoresearch_objective.py
@@ -1,0 +1,262 @@
+"""Tests for the autoresearch :class:`Objective` (the keep-if-better scorer).
+
+Core contract code -> high coverage tier. Covers feasibility gating, goal
+normalization, Pareto dominance (dominating / dominated / incomparable / tie),
+the ``is_better`` decision against ``None`` and feasible/infeasible incumbents,
+the ergonomic constructors, and every fail-loud validation branch.
+"""
+
+import pytest
+
+from langres.core.autoresearch.objective import (
+    Constraint,
+    Goal,
+    Objective,
+)
+
+# ---------------------------------------------------------------------------
+# Goal
+# ---------------------------------------------------------------------------
+
+
+def test_goal_is_frozen() -> None:
+    g = Goal("recall", "maximize")
+    with pytest.raises((AttributeError, TypeError)):
+        g.metric = "precision"  # type: ignore[misc]
+
+
+def test_goal_bad_direction_raises() -> None:
+    with pytest.raises(ValueError, match="direction must be one of"):
+        Goal("recall", "maximise")  # type: ignore[arg-type]
+
+
+# ---------------------------------------------------------------------------
+# Constraint
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    ("op", "threshold", "value", "expected"),
+    [
+        (">=", 0.9, 0.9, True),
+        (">=", 0.9, 0.89, False),
+        ("<=", 0.1, 0.1, True),
+        ("<=", 0.1, 0.11, False),
+        (">", 0.5, 0.6, True),
+        (">", 0.5, 0.5, False),
+        ("<", 0.5, 0.4, True),
+        ("<", 0.5, 0.5, False),
+    ],
+)
+def test_constraint_satisfied_each_op(
+    op: str, threshold: float, value: float, expected: bool
+) -> None:
+    c = Constraint("m", op, threshold)  # type: ignore[arg-type]
+    assert c.satisfied({"m": value}) is expected
+
+
+def test_constraint_bad_op_raises() -> None:
+    with pytest.raises(ValueError, match="constraint op must be one of"):
+        Constraint("m", ">>", 0.5)  # type: ignore[arg-type]
+
+
+def test_constraint_missing_metric_raises() -> None:
+    c = Constraint("precision", ">=", 0.9)
+    with pytest.raises(ValueError, match="metric 'precision' is missing"):
+        c.satisfied({"recall": 0.9})
+
+
+# ---------------------------------------------------------------------------
+# Objective construction / value normalization
+# ---------------------------------------------------------------------------
+
+
+def test_objective_requires_a_goal() -> None:
+    with pytest.raises(ValueError, match="at least one goal"):
+        Objective(goals=())
+
+
+def test_value_maximize_passthrough() -> None:
+    obj = Objective.maximize("recall")
+    assert obj.value({"recall": 0.8}) == (0.8,)
+
+
+def test_value_minimize_is_negated() -> None:
+    obj = Objective.minimize("log_loss")
+    # Normalized to higher-is-better: a minimize goal is negated.
+    assert obj.value({"log_loss": 0.3}) == (-0.3,)
+
+
+def test_value_orders_by_goals() -> None:
+    obj = Objective.pareto([("recall", "maximize"), ("cost", "minimize")])
+    assert obj.value({"recall": 0.9, "cost": 2.0}) == (0.9, -2.0)
+
+
+def test_value_missing_metric_raises() -> None:
+    obj = Objective.maximize("recall")
+    with pytest.raises(ValueError, match="metric 'recall' is missing"):
+        obj.value({"precision": 0.9})
+
+
+# ---------------------------------------------------------------------------
+# Feasibility
+# ---------------------------------------------------------------------------
+
+
+def test_is_feasible_no_constraints_is_vacuously_true() -> None:
+    obj = Objective.maximize("recall")
+    assert obj.is_feasible({"recall": 0.1}) is True
+
+
+def test_is_feasible_all_satisfied() -> None:
+    obj = Objective.maximize("recall", subject_to=[("precision", ">=", 0.9)])
+    assert obj.is_feasible({"recall": 0.8, "precision": 0.95}) is True
+
+
+def test_is_feasible_one_violated() -> None:
+    obj = Objective.maximize("recall", subject_to=[("precision", ">=", 0.9)])
+    assert obj.is_feasible({"recall": 0.8, "precision": 0.85}) is False
+
+
+def test_is_feasible_missing_constraint_metric_raises() -> None:
+    obj = Objective.maximize("recall", subject_to=[("precision", ">=", 0.9)])
+    with pytest.raises(ValueError, match="metric 'precision' is missing"):
+        obj.is_feasible({"recall": 0.8})
+
+
+# ---------------------------------------------------------------------------
+# Pareto dominance
+# ---------------------------------------------------------------------------
+
+
+def test_dominates_strictly_better_on_all() -> None:
+    obj = Objective.pareto([("recall", "maximize"), ("precision", "maximize")])
+    a = {"recall": 0.9, "precision": 0.9}
+    b = {"recall": 0.8, "precision": 0.8}
+    assert obj.dominates(a, b) is True
+    assert obj.dominates(b, a) is False
+
+
+def test_dominates_equal_on_one_better_on_other() -> None:
+    obj = Objective.pareto([("recall", "maximize"), ("precision", "maximize")])
+    a = {"recall": 0.9, "precision": 0.8}
+    b = {"recall": 0.8, "precision": 0.8}  # a is >= on both and > on recall
+    assert obj.dominates(a, b) is True
+
+
+def test_dominates_incomparable_tradeoff() -> None:
+    obj = Objective.pareto([("recall", "maximize"), ("precision", "maximize")])
+    a = {"recall": 0.9, "precision": 0.7}
+    b = {"recall": 0.8, "precision": 0.8}  # a better on recall, worse on precision
+    assert obj.dominates(a, b) is False
+    assert obj.dominates(b, a) is False
+
+
+def test_dominates_tie_is_not_dominance() -> None:
+    obj = Objective.pareto([("recall", "maximize"), ("precision", "maximize")])
+    m = {"recall": 0.9, "precision": 0.9}
+    assert obj.dominates(m, dict(m)) is False
+
+
+def test_dominates_respects_minimize_direction() -> None:
+    obj = Objective.pareto([("recall", "maximize"), ("cost", "minimize")])
+    a = {"recall": 0.9, "cost": 1.0}
+    b = {"recall": 0.9, "cost": 2.0}  # same recall, lower cost -> a dominates
+    assert obj.dominates(a, b) is True
+    assert obj.dominates(b, a) is False
+
+
+# ---------------------------------------------------------------------------
+# is_better — the loop's keep/revert decision
+# ---------------------------------------------------------------------------
+
+
+def test_is_better_feasible_beats_none_incumbent() -> None:
+    obj = Objective.maximize("recall")
+    assert obj.is_better({"recall": 0.5}, None) is True
+
+
+def test_is_better_infeasible_candidate_never_better_even_vs_none() -> None:
+    obj = Objective.maximize("recall", subject_to=[("precision", ">=", 0.9)])
+    assert obj.is_better({"recall": 0.99, "precision": 0.5}, None) is False
+
+
+def test_is_better_feasible_beats_infeasible_incumbent() -> None:
+    obj = Objective.maximize("recall", subject_to=[("precision", ">=", 0.9)])
+    candidate = {"recall": 0.5, "precision": 0.95}  # feasible
+    incumbent = {"recall": 0.99, "precision": 0.5}  # infeasible
+    assert obj.is_better(candidate, incumbent) is True
+
+
+def test_is_better_single_goal_strict_improvement() -> None:
+    obj = Objective.maximize("recall")
+    assert obj.is_better({"recall": 0.9}, {"recall": 0.8}) is True
+    assert obj.is_better({"recall": 0.8}, {"recall": 0.9}) is False
+
+
+def test_is_better_single_goal_tie_keeps_incumbent() -> None:
+    obj = Objective.maximize("recall")
+    assert obj.is_better({"recall": 0.8}, {"recall": 0.8}) is False
+
+
+def test_is_better_minimize_single_goal() -> None:
+    obj = Objective.minimize("log_loss")
+    assert obj.is_better({"log_loss": 0.2}, {"log_loss": 0.3}) is True
+    assert obj.is_better({"log_loss": 0.4}, {"log_loss": 0.3}) is False
+
+
+def test_is_better_multi_goal_dominating() -> None:
+    obj = Objective.pareto([("recall", "maximize"), ("precision", "maximize")])
+    assert (
+        obj.is_better({"recall": 0.9, "precision": 0.9}, {"recall": 0.8, "precision": 0.8}) is True
+    )
+
+
+def test_is_better_multi_goal_incomparable_keeps_incumbent() -> None:
+    obj = Objective.pareto([("recall", "maximize"), ("precision", "maximize")])
+    # Better on recall, worse on precision: incomparable -> not better.
+    assert (
+        obj.is_better({"recall": 0.9, "precision": 0.7}, {"recall": 0.8, "precision": 0.8}) is False
+    )
+
+
+def test_is_better_missing_metric_raises() -> None:
+    obj = Objective.maximize("recall")
+    with pytest.raises(ValueError, match="metric 'recall' is missing"):
+        obj.is_better({"precision": 0.9}, {"recall": 0.8})
+
+
+# ---------------------------------------------------------------------------
+# Ergonomic constructors
+# ---------------------------------------------------------------------------
+
+
+def test_maximize_builds_single_goal_and_constraints() -> None:
+    obj = Objective.maximize("recall", subject_to=[("precision", ">=", 0.9)])
+    assert obj.goals == (Goal("recall", "maximize"),)
+    assert obj.constraints == (Constraint("precision", ">=", 0.9),)
+
+
+def test_minimize_builds_single_minimize_goal() -> None:
+    obj = Objective.minimize("log_loss")
+    assert obj.goals == (Goal("log_loss", "minimize"),)
+    assert obj.constraints == ()
+
+
+def test_pareto_builds_multiple_goals_with_mixed_directions() -> None:
+    obj = Objective.pareto(
+        [("recall", "maximize"), ("cost", "minimize")],
+        subject_to=[("precision", ">=", 0.8)],
+    )
+    assert obj.goals == (Goal("recall", "maximize"), Goal("cost", "minimize"))
+    assert obj.constraints == (Constraint("precision", ">=", 0.8),)
+
+
+def test_pareto_bad_direction_raises() -> None:
+    with pytest.raises(ValueError, match="direction must be one of"):
+        Objective.pareto([("recall", "up")])
+
+
+def test_constructor_bad_constraint_op_raises() -> None:
+    with pytest.raises(ValueError, match="constraint op must be one of"):
+        Objective.maximize("recall", subject_to=[("precision", "=>", 0.9)])

--- a/tests/core/test_autoresearch_search_space.py
+++ b/tests/core/test_autoresearch_search_space.py
@@ -1,0 +1,157 @@
+"""Tests for the autoresearch :class:`SearchSpace` (the proposal substrate).
+
+Core contract code -> high coverage tier. Covers the config Cartesian product,
+its size (``__len__`` vs enumerated count), the **k_neighbors-innermost** ordering
+guarantee the loop depends on for index reuse, fail-loud empty-axis validation,
+frozenness, and import-lightness (no faiss/torch pulled by importing this module).
+"""
+
+import subprocess
+import sys
+
+import pytest
+
+from langres.core.autoresearch.search_space import SearchSpace
+
+
+def test_defaults_are_a_vector_k_sweep() -> None:
+    space = SearchSpace()
+    assert space.blocker == ("vector",)
+    assert space.embedding_model == ("all-MiniLM-L6-v2",)
+    assert space.metric == ("cosine",)
+    assert space.text_field == ("name",)
+    assert space.k_neighbors == (5, 10, 20)
+
+
+def test_is_frozen() -> None:
+    space = SearchSpace()
+    with pytest.raises((AttributeError, TypeError)):
+        space.k_neighbors = (1, 2)  # type: ignore[misc]
+
+
+def test_len_is_product_of_axis_sizes() -> None:
+    space = SearchSpace(
+        blocker=("vector",),
+        embedding_model=("m1", "m2"),
+        metric=("cosine", "L2"),
+        text_field=("a", "b", "c"),
+        k_neighbors=(5, 10),
+    )
+    assert len(space) == 1 * 2 * 2 * 3 * 2 == 24
+
+
+def test_configs_count_matches_len() -> None:
+    space = SearchSpace(
+        embedding_model=("m1", "m2"),
+        metric=("cosine", "L2"),
+        text_field=("a", "b"),
+        k_neighbors=(5, 10, 20),
+    )
+    configs = list(space.configs())
+    assert len(configs) == len(space)
+
+
+def test_configs_default_is_the_k_sweep() -> None:
+    configs = list(SearchSpace().configs())
+    # Only k varies; everything else is the single default value.
+    assert [c["k_neighbors"] for c in configs] == [5, 10, 20]
+    assert {c["blocker"] for c in configs} == {"vector"}
+    assert {c["embedding_model"] for c in configs} == {"all-MiniLM-L6-v2"}
+    assert {c["metric"] for c in configs} == {"cosine"}
+    assert {c["text_field"] for c in configs} == {"name"}
+
+
+def test_config_dict_has_the_expected_keys() -> None:
+    config = next(SearchSpace().configs())
+    assert set(config) == {"blocker", "embedding_model", "metric", "text_field", "k_neighbors"}
+
+
+def test_k_neighbors_is_the_innermost_dimension() -> None:
+    """The load-bearing contract: k varies fastest, outer keys held fixed per k-block.
+
+    Consecutive configs must share ``(blocker, embedding_model, metric,
+    text_field)`` while ``k_neighbors`` cycles through its full range, so the
+    downstream loop can build one index per outer tuple and reuse it across k.
+    """
+    ks = (5, 10, 20)
+    space = SearchSpace(
+        blocker=("vector",),
+        embedding_model=("m1", "m2"),
+        metric=("cosine", "L2"),
+        text_field=("a", "b"),
+        k_neighbors=ks,
+    )
+    configs = list(space.configs())
+    outer_keys = ("blocker", "embedding_model", "metric", "text_field")
+
+    for i, config in enumerate(configs):
+        # k cycles through the full range in order, fastest-varying.
+        assert config["k_neighbors"] == ks[i % len(ks)]
+
+    # Within each block of len(ks) configs the outer tuple is constant; it only
+    # advances at block boundaries.
+    for start in range(0, len(configs), len(ks)):
+        block = configs[start : start + len(ks)]
+        outer_tuples = {tuple(c[k] for k in outer_keys) for c in block}
+        assert len(outer_tuples) == 1, f"outer keys changed within a k-block at {start}"
+
+    # Every outer tuple is distinct across blocks (no block repeats).
+    block_starts = range(0, len(configs), len(ks))
+    outer_per_block = [tuple(configs[s][k] for k in outer_keys) for s in block_starts]
+    assert len(set(outer_per_block)) == len(outer_per_block)
+
+
+def test_consecutive_configs_within_a_block_differ_only_in_k() -> None:
+    ks = (5, 10, 20)
+    space = SearchSpace(embedding_model=("m1", "m2"), k_neighbors=ks)
+    configs = list(space.configs())
+    for i in range(len(configs) - 1):
+        if (i + 1) % len(ks) != 0:  # not a block boundary
+            a, b = configs[i], configs[i + 1]
+            assert {k: v for k, v in a.items() if k != "k_neighbors"} == {
+                k: v for k, v in b.items() if k != "k_neighbors"
+            }
+
+
+def test_all_pairs_in_blocker_axis_still_products() -> None:
+    """The product spans all axes; ``all_pairs`` configs carry the same keys.
+
+    (The factory ignores the vector-only keys for the all_pairs path.)
+    """
+    space = SearchSpace(blocker=("vector", "all_pairs"), k_neighbors=(5,))
+    kinds = [c["blocker"] for c in space.configs()]
+    assert kinds == ["vector", "all_pairs"]
+    assert len(space) == 2
+
+
+@pytest.mark.parametrize(
+    "kwargs",
+    [
+        {"blocker": ()},
+        {"embedding_model": ()},
+        {"metric": ()},
+        {"text_field": ()},
+        {"k_neighbors": ()},
+    ],
+)
+def test_empty_axis_raises(kwargs: dict[str, tuple[object, ...]]) -> None:
+    with pytest.raises(ValueError, match="must be a non-empty tuple"):
+        SearchSpace(**kwargs)  # type: ignore[arg-type]
+
+
+def test_import_is_light() -> None:
+    """Importing search_space must not pull faiss/torch/sentence_transformers.
+
+    Run in a fresh interpreter so no other test's heavy imports contaminate
+    ``sys.modules``. This module lives on the public API surface, so it must
+    stay as import-light as a bare ``import langres`` (see test_import_budget.py).
+    """
+    code = (
+        "import sys\n"
+        "import langres.core.autoresearch.search_space  # noqa: F401\n"
+        "heavy = sorted(m for m in ('faiss', 'torch', 'sentence_transformers') "
+        "if m in sys.modules)\n"
+        "assert not heavy, f'unexpectedly imported: {heavy}'\n"
+    )
+    result = subprocess.run([sys.executable, "-c", code], capture_output=True, text=True)
+    assert result.returncode == 0, result.stderr

--- a/tests/core/test_metrics_calibration.py
+++ b/tests/core/test_metrics_calibration.py
@@ -10,9 +10,11 @@ import pytest
 
 from langres.core.metrics import (
     _bin_indices,
+    _LOG_LOSS_EPS,
     brier_score,
     cohens_kappa,
     expected_calibration_error,
+    log_loss,
     matthews_corrcoef,
     reliability_bins,
 )
@@ -144,6 +146,71 @@ def test_brier_confidence_out_of_range_raises() -> None:
 def test_brier_confidence_negative_raises() -> None:
     with pytest.raises(ValueError, match=r"\[0, 1\]"):
         brier_score([-0.1], [True])
+
+
+# ---------------------------------------------------------------------------
+# Log loss (binary cross-entropy)
+# ---------------------------------------------------------------------------
+
+
+def test_log_loss_hand_computed() -> None:
+    # -(log(0.9) + log(1-0.1)) / 2 = -log(0.9).
+    assert log_loss([0.9, 0.1], [True, False]) == pytest.approx(-math.log(0.9))
+
+
+def test_log_loss_perfect_is_near_zero() -> None:
+    # Clamped to [eps, 1-eps]; the residual is ~eps, i.e. effectively 0.
+    assert log_loss([1.0, 0.0], [True, False]) == pytest.approx(0.0, abs=1e-12)
+
+
+def test_log_loss_confident_and_wrong_is_large_but_finite() -> None:
+    # p=0 for a True and p=1 for a False both clamp to the eps bound.
+    worst = log_loss([0.0, 1.0], [True, False])
+    assert worst == pytest.approx(-math.log(_LOG_LOSS_EPS))
+    assert math.isfinite(worst)
+
+
+def test_log_loss_constant_half_is_log_two() -> None:
+    assert log_loss([0.5, 0.5], [True, False]) == pytest.approx(math.log(2.0))
+
+
+def test_log_loss_is_symmetric_under_label_flip() -> None:
+    # Flipping every (p, y) to (1-p, not y) leaves the loss unchanged.
+    assert log_loss([0.9, 0.1], [True, False]) == pytest.approx(log_loss([0.1, 0.9], [False, True]))
+
+
+def test_log_loss_small_vector() -> None:
+    conf = [0.8, 0.6, 0.3]
+    out = [True, True, False]
+    expected = -(math.log(0.8) + math.log(0.6) + math.log(1 - 0.3)) / 3
+    assert log_loss(conf, out) == pytest.approx(expected)
+
+
+def test_log_loss_epsilon_clamp_at_zero() -> None:
+    # p=0: correct-False stays ~0, wrong-True clamps to the eps penalty (finite).
+    assert log_loss([0.0], [False]) == pytest.approx(0.0, abs=1e-12)
+    assert log_loss([0.0], [True]) == pytest.approx(-math.log(_LOG_LOSS_EPS))
+
+
+def test_log_loss_epsilon_clamp_at_one() -> None:
+    # p=1: correct-True stays ~0, wrong-False clamps to the eps penalty (finite).
+    assert log_loss([1.0], [True]) == pytest.approx(0.0, abs=1e-12)
+    assert log_loss([1.0], [False]) == pytest.approx(-math.log(_LOG_LOSS_EPS))
+
+
+def test_log_loss_length_mismatch_raises() -> None:
+    with pytest.raises(ValueError, match="equal length"):
+        log_loss([0.5], [True, False])
+
+
+def test_log_loss_empty_raises() -> None:
+    with pytest.raises(ValueError, match="non-empty"):
+        log_loss([], [])
+
+
+def test_log_loss_confidence_out_of_range_raises() -> None:
+    with pytest.raises(ValueError, match=r"\[0, 1\]"):
+        log_loss([1.5], [True])
 
 
 # ---------------------------------------------------------------------------

--- a/tests/examples/test_blocking_recall_autoresearch.py
+++ b/tests/examples/test_blocking_recall_autoresearch.py
@@ -1,0 +1,64 @@
+"""Smoke test: the autoresearch E1 proof example runs and its loop closes.
+
+Drives the importable core of ``examples/research/blocking_recall_autoresearch.py``
+(``run_search``) over a tiny two-config grid on the real amazon_google benchmark
+with real MiniLM embeddings, asserting the loop produces a feasible incumbent with
+non-zero blocking recall and persists every trial (accepted + rejected) to the
+owned ``RunStore`` off-git.
+
+Marked ``slow`` (loads an embedding model + builds a FAISS index) but network-free
+and $0. Uses a 2-config space (one index build) to stay lean — the full 20-config
+grid is exercised by running the example directly, not by fast CI.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from examples.research.blocking_recall_autoresearch import (
+    RR_BUDGET,
+    build_space,
+    run_search,
+)
+from langres.core.autoresearch.loop import LoopResult
+from langres.core.autoresearch.search_space import SearchSpace
+from langres.core.runs import RunStore
+
+pytestmark = pytest.mark.slow
+
+
+def test_run_search_closes_the_loop_and_logs_every_trial(tmp_path) -> None:  # type: ignore[no-untyped-def]
+    """A tiny k-sweep yields a feasible incumbent with recall>0; all trials logged."""
+    store = str(tmp_path / "runs.jsonl")
+    # Two ascending-k configs, one (metric, text_field) group => a single index build.
+    tiny = SearchSpace(
+        blocker=("vector",),
+        embedding_model=("all-MiniLM-L6-v2",),
+        metric=("cosine",),
+        text_field=("embed_text",),
+        k_neighbors=(5, 10),
+    )
+
+    result = run_search(tiny, RR_BUDGET, store, seed=0)
+
+    # 1. The loop returned a real result with a feasible incumbent that has signal.
+    assert isinstance(result, LoopResult)
+    assert result.best_metrics is not None
+    assert result.best_metrics["candidate_recall"] > 0.0
+    assert result.best_metrics["reduction_ratio"] >= RR_BUDGET
+
+    # 2. Both configs were evaluated (recall climbs with k => the second is kept).
+    assert len(result.trials) == 2
+    assert all(t.status == "completed" for t in result.trials)
+    assert result.best_config["k_neighbors"] == 10  # more neighbours => more recall
+
+    # 3. Every trial — accepted and rejected — is durable off-git in the RunStore.
+    records = RunStore(store).read()
+    assert len(records) == 2
+    assert all(r.metrics is not None and "accepted" in r.metrics for r in records)
+    assert sum(1 for r in records if r.metrics["accepted"] == 1.0) >= 1
+
+
+def test_full_search_space_is_the_documented_modest_grid() -> None:
+    """The example's grid is the modest 20-config sweep (cheap; no run)."""
+    assert len(build_space()) == 20

--- a/tests/test_import_budget.py
+++ b/tests/test_import_budget.py
@@ -81,6 +81,44 @@ def test_import_langres_excludes_heavy_modules_from_sys_modules() -> None:
     )
 
 
+# The autoresearch facade (``langres.optimize`` / ``langres.score_blocking``,
+# PR P-C) is eager-exported from ``langres/__init__.py`` -- so a bare
+# ``import langres`` must expose both as callables WHILE staying import-light:
+# ``langres/optimize.py``'s module top is stdlib/typing only (every factory /
+# data / metrics / faiss import is lazy inside a function body), so pulling the
+# module into the eager graph must not drag torch / faiss / sentence-transformers
+# / litellm / scikit-learn into ``sys.modules``. Fresh-process for an unpolluted
+# import state (same pattern as the checks above).
+_OPTIMIZE_FACADE_HEAVY_DEPS = [
+    "torch",
+    "faiss",
+    "sentence_transformers",
+    "litellm",
+    "sklearn",
+]
+
+_OPTIMIZE_FACADE_SCRIPT = (
+    "import sys; import langres; "
+    "assert callable(langres.optimize), 'langres.optimize missing or not callable'; "
+    "assert callable(langres.score_blocking), 'langres.score_blocking missing or not callable'; "
+    "leaked = [m for m in {modules!r} if m in sys.modules]; "
+    "assert not leaked, f'optimize facade leaked heavy modules on bare import: {{leaked}}'; "
+    "print('OK')"
+).format(modules=_OPTIMIZE_FACADE_HEAVY_DEPS)
+
+
+def test_optimize_facade_is_eager_and_import_light() -> None:
+    """``langres.optimize``/``score_blocking`` are callable on bare import, pulling no heavy dep."""
+    result = subprocess.run(
+        [sys.executable, "-c", _OPTIMIZE_FACADE_SCRIPT],
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode == 0, (
+        f"optimize-facade import-budget check failed.\nSTDOUT:\n{result.stdout}\nSTDERR:\n{result.stderr}"
+    )
+
+
 # The prompt-optimize ``Method`` objects (``Bootstrap`` / ``MIPRO`` / ``GEPA``)
 # are pure config a caller constructs at the fit call site -- constructing one
 # (even ``GEPA(reflection_model=...)``, which names a DSPy optimizer) must never

--- a/tests/test_optimize.py
+++ b/tests/test_optimize.py
@@ -1,0 +1,237 @@
+"""Tests for the public ``langres.optimize`` facade (score_blocking + optimize).
+
+The fast tests use a TINY hand-built in-memory benchmark (a few records + gold),
+passed to the facade as a benchmark *object* (the offline seam alongside the
+public name-string DX). The ``all_pairs`` path needs no embeddings at all; the
+vector path injects a ``FakeEmbedder`` (and is guarded by ``importorskip`` so it
+skips without the [semantic] extra). One ``@pytest.mark.slow`` smoke exercises a
+registered benchmark with the real SentenceTransformer + FAISS stack.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Literal
+
+import pytest
+from pydantic import BaseModel
+
+from langres import optimize, score_blocking
+from langres.core.autoresearch.loop import LoopResult
+from langres.core.autoresearch.objective import Objective
+from langres.core.autoresearch.search_space import SearchSpace
+from langres.core.runs import RunStore
+
+
+class _ProductRec(BaseModel):
+    """A tiny two-source product record (offline test schema)."""
+
+    id: str
+    name: str
+    source: Literal["a", "b"]
+
+
+class _MemoryBenchmark:
+    """A minimal in-memory benchmark: ``name`` + ``load()`` is all the facade needs."""
+
+    name = "memory_products"
+
+    def load(self) -> tuple[list[_ProductRec], list[set[str]], set[frozenset[str]]]:
+        corpus = [
+            _ProductRec(id="a1", name="apple iphone 12", source="a"),
+            _ProductRec(id="a2", name="samsung galaxy s21", source="a"),
+            _ProductRec(id="b1", name="apple iphone 12", source="b"),
+            _ProductRec(id="b2", name="samsung galaxy s21", source="b"),
+        ]
+        gold_clusters = [{"a1", "b1"}, {"a2", "b2"}]
+        gold_pairs = {frozenset({"a1", "b1"}), frozenset({"a2", "b2"})}
+        return corpus, gold_clusters, gold_pairs
+
+
+_VECTOR_CFG = {
+    "blocker": "vector",
+    "embedding_model": "unused-with-fake",
+    "metric": "cosine",
+    "text_field": "name",
+    "k_neighbors": 3,
+}
+
+
+def _fake_embedder() -> Any:
+    pytest.importorskip("faiss", reason="requires the [semantic] extra")
+    from langres.core.embeddings import FakeEmbedder
+
+    return FakeEmbedder(embedding_dim=16)
+
+
+# ---------------------------------------------------------------------------
+# score_blocking
+# ---------------------------------------------------------------------------
+
+
+def test_score_blocking_all_pairs_returns_metrics_offline() -> None:
+    metrics = score_blocking({"blocker": "all_pairs"}, _MemoryBenchmark())
+    assert set(metrics) == {
+        "candidate_recall",
+        "candidate_precision",
+        "reduction_ratio",
+        "total_candidates",
+    }
+    # AllPairs surfaces every cross-source pair -> perfect blocking recall.
+    assert metrics["candidate_recall"] == 1.0
+    # Cross-source filter drops the two intra-source pairs (a1-a2, b1-b2).
+    assert metrics["total_candidates"] == 4.0
+
+
+def test_score_blocking_vector_with_fake_embedder() -> None:
+    embedder = _fake_embedder()
+    metrics = score_blocking(_VECTOR_CFG, _MemoryBenchmark(), embedder=embedder)
+    assert "candidate_recall" in metrics
+    assert 0.0 <= metrics["candidate_recall"] <= 1.0
+    assert isinstance(metrics["total_candidates"], float)
+
+
+def test_score_blocking_accepts_a_prebuilt_index() -> None:
+    embedder = _fake_embedder()
+    from langres.core.autoresearch.factory import build_index
+
+    corpus, _gc, _gp = _MemoryBenchmark().load()
+    index = build_index("x", "cosine", [r.name for r in corpus], embedder=embedder)
+    metrics = score_blocking(_VECTOR_CFG, _MemoryBenchmark(), index=index)
+    assert "candidate_recall" in metrics
+
+
+def test_score_blocking_by_registered_name_offline() -> None:
+    # The public name-string DX: get_benchmark("tiny_fixture") loads offline, and
+    # all_pairs blocking needs no embeddings -> a fully offline name-path check.
+    metrics = score_blocking({"blocker": "all_pairs"}, "tiny_fixture")
+    assert metrics["candidate_recall"] == 1.0
+
+
+def test_score_blocking_empty_corpus_raises() -> None:
+    class _Empty:
+        name = "empty"
+
+        def load(self) -> tuple[list[_ProductRec], list[set[str]], set[frozenset[str]]]:
+            return [], [], set()
+
+    with pytest.raises(ValueError, match="empty corpus"):
+        score_blocking({"blocker": "all_pairs"}, _Empty())
+
+
+# ---------------------------------------------------------------------------
+# optimize
+# ---------------------------------------------------------------------------
+
+
+def test_optimize_all_pairs_returns_loop_result_and_logs_trials(tmp_path: Any) -> None:
+    store_path = tmp_path / "runs.jsonl"
+    space = SearchSpace(blocker=("all_pairs",), text_field=("name",), k_neighbors=(5,))
+    result = optimize(
+        space, Objective.maximize("candidate_recall"), _MemoryBenchmark(), store=store_path
+    )
+
+    assert isinstance(result, LoopResult)
+    assert result.best_metrics is not None
+    assert result.best_metrics["candidate_recall"] == 1.0
+    assert result.best_config == {"blocker": "all_pairs"}  # canonicalized
+
+    records = RunStore(store_path).read()
+    assert len(records) == 1
+    assert records[0].metrics["accepted"] == 1.0
+    assert records[0].context.dataset_name == "memory_products"
+    assert records[0].context.split_id == "full"
+    assert records[0].context.dataset_fingerprint is not None
+
+
+def test_optimize_dedup_collapses_degenerate_all_pairs(tmp_path: Any) -> None:
+    store_path = tmp_path / "runs.jsonl"
+    # Several all_pairs configs differing only in (ignored) vector axes -> after
+    # canonicalization they share one recipe_id and the loop scores just one.
+    space = SearchSpace(
+        blocker=("all_pairs",),
+        embedding_model=("m1", "m2"),
+        metric=("cosine", "L2"),
+        text_field=("name",),
+        k_neighbors=(5, 10),
+    )
+    assert len(space) == 8  # 2 * 2 * 1 * 2 degenerate configs
+    result = optimize(
+        space, Objective.maximize("candidate_recall"), _MemoryBenchmark(), store=store_path
+    )
+    assert len(result.trials) == 1  # all collapsed to one
+    assert len(RunStore(store_path).read()) == 1
+
+
+def test_optimize_vector_reuses_index_across_k() -> None:
+    pytest.importorskip("faiss", reason="requires the [semantic] extra")
+    from langres.core.embeddings import FakeEmbedder
+
+    class _CountingEmbedder(FakeEmbedder):
+        encode_calls = 0
+
+        def encode(self, texts: Any) -> Any:
+            type(self).encode_calls += 1
+            return super().encode(texts)
+
+    space = SearchSpace(
+        blocker=("vector",),
+        embedding_model=("x",),
+        metric=("cosine",),
+        text_field=("name",),
+        k_neighbors=(1, 2, 3),
+    )
+    embedder = _CountingEmbedder(embedding_dim=16)
+    result = optimize(
+        space, Objective.maximize("candidate_recall"), _MemoryBenchmark(), embedder=embedder
+    )
+
+    assert len(result.trials) == 3
+    # One index built (one encode call) for the whole k-sweep, since k varies
+    # innermost within the shared (model, metric, text_field) group.
+    assert _CountingEmbedder.encode_calls == 1
+
+
+def test_optimize_store_none_writes_nothing(tmp_path: Any) -> None:
+    space = SearchSpace(blocker=("all_pairs",), text_field=("name",), k_neighbors=(5,))
+    result = optimize(space, Objective.maximize("candidate_recall"), _MemoryBenchmark(), store=None)
+    assert isinstance(result, LoopResult)
+    assert list(tmp_path.iterdir()) == []
+
+
+def test_optimize_records_seed_when_given(tmp_path: Any) -> None:
+    store_path = tmp_path / "runs.jsonl"
+    space = SearchSpace(blocker=("all_pairs",), text_field=("name",), k_neighbors=(5,))
+    optimize(
+        space,
+        Objective.maximize("candidate_recall"),
+        _MemoryBenchmark(),
+        store=store_path,
+        seed=7,
+    )
+    records = RunStore(store_path).read()
+    assert records[0].context.seeds == {"optimize": 7}
+
+
+# ---------------------------------------------------------------------------
+# Slow: real embedder + FAISS on a registered benchmark
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.slow
+def test_optimize_vector_real_embedder_on_registered_benchmark() -> None:
+    """End-to-end with the real SentenceTransformer + FAISS stack (downloads a model)."""
+    pytest.importorskip("faiss", reason="requires the [semantic] extra")
+    pytest.importorskip("sentence_transformers", reason="requires the [semantic] extra")
+
+    space = SearchSpace(
+        blocker=("vector",),
+        embedding_model=("all-MiniLM-L6-v2",),
+        metric=("cosine",),
+        text_field=("embed_text",),
+        k_neighbors=(3, 5),
+    )
+    result = optimize(space, Objective.maximize("candidate_recall"), "tiny_fixture")
+    assert isinstance(result, LoopResult)
+    assert result.best_metrics is not None
+    assert 0.0 <= result.best_metrics["candidate_recall"] <= 1.0
+    assert len(result.trials) == 2


### PR DESCRIPTION
## Autoresearch M1 — the loop closes on blocking recall (epic #145)

Ships the **minimal-friction core** of the Karpathy-style autoresearch loop for entity resolution: `propose → run → evaluate → keep-if-better`, steered by a **loss-like** objective (ER F1 saturates near 99%, so we steer on continuous `candidate_recall` subject to a reduction-ratio budget — not thresholded F1). Everything runs offline, `$0`, with **nothing generated committed to git**.

**This is yours to merge** — I orchestrated + self-verified the sub-PRs; the final call is yours.

### New public API
```python
from langres import optimize, score_blocking
from langres.core.autoresearch.search_space import SearchSpace
from langres.core.autoresearch.objective import Objective

space = SearchSpace(embedding_model=("all-MiniLM-L6-v2",), metric=("cosine","L2"),
                    text_field=("embed_text","title"), k_neighbors=(5,10,20,40,80))
obj = Objective.maximize("candidate_recall", subject_to=[("reduction_ratio",">=",0.985)])
result = optimize(space, obj, "amazon_google", store="tmp/autoresearch/run.jsonl", seed=0)
```
`optimize()` and `score_blocking()` are eager-exported and **import-light** — a bare `import langres` still pulls no torch/faiss/litellm/sklearn (guarded by `tests/test_import_budget.py`).

### The 5 merged sub-PRs (each independently reviewed + CI-green before merge)
| PR | What |
|----|------|
| #153 | **Bug-fix** — OpenMP guard for faiss/torch (macOS segfault) + corrected stale `VectorBlocker` docstrings |
| #154 | **Objective** — Pareto-capable, metric-source-agnostic, import-light; + stdlib `log_loss` steering signal |
| #155 | **SearchSpace + factory** — declarative grid (k-innermost for index reuse) + `build_blocker_from_config` mirroring the canonical VectorBlocker path |
| #156 | **Facade + loop + persistence** — `langres.optimize`, the propose→run→eval→keep loop (injected-scorer testability seam), reusing `core/runs` (`RunStore`); `store=None` writes nothing |
| #158 | **E1 proof** — runnable amazon_google example + doc + slow smoke test |

### The proof (real run, amazon_google, ~41s, $0 offline)
Incumbent `candidate_recall` **climbed** across the k-sweep, then the budget gate rejected the over-spend:

| accepted trial | config | candidate_recall | reduction_ratio |
|---|---|---:|---:|
| 1 | cosine/embed_text/k=5 | 0.7568 | 0.9987 |
| 2 | k=10 | 0.8129 | 0.9974 |
| 3 | k=20 | 0.8317 | 0.9947 |
| 4 | k=40 | **0.8388** | 0.9891 |

`k=80` is **rejected** (RR 0.9776 < 0.985 target — 2× the candidates for zero recall gain), so the budget is a genuine gate. **20 trials logged incl. rejects** (4 accepted / 16 rejected / 0 failed), all in the owned `RunStore` under gitignored `tmp/` — nothing in git. The observed recall values exactly match the pinned measured sweep in `amazon_google.py`.

### Persistence & rigor
- Every trial (incumbent, rejected, failed) logged with `parent_run_id` lineage + an `accepted` flag; `compute_recipe_id` dedups degenerate configs; `store=None` → no files at all.
- New `core` modules covered to the 95–100% tier (Objective 100%, SearchSpace/factory/loop full line); import budget locked.
- **`test-full` (slow tests + 95% coverage gate) dispatched on this branch** to validate the coverage gate before merge — see the Actions run linked from the checks.

### Deferred (tracked follow-ons, out of this g-stack)
- Full Trackio → HF Space dashboard + models-on-Hub durability (remainder of #150) — this ships the local `RunStore` + optional tracker hook; the HF dashboard is fast-follow.
- Optuna / LLAMBO proposer as a `Proposer` swap (P2 seam, #148 remainder); `BlockerOptimizer` refactor onto `SearchSpace`.
- Matching vertical (log_loss / AUC-PR steer), adapters/fine-tuning (E2/E3, M2/M3).
- 3 cosmetic nits from review (a loose `store: str | Any | None` hint in loop.py; a test-only `encode` signature; a fast structural test caught under a module `slow` mark) — non-gating, trivially fixable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Introduce an import-light autoresearch loop for blocking optimization in entity resolution, centered on a new Objective/SearchSpace/factory stack and the public langres.optimize/score_blocking facades, with durable run logging, macOS OpenMP safeguards, and an end-to-end blocking recall example and tests that prove the loop closes on a real benchmark.

New Features:
- Introduce langres.optimize and score_blocking as public, import-light facades for running autoresearch blocking sweeps over configurable search spaces and objectives.
- Add an autoresearch Objective API, SearchSpace definition, and config-to-blocker factory to support propose→run→evaluate→keep blocking optimization, plus a runnable amazon_google example as an E1 proof.

Bug Fixes:
- Guard FAISS/Torch OpenMP loading on macOS to prevent duplicate libomp runtime crashes when using vector indexes.

Enhancements:
- Extend core metrics with a numerically stable binary log_loss calibration metric and tests, intended as a loss-like steering signal for optimization.
- Wire the autoresearch loop driver around an injected scorer, integrating with RunStore and trackers for durable, deduplicated, lineage-aware trial logging, including feasibility gates and Pareto objectives.
- Ensure the optimize facade is eagerly exported yet remains import-light by verifying heavy ML dependencies are not pulled in on bare langres import, and update BlockerOptimizer examples to reflect the canonical vector-index-based construction.

Build:
- Update lint workflow branch filters to include the feat/autoresearch branch.

Documentation:
- Document the autoresearch blocking recall example and research scripts in a new README, explaining the recall@budget objective, loop behavior, and offline, $0 workflow.

Tests:
- Add high-coverage test suites for the Objective API, autoresearch loop, SearchSpace ordering and import-lightness, config factory, optimize/score_blocking facades, and the blocking_recall_autoresearch example, including slow end-to-end smoke tests with real embeddings and FAISS.
- Add an import-budget test ensuring langres.optimize and score_blocking are callable on bare import without loading heavy ML dependencies.