### PR TITLE
docs(autoresearch): document the langres.optimize self-tuning loop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,10 +42,9 @@ Optuna/LLAMBO proposer swap.
   (penalizes confident mistakes far more than `brier_score`; per-item penalty
   clamped near `-log(1e-15)` so a confident-and-wrong `p=0/1` is large but finite).
 - **`examples/research/blocking_recall_autoresearch.py`** — the E1 proof: the loop
-  hill-climbs blocking recall@budget on amazon_google at **$0, offline**. Incumbent
-  `candidate_recall` climbs `0.7568 → 0.8129 → 0.8317 → 0.8388` (`k = 5 → 40`),
-  `k = 80` is rejected as over-budget (RR `0.9776` < `0.985`), and all 20 trials
-  (4 accepted / 16 rejected) are logged off-git.
+  hill-climbs blocking recall@budget on amazon_google at **$0, offline** (measured
+  climb + budget-rejection numbers in
+  [`docs/EXPERIMENTS.md`](docs/EXPERIMENTS.md)).
 
 ### Model identity + one method registry (v0.3 slice, closes #103)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,8 +43,7 @@ Optuna/LLAMBO proposer swap.
   clamped near `-log(1e-15)` so a confident-and-wrong `p=0/1` is large but finite).
 - **`examples/research/blocking_recall_autoresearch.py`** — the E1 proof: the loop
   hill-climbs blocking recall@budget on amazon_google at **$0, offline** (measured
-  climb + budget-rejection numbers in
-  [`docs/EXPERIMENTS.md`](docs/EXPERIMENTS.md)).
+  climb + budget-rejection numbers in `docs/EXPERIMENTS.md`).
 
 ### Model identity + one method registry (v0.3 slice, closes #103)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,51 @@
 
 ## [Unreleased]
 
+### Autoresearch: the self-tuning loop over blocking (epic #145, M1)
+
+A `propose → run → evaluate → keep-if-better` hill-climber that tunes a pipeline
+against a **loss-like** objective instead of a saturated F1. M1 proves the loop on
+the **blocking** vertical; the matching vertical (`log_loss` / AUC-PR steering) and
+small-LM fine-tuning are deferred, as is a durable off-laptop **Trackio + Hugging
+Face** dashboard (an optional `tracker=` hook is wired but no-op by default) and an
+Optuna/LLAMBO proposer swap.
+
+#### Added
+
+- **`langres.optimize(space, objective, benchmark, *, seed=None, store=None,
+  dedup=True, split="full", embedder=None, tracker=None) -> LoopResult`** — the
+  one-call autoresearch facade over blocking search. Loads the benchmark once,
+  wraps an index-caching scorer (one vector index per
+  `(embedding_model, metric, text_field)` group, reused across every `k`), drives
+  the loop over `space.configs()`, keeps the incumbent the `objective` prefers, and
+  persists **every** trial (accepted, over-budget reject, and scorer failure) to a
+  local `RunStore` JSONL at `store=` (`store=None` writes nothing). **Local-only
+  persistence today.**
+- **`langres.score_blocking(config, benchmark, *, embedder=None, index=None) ->
+  dict[str, float]`** — the concrete one-config blocking scorer `optimize` wraps,
+  returning `candidate_recall` / `reduction_ratio` / `candidate_precision` /
+  `total_candidates`. Both `optimize` and `score_blocking` are **root exports and
+  import-light** (heavy imports are lazy inside the call, so a bare `import langres`
+  never pulls faiss; `tests/test_import_budget.py` guards it).
+- **`Objective`** (`langres.core.autoresearch.objective`) — the immutable
+  keep-if-better scorer: `Objective.maximize` / `minimize` / `pareto`, feasibility
+  `subject_to=[(metric, op, threshold), ...]` constraints, feasibility-first then
+  strict-Pareto-dominance `is_better` (ties keep the incumbent). Pure-stdlib,
+  metric-source-agnostic.
+- **`SearchSpace`** (`langres.core.autoresearch.search_space`) — a frozen,
+  declarative Cartesian grid of blocker configs; `configs()` yields config dicts
+  with `k_neighbors` as the **innermost** axis (the index-reuse ordering contract).
+  Pure-stdlib.
+- **`langres.core.metrics.log_loss(confidences, outcomes)`** — binary
+  cross-entropy, the strictly-proper loss-like steering signal for the loop
+  (penalizes confident mistakes far more than `brier_score`; per-item penalty
+  clamped near `-log(1e-15)` so a confident-and-wrong `p=0/1` is large but finite).
+- **`examples/research/blocking_recall_autoresearch.py`** — the E1 proof: the loop
+  hill-climbs blocking recall@budget on amazon_google at **$0, offline**. Incumbent
+  `candidate_recall` climbs `0.7568 → 0.8129 → 0.8317 → 0.8388` (`k = 5 → 40`),
+  `k = 80` is rejected as over-budget (RR `0.9776` < `0.985`), and all 20 trials
+  (4 accepted / 16 rejected) are logged off-git.
+
 ### Model identity + one method registry (v0.3 slice, closes #103)
 
 The maintainer complaint this fixes: *"`langres.dedupe` is too simple — you

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -46,6 +46,7 @@ load only when you read/edit a file matching their `paths:`.
 langres/
 ├── src/langres/
 │   ├── verbs.py        # User-facing verbs: link(), dedupe(), LinkVerdict
+│   ├── optimize.py     # langres.optimize / score_blocking: import-light autoresearch facade over blocking search
 │   ├── eval.py         # Curated evaluation facade (lazy): evaluate, list_benchmarks/get_benchmark, ER metrics
 │   ├── cli.py          # langres CLI: review / export-csv / import-csv (labeling loop)
 │   ├── core/           # Low-level primitives + the Resolver
@@ -62,7 +63,8 @@ langres/
 │   │   ├── harvest.py      # Correction/CorrectionLog, harvest_labeled_pairs, derive_threshold_from_pairs
 │   │   ├── calibration.py          # derive_threshold
 │   │   ├── reports.py              # inspection/evaluation report models (ScoreInspectionReport, BlockerEvaluationReport, ...)
-│   │   └── optimizers/             # BlockerOptimizer (Optuna)
+│   │   ├── optimizers/             # BlockerOptimizer (Optuna)
+│   │   └── autoresearch/           # the langres.optimize engine: objective (keep-if-better) / search_space / factory / loop (propose→run→eval→keep)
 │   ├── methods.py      # method registry / _make_module_builder (benchmark path)
 │   ├── clients/        # OpenRouter client, SpendMonitor, pricing
 │   └── data/           # benchmark dataset loaders (FZ, Amazon-Google, ...)

--- a/README.md
+++ b/README.md
@@ -223,6 +223,7 @@ custom pipelines. See [docs/DX_RESOLVER.md](docs/DX_RESOLVER.md) and
 | **Incremental single-record assignment** (`Resolver.build_anchor_store` / `assign`, serializable `AnchorStore`) | ✅ shipped |
 | **Golden records / canonicalization** (`Canonicalizer` survivorship + `enrich`) | ✅ shipped |
 | Evaluation instrument: benchmark registry, `evaluate()`, `EvalReport` tearsheet | ✅ shipped |
+| **Self-tuning blocking search** (`langres.optimize` — `propose→run→eval→keep` over a `SearchSpace`, gated by a loss-like `Objective`) | ✅ shipped (blocking vertical; matching + fine-tuning roadmap) |
 | Cross-source linking (`Resolver.link`, `stream_against`) | 🚧 reserved stubs (raise `NotImplementedError`) — roadmap |
 | Fine-tuning a small LM on harvested labels (the next cost rung) | 🚧 roadmap |
 | Negative constraints (cannot-link clustering) | 🚧 roadmap |

--- a/docs/EXPERIMENTS.md
+++ b/docs/EXPERIMENTS.md
@@ -294,6 +294,117 @@ captures a two-threshold sweep, reads it back, and prints the two-run metric dif
 plus the agent two-liner. Run it:
 `uv run python examples/research/experiment_tracking_demo.py`.
 
+## Self-tuning: the autoresearch loop (`langres.optimize`)
+
+Every surface above measures *one* configuration you chose. The **autoresearch
+loop** closes the outer loop: it **propose**s configs from a search space,
+**run**s and **evaluate**s each into metrics, and **keep**s the one an
+`Objective` prefers — a small, deterministic hill-climber. Because ER F1
+saturates near 99%, the loop steers on a **loss-like signal, not a thresholded
+F1**: `candidate_recall@budget`, `log_loss`, or a quality×cost Pareto front.
+
+`langres.optimize` is the one-call facade; it is **import-light** (`optimize` and
+`score_blocking` are root exports, but every heavy import — faiss, the benchmark
+loader — is lazy inside the call, so a bare `import langres` never pulls the
+[semantic] stack; `tests/test_import_budget.py` guards this).
+
+```python
+from langres import optimize
+from langres.core.autoresearch.objective import Objective
+from langres.core.autoresearch.search_space import SearchSpace
+
+# 1. A SearchSpace is a declarative Cartesian grid of blocker configs. k_neighbors
+#    is the INNERMOST axis, so one vector index is built per
+#    (embedding_model, metric, text_field) group and reused across every k.
+space = SearchSpace(
+    blocker=("vector",),
+    embedding_model=("all-MiniLM-L6-v2",),   # local + free ($0, offline)
+    metric=("cosine", "L2"),
+    text_field=("embed_text", "title"),
+    k_neighbors=(5, 10, 20, 40, 80),         # ascending: recall climbs with k
+)
+
+# 2. An Objective is the immutable keep-if-better rule. Maximize a continuous
+#    recall signal subject to a reduction-ratio floor (>=98.5% of the |A|x|B|
+#    comparisons eliminated) — a real recall@budget tradeoff, not a saturated F1.
+objective = Objective.maximize(
+    "candidate_recall", subject_to=[("reduction_ratio", ">=", 0.985)]
+)
+
+# 3. optimize() loads the benchmark once, drives the loop, and persists EVERY
+#    trial (accepted + rejected) to the local JSONL at store=.
+result = optimize(
+    space, objective, "amazon_google",
+    store="tmp/autoresearch/ag_blocking.jsonl",   # gitignored; store=None writes nothing
+    seed=0,
+)
+print(result.best_config, result.best_metrics)     # the winning feasible config
+```
+
+**Defining the `Objective` — three ergonomic constructors.** An `Objective`
+bundles one or more goals with zero or more feasibility constraints
+(`(metric, op, threshold)` triples, `op` in `>= <= > <`). A candidate that
+violates any constraint is never kept; among feasible candidates the incumbent is
+displaced only by a strict Pareto win (`>=` on every goal, `>` on at least one) —
+ties and incomparable trade-offs keep the incumbent, so the loop is monotone.
+
+```python
+# single maximize goal, optionally constrained
+Objective.maximize("candidate_recall", subject_to=[("reduction_ratio", ">=", 0.985)])
+
+# single minimize goal (e.g. log_loss, cost) — the matching vertical's steering signal
+Objective.minimize("log_loss")
+
+# multi-objective Pareto front — never scalarized (recall up, work down)
+Objective.pareto([("candidate_recall", "maximize"), ("reduction_ratio", "maximize")])
+```
+
+**Where results are stored — local JSONL only, today.** `optimize(store=...)`
+appends **every** trial — accepted, over-budget rejects, and scorer failures — as
+one line to a local `RunStore` JSONL (the same `core.runs` spine as
+`capture_run` above), so the full audit trail is durable off-git. `store=None`
+persists **nothing** (the offline path); the same `LoopResult` is returned either
+way. Read the trail back with `RunStore(path).read()`:
+
+```python
+from langres.core.runs import RunStore
+
+records = RunStore("tmp/autoresearch/ag_blocking.jsonl").read()   # last-wins per attempt
+accepted = [r for r in records if (r.metrics or {}).get("accepted") == 1.0]
+```
+
+This persistence is **local-only for now.** A durable, off-laptop dashboard
+(Trackio + Hugging Face, with the winning artifact pushed to the Hub) is
+**deferred** — an optional `tracker=` hook is wired into `optimize`/`run_loop` but
+defaults to a no-op. Also deferred: swapping the exhaustive grid proposer for an
+Optuna/LLAMBO one, and the **matching vertical** (steering a judge on `log_loss` /
+AUC-PR) plus small-LM fine-tuning. **M1 proves the loop on the blocking vertical
+only** (epic #145).
+
+### Worked proof — climbing blocking recall@budget on amazon_google
+
+`examples/research/blocking_recall_autoresearch.py` runs exactly the loop above
+over the 20-config grid at **$0, offline** (local MiniLM embeddings, no LLM; the
+benchmark is vendored). amazon_google is a genuinely hard, *unsaturated* two-source
+linkage benchmark — blocking recall plateaus ~0.84, never reaching a 0.90 gate —
+which is what makes the climb and the budget tradeoff honest rather than a
+foregone conclusion. A measured run:
+
+- The incumbent `candidate_recall` **climbs** as `k` grows within the winning
+  `(metric, text_field)` group: **0.7568 → 0.8129 → 0.8317 → 0.8388** for
+  `k = 5 → 10 → 20 → 40`.
+- `k = 80` is **rejected as over-budget** — it spends ~2× the comparisons for no
+  extra recall, so its `reduction_ratio` (0.9776) breaches the 0.985 floor. The
+  loop keeps the best *feasible* incumbent. The budget is a real gate, not
+  decoration.
+- **20 trials logged (4 accepted / 16 rejected)** to the gitignored
+  `tmp/autoresearch/` JSONL; ~41 s wall-clock, **$0**.
+
+```bash
+uv run --env-file .env python examples/research/blocking_recall_autoresearch.py
+# needs the [semantic] extra: uv sync --all-extras --no-extra finetune
+```
+
 ## W3 paid smoke — SelectMatcher vs pairwise, measured
 
 `examples/research/w3_paid_smoke.py` is the ≤$10, SpendMonitor-capped operator run
@@ -399,6 +510,8 @@ with `examples/data/flywheel/generate_fixtures.py`.
   scoring walkthrough.
 - `examples/research/portfolio_race.py` — registry-driven race over every loadable
   benchmark (offline by default; optional capped LLM row).
+- `examples/research/blocking_recall_autoresearch.py` — the autoresearch loop
+  (`langres.optimize`) hill-climbing blocking recall@budget on amazon_google, $0/offline.
 - `examples/research/m4_experiment_loop.py` — the runnable zero-spend loop documented here.
 - `examples/research/m4_dspy_judge.py` — DSPyMatcher compile + save/load round-trip.
 - `examples/research/m4_calibration.py` — honest held-out `derive_threshold` lift on AG.

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -380,6 +380,27 @@ model/version registry, production/operability guidance, cannot-link clustering.
 - **Exit:** Person resolver meets **BCubed F1 ≥ 0.85**; documented deploy/rollback
   path; reproducible artifact versioning.
 
+### Autoresearch (epic #145) — the self-tuning loop — M1 LANDED
+The Karpathy-style `propose → run → evaluate → keep-if-better` outer loop, so
+langres *tunes itself* against a **loss-like** objective (`recall@budget`,
+`log_loss`, quality×cost Pareto) instead of a saturated F1. Shipped as the
+import-light `langres.optimize` / `score_blocking` facade over a declarative
+`SearchSpace` + an immutable `Objective`, with every trial (accepted and rejected)
+persisted to a local `RunStore` JSONL.
+
+- **M1 (landed) — proven on the blocking vertical.** The loop hill-climbs blocking
+  recall@budget on the hard, unsaturated amazon_google benchmark at **$0, offline**:
+  incumbent `candidate_recall` climbs `0.7568 → 0.8388` (`k = 5 → 40`) while the
+  over-budget `k = 80` config is correctly rejected — a real recall-vs-cost tradeoff,
+  not a foregone conclusion. See
+  [`docs/EXPERIMENTS.md`](EXPERIMENTS.md#self-tuning-the-autoresearch-loop-langresoptimize)
+  and `examples/research/blocking_recall_autoresearch.py`.
+- **Deferred (do not reference as existing):** the **matching** vertical (steering a
+  judge on `log_loss` / AUC-PR) and small-LM fine-tuning; an Optuna/LLAMBO proposer
+  swap; and a durable off-laptop **Trackio + Hugging Face** dashboard with the
+  winning artifact pushed to the Hub (an optional `tracker=` hook is wired but
+  defaults to a no-op — persistence is **local JSONL only** today).
+
 ---
 
 ## 7. Mapping to the first production consumer

--- a/docs/TECHNICAL_OVERVIEW.md
+++ b/docs/TECHNICAL_OVERVIEW.md
@@ -354,6 +354,10 @@ best_params = optimizer.optimize()   # -> {"embedding_model": ..., "k_neighbors"
 (Optuna lives in the dev dependency group, not a runtime extra — `BlockerOptimizer`
 is an eval-time tool, not part of the `link()`/`dedupe()` path.)
 
+> For a higher-level, self-tuning blocking search — a declarative `SearchSpace`
+> driven by an `Objective` through the `propose → run → evaluate → keep` loop, with
+> every trial persisted — see `langres.optimize` in §10.
+
 ### core.Canonicalizer (`langres.core.canonicalizer`, M5/W2.3) — ✅ ships today
 
 **Definition:** The "last mile" of Master Data Creation (Use Case 4): merge one
@@ -861,3 +865,143 @@ see `examples/research/w1_blocking_algebra_output.md` for the full tables and th
 default-flip decision (kept opt-in; recommended for harder/messier
 entity-resolution problems, not flipped globally on a single hard-dataset
 win).
+
+## 10. Self-tuning: the autoresearch loop (`langres.optimize`)
+
+The autoresearch loop (epic #145, M1) is a small **propose → run → evaluate →
+keep-if-better** hill-climber: it enumerates blocker configs, scores each into
+blocking metrics, and keeps the one an `Objective` prefers. Because ER F1
+saturates near 99%, it steers on a **loss-like** signal (`candidate_recall@budget`,
+`log_loss`, quality×cost Pareto) rather than a thresholded F1.
+
+`optimize` / `score_blocking` are **root exports** (`from langres import optimize`)
+and **import-light**: every heavy import (faiss, the benchmark loader,
+`core.autoresearch.factory`) is lazy inside the call, so a bare `import langres`
+never pulls the `[semantic]` stack (`tests/test_import_budget.py` guards this). The
+proposal/objective types (`SearchSpace`, `Objective`) are pure-stdlib and safe to
+import anywhere; only the concrete blocking scorer touches faiss.
+
+> This is a **blocking-search** facade, distinct from `core.optimizers.BlockerOptimizer`
+> (§5): `BlockerOptimizer` runs an Optuna study returning best params, while
+> `optimize` runs the deterministic keep-if-better loop over a declarative
+> `SearchSpace`, gated by an `Objective`, persisting every trial. A general
+> `Optimizer` over full *pipelines* remains roadmap.
+
+### langres.optimize (the loop facade)
+
+`optimize(space, objective, benchmark, *, seed=None, store=None, dedup=True, split="full", embedder=None, tracker=None) -> LoopResult`
+
+Loads `benchmark` **once**, fingerprints it once, wraps an index-caching blocking
+scorer (one vector index per `(embedding_model, metric, text_field)` group, reused
+across every `k`), and drives the loop over `space.configs()`.
+
+- `space: SearchSpace` — the declarative config grid (below).
+- `objective: Objective` — the immutable keep-if-better decision (below).
+- `benchmark: str | Benchmark` — a registered benchmark **name** (loaded via
+  `langres.data`) or an already-built benchmark object (offline / test path).
+- `seed: int | None` — recorded on every run for provenance under
+  `seeds["optimize"]` (blocking is deterministic, so this only labels the run).
+- `store: str | Path | RunStore | None` — where to persist run records;
+  **`store=None` writes nothing.**
+- `dedup: bool = True` — skip a config whose `recipe_id` was already scored this
+  run (degenerate `all_pairs` repeats are collapsed first).
+- `split: str = "full"` — split label recorded on every run (M1 measures over the
+  whole loaded corpus).
+- `embedder: EmbeddingProvider | None` — optional pre-built embedder (a fake keeps
+  tests offline); production leaves it `None` to load the real SentenceTransformer.
+- `tracker: ExperimentTracker | None` — optional experiment tracker; defaults to a
+  no-op (the deferred Trackio/HF hook).
+
+### score_blocking (the one-config scorer)
+
+`score_blocking(config, benchmark, *, embedder=None, index=None) -> dict[str, float]`
+
+Blocking metrics for **one** config — builds the index + blocker the config
+describes, streams the full corpus to candidates, and evaluates blocking. This is
+the concrete scorer `optimize` wraps; call it directly to score a single config.
+`index=` reuses a prebuilt vector index instead of building one. Returns a plain
+metrics dict (all values `float`):
+
+| Key | Meaning |
+|---|---|
+| `candidate_recall` | Fraction of true match pairs the blocker surfaced (the recall signal the loop maximizes). |
+| `reduction_ratio` | Fraction of the `O(|A|·|B|)` (or `num_records`-choose-2) comparison space eliminated — the budget/cost axis. |
+| `candidate_precision` | Fraction of surfaced candidates that are true matches. |
+| `total_candidates` | Count of candidate pairs emitted (as a float). |
+
+For a two-source (linkage) corpus the candidates are filtered to cross-source
+pairs and `reduction_ratio` uses `|A|·|B|`; otherwise it uses `num_records`.
+
+### SearchSpace (`langres.core.autoresearch.search_space`)
+
+A frozen, declarative Cartesian grid of blocker configs. Each field is a
+non-empty tuple of candidate values for one axis (an empty axis raises).
+
+- `blocker: tuple[str, ...] = ("vector",)` — `"vector"` and/or `"all_pairs"`
+  (the vector axes below are ignored by `"all_pairs"`).
+- `embedding_model: tuple[str, ...] = ("all-MiniLM-L6-v2",)`
+- `metric: tuple[str, ...] = ("cosine",)` — FAISS metric `"L2"` / `"cosine"`.
+- `text_field: tuple[str, ...] = ("name",)` — record attribute holding the
+  blocking text (dataset-specific; override to your schema's field).
+- `k_neighbors: tuple[int, ...] = (5, 10, 20)`
+
+`configs() -> Iterator[dict[str, Any]]` yields the Cartesian product as config
+dicts (keys `blocker`, `embedding_model`, `metric`, `text_field`, `k_neighbors`).
+**Ordering contract (the loop relies on it):** `k_neighbors` is the **innermost**
+varying axis, so consecutive configs hold `(blocker, embedding_model, metric,
+text_field)` fixed while `k` sweeps its full range — letting `optimize` build one
+index per group and reuse it across every `k`. `len(space)` is the product of the
+axis sizes.
+
+### Objective (`langres.core.autoresearch.objective`)
+
+The immutable keep-if-better scorer, metric-source-agnostic (it operates on a
+plain `Mapping[str, float]` and never computes a metric itself). It bundles one or
+more `Goal`s (optimization targets) with zero or more `Constraint`s (feasibility
+gates). Prefer the three ergonomic constructors:
+
+- `Objective.maximize(metric, *, subject_to=())` — one maximize goal.
+- `Objective.minimize(metric, *, subject_to=())` — one minimize goal (e.g.
+  `log_loss`, cost).
+- `Objective.pareto(goals, *, subject_to=())` — a multi-objective Pareto front,
+  `goals` = `(metric, direction)` pairs; **never scalarized**.
+
+`subject_to` is an iterable of `(metric, op, threshold)` triples with `op` in
+`>= <= > <`; a missing metric raises (it never defaults to `0.0`).
+
+**`is_better(candidate, incumbent) -> bool`** — the loop's decision, in order:
+(1) **feasibility first** — an infeasible candidate is never better; a feasible
+candidate beats a `None` or infeasible incumbent; (2) **Pareto improvement** —
+with both feasible, the candidate wins iff it *dominates* the incumbent (`>=` on
+every goal, `>` on at least one; for a single goal, a strict scalar improvement).
+A tie or an incomparable trade-off keeps the incumbent, so the decision is
+deterministic and monotone.
+
+### LoopResult / Trial (`langres.core.autoresearch.loop`)
+
+`run_loop` (the driver `optimize` calls) returns a frozen `LoopResult`:
+
+- `best_config: dict[str, Any] | None` — the winning config, or `None` if no
+  config was ever accepted (empty input, or every trial infeasible/failed).
+- `best_metrics: dict[str, float] | None` — the winning config's metrics (or `None`).
+- `trials: tuple[Trial, ...]` — every trial in evaluation order (accepted,
+  rejected, and failed), for reconstructing why the incumbent won.
+
+Each `Trial` is frozen: `config` (the scored dict), `metrics` (`dict | None` —
+`None` if the scorer raised), `accepted` (whether it displaced the incumbent),
+`recipe_id` (the content-addressed dedup key), `attempt_id` (the run record PK),
+and `status` (`"completed"` or `"failed"` — one bad config is logged and skipped,
+never aborting the sweep).
+
+### Persistence — local JSONL only, today
+
+Every trial (including over-budget rejects and scorer failures) is appended to the
+`store` path's `RunStore` JSONL (the `core.runs` spine, §2). `store=None` writes
+nothing; read a trail back with `RunStore(path).read()` (each `RunRecord`'s
+`metrics["accepted"]` is `1.0`/`0.0`, so the incumbent timeline is reconstructable
+from the store alone). This is **local-only for now**: a durable off-laptop
+dashboard (Trackio + Hugging Face + models-on-Hub) is deferred behind the optional
+`tracker=` hook (a no-op by default), as are an Optuna/LLAMBO proposer and the
+matching vertical (`log_loss` / AUC-PR steering) + fine-tuning. See
+[EXPERIMENTS.md](EXPERIMENTS.md#self-tuning-the-autoresearch-loop-langresoptimize)
+for the worked amazon_google proof and `examples/research/blocking_recall_autoresearch.py`.


### PR DESCRIPTION
Docs-only PR documenting the newly-shipped **autoresearch loop** (`langres.optimize`) so users can discover and use it. Part of **epic #145, M1**; folds into integration PR #160 (base: `feat/autoresearch`).

## What changed (docs only — no `src/` edits)

- **`docs/EXPERIMENTS.md`** — new "Self-tuning: the autoresearch loop (`langres.optimize`)" section: what the loop is (`propose → run → evaluate → keep-if-better` on a loss-like objective, **not** a saturated F1), a runnable `optimize(...)` snippet, how to build a `SearchSpace` and an `Objective` (both the `maximize`-subject-to-constraint **and** the `pareto` forms), where results are stored, a pointer to the example, and the measured amazon_google climbing-recall proof. Example added to "See also".
- **`docs/TECHNICAL_OVERVIEW.md`** — new §10 API contract: `optimize` / `score_blocking` signatures, `SearchSpace` (fields + `configs()` ordering contract), `Objective` (+ `maximize`/`minimize`/`pareto` constructors, `is_better` semantics), `LoopResult`/`Trial` shape, and the `score_blocking` metrics dict (`candidate_recall`, `reduction_ratio`, `candidate_precision`, `total_candidates`). Plus a one-line cross-reference from the §5 `BlockerOptimizer` section.
- **`CHANGELOG.md`** — `[Unreleased]` entry: `langres.optimize` + `score_blocking` (autoresearch loop over blocking) + `Objective` + `SearchSpace` + the `log_loss` metric; noted import-light.
- **`README.md`** — one row in the "What's real today vs. roadmap" table.
- **`docs/ROADMAP.md`** — a note under §6 that autoresearch M1 (the loop, proven on blocking recall) landed, with the deferred pieces.
- **`CLAUDE.md`** — `core/autoresearch/` and `optimize.py` added to the Project Structure module map.

## Honesty caveats kept explicit
- **Storage is local-only today** — every trial (incl. rejects + failures) is appended to a local `RunStore` JSONL at `store=`; `store=None` writes nothing; read back with `RunStore(path).read()`.
- **Deferred, not implied as existing:** the durable off-laptop **Trackio + Hugging Face** dashboard + models-on-Hub (an optional `tracker=` hook is wired but no-op by default); an Optuna/LLAMBO proposer swap; and the **matching vertical** (`log_loss` / AUC-PR steering) + small-LM fine-tuning. **M1 proves the loop on the blocking vertical only.**

## Verification
- Signatures/behavior verified against source (`optimize.py`, `core/autoresearch/{objective,search_space,loop,factory}.py`, `core/runs.py`, `core/metrics.py:log_loss`) and the example.
- `uv run ruff check .` + `uv run ruff format --check .` clean; only the 6 docs files changed, no `src/`.
- `uv run --group docs mkdocs build --strict` passes (validates links/anchors).

## Summary by Sourcery

Document the new autoresearch self-tuning loop (`langres.optimize`) and its blocking-focused API so users can discover, understand, and use it.

Documentation:
- Add conceptual and API documentation for the self-tuning autoresearch loop (`langres.optimize`), including `score_blocking`, `SearchSpace`, `Objective`, `LoopResult`, and persistence semantics in TECHNICAL_OVERVIEW.md.
- Describe practical usage of the autoresearch loop with runnable examples, storage behavior, and an amazon_google blocking recall@budget case study in EXPERIMENTS.md.
- Note the shipped state and future roadmap of autoresearch M1 (blocking vertical only, local JSONL persistence) in ROADMAP.md and the README feature table.
- Record the autoresearch loop, related APIs, and the `log_loss` metric in the Unreleased section of the changelog.
- Update the internal project structure guide to include the autoresearch engine module and optimize facade paths.