### PR TITLE
feat(data): mining substrate — miners + colval serializer + readiness section

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -53,6 +53,11 @@ flywheel harvest → closed-loop flywheel → person:
   slice, serve the weightless `model_ref` in-process, and evaluate held-out F1,
   reporting the honest cost in GPU-seconds. A REAL (small) fine-tune, slow on
   CPU/MPS; needs the `[finetune,semantic,llm]` extras (see its docstring).
+- **`quickstart_mining.py`** — the data-prep substrate that *feeds* training:
+  mine AnyMatch hard positives, balance negatives 2:1, attribute-augment, and
+  confident-learning denoise a labeled pair set, then print a
+  `MiningReadinessSection`. Offline and $0; uses the `[trained]` extra (sklearn)
+  for the out-of-fold RandomForest behind the featurizing miners.
 
 ## Example Data
 

--- a/examples/quickstart_mining.py
+++ b/examples/quickstart_mining.py
@@ -1,0 +1,129 @@
+"""Quickstart: mine a training-ready pair set from labeled candidates -- for free.
+
+Before you fine-tune or fit a matcher, the *labeled pairs* need preparation: the
+classes are usually lopsided (many more non-matches than matches), some positives
+are boundary-hard, and a few labels are simply wrong. This example runs the
+:mod:`langres.data.mining` substrate over a tiny in-file company dataset and then
+summarises the result with a :class:`MiningReadinessSection`.
+
+The miners work on the pair currency ``(ERCandidate, is_match)``. The two
+*featurizing* miners (hard-positive mining, denoise) need a ``comparison`` vector
+on each candidate, so we attach one with a single ``StringComparator`` pass -- the
+same thing ``Resolver.candidates(records)`` does inside a pipeline.
+
+Fully offline: no API key, no network, no LLM. It does use scikit-learn (the
+``[trained]`` extra) for the out-of-fold RandomForest behind hard-positive mining
+and denoising.
+
+Run it:
+    uv run python examples/quickstart_mining.py
+"""
+
+from langres.core.comparator import StringComparator
+from langres.core.models import CompanySchema, ERCandidate
+from langres.data import (
+    augment_by_attribute,
+    denoise_pairs,
+    mine_misclassified_pairs,
+    sample_negative_pairs,
+)
+from langres.data.data_profile import profile_mining_readiness
+
+# A tiny labeled dataset: matching companies share their strings; non-matches do
+# not. One positive (id "hardL") is deliberately hard -- a true match whose
+# strings look nothing alike. One label is deliberately WRONG (id "noisyL") -- a
+# non-match mislabeled as a match -- for the denoiser to catch.
+comparator = StringComparator.from_schema(CompanySchema)
+
+
+def candidate(left: CompanySchema, right: CompanySchema) -> ERCandidate[CompanySchema]:
+    """Block-then-compare: attach a comparison vector (one Comparator pass)."""
+    pair = ERCandidate(left=left, right=right, blocker_name="quickstart")
+    return pair.model_copy(update={"comparison": comparator.compare(left, right)})
+
+
+def company(id: str, name: str, address: str) -> CompanySchema:
+    return CompanySchema(id=id, name=name, address=address)
+
+
+labeled: list[tuple[ERCandidate[CompanySchema], bool]] = []
+
+# 15 easy positives.
+for i in range(15):
+    labeled.append(
+        (
+            candidate(
+                company(f"m{i}L", f"Acme Corporation {i}", f"{i} Main Street"),
+                company(f"m{i}R", f"Acme Corporation {i}", f"{i} Main Street"),
+            ),
+            True,
+        )
+    )
+# 15 easy negatives.
+for i in range(15):
+    labeled.append(
+        (
+            candidate(
+                company(f"n{i}L", f"Zephyr Holdings {i}", f"{i} Ocean Avenue"),
+                company(f"n{i}R", f"Quasar Industries {i}", f"{i} Mountain Road"),
+            ),
+            False,
+        )
+    )
+# 1 hard positive: a true match whose strings look like a non-match.
+labeled.append(
+    (
+        candidate(
+            company("hardL", "Aardvark Systems", "1 Alpha Way"),
+            company("hardR", "Zenith Partners", "9 Omega Blvd"),
+        ),
+        True,
+    )
+)
+# 1 label error: a genuine non-match mislabeled as a match.
+labeled.append(
+    (
+        candidate(
+            company("noisyL", "Willow Foods", "3 Cedar Lane"),
+            company("noisyR", "Ironclad Metals", "7 Steel Court"),
+        ),
+        True,
+    )
+)
+
+print(
+    f"Input: {len(labeled)} labeled pairs "
+    f"({sum(1 for _, m in labeled if m)} positive, "
+    f"{sum(1 for _, m in labeled if not m)} negative)\n"
+)
+
+# 1) Mine AnyMatch-style hard positives (out-of-fold misclassified positives).
+hard_positives = mine_misclassified_pairs(labeled, cap=5)
+print(
+    f"Hard positives mined: {len(hard_positives)} (ids: {[c.left.id for c, _ in hard_positives]})"
+)
+
+# 2) Balance the negatives to 2:1 (the AnyMatch lever).
+negatives = sample_negative_pairs(labeled, ratio=2.0)
+print(f"Negatives sampled at 2:1: {len(negatives)}")
+
+# 3) Attribute augmentation (blank one field at a time; comparison reset to None,
+#    so a real training run re-compares the augmented set in one pass).
+augmented = augment_by_attribute(labeled, cap=10)
+print(f"Attribute-augmented positives: {len(augmented)} (comparison=None -> re-compare before use)")
+
+# 4) Confident-learning denoise: split the set into clean vs likely-mislabeled.
+clean, flagged = denoise_pairs(labeled)
+print(
+    f"Denoise: {len(clean)} clean, {len(flagged)} flagged "
+    f"(ids: {[c.left.id for c, _ in flagged]})\n"
+)
+
+# Summarise the readiness of the labeled set (a pure consumer of the counts above).
+section = profile_mining_readiness(
+    n_positive=sum(1 for _, m in labeled if m),
+    n_negative=sum(1 for _, m in labeled if not m),
+    n_hard_positive=len(hard_positives),
+    n_flagged_noise=len(flagged),
+)
+print(section.to_markdown())

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -153,6 +153,7 @@ exclude = [
 
 [dependency-groups]
 dev = [
+    "cleanlab>=2.9.0",
     # Experimentation/eval tooling (hyperparameter tuning via optuna) plus
     # experiment-tracking integrations (wandb, langfuse) -- not needed by the
     # production link()/dedupe() path, so they live in the dev group (not a

--- a/src/langres/core/matchers/llm_judge.py
+++ b/src/langres/core/matchers/llm_judge.py
@@ -192,6 +192,25 @@ def default_record_serializer(entity: Any) -> str:
     return str(entity.model_dump_json(indent=2))
 
 
+def colval_serializer(entity: Any) -> str:
+    """COL/VAL ``record_serializer`` (the AnyMatch / Ditto flat serialization).
+
+    Renders each ``model_dump()`` field as ``COL <field> VAL <value>``, space
+    joined -- e.g. ``COL name VAL Acme Corp COL city VAL Berlin``. A ``None``
+    value renders as an empty ``VAL`` (the field is present but blank), so a
+    record with a missing attribute is distinguishable from one where the field
+    was never declared. A serialization *strategy* (a sibling of ``json``), not a
+    miner: it is the flat text small-LM matchers/finetunes are trained on, so it
+    lives beside :func:`default_record_serializer` and is name-selectable via
+    :data:`RECORD_SERIALIZERS` (``record_serializer="colval"``).
+    """
+    parts = [
+        f"COL {field} VAL {'' if value is None else value}"
+        for field, value in entity.model_dump().items()
+    ]
+    return " ".join(parts)
+
+
 #: Named ``response_parser`` registry: these names are accepted anywhere a
 #: parser is (``LLMMatcher(response_parser=...)``, the verbs' / ``from_schema``'s
 #: ``matcher="prompt_llm"`` seam) and -- unlike a bare callable -- **serialize**
@@ -208,6 +227,7 @@ RESPONSE_PARSERS: dict[str, Callable[[str], ParsedVerdict]] = {
 #: custom callables do not).
 RECORD_SERIALIZERS: dict[str, Callable[[Any], str]] = {
     "json": default_record_serializer,
+    "colval": colval_serializer,
 }
 
 

--- a/src/langres/data/__init__.py
+++ b/src/langres/data/__init__.py
@@ -4,8 +4,16 @@ This module provides utilities for loading, splitting, and managing
 entity resolution datasets.
 """
 
+from langres.core.finetune import LabeledCandidate
 from langres.data._benchmark_utils import BenchmarkDataNotFoundError
 from langres.data.loaders import load_labeled_dedup_data
+from langres.data.mining import (
+    augment_by_attribute,
+    denoise_pairs,
+    flip_pairs,
+    mine_misclassified_pairs,
+    sample_negative_pairs,
+)
 from langres.data.registry import (
     BenchmarkEntry,
     get_benchmark,
@@ -23,6 +31,13 @@ __all__ = [
     "load_labeled_dedup_data",
     # Splitting
     "stratified_dedup_split",
+    # Training-pair mining (sklearn stays lazy inside the featurizing miners)
+    "LabeledCandidate",
+    "mine_misclassified_pairs",
+    "sample_negative_pairs",
+    "augment_by_attribute",
+    "flip_pairs",
+    "denoise_pairs",
     # Benchmark data availability (corpora are git-checkout-only, not in the wheel)
     "BenchmarkDataNotFoundError",
     # Benchmark registry (import-light manifest)

--- a/src/langres/data/data_profile/__init__.py
+++ b/src/langres/data/data_profile/__init__.py
@@ -2,7 +2,8 @@
 
 The public surface of the data-layer profiler (plan §2). The report is a *bag of
 sections* -- one self-contained :class:`ProfileSection` per metric family (label
-structure, corpus fields, separability, embeddings, the KPI hero), composed into a
+structure, mining readiness, corpus fields, separability, embeddings, the KPI
+hero), composed into a
 :class:`DataProfileReport` that renders exactly the sections it is given. Build one
 explicitly from the profiler functions, or via the convenience constructors
 :func:`from_benchmark` / :func:`from_records` (and the ``[semantic]``-gated
@@ -45,6 +46,10 @@ from langres.data.data_profile.label_structure import (
     LabelStructureSection,
     profile_label_structure,
 )
+from langres.data.data_profile.mining_readiness import (
+    MiningReadinessSection,
+    profile_mining_readiness,
+)
 from langres.data.data_profile.separability import (
     SeparabilitySection,
     SimilaritySignal,
@@ -59,6 +64,7 @@ __all__ = [
     # Sections
     "HeroSection",
     "LabelStructureSection",
+    "MiningReadinessSection",
     "CorpusFieldSection",
     "FieldStat",
     "SeparabilitySection",
@@ -67,6 +73,7 @@ __all__ = [
     # Profiler functions
     "build_hero",
     "profile_label_structure",
+    "profile_mining_readiness",
     "profile_corpus_fields",
     "profile_separability",
     "profile_embedding",

--- a/src/langres/data/data_profile/builders.py
+++ b/src/langres/data/data_profile/builders.py
@@ -7,11 +7,15 @@ composition over the Wave-1 profiler functions -- it computes nothing new. Both
 entry points converge on one internal assembler (:func:`_assemble`) so the two
 paths return the *same* pinned section layout:
 
-    hero -> label-structure -> separability -> corpus-fields -> embeddings ->
-    embedding-comparison
+    hero -> label-structure -> separability -> [mining-readiness] ->
+    corpus-fields -> embeddings -> embedding-comparison
 
 Each section is included only when its input is present; omitting an input drops
-that section silently (never a raise). ``include=`` narrows the set further -- it
+that section silently (never a raise). Mining readiness is the one section this
+package does not *compute* -- it is a precomputed
+:class:`~langres.data.data_profile.mining_readiness.MiningReadinessSection` the
+caller assembles from the miners (which need scikit-learn) and passes in, keeping
+this package import-light. ``include=`` narrows the set further -- it
 is a **selector of section kinds** (it validates its keys and raises on an unknown
 one, because a typo there means "select nothing you meant to"), never a data
 input.

--- a/src/langres/data/data_profile/builders.py
+++ b/src/langres/data/data_profile/builders.py
@@ -46,6 +46,7 @@ from langres.data.data_profile.embedding_source import (
 )
 from langres.data.data_profile.hero import build_hero
 from langres.data.data_profile.label_structure import profile_label_structure
+from langres.data.data_profile.mining_readiness import MiningReadinessSection
 from langres.data.data_profile.separability import (
     SeparabilitySection,
     profile_separability,
@@ -66,6 +67,7 @@ _KNOWN_KINDS: frozenset[str] = frozenset(
     {
         "hero",
         "label_structure",
+        "mining_readiness",
         "separability",
         "corpus_field",
         "embedding",
@@ -92,6 +94,7 @@ def from_benchmark(
     *,
     include: Collection[str] | None = None,
     embeddings: Sequence[EmbeddingSource] | None = None,
+    mining_readiness: MiningReadinessSection | None = None,
     negatives_cap: int = _DEFAULT_NEGATIVES_CAP,
     top_n_fields: int = 50,
     seed: int = _NEGATIVES_SEED,
@@ -116,6 +119,10 @@ def from_benchmark(
             :class:`~langres.data.data_profile.embedding_source.EmbeddingSource` s
             (aligned to the corpus ids). Omitting them drops the embedding sections
             -- never a raise.
+        mining_readiness: Optional precomputed
+            :class:`~langres.data.data_profile.mining_readiness.MiningReadinessSection`
+            (built by the caller from the miners -- this package runs no matcher).
+            Omitting it drops the mining-readiness section.
         negatives_cap: Cap on sampled non-matching pairs for the separability
             chart (logged when it truncates).
         top_n_fields: Row cap for the corpus-field table.
@@ -150,6 +157,7 @@ def from_benchmark(
         top_n_fields=top_n_fields,
         seed=seed,
         id_key="id",
+        mining_readiness=mining_readiness,
     )
 
 
@@ -159,6 +167,7 @@ def from_records(
     gold: Sequence[Collection[Hashable]] | None = None,
     schema: "type[BaseModel] | None" = None,
     embeddings: Sequence[EmbeddingSource] | None = None,
+    mining_readiness: MiningReadinessSection | None = None,
     include: Collection[str] | None = None,
     id_key: str = "id",
     negatives_cap: int = _DEFAULT_NEGATIVES_CAP,
@@ -182,6 +191,9 @@ def from_records(
             ``string_signal`` separability.
         embeddings: Optional precomputed
             :class:`~langres.data.data_profile.embedding_source.EmbeddingSource` s.
+        mining_readiness: Optional precomputed
+            :class:`~langres.data.data_profile.mining_readiness.MiningReadinessSection`
+            (see :func:`from_benchmark`).
         include: Optional selector of section *kinds* (see :func:`from_benchmark`).
         id_key: The record field holding the id used for pairs / embedding
             alignment (default ``"id"``).
@@ -205,6 +217,7 @@ def from_records(
         top_n_fields=top_n_fields,
         seed=seed,
         id_key=id_key,
+        mining_readiness=mining_readiness,
     )
 
 
@@ -314,11 +327,15 @@ def _assemble(
     top_n_fields: int,
     seed: int,
     id_key: str,
+    mining_readiness: MiningReadinessSection | None = None,
 ) -> DataProfileReport:
     """Compose the pinned default section set; ``include=`` narrows it.
 
     Builds each section only when its input is present, in the pinned order, then
-    prepends the derived hero and applies the ``include=`` kind filter.
+    prepends the derived hero and applies the ``include=`` kind filter. A
+    ``mining_readiness`` section, when supplied, is a **precomputed** input the
+    caller assembled from the miners (this package never runs a matcher), inserted
+    after the label-structure / separability blocks.
     """
     sources = list(embeddings or [])
     id_map = _index_by_id(records, id_key)
@@ -340,6 +357,9 @@ def _assemble(
             seed=seed,
         )
     )
+
+    if mining_readiness is not None:
+        body.append(mining_readiness)
 
     fields = profile_corpus_fields(records, top_n=top_n_fields)
     if fields is not None:

--- a/src/langres/data/data_profile/mining_readiness.py
+++ b/src/langres/data/data_profile/mining_readiness.py
@@ -1,0 +1,252 @@
+"""Mining-readiness profile section: is this labeled set ready to train on?
+
+The training-preparation companion to the label-structure block. Where label
+structure profiles the *gold clustering*, this section profiles a *labeled pair
+set* the way the training wave will consume it: how balanced the classes are
+(the AnyMatch 2:1 lever), how many **hard positives** a miner surfaced, how many
+pairs a denoiser flagged as likely mislabeled, and -- when per-pair margins /
+``|1 − p|`` scores are supplied -- how confident a model is across the set.
+
+It is a **pure consumer of precomputed stats**: it never runs a matcher or
+featurizes anything (that would drag scikit-learn into the import-light
+``data_profile`` package). The caller runs the miners
+(:mod:`langres.data.mining`) and hands the resulting counts (and optional
+margins) to :func:`profile_mining_readiness`. Every input beyond the two class
+counts is optional and degrades to an honest ``"n/a"`` card when absent -- the
+same graceful-degradation contract the rest of the report keeps.
+"""
+
+from __future__ import annotations
+
+import html
+import math
+from collections.abc import Sequence
+from typing import Any, Literal
+
+from langres.core import _report_html, _svg
+from langres.data.data_profile.base import ProfileSection
+
+#: Single-series bar color for the margin histogram (explicit, not
+#: ``currentColor``, so it reads in light and dark themes -- matches the
+#: label-structure / eval_report palette).
+_COLOR_MARGIN = "#8338ec"
+
+#: Default number of bins for the margin / ``|1 − p|`` histogram.
+_DEFAULT_MARGIN_BINS = 20
+
+
+class MiningReadinessSection(ProfileSection):
+    """Class balance + hard-positive / label-noise yields of a labeled pair set.
+
+    A frozen :class:`ProfileSection` holding the headline mining-readiness counts
+    and (optionally) a precomputed per-pair margin histogram. Build it with
+    :func:`profile_mining_readiness`; it computes nothing that needs a model.
+
+    Attributes:
+        n_positive: Positive (match) labeled pairs.
+        n_negative: Negative (non-match) labeled pairs.
+        n_hard_positive: Hard positives a miner surfaced (e.g.
+            :func:`~langres.data.mining.mine_misclassified_pairs`); ``None`` when
+            not measured.
+        n_flagged_noise: Pairs a denoiser flagged as likely mislabeled (e.g.
+            :func:`~langres.data.mining.denoise_pairs`); ``None`` when not measured.
+        margin_label: Human label of the per-pair margin scores (e.g.
+            ``"|1 − p|"``); shown on the histogram x-axis.
+        margin_edges: Bin edges (``B + 1`` values) of the margin histogram; empty
+            when no margins were supplied.
+        margin_counts: Per-bin counts (``B`` values); empty when no margins.
+    """
+
+    kind: Literal["mining_readiness"] = "mining_readiness"
+
+    n_positive: int
+    n_negative: int
+    n_hard_positive: int | None
+    n_flagged_noise: int | None
+    margin_label: str
+    margin_edges: list[float]
+    margin_counts: list[float]
+
+    # ------------------------------------------------------------- derived stats
+    @property
+    def total(self) -> int:
+        """Total labeled pairs (positives + negatives)."""
+        return self.n_positive + self.n_negative
+
+    @property
+    def positive_share(self) -> float | None:
+        """Fraction of pairs that are positive; ``None`` for an empty set."""
+        return self.n_positive / self.total if self.total else None
+
+    @property
+    def imbalance_ratio(self) -> float | None:
+        """Negatives per positive (the ``N`` in ``1:N``); ``None`` with no positives."""
+        return self.n_negative / self.n_positive if self.n_positive else None
+
+    @property
+    def hard_positive_share(self) -> float | None:
+        """Hard positives as a fraction of positives; ``None`` when unmeasured/empty."""
+        if self.n_hard_positive is None or self.n_positive == 0:
+            return None
+        return self.n_hard_positive / self.n_positive
+
+    @property
+    def flagged_noise_share(self) -> float | None:
+        """Flagged pairs as a fraction of all pairs; ``None`` when unmeasured/empty."""
+        if self.n_flagged_noise is None or self.total == 0:
+            return None
+        return self.n_flagged_noise / self.total
+
+    # ------------------------------------------------------------- shared render
+    def _metrics_kv(self) -> list[tuple[str, str]]:
+        """The headline metrics as ``(label, display)`` pairs (markdown + HTML share this)."""
+        imbalance = f"1:{self.imbalance_ratio:,.1f}" if self.imbalance_ratio is not None else "n/a"
+        return [
+            ("positive pairs", f"{self.n_positive:,}"),
+            ("negative pairs", f"{self.n_negative:,}"),
+            ("total pairs", f"{self.total:,}"),
+            ("positive share", _fmt_pct(self.positive_share)),
+            ("class imbalance (pos:neg)", imbalance),
+            ("hard positives", _fmt_count_share(self.n_hard_positive, self.hard_positive_share)),
+            (
+                "flagged label noise",
+                _fmt_count_share(self.n_flagged_noise, self.flagged_noise_share),
+            ),
+        ]
+
+    # ------------------------------------------------------------ text surfaces
+    def to_markdown(self) -> str:
+        """Markdown: a metrics table (and a note when the set is empty)."""
+        lines = [f"## {self.title}", "", "| metric | value |", "|---|---|"]
+        lines += [
+            f"| {_report_html._md_cell(k)} | {_report_html._md_cell(v)} |"
+            for k, v in self._metrics_kv()
+        ]
+        if self.total == 0:
+            lines += ["", "_No labeled pairs: nothing to train on yet._"]
+        return "\n".join(lines)
+
+    @property
+    def summary(self) -> dict[str, Any]:
+        """Headline numbers as a flat, title-namespaced dict (collision-free per report)."""
+        return {
+            f"{self.title}.n_positive": self.n_positive,
+            f"{self.title}.n_negative": self.n_negative,
+            f"{self.title}.imbalance_ratio": self.imbalance_ratio,
+            f"{self.title}.n_hard_positive": self.n_hard_positive,
+            f"{self.title}.n_flagged_noise": self.n_flagged_noise,
+        }
+
+    def rows(self) -> list[dict[str, Any]]:
+        """A single row of the raw readiness counts -- ``pd.DataFrame(section.rows())``-ready."""
+        return [
+            {
+                "n_positive": self.n_positive,
+                "n_negative": self.n_negative,
+                "imbalance_ratio": self.imbalance_ratio,
+                "n_hard_positive": self.n_hard_positive,
+                "n_flagged_noise": self.n_flagged_noise,
+            }
+        ]
+
+    # -------------------------------------------------------------- html panel
+    def panels(self) -> list[str]:
+        """A single ``<section>``: the metrics KV table, plus the margin histogram when present."""
+        kv = "".join(
+            f"<tr><th>{html.escape(k)}</th><td>{html.escape(v)}</td></tr>"
+            for k, v in self._metrics_kv()
+        )
+        body = f'<table class="kv">{kv}</table>'
+        if self.margin_counts:
+            body += _svg.bar_chart(
+                self.margin_edges,
+                [(self.margin_label, _COLOR_MARGIN, self.margin_counts)],
+                x_label=self.margin_label,
+                y_label="count",
+            )
+        return [_report_html.section(self.title, body)]
+
+
+def profile_mining_readiness(
+    *,
+    n_positive: int,
+    n_negative: int,
+    n_hard_positive: int | None = None,
+    n_flagged_noise: int | None = None,
+    margins: Sequence[float] | None = None,
+    n_bins: int = _DEFAULT_MARGIN_BINS,
+    margin_label: str = "|1 − p|",
+    title: str = "Mining readiness",
+) -> MiningReadinessSection:
+    """Build a :class:`MiningReadinessSection` from precomputed mining stats.
+
+    Pure assembly over counts the caller already computed -- it runs no matcher and
+    featurizes nothing (keeping ``data_profile`` import-light). When ``margins`` is
+    supplied, it is binned into a histogram here (a stat computation, not a model
+    call); otherwise the histogram is omitted and the section still renders.
+
+    Args:
+        n_positive: Positive (match) labeled pairs.
+        n_negative: Negative (non-match) labeled pairs.
+        n_hard_positive: Optional count of hard positives a miner surfaced.
+        n_flagged_noise: Optional count of pairs a denoiser flagged.
+        margins: Optional per-pair confidence margins (e.g. ``|1 − p|`` or
+            ``|p − threshold|``); binned into the section's histogram. Non-finite
+            values are dropped.
+        n_bins: Number of histogram bins over the observed margin range.
+        margin_label: Human label of the margin scores (histogram x-axis).
+        title: Section heading; also the report lookup key and the namespace for
+            this section's :attr:`~MiningReadinessSection.summary` keys.
+
+    Returns:
+        A :class:`MiningReadinessSection` (always -- there is no ``None`` path; an
+        all-zero set renders honestly).
+    """
+    edges, counts = _margin_histogram(margins, n_bins)
+    return MiningReadinessSection(
+        title=title,
+        n_positive=n_positive,
+        n_negative=n_negative,
+        n_hard_positive=n_hard_positive,
+        n_flagged_noise=n_flagged_noise,
+        margin_label=margin_label,
+        margin_edges=edges,
+        margin_counts=counts,
+    )
+
+
+def _margin_histogram(
+    margins: Sequence[float] | None, n_bins: int
+) -> tuple[list[float], list[float]]:
+    """Bin finite ``margins`` into ``(edges, counts)``; ``([], [])`` when absent/empty.
+
+    A degenerate range (all margins equal) is widened to unit width so the bars
+    keep real pixel extent instead of collapsing onto one line.
+    """
+    if not margins:
+        return [], []
+    finite = [float(m) for m in margins if math.isfinite(m)]
+    if not finite:
+        return [], []
+    lo, hi = min(finite), max(finite)
+    if hi <= lo:
+        hi = lo + 1.0
+    edges = [lo + (hi - lo) * i / n_bins for i in range(n_bins + 1)]
+    counts = _report_html._histogram(finite, edges)
+    return edges, counts
+
+
+def _fmt_pct(value: float | None) -> str:
+    """A fraction as a scannable percentage (2 sig figs); ``None``/NaN/Inf -> ``"n/a"``."""
+    if value is None or not math.isfinite(value):
+        return "n/a"
+    return f"{value * 100:.2g}%"
+
+
+def _fmt_count_share(count: int | None, share: float | None) -> str:
+    """``"<count> (<pct>)"`` for a measured count, else ``"n/a"`` (never measured)."""
+    if count is None:
+        return "n/a"
+    if share is None:
+        return f"{count:,}"
+    return f"{count:,} ({_fmt_pct(share)})"

--- a/src/langres/data/mining.py
+++ b/src/langres/data/mining.py
@@ -1,0 +1,457 @@
+"""Training-pair miners: the data-preparation substrate for the training wave.
+
+A leaf module of small, composable functions over the pair currency
+:data:`~langres.core.finetune.LabeledCandidate` (``(ERCandidate, is_match)``) --
+the working shape both the ``fit`` surface and ``finetune`` consume. Each miner
+takes labeled candidates in and returns labeled candidates out, so they compose
+freely and a Wave-B harness can chain them (mine hard positives, balance the
+negatives, augment, denoise) before one comparator pass over the assembled set.
+
+Two miners are *featurizing* -- :func:`mine_misclassified_pairs` and
+:func:`denoise_pairs` train an out-of-fold RandomForest to find, respectively,
+the AnyMatch-style **hard positives** and the confident-learning **label noise**.
+They featurize each candidate with the *same* logic the served
+:class:`~langres.core.matchers.random_forest_judge.RandomForestMatcher` uses
+(a throwaway matcher is the single source of truth, so there is no drift), which
+means they require a ``comparison`` vector on every candidate and raise a clear
+:class:`ValueError` otherwise. The remaining three
+(:func:`sample_negative_pairs`, :func:`augment_by_attribute`, :func:`flip_pairs`)
+are pure record/label transforms and need no model.
+
+**Import-light by construction.** Module scope is numpy + stdlib + core data
+contracts only; scikit-learn (the ``[trained]`` extra) is imported **lazily
+inside** the two featurizing miners, never at module load -- so ``import
+langres`` / ``import langres.data`` stay sklearn-free (locked by
+``tests/test_import_budget.py`` and a guard in ``tests/data/test_mining.py``).
+"""
+
+from __future__ import annotations
+
+import logging
+from collections.abc import Sequence
+from typing import TYPE_CHECKING, Any
+
+import numpy as np
+
+from langres.core.feature import FeatureSpec
+from langres.core.finetune import LabeledCandidate
+
+if TYPE_CHECKING:
+    import numpy.typing as npt
+
+logger = logging.getLogger(__name__)
+
+#: The clear error every featurizing miner raises when a candidate carries no
+#: comparison vector -- mirrors ``RandomForestMatcher._feature_vector``'s
+#: behaviour, but names the mining-side fix (run a comparator pass first).
+_NO_COMPARISON_MSG = (
+    "mining requires candidates carrying a comparison vector, but a candidate "
+    "had comparison=None. Run a Comparator pass first (e.g. "
+    "Resolver.from_schema(Schema).candidates(records)) so every candidate "
+    "carries a ComparisonVector, then mine."
+)
+
+
+# ---------------------------------------------------------------------------
+# Shared helpers
+# ---------------------------------------------------------------------------
+
+
+def _class_counts(labeled: Sequence[LabeledCandidate]) -> tuple[int, int]:
+    """``(n_positive, n_negative)`` over the labels."""
+    n_positive = sum(1 for _, label in labeled if label)
+    return n_positive, len(labeled) - n_positive
+
+
+def _require_both_classes(labeled: Sequence[LabeledCandidate], *, fn: str) -> tuple[int, int]:
+    """Guard: a featurizing miner needs both a positive and a negative example.
+
+    A single-class (or empty) input cannot train a discriminative fold, so the
+    RandomForest would learn nothing -- fail loudly rather than return a
+    misleading empty/degenerate result.
+    """
+    n_positive, n_negative = _class_counts(labeled)
+    if n_positive == 0 or n_negative == 0:
+        raise ValueError(
+            f"{fn} needs both positive and negative labeled pairs to train an "
+            f"out-of-fold classifier; got {n_positive} positive and "
+            f"{n_negative} negative."
+        )
+    return n_positive, n_negative
+
+
+def _resolve_feature_specs(
+    labeled: Sequence[LabeledCandidate],
+    feature_specs: Sequence[FeatureSpec] | None,
+) -> list[FeatureSpec]:
+    """The feature set to featurize with: explicit, or derived from the comparisons.
+
+    When ``feature_specs`` is ``None``, derive one :class:`FeatureSpec` per
+    feature name in the union of every candidate's ``comparison.levels`` keys
+    (sorted for determinism) -- so featurization spans exactly the features the
+    comparator declared, mirroring what a served matcher fit on the same
+    candidates would see. Raises when a candidate carries no comparison.
+    """
+    if feature_specs is not None:
+        return list(feature_specs)
+    names: set[str] = set()
+    for candidate, _ in labeled:
+        if candidate.comparison is None:
+            raise ValueError(_NO_COMPARISON_MSG)
+        names.update(candidate.comparison.levels)
+    return [FeatureSpec(name=name) for name in sorted(names)]
+
+
+def _feature_matrix(
+    labeled: Sequence[LabeledCandidate],
+    feature_specs: Sequence[FeatureSpec],
+) -> list[list[float]]:
+    """Featurize candidates exactly as ``RandomForestMatcher`` serves them.
+
+    A throwaway ``RandomForestMatcher`` is the single source of truth for the
+    feature vector (mirrors ``finetune._render_conversation``'s throwaway
+    ``LLMMatcher``), so the mined-on features cannot drift from the served ones:
+    each row is ``[similarities.get(spec.name, -1.0) for spec in feature_specs]``
+    with the ``-1.0`` MISSING sentinel. Pre-checks for a missing comparison so
+    the error names the mining fix rather than the pipeline one.
+    """
+    for candidate, _ in labeled:
+        if candidate.comparison is None:
+            raise ValueError(_NO_COMPARISON_MSG)
+    # Lazy: importing random_forest_judge pulls scikit-learn ([trained]); keep it
+    # out of module load so ``import langres.data`` stays import-light.
+    from langres.core.matchers.random_forest_judge import RandomForestMatcher
+
+    featurizer: RandomForestMatcher[Any] = RandomForestMatcher(feature_specs=list(feature_specs))
+    return [featurizer._feature_vector(candidate) for candidate, _ in labeled]
+
+
+def _oof_predictions(
+    x: list[list[float]],
+    y: list[int],
+    *,
+    cv: int,
+    seed: int,
+    method: str,
+) -> npt.NDArray[Any] | None:
+    """Out-of-fold RandomForest predictions; ``None`` when a fold can't hold both classes.
+
+    A model fit to completion has ~zero *in-sample* error, so mining on in-sample
+    predictions finds nothing -- these MUST be out-of-fold. Uses stratified
+    ``cross_val_predict`` with ``n_splits = min(cv, n_positive, n_negative)`` so no
+    fold is single-class; when that floor drops below 2 (a minority class of one)
+    out-of-fold prediction is impossible, so we return ``None`` and let the caller
+    degrade gracefully. ``method`` is ``"predict"`` (0/1 labels) or
+    ``"predict_proba"`` (an ``(n, 2)`` probability matrix).
+    """
+    from sklearn.ensemble import RandomForestClassifier
+    from sklearn.model_selection import cross_val_predict
+
+    n_positive = sum(y)
+    n_negative = len(y) - n_positive
+    n_splits = min(cv, n_positive, n_negative)
+    if n_splits < 2:
+        return None
+    classifier = RandomForestClassifier(random_state=seed)
+    predictions = cross_val_predict(classifier, x, y, cv=n_splits, method=method)
+    return np.asarray(predictions)
+
+
+# ---------------------------------------------------------------------------
+# Featurizing miners (scikit-learn, lazy)
+# ---------------------------------------------------------------------------
+
+
+def mine_misclassified_pairs(
+    labeled: Sequence[LabeledCandidate],
+    *,
+    cap: int = 400,
+    feature_specs: Sequence[FeatureSpec] | None = None,
+    cv: int = 5,
+    seed: int = 0,
+) -> list[LabeledCandidate]:
+    """Mine AnyMatch-style **hard positives**: positives an RF gets wrong out-of-fold.
+
+    Trains a RandomForest and takes its *out-of-fold* predictions (a fit-to-
+    completion forest has ~0 in-sample error, so in-sample mining returns nothing).
+    Positives whose out-of-fold prediction is negative are the hard ones -- the
+    boundary examples worth over-weighting in a training set. They are returned
+    first (up to ``cap``); if there are fewer than ``cap`` hard positives, the set
+    is topped up with correctly-classified positives so the caller gets a stable
+    ``min(cap, n_positive)`` positives to train on.
+
+    Args:
+        labeled: Comparison-attached labeled candidates. Must contain both classes.
+        cap: Maximum positives to return.
+        feature_specs: Features to featurize with; when ``None``, derived from the
+            union of the candidates' comparison levels (see module docs).
+        cv: Requested number of out-of-fold folds (reduced automatically when a
+            class is too small to stratify; when the minority class has a single
+            member, out-of-fold prediction is skipped and the first ``cap``
+            positives are returned unranked, logged).
+        seed: RandomForest seed (deterministic folds/fit).
+
+    Returns:
+        Up to ``cap`` positive :data:`LabeledCandidate`\\ s, hard ones first.
+
+    Raises:
+        ValueError: If the input lacks either class, or a candidate has no
+            comparison vector.
+    """
+    materialized = list(labeled)
+    _require_both_classes(materialized, fn="mine_misclassified_pairs")
+    specs = _resolve_feature_specs(materialized, feature_specs)
+    x = _feature_matrix(materialized, specs)
+    y = [int(label) for _, label in materialized]
+
+    positives = [i for i, label in enumerate(y) if label == 1]
+    predictions = _oof_predictions(x, y, cv=cv, seed=seed, method="predict")
+    if predictions is None:
+        logger.warning(
+            "mine_misclassified_pairs: minority class too small for %d-fold "
+            "out-of-fold prediction; returning the first %d positives unranked "
+            "(cannot identify hard positives).",
+            cv,
+            min(cap, len(positives)),
+        )
+        return [materialized[i] for i in positives[:cap]]
+
+    hard = [i for i in positives if int(predictions[i]) == 0]
+    easy = [i for i in positives if int(predictions[i]) == 1]
+    selected = hard[:cap]
+    if len(selected) < cap:
+        selected = selected + easy[: cap - len(selected)]
+    logger.info(
+        "mine_misclassified_pairs: %d hard positive(s) of %d positives; returning %d (cap=%d).",
+        len(hard),
+        len(positives),
+        len(selected),
+        cap,
+    )
+    return [materialized[i] for i in selected]
+
+
+def denoise_pairs(
+    labeled: Sequence[LabeledCandidate],
+    *,
+    method: str = "confident_learning",
+    cv: int = 5,
+    seed: int = 0,
+) -> tuple[list[LabeledCandidate], list[LabeledCandidate]]:
+    """Flag likely-mislabeled pairs via confident learning; return ``(clean, flagged)``.
+
+    Trains an out-of-fold RandomForest for predicted class probabilities, then
+    applies the Northcutt et al. *confident learning* rule: for each class, the
+    self-confidence threshold is the mean predicted probability of that class over
+    the examples labeled with it; a pair is flagged when it is *confidently*
+    assigned (its probability clears the threshold) to a class different from its
+    given label. Robust to class imbalance because the threshold is per-class, not
+    a global 0.5.
+
+    Args:
+        labeled: Comparison-attached labeled candidates. Must contain both classes.
+        method: Denoise strategy; only ``"confident_learning"`` is supported.
+        cv: Requested out-of-fold folds (reduced when a class is small; when a
+            fold cannot hold both classes, nothing is flagged and the split is
+            ``(all, [])``, logged).
+        seed: RandomForest seed.
+
+    Returns:
+        ``(clean, flagged)`` -- the pairs kept as-is and the pairs whose label the
+        confident joint disputes, both preserving input order.
+
+    Raises:
+        ValueError: For an unknown ``method``, an input lacking either class, or a
+            candidate with no comparison vector.
+    """
+    if method != "confident_learning":
+        raise ValueError(
+            f"unknown denoise method {method!r}; only 'confident_learning' is supported."
+        )
+    materialized = list(labeled)
+    _require_both_classes(materialized, fn="denoise_pairs")
+    specs = _resolve_feature_specs(materialized, feature_specs=None)
+    x = _feature_matrix(materialized, specs)
+    y = [int(label) for _, label in materialized]
+
+    proba = _oof_predictions(x, y, cv=cv, seed=seed, method="predict_proba")
+    if proba is None:
+        logger.warning(
+            "denoise_pairs: minority class too small for %d-fold out-of-fold "
+            "probabilities; flagging nothing.",
+            cv,
+        )
+        return list(materialized), []
+
+    flagged = _confident_label_errors(np.asarray(proba, dtype=float), y)
+    clean = [materialized[i] for i in range(len(materialized)) if i not in flagged]
+    flagged_pairs = [materialized[i] for i in sorted(flagged)]
+    logger.info(
+        "denoise_pairs: flagged %d of %d pairs as likely mislabeled (confident learning).",
+        len(flagged),
+        len(materialized),
+    )
+    return clean, flagged_pairs
+
+
+def _confident_label_errors(proba: npt.NDArray[Any], y: list[int]) -> set[int]:
+    """Indices confidently assigned to a class other than their label (confident joint).
+
+    ``proba`` is the out-of-fold ``(n, 2)`` probability matrix; column ``j`` is the
+    model's probability of class ``j``. ``y`` is the given binary label per row.
+    Both classes are guaranteed present by the caller, so each per-class threshold
+    averages over a non-empty set (no divide-by-zero).
+    """
+    n = len(y)
+    thresholds = [float(np.mean([proba[i, j] for i in range(n) if y[i] == j])) for j in (0, 1)]
+    flagged: set[int] = set()
+    for i in range(n):
+        eligible = [j for j in (0, 1) if proba[i, j] >= thresholds[j]]
+        if not eligible:
+            continue  # unconfident about either class -> trust the given label
+        suggested = max(eligible, key=lambda j: proba[i, j])
+        if suggested != y[i]:
+            flagged.add(i)
+    return flagged
+
+
+# ---------------------------------------------------------------------------
+# Pure record/label transforms (no model)
+# ---------------------------------------------------------------------------
+
+
+def sample_negative_pairs(
+    labeled: Sequence[LabeledCandidate],
+    *,
+    ratio: float = 2.0,
+    seed: int = 0,
+) -> list[LabeledCandidate]:
+    """Seeded down-sample of negatives to ``ratio × (#positives)`` -- the AnyMatch balance lever.
+
+    Returns a reproducible random subset of the negative-labeled pairs sized to
+    ``round(ratio × n_positive)``. When fewer negatives exist than the target, all
+    of them are returned and the shortfall is logged (never silent). The sampled
+    subset keeps input order for determinism.
+
+    Args:
+        labeled: Labeled candidates (positives are counted; negatives are sampled).
+        ratio: Negatives-per-positive target (AnyMatch uses ``2.0``).
+        seed: Sampling seed.
+
+    Returns:
+        The sampled negative :data:`LabeledCandidate`\\ s.
+    """
+    materialized = list(labeled)
+    n_positive = sum(1 for _, label in materialized if label)
+    negatives = [pair for pair in materialized if not pair[1]]
+    target = int(round(ratio * n_positive))
+
+    if target >= len(negatives):
+        if target > len(negatives):
+            logger.info(
+                "sample_negative_pairs: only %d negative(s) available for a "
+                "%.2f×%d = %d target; returning all.",
+                len(negatives),
+                ratio,
+                n_positive,
+                target,
+            )
+        return list(negatives)
+
+    rng = np.random.default_rng(seed)
+    chosen = sorted(int(i) for i in rng.choice(len(negatives), size=target, replace=False))
+    return [negatives[i] for i in chosen]
+
+
+def augment_by_attribute(
+    labeled: Sequence[LabeledCandidate],
+    *,
+    cap: int = 800,
+    seed: int = 0,
+) -> list[LabeledCandidate]:
+    """AnyMatch attribute augmentation: for each positive, blank one attribute at a time.
+
+    For every positive pair, emit new positive :data:`LabeledCandidate`\\ s each
+    with a single string attribute blanked (set to ``""``) on **both** records --
+    teaching a matcher/finetune robustness to a missing field while the pair stays
+    a genuine positive (same real-world entity). One variant per (positive,
+    blankable field); the field set is the union of each side's non-empty string
+    fields (excluding ``id``). Capped, seeded when it bites.
+
+    Because the emitted candidates mutate the underlying **records**, their
+    ``comparison`` is set to ``None``: a featurizing consumer MUST re-run the
+    comparator over the augmented set before using it (the Wave-B harness does one
+    comparator pass over the whole assembled set).
+
+    Args:
+        labeled: Labeled candidates (only the positives are augmented).
+        cap: Maximum augmented pairs to return.
+        seed: Sampling seed for the cap.
+
+    Returns:
+        Up to ``cap`` augmented positive :data:`LabeledCandidate`\\ s, each with
+        ``comparison=None``.
+    """
+    positives = [candidate for candidate, label in labeled if label]
+    augmented: list[LabeledCandidate] = []
+    for candidate in positives:
+        fields = _nonempty_string_fields(candidate.left) | _nonempty_string_fields(candidate.right)
+        for field in sorted(fields):
+            blanked = candidate.model_copy(
+                update={
+                    "left": candidate.left.model_copy(update={field: ""}),
+                    "right": candidate.right.model_copy(update={field: ""}),
+                    "comparison": None,
+                }
+            )
+            augmented.append((blanked, True))
+
+    if len(augmented) > cap:
+        rng = np.random.default_rng(seed)
+        keep = sorted(int(i) for i in rng.choice(len(augmented), size=cap, replace=False))
+        logger.info(
+            "augment_by_attribute: generated %d augmentation(s), capped to %d.",
+            len(augmented),
+            cap,
+        )
+        augmented = [augmented[i] for i in keep]
+    return augmented
+
+
+def _nonempty_string_fields(record: Any) -> set[str]:
+    """Names of the record's non-empty string fields, excluding ``id``.
+
+    These are exactly the attributes a string comparator compares and a text
+    serializer renders, so blanking one is a meaningful "missing field" signal.
+    """
+    return {
+        field
+        for field, value in record.model_dump().items()
+        if field != "id" and isinstance(value, str) and value.strip()
+    }
+
+
+def flip_pairs(pairs: Sequence[LabeledCandidate]) -> list[LabeledCandidate]:
+    """Swap ``left`` <-> ``right`` on each candidate, keeping the label.
+
+    Order-invariance augmentation, primarily for the finetune/text path (which
+    renders ``left`` then ``right`` into the prompt): a matcher should judge a pair
+    the same regardless of which record comes first. The existing ``comparison`` is
+    **kept**: string comparison is symmetric and a ``ComparisonVector`` is keyed by
+    feature name (not by side), so a flip leaves the per-feature similarities
+    unchanged -- the flipped candidates stay featurizable without a re-compare.
+
+    Orientation is preserved because these tuples feed ``Matcher.fit`` directly and
+    never round-trip through ``align_pairs``' frozenset dedup (which would collapse
+    a pair and its flip).
+
+    Args:
+        pairs: The labeled candidates to flip.
+
+    Returns:
+        One flipped :data:`LabeledCandidate` per input, same labels.
+    """
+    return [
+        (candidate.model_copy(update={"left": candidate.right, "right": candidate.left}), label)
+        for candidate, label in pairs
+    ]

--- a/tests/core/modules/test_llm_judge_serialization.py
+++ b/tests/core/modules/test_llm_judge_serialization.py
@@ -354,3 +354,24 @@ def test_named_record_serializer_resolves_and_serializes() -> None:
     judge = LLMMatcher(client=object(), record_serializer="json")
     assert judge._serialize is default_record_serializer
     assert judge.config["record_serializer"] == "json"
+
+
+def test_colval_serializer_is_registered_and_round_trips() -> None:
+    """The AnyMatch/Ditto COL/VAL serializer is a name-selectable sibling of json."""
+    from langres.core.matchers.llm_judge import colval_serializer
+
+    judge = LLMMatcher(client=object(), record_serializer="colval")
+    assert judge._serialize is colval_serializer
+    assert judge.config["record_serializer"] == "colval"
+    assert LLMMatcher.from_config(judge.config)._serialize is colval_serializer
+
+
+def test_colval_serializer_renders_col_val_and_blanks_none() -> None:
+    """`COL <field> VAL <value>` over model_dump; a None field renders a blank VAL."""
+    from langres.core.matchers.llm_judge import colval_serializer
+    from langres.core.models import CompanySchema
+
+    text = colval_serializer(CompanySchema(id="1", name="Acme Corp", address=None))
+    assert text.startswith("COL id VAL 1 COL name VAL Acme Corp")
+    # A None attribute is present-but-blank, not omitted.
+    assert "COL address VAL " in text

--- a/tests/data/data_profile/test_mining_readiness.py
+++ b/tests/data/data_profile/test_mining_readiness.py
@@ -1,0 +1,199 @@
+"""Tests for the ``MiningReadinessSection`` + ``profile_mining_readiness``.
+
+Covers the render ladder (markdown / summary / rows / panels), the derived
+class-balance stats, the graceful-degrade path (unmeasured counts -> ``"n/a"``,
+absent margins -> no chart, empty set -> honest note, never a raise or literal
+NaN), the margin histogram, and the section's wiring into ``DataProfileReport``
+(``from_records(mining_readiness=...)`` + the ``include=`` kind filter).
+"""
+
+from __future__ import annotations
+
+from langres.data.data_profile import (
+    DataProfileReport,
+    MiningReadinessSection,
+    from_records,
+    profile_mining_readiness,
+)
+
+
+def _full_section() -> MiningReadinessSection:
+    return profile_mining_readiness(
+        n_positive=100,
+        n_negative=400,
+        n_hard_positive=25,
+        n_flagged_noise=10,
+        margins=[0.05, 0.1, 0.1, 0.9, 0.95, 0.5],
+    )
+
+
+class TestDerivedStats:
+    def test_class_balance_and_imbalance(self) -> None:
+        section = profile_mining_readiness(n_positive=100, n_negative=400)
+        assert section.total == 500
+        assert section.positive_share == 100 / 500
+        assert section.imbalance_ratio == 4.0
+
+    def test_hard_positive_and_noise_shares(self) -> None:
+        section = _full_section()
+        assert section.hard_positive_share == 25 / 100
+        assert section.flagged_noise_share == 10 / 500
+
+    def test_shares_are_none_when_unmeasured(self) -> None:
+        section = profile_mining_readiness(n_positive=10, n_negative=10)
+        assert section.hard_positive_share is None
+        assert section.flagged_noise_share is None
+
+    def test_empty_set_stats_are_none(self) -> None:
+        section = profile_mining_readiness(n_positive=0, n_negative=0)
+        assert section.total == 0
+        assert section.positive_share is None
+        assert section.imbalance_ratio is None
+
+
+class TestRenderLadder:
+    def test_markdown_has_all_metrics(self) -> None:
+        md = _full_section().to_markdown()
+        assert md.startswith("## Mining readiness")
+        assert "class imbalance (pos:neg)" in md
+        assert "1:4" in md
+        assert "hard positives" in md
+        assert "NaN" not in md
+
+    def test_summary_is_title_namespaced(self) -> None:
+        section = _full_section()
+        assert section.summary == {
+            "Mining readiness.n_positive": 100,
+            "Mining readiness.n_negative": 400,
+            "Mining readiness.imbalance_ratio": 4.0,
+            "Mining readiness.n_hard_positive": 25,
+            "Mining readiness.n_flagged_noise": 10,
+        }
+
+    def test_rows_single_raw_row(self) -> None:
+        rows = _full_section().rows()
+        assert rows == [
+            {
+                "n_positive": 100,
+                "n_negative": 400,
+                "imbalance_ratio": 4.0,
+                "n_hard_positive": 25,
+                "n_flagged_noise": 10,
+            }
+        ]
+
+    def test_panels_render_kv_table_and_margin_chart(self) -> None:
+        panels = _full_section().panels()
+        assert len(panels) == 1
+        panel = panels[0]
+        assert panel.startswith("<section><h2>Mining readiness</h2>")
+        assert 'table class="kv"' in panel
+        assert "<svg" in panel  # margins supplied -> histogram
+        assert "NaN" not in panel and "Infinity" not in panel
+
+    def test_panels_without_margins_have_no_chart(self) -> None:
+        section = profile_mining_readiness(n_positive=10, n_negative=10)
+        panel = section.panels()[0]
+        assert 'table class="kv"' in panel
+        assert "<svg" not in panel
+
+
+class TestGracefulDegradation:
+    def test_unmeasured_counts_render_na(self) -> None:
+        section = profile_mining_readiness(n_positive=10, n_negative=10)
+        kv = dict(section._metrics_kv())
+        assert kv["hard positives"] == "n/a"
+        assert kv["flagged label noise"] == "n/a"
+
+    def test_measured_counts_render_count_and_share(self) -> None:
+        kv = dict(_full_section()._metrics_kv())
+        assert kv["hard positives"] == "25 (25%)"
+        assert kv["flagged label noise"] == "10 (2%)"
+
+    def test_count_without_share_renders_bare_count(self) -> None:
+        """A measured count with an undefined share (no positives) renders just the count."""
+        section = profile_mining_readiness(n_positive=0, n_negative=0, n_hard_positive=3)
+        assert section.hard_positive_share is None
+        assert dict(section._metrics_kv())["hard positives"] == "3"
+
+    def test_empty_set_renders_note_never_raises(self) -> None:
+        section = profile_mining_readiness(n_positive=0, n_negative=0)
+        md = section.to_markdown()
+        assert "nothing to train on" in md
+        assert "NaN" not in md
+        kv = dict(section._metrics_kv())
+        assert kv["positive share"] == "n/a"
+        assert kv["class imbalance (pos:neg)"] == "n/a"
+
+
+class TestMarginHistogram:
+    def test_margins_are_binned(self) -> None:
+        section = profile_mining_readiness(
+            n_positive=3, n_negative=3, margins=[0.0, 0.5, 1.0], n_bins=4
+        )
+        assert len(section.margin_edges) == 5  # n_bins + 1
+        assert len(section.margin_counts) == 4
+        assert sum(section.margin_counts) == 3.0
+
+    def test_no_margins_leave_empty_histogram(self) -> None:
+        section = profile_mining_readiness(n_positive=3, n_negative=3)
+        assert section.margin_edges == []
+        assert section.margin_counts == []
+
+    def test_non_finite_margins_dropped(self) -> None:
+        section = profile_mining_readiness(
+            n_positive=1, n_negative=1, margins=[float("nan"), float("inf"), 0.5]
+        )
+        assert sum(section.margin_counts) == 1.0
+
+    def test_all_non_finite_margins_leave_empty_histogram(self) -> None:
+        section = profile_mining_readiness(
+            n_positive=1, n_negative=1, margins=[float("nan"), float("inf")]
+        )
+        assert section.margin_edges == []
+        assert section.margin_counts == []
+
+
+class TestReportWiring:
+    def _records(self) -> tuple[list[dict[str, str]], list[set[str]]]:
+        records = [
+            {"id": "1", "name": "Acme"},
+            {"id": "2", "name": "Acme Inc"},
+            {"id": "3", "name": "Zephyr"},
+        ]
+        gold = [{"1", "2"}, {"3"}]
+        return records, gold
+
+    def test_section_included_when_supplied(self) -> None:
+        records, gold = self._records()
+        section = profile_mining_readiness(n_positive=1, n_negative=2, n_hard_positive=1)
+        report = from_records(records, gold=gold, mining_readiness=section)
+        assert isinstance(report["Mining readiness"], MiningReadinessSection)
+
+    def test_section_absent_when_not_supplied(self) -> None:
+        records, gold = self._records()
+        report = from_records(records, gold=gold)
+        kinds = {section.kind for section in report.sections}
+        assert "mining_readiness" not in kinds
+
+    def test_include_selects_the_kind(self) -> None:
+        records, gold = self._records()
+        section = profile_mining_readiness(n_positive=1, n_negative=2)
+        report = from_records(
+            records, gold=gold, mining_readiness=section, include=["mining_readiness"]
+        )
+        kinds = {section.kind for section in report.sections}
+        assert kinds == {"mining_readiness"}
+
+    def test_report_renders_with_section(self) -> None:
+        records, gold = self._records()
+        section = profile_mining_readiness(n_positive=1, n_negative=2, n_flagged_noise=0)
+        report = from_records(records, gold=gold, mining_readiness=section)
+        assert "Mining readiness" in report.to_markdown()
+        assert "<section><h2>Mining readiness</h2>" in report.to_html()
+
+    def test_report_is_a_data_profile_report(self) -> None:
+        records, gold = self._records()
+        section = profile_mining_readiness(n_positive=1, n_negative=2)
+        report = from_records(records, gold=gold, mining_readiness=section)
+        assert isinstance(report, DataProfileReport)

--- a/tests/data/test_mining.py
+++ b/tests/data/test_mining.py
@@ -1,0 +1,422 @@
+"""Tests for the training-pair miners (:mod:`langres.data.mining`).
+
+Covers each miner's behaviour and edges: the featurizer-parity guarantee, the
+cap + top-up of hard-positive mining, the 2:1 negative-sampling lever, multi-
+attribute augmentation, flip orientation/symmetry, the single-class / no-
+comparison guards, and the confident-learning denoiser. The denoise gate is a
+seeded synthetic-noise injection with known ground truth (recall + precision
+thresholds), plus a cleanlab cross-check on the same out-of-fold probabilities.
+"""
+
+from __future__ import annotations
+
+import random
+import subprocess
+import sys
+
+import numpy as np
+import pytest
+
+from langres.core.comparator import StringComparator
+from langres.core.feature import FeatureSpec
+from langres.core.finetune import LabeledCandidate
+from langres.core.models import CompanySchema, ERCandidate
+from langres.data.mining import (
+    _feature_matrix,
+    _oof_predictions,
+    _resolve_feature_specs,
+    augment_by_attribute,
+    denoise_pairs,
+    flip_pairs,
+    mine_misclassified_pairs,
+    sample_negative_pairs,
+)
+
+_COMPARATOR: StringComparator[CompanySchema] = StringComparator.from_schema(CompanySchema)
+
+
+def _company(id: str, name: str, address: str | None = None) -> CompanySchema:
+    return CompanySchema(id=id, name=name, address=address)
+
+
+def _compared(left: CompanySchema, right: CompanySchema) -> ERCandidate[CompanySchema]:
+    """A candidate with its comparison vector attached (what a Comparator pass yields)."""
+    candidate = ERCandidate(left=left, right=right, blocker_name="test")
+    return candidate.model_copy(update={"comparison": _COMPARATOR.compare(left, right)})
+
+
+def _bare(left: CompanySchema, right: CompanySchema) -> ERCandidate[CompanySchema]:
+    """A candidate WITHOUT a comparison vector (blocker-only, no Comparator pass)."""
+    return ERCandidate(left=left, right=right, blocker_name="test")
+
+
+def _separable_dataset(n_positive: int = 30, n_negative: int = 30) -> list[LabeledCandidate]:
+    """A cleanly separable labeled set: matches share strings, non-matches don't."""
+    labeled: list[LabeledCandidate] = []
+    for i in range(n_positive):
+        left = _company(f"m{i}L", f"Acme Corporation {i}", f"{i} Main Street")
+        right = _company(f"m{i}R", f"Acme Corporation {i}", f"{i} Main Street")
+        labeled.append((_compared(left, right), True))
+    for i in range(n_negative):
+        left = _company(f"n{i}L", f"Zephyr Holdings {i}", f"{i} Ocean Avenue")
+        right = _company(f"n{i}R", f"Quasar Industries {i}", f"{i} Mountain Road")
+        labeled.append((_compared(left, right), False))
+    return labeled
+
+
+# ---------------------------------------------------------------------------
+# Featurization parity + resolution
+# ---------------------------------------------------------------------------
+
+
+class TestFeaturization:
+    def test_feature_matrix_matches_random_forest_matcher(self) -> None:
+        """The X the miners build is byte-identical to RandomForestMatcher._feature_vector."""
+        from langres.core.matchers.random_forest_judge import RandomForestMatcher
+
+        labeled = _separable_dataset(n_positive=5, n_negative=5)
+        specs = _resolve_feature_specs(labeled, None)
+        x = _feature_matrix(labeled, specs)
+
+        matcher: RandomForestMatcher[CompanySchema] = RandomForestMatcher(feature_specs=specs)
+        x_rf = [matcher._feature_vector(candidate) for candidate, _ in labeled]
+        assert x == x_rf
+
+    def test_derived_specs_span_comparison_levels(self) -> None:
+        """With feature_specs=None, specs are the sorted union of comparison levels."""
+        labeled = _separable_dataset(n_positive=2, n_negative=2)
+        names = [spec.name for spec in _resolve_feature_specs(labeled, None)]
+        # CompanySchema's comparable string fields, id excluded, sorted.
+        assert names == ["address", "name", "phone", "website"]
+
+    def test_missing_feature_uses_minus_one_sentinel(self) -> None:
+        """A MISSING feature (absent from similarities) featurizes to the -1.0 sentinel."""
+        # address is None on the left -> MISSING -> not in similarities.
+        candidate = _compared(_company("a", "Acme", None), _company("b", "Acme", "1 St"))
+        specs = [FeatureSpec(name="address")]
+        assert _feature_matrix([(candidate, True)], specs) == [[-1.0]]
+
+    def test_explicit_feature_specs_are_honoured(self) -> None:
+        """Passing feature_specs pins the featurization order/columns."""
+        labeled = _separable_dataset(n_positive=2, n_negative=2)
+        specs = [FeatureSpec(name="name")]
+        x = _feature_matrix(labeled, specs)
+        assert all(len(row) == 1 for row in x)
+
+    def test_resolve_feature_specs_passes_explicit_through(self) -> None:
+        """An explicit spec list is used verbatim (comparisons are not consulted)."""
+        specs = [FeatureSpec(name="name"), FeatureSpec(name="phone")]
+        assert _resolve_feature_specs([], specs) == specs
+
+    def test_feature_matrix_missing_comparison_with_explicit_specs_raises(self) -> None:
+        """The _feature_matrix guard fires even when specs are explicit (no derive step)."""
+        bare = (_bare(_company("a", "Acme"), _company("b", "Acme")), True)
+        with pytest.raises(ValueError, match="comparison"):
+            _feature_matrix([bare], [FeatureSpec(name="name")])
+
+
+# ---------------------------------------------------------------------------
+# mine_misclassified_pairs
+# ---------------------------------------------------------------------------
+
+
+class TestMineMisclassified:
+    def test_returns_only_positives_capped(self) -> None:
+        labeled = _separable_dataset(n_positive=20, n_negative=20)
+        mined = mine_misclassified_pairs(labeled, cap=5, cv=4)
+        assert len(mined) == 5
+        assert all(label for _, label in mined)
+
+    def test_surfaces_injected_hard_positives_first(self) -> None:
+        """Positives that look like non-matches are surfaced before easy positives."""
+        labeled = _separable_dataset(n_positive=25, n_negative=25)
+        # Hard positives: label True but strings look like a non-match (low similarity).
+        hard_ids = set()
+        for i in range(3):
+            left = _company(f"hard{i}L", f"Aardvark Systems {i}", f"{i} Alpha Way")
+            right = _company(f"hard{i}R", f"Zenith Partners {i}", f"{i} Omega Blvd")
+            labeled.append((_compared(left, right), True))
+            hard_ids.add(f"hard{i}L")
+
+        mined = mine_misclassified_pairs(labeled, cap=3, cv=4)
+        assert {candidate.left.id for candidate, _ in mined} == hard_ids
+
+    def test_tops_up_with_easy_positives_when_few_hard(self) -> None:
+        """Fewer hard positives than cap -> topped up to min(cap, n_positive)."""
+        labeled = _separable_dataset(n_positive=15, n_negative=15)
+        mined = mine_misclassified_pairs(labeled, cap=10, cv=4)
+        assert len(mined) == 10  # separable: ~0 hard, filled with easy positives
+
+    def test_cap_larger_than_positives_returns_all_positives(self) -> None:
+        labeled = _separable_dataset(n_positive=8, n_negative=8)
+        mined = mine_misclassified_pairs(labeled, cap=100, cv=4)
+        assert len(mined) == 8
+
+    def test_single_class_input_raises(self) -> None:
+        labeled = _separable_dataset(n_positive=10, n_negative=0)
+        with pytest.raises(ValueError, match="both positive and negative"):
+            mine_misclassified_pairs(labeled)
+
+    def test_empty_input_raises(self) -> None:
+        with pytest.raises(ValueError, match="both positive and negative"):
+            mine_misclassified_pairs([])
+
+    def test_missing_comparison_raises(self) -> None:
+        labeled: list[LabeledCandidate] = [
+            (_bare(_company("a", "Acme"), _company("b", "Acme")), True),
+            (_bare(_company("c", "Zed"), _company("d", "Yak")), False),
+        ]
+        with pytest.raises(ValueError, match="comparison"):
+            mine_misclassified_pairs(labeled)
+
+    def test_tiny_minority_class_degrades_without_oof(self) -> None:
+        """A minority class of one can't be stratified -> unranked fallback, no raise."""
+        labeled = _separable_dataset(n_positive=1, n_negative=10)
+        mined = mine_misclassified_pairs(labeled, cap=5, cv=5)
+        assert len(mined) == 1
+        assert all(label for _, label in mined)
+
+
+# ---------------------------------------------------------------------------
+# sample_negative_pairs
+# ---------------------------------------------------------------------------
+
+
+class TestSampleNegatives:
+    def test_two_to_one_ratio_exact(self) -> None:
+        labeled = _separable_dataset(n_positive=10, n_negative=40)
+        sampled = sample_negative_pairs(labeled, ratio=2.0, seed=0)
+        assert len(sampled) == 20
+        assert all(not label for _, label in sampled)
+
+    def test_shortfall_returns_all_negatives(self) -> None:
+        labeled = _separable_dataset(n_positive=10, n_negative=5)
+        sampled = sample_negative_pairs(labeled, ratio=2.0)  # wants 20, has 5
+        assert len(sampled) == 5
+
+    def test_seeded_determinism(self) -> None:
+        labeled = _separable_dataset(n_positive=10, n_negative=40)
+        first = sample_negative_pairs(labeled, ratio=2.0, seed=7)
+        second = sample_negative_pairs(labeled, ratio=2.0, seed=7)
+        assert [c.left.id for c, _ in first] == [c.left.id for c, _ in second]
+
+    def test_no_positives_samples_nothing(self) -> None:
+        labeled = _separable_dataset(n_positive=0, n_negative=10)
+        assert sample_negative_pairs(labeled, ratio=2.0) == []
+
+    def test_target_equal_to_available_returns_all(self) -> None:
+        """Exactly enough negatives (target == available): return all, no shortfall log."""
+        labeled = _separable_dataset(n_positive=10, n_negative=20)
+        sampled = sample_negative_pairs(labeled, ratio=2.0)  # target 20 == 20
+        assert len(sampled) == 20
+
+
+# ---------------------------------------------------------------------------
+# augment_by_attribute
+# ---------------------------------------------------------------------------
+
+
+class TestAugmentByAttribute:
+    def test_blanks_each_string_field_of_each_positive(self) -> None:
+        """One variant per (positive, non-empty string field); comparison reset to None."""
+        left = _company("a", "Acme", "1 Main St")
+        right = _company("b", "Acme", "1 Main St")
+        labeled: list[LabeledCandidate] = [(_compared(left, right), True)]
+        augmented = augment_by_attribute(labeled)
+        # name + address are the non-empty string fields -> 2 variants.
+        assert len(augmented) == 2
+        assert all(label for _, label in augmented)
+        assert all(candidate.comparison is None for candidate, _ in augmented)
+
+    def test_blanked_field_is_emptied_on_both_sides(self) -> None:
+        left = _company("a", "Acme", "1 Main St")
+        right = _company("b", "Acme", "1 Main St")
+        augmented = augment_by_attribute([(_compared(left, right), True)])
+        blanked_fields = set()
+        for candidate, _ in augmented:
+            for field in ("name", "address"):
+                if getattr(candidate.left, field) == "":
+                    assert getattr(candidate.right, field) == ""
+                    blanked_fields.add(field)
+        assert blanked_fields == {"name", "address"}
+
+    def test_cap_bounds_output(self) -> None:
+        labeled = _separable_dataset(n_positive=20, n_negative=5)
+        augmented = augment_by_attribute(labeled, cap=7)
+        assert len(augmented) == 7
+
+    def test_no_positives_yields_nothing(self) -> None:
+        labeled = _separable_dataset(n_positive=0, n_negative=5)
+        assert augment_by_attribute(labeled) == []
+
+
+# ---------------------------------------------------------------------------
+# flip_pairs
+# ---------------------------------------------------------------------------
+
+
+class TestFlipPairs:
+    def test_swaps_left_right_keeps_label_and_comparison(self) -> None:
+        left = _company("a", "Acme", "1 Main St")
+        right = _company("b", "Acme Inc", "1 Main Street")
+        original = _compared(left, right)
+        ((flipped, label),) = flip_pairs([(original, True)])
+        assert flipped.left.id == "b" and flipped.right.id == "a"
+        assert label is True
+        # Comparison kept: string comparison is symmetric and feature-keyed.
+        assert flipped.comparison is not None
+        assert flipped.comparison.similarities == original.comparison.similarities
+
+    def test_flip_of_flip_restores_orientation(self) -> None:
+        labeled = _separable_dataset(n_positive=2, n_negative=2)
+        once = flip_pairs(labeled)
+        twice = flip_pairs(once)
+        assert [c.left.id for c, _ in twice] == [c.left.id for c, _ in labeled]
+
+    def test_empty_input(self) -> None:
+        assert flip_pairs([]) == []
+
+
+# ---------------------------------------------------------------------------
+# denoise_pairs
+# ---------------------------------------------------------------------------
+
+
+def _inject_noise(
+    clean: list[LabeledCandidate], k: int, seed: int
+) -> tuple[list[LabeledCandidate], set[int]]:
+    """Flip ``k`` known labels; return the noisy set and the flipped indices."""
+    rng = random.Random(seed)
+    noisy = list(clean)
+    flipped = set(rng.sample(range(len(noisy)), k))
+    for i in flipped:
+        candidate, label = noisy[i]
+        noisy[i] = (candidate, not label)
+    return noisy, flipped
+
+
+def _flagged_indices(noisy: list[LabeledCandidate], flagged: list[LabeledCandidate]) -> set[int]:
+    """Recover the input indices of the flagged pairs by identity."""
+    flagged_ids = {id(candidate) for candidate, _ in flagged}
+    return {i for i, (candidate, _) in enumerate(noisy) if id(candidate) in flagged_ids}
+
+
+class TestDenoisePairs:
+    def test_ground_truth_noise_injection_recall_and_precision(self) -> None:
+        """The hard gate: flag injected label errors with high recall + precision."""
+        clean = _separable_dataset(n_positive=40, n_negative=40)
+        noisy, injected = _inject_noise(clean, k=8, seed=0)
+
+        cleaned, flagged = denoise_pairs(noisy, cv=5, seed=0)
+        assert len(cleaned) + len(flagged) == len(noisy)
+
+        found = _flagged_indices(noisy, flagged)
+        true_positive = len(found & injected)
+        recall = true_positive / len(injected)
+        precision = true_positive / len(found) if found else 1.0
+        assert recall >= 0.75, f"recall={recall}"
+        assert precision >= 0.75, f"precision={precision}"
+
+    def test_class_imbalanced_noise(self) -> None:
+        """Confident learning stays honest under 1:4 class imbalance."""
+        clean = _separable_dataset(n_positive=16, n_negative=64)
+        noisy, injected = _inject_noise(clean, k=6, seed=3)
+
+        _cleaned, flagged = denoise_pairs(noisy, cv=5, seed=0)
+        found = _flagged_indices(noisy, flagged)
+        recall = len(found & injected) / len(injected)
+        assert recall >= 0.5, f"recall={recall}"
+
+    def test_clean_data_flags_few(self) -> None:
+        """A clean, separable set should flag (almost) nothing."""
+        clean = _separable_dataset(n_positive=40, n_negative=40)
+        _cleaned, flagged = denoise_pairs(clean, cv=5, seed=0)
+        assert len(flagged) <= 2
+
+    def test_unknown_method_raises(self) -> None:
+        with pytest.raises(ValueError, match="unknown denoise method"):
+            denoise_pairs(_separable_dataset(4, 4), method="magic")
+
+    def test_single_class_input_raises(self) -> None:
+        with pytest.raises(ValueError, match="both positive and negative"):
+            denoise_pairs(_separable_dataset(n_positive=6, n_negative=0))
+
+    def test_missing_comparison_raises(self) -> None:
+        labeled: list[LabeledCandidate] = [
+            (_bare(_company("a", "Acme"), _company("b", "Acme")), True),
+            (_bare(_company("c", "Zed"), _company("d", "Yak")), False),
+        ]
+        with pytest.raises(ValueError, match="comparison"):
+            denoise_pairs(labeled)
+
+    def test_degenerate_folds_flag_nothing(self) -> None:
+        """A minority class of one can't be stratified -> (all, []), no raise."""
+        labeled = _separable_dataset(n_positive=1, n_negative=10)
+        cleaned, flagged = denoise_pairs(labeled, cv=5)
+        assert len(cleaned) == 11
+        assert flagged == []
+
+    def test_agrees_with_cleanlab_on_same_probabilities(self) -> None:
+        """Cross-check: our confident-joint flags match cleanlab on the same OOF probs."""
+        cleanlab_filter = pytest.importorskip("cleanlab.filter")
+
+        clean = _separable_dataset(n_positive=40, n_negative=40)
+        noisy, _injected = _inject_noise(clean, k=8, seed=0)
+        _cleaned, flagged = denoise_pairs(noisy, cv=5, seed=0)
+        ours = _flagged_indices(noisy, flagged)
+
+        specs = _resolve_feature_specs(noisy, None)
+        x = _feature_matrix(noisy, specs)
+        y = [int(label) for _, label in noisy]
+        proba = np.asarray(
+            _oof_predictions(x, y, cv=5, seed=0, method="predict_proba"), dtype=float
+        )
+        mask = cleanlab_filter.find_label_issues(
+            labels=np.asarray(y), pred_probs=proba, return_indices_ranked_by=None
+        )
+        cleanlab_flags = {int(i) for i in np.where(mask)[0]}
+
+        overlap = ours & cleanlab_flags
+        union = ours | cleanlab_flags
+        jaccard = len(overlap) / len(union) if union else 1.0
+        assert jaccard >= 0.5, f"ours={sorted(ours)} cleanlab={sorted(cleanlab_flags)}"
+
+
+class TestConfidentJoint:
+    def test_flags_confident_disagreement_and_skips_unconfident(self) -> None:
+        """The confident-joint rule on a hand-built OOF probability matrix.
+
+        Columns are ``[p(neg), p(pos)]``. Per-class thresholds are the mean
+        self-confidence over each class's members: t0 = mean(0.85, 0.7) = 0.775,
+        t1 = mean(0.1, 0.9) = 0.5. Row 0 is labeled positive but confidently
+        negative (flagged); row 3 clears neither threshold (unconfident -> the
+        ``continue`` branch, keeps its label).
+        """
+        from langres.data.mining import _confident_label_errors
+
+        proba = np.array(
+            [
+                [0.9, 0.1],  # y=1, confidently neg -> flagged
+                [0.1, 0.9],  # y=1, confidently pos -> kept
+                [0.85, 0.15],  # y=0, confidently neg -> kept
+                [0.7, 0.3],  # y=0, clears neither threshold -> unconfident, kept
+            ]
+        )
+        assert _confident_label_errors(proba, [1, 1, 0, 0]) == {0}
+
+
+# ---------------------------------------------------------------------------
+# Import-light budget: sklearn must stay lazy behind the featurizing miners.
+# ---------------------------------------------------------------------------
+
+
+def test_importing_data_and_mining_does_not_pull_sklearn() -> None:
+    """A bare ``import langres.data`` / ``import langres.data.mining`` stays sklearn-free."""
+    script = (
+        "import sys; import langres.data; import langres.data.mining; "
+        "leaked = [m for m in ['sklearn', 'torch', 'litellm', 'faiss'] if m in sys.modules]; "
+        "assert not leaked, f'mining pulled heavy modules: {leaked}'; "
+        "print('OK')"
+    )
+    result = subprocess.run([sys.executable, "-c", script], capture_output=True, text=True)
+    assert result.returncode == 0, f"STDOUT:\n{result.stdout}\nSTDERR:\n{result.stderr}"


### PR DESCRIPTION
**Wave A** of the data-preparation layer (stacked on #162, now merged). Adds the miners that curate training pairs, plus the profiler section that reports mining readiness.

## What
- `src/langres/data/mining.py` — five miners over the verified currency `LabeledCandidate = tuple[ERCandidate, bool]` (sklearn imported lazily, `[trained]` extra):
  - `mine_misclassified_pairs` — AnyMatch hard positives via **out-of-fold** `cross_val_predict` (an RF fit to completion has ~0 in-sample error, so in-sample mining would return nothing); cap + top-up; **single-class guard**.
  - `sample_negative_pairs` — seeded 2:1 label balancing.
  - `augment_by_attribute` — blank-one-attribute augmentation (sets `comparison=None`; consumers re-compare).
  - `flip_pairs` — orientation swap; keeps `.comparison` (string sim is symmetric, verified).
  - `denoise_pairs` — confident-learning label denoise (Northcutt confident-joint on OOF probabilities).
- `colval_serializer` registered as `"colval"` in the core `RECORD_SERIALIZERS` (the AnyMatch `COL … VAL …` format; a serialization strategy sibling of `json`, so it lives with the registry).
- `MiningReadinessSection` + `profile_mining_readiness` in `langres/data/data_profile/` — consumes **precomputed** counts/scores (no matcher run), wired into the report assembler.
- `examples/quickstart_mining.py` (offline, $0).

## Correctness
- **Featurizer parity:** miners featurize via a throwaway `RandomForestMatcher` (single source of truth); explicit test asserts the built `X == [matcher._feature_vector(c) …]` byte-for-byte, MISSING → `-1.0` sentinel.
- **Denoise validated two ways:** seeded ground-truth injection (recall/precision 1.0 on separable; recall ≥ 0.5 under 1:4 imbalance) **and** exact Jaccard agreement (1.0) with `cleanlab.filter.find_label_issues` on the same OOF probabilities (cleanlab added as a dev dep).

## Verification (local, `uv sync --all-extras`)
- new tests: **79 passed**, both new modules **100%** coverage
- full fast suite: **3280 passed**, 6 skipped, 97.90% total coverage
- `test_import_budget`: passed — `import langres` / `import langres.data` stay sklearn-free
- ruff check + format, mypy strict: clean
- `examples/quickstart_mining.py`: runs at $0, surfaces the injected hard positive + label error

## Summary by Sourcery

Add a mining substrate for labeled training pairs and surface its readiness in the data profiler, while extending LLM matchers with a COL/VAL record serializer and example usage.

New Features:
- Introduce training-pair mining utilities over LabeledCandidate, including hard-positive mining, negative sampling, attribute augmentation, pair flipping, and confident-learning-based denoising.
- Expose mining functions and the LabeledCandidate type from the langres.data package for external consumption.
- Add a MiningReadinessSection to the data profile report, with a builder that consumes precomputed mining statistics and optional margin histograms.
- Provide a quickstart_mining example script that demonstrates mining, balancing, augmenting, denoising, and profiling a small labeled dataset.
- Register a COL/VAL record serializer for LLMMatcher so records can be serialized in the AnyMatch/Ditto flat text format.

Enhancements:
- Wire the mining readiness section into the data profile builders, including from_benchmark/from_records constructors and the include filter, without introducing sklearn imports into the profiling package.
- Document the new mining quickstart in the examples README and clarify the report section ordering.
- Ensure mining and data imports remain lightweight by lazily importing sklearn within featurizing miners and adding tests guarding the import budget.

Build:
- Add cleanlab as a development dependency for validating the denoising logic against an external implementation.

Documentation:
- Update examples documentation to describe the new mining quickstart and its dependencies.

Tests:
- Add comprehensive tests for the mining utilities covering featurization parity with RandomForestMatcher, edge cases for class balance, caps, augmentation, flipping, and confident-learning denoising including cleanlab cross-checks.
- Add tests for the MiningReadinessSection covering derived stats, render outputs, margin histogram behavior, graceful degradation, and integration into DataProfileReport and from_records.
- Extend LLMMatcher serializer tests to cover registration, config round-tripping, and COL/VAL formatting semantics including handling of None-valued fields.