### PR TITLE
feat(data): failure-mode loop + $0 recipe-lift proof

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -58,6 +58,16 @@ flywheel harvest → closed-loop flywheel → person:
   confident-learning denoise a labeled pair set, then print a
   `MiningReadinessSection`. Offline and $0; uses the `[trained]` extra (sklearn)
   for the out-of-fold RandomForest behind the featurizing miners.
+- **`recipe_lift_proof.py`** — the data-prep payoff: on abt_buy's all-pairs
+  blocked pool a curated training recipe (denoise + hard positives + attribute
+  augmentation + 2:1 balance) beats the mean of equal-budget random draws on
+  held-out pair F1. Prints baseline vs recipe F1 + margin. Offline and $0
+  (`RandomForestMatcher`); self-contained OpenMP guard.
+- **`curation_loop.py`** — the failure-mode flywheel end to end: run a matcher,
+  log its judgements, build a `FailureModeSection` to find the failing slice,
+  mine/augment that slice with the Wave-A miners, retrain, and confirm the
+  targeted slice's error rate dropped. Offline and $0; self-contained OpenMP
+  guard.
 
 ## Example Data
 

--- a/examples/curation_loop.py
+++ b/examples/curation_loop.py
@@ -1,0 +1,266 @@
+"""The failure-mode curation loop: profile errors, mine the failing slice, re-profile.
+
+Where ``recipe_lift_proof.py`` shows that curation *helps*, this example shows the
+**loop** you run to decide what to curate -- the data-preparation flywheel, end to
+end, for $0:
+
+    1. PROFILE  -- run a matcher, log its judgements, and build a
+       FailureModeSection: which slice of the data do the errors concentrate in?
+    2. CURATE   -- mine the hard positives + augment + balance (the Wave-A miners),
+       targeting that failure mode.
+    3. RE-PROFILE -- retrain, re-judge, and confirm the targeted slice's error
+       rate actually dropped.
+
+On abt_buy, an initial matcher trained on a naive random draw from the imbalanced
+pool is too conservative: it misses matches (all its errors are false negatives),
+and those misses concentrate on a stable slice -- the cross-source pairs (where
+every true match lives) and the missing-field pairs (where it leans on a field it
+does not always have). The failure-mode profile names the worst such slice. The
+curation round mines exactly the positives the matcher got wrong and augments them
+with blanked fields (missing-field robustness), so the retrained matcher recovers
+the misses and that slice's error rate collapses.
+
+To keep the error rates legible, the held-out set is balanced down to ~1:4 (a
+1:150 blocked set drowns every slice's error rate in the easy-negative majority);
+this is a diagnostic view, not a deployment F1 benchmark. No LLM, no network, no
+spend -- the matcher is a RandomForest and the log is a real
+:class:`~langres.core.judgement_log.JudgementLog` round-tripped through disk.
+
+Run it (self-contained -- sets the macOS OpenMP guard itself):
+    uv run python examples/curation_loop.py
+"""
+
+import os
+
+# See recipe_lift_proof.py: importing the abt_buy loader pulls faiss + torch; the
+# guard avoids their macOS OpenMP double-load crash. This example blocks with the
+# core AllPairsBlocker and never runs the VectorBlocker, so it stays $0 and offline.
+os.environ.setdefault("OMP_NUM_THREADS", "1")
+os.environ.setdefault("KMP_DUPLICATE_LIB_OK", "TRUE")
+
+import random
+import tempfile
+from pathlib import Path
+
+from langres.core.comparator import StringComparator
+from langres.core.finetune import LabeledCandidate
+from langres.core.judgement_log import JudgementLog, LoggingMatcher
+from langres.core.matchers.random_forest_judge import RandomForestMatcher
+from langres.core.models import ERCandidate
+from langres.core.resolver import Resolver
+from langres.data.data_profile import FailureModeSection, FailureSlice, profile_failure_mode
+from langres.data.mining import (
+    augment_by_attribute,
+    denoise_pairs,
+    mine_misclassified_pairs,
+    sample_negative_pairs,
+)
+from langres.data.registry import get_benchmark
+
+BENCHMARK = "abt_buy"
+SEED = 0
+THRESHOLD = 0.5  # fixed deployment operating point (no test-set tuning) for the verdicts
+POS_CAP = 40
+N_TRAIN_CLUSTERS = 80
+N_EVAL_CLUSTERS = 60
+N_TRAIN_SINGLETONS = 120
+N_EVAL_SINGLETONS = 120
+EVAL_NEG_RATIO = 4  # balance the eval set to ~1:4 so slice error rates are legible
+INITIAL_BUDGET = 240  # the naive matcher's random training draw
+
+
+def build_pool(
+    resolver: Resolver,
+    by_id: dict[str, object],
+    gold_pairs: set[frozenset[str]],
+    ids: list[str],
+) -> list[LabeledCandidate]:
+    """Block records all-pairs (comparison attached) and label each pair against gold."""
+    records = [by_id[i].model_dump() for i in ids]  # type: ignore[attr-defined]
+    candidates = resolver.candidates(records)
+    return [(c, frozenset({c.left.id, c.right.id}) in gold_pairs) for c in candidates]
+
+
+def profile_matcher(
+    matcher: RandomForestMatcher[object],
+    eval_candidates: list[ERCandidate[object]],
+    gold_pairs: set[frozenset[str]],
+    records: dict[str, dict[str, object]],
+    log_path: Path,
+) -> FailureModeSection:
+    """Judge the eval set through a real JudgementLog, then profile the failures.
+
+    Wraps the matcher in a :class:`LoggingMatcher` so every verdict is appended to
+    a JSONL :class:`JudgementLog` (the flywheel inlet), reads it back, and hands
+    the rows + gold + records to :func:`profile_failure_mode` -- exactly the
+    log -> harvest -> profile path a production loop follows.
+    """
+    log = JudgementLog(log_path)
+    logged = LoggingMatcher(matcher, log=log, threshold=THRESHOLD)
+    list(logged.forward(iter(eval_candidates)))  # drain the stream: writes one row per pair
+    section = profile_failure_mode(log.read(), gold_pairs=gold_pairs, records=records)
+    assert section is not None  # eval set is non-empty and gold is provided
+    return section
+
+
+def worst_stable_slice(section: FailureModeSection) -> FailureSlice | None:
+    """The highest-lift *categorical* slice (field emptiness / source).
+
+    Score bands shift between two matchers (a different score distribution), so
+    they are not comparable across the two profiles; the field-emptiness and
+    source slices cover the SAME pairs each time, so their error rate is
+    apples-to-apples before and after curation.
+    """
+    stable = [
+        s
+        for s in section.slices
+        if (s.dimension.startswith("empty:") or s.dimension == "source") and s.lift is not None
+    ]
+    return max(stable, key=lambda s: s.lift or 0.0) if stable else None
+
+
+def slice_error(section: FailureModeSection, dimension: str, value: str) -> float | None:
+    """Look up one slice's error rate in a profile (``None`` if that slice is absent)."""
+    for s in section.slices:
+        if s.dimension == dimension and s.value == value:
+            return s.error_rate
+    return None
+
+
+def curate(
+    train_pool: list[LabeledCandidate], comparator: StringComparator[object]
+) -> list[LabeledCandidate]:
+    """Mine the failing pairs into a targeted training set (the four Wave-A miners).
+
+    Denoise -> mine the hard (misclassified) positives -> augment them with blanked
+    fields (missing-field robustness, re-compared) -> balance the negatives to 2:1.
+    Hard-positive mining surfaces exactly the matches the matcher got wrong -- the
+    false negatives the profile flagged -- so the recipe targets the failure mode.
+    """
+    clean, _flagged = denoise_pairs(train_pool, seed=SEED)
+    hard = mine_misclassified_pairs(clean, cap=POS_CAP, seed=SEED)
+    augmented = [
+        (c.model_copy(update={"comparison": comparator.compare(c.left, c.right)}), label)
+        for c, label in augment_by_attribute(hard, cap=POS_CAP, seed=SEED)
+    ]
+    positives = list(hard) + augmented
+    negatives = sample_negative_pairs(
+        positives + [pair for pair in clean if not pair[1]], ratio=2.0, seed=SEED
+    )
+    return positives + negatives
+
+
+def fit(
+    labeled: list[LabeledCandidate], feature_specs: list[object]
+) -> RandomForestMatcher[object]:
+    """Fit a RandomForest on the labeled pairs."""
+    matcher: RandomForestMatcher[object] = RandomForestMatcher(
+        feature_specs=feature_specs,  # type: ignore[arg-type]
+        random_state=SEED,
+    )
+    matcher.fit(iter([c for c, _ in labeled]), [label for _, label in labeled])
+    return matcher
+
+
+def main() -> None:
+    print("Failure-mode curation loop: profile -> mine the failing slice -> re-profile")
+    print("=" * 76)
+
+    bench = get_benchmark(BENCHMARK)
+    corpus, clusters, gold_pairs = bench.load()
+    by_id = {record.id: record for record in corpus}
+    multi = sorted((sorted(c) for c in clusters if len(c) >= 2), key=lambda c: c[0])
+    singletons = sorted(next(iter(c)) for c in clusters if len(c) == 1)
+
+    resolver = Resolver.from_schema(bench.schema)  # AllPairsBlocker + StringComparator
+    comparator = resolver.comparator
+    feature_specs = list(comparator.feature_specs)
+
+    train_ids = [i for c in multi[:N_TRAIN_CLUSTERS] for i in c] + singletons[:N_TRAIN_SINGLETONS]
+    eval_slice = multi[N_TRAIN_CLUSTERS : N_TRAIN_CLUSTERS + N_EVAL_CLUSTERS]
+    eval_ids = [i for c in eval_slice for i in c] + singletons[
+        N_TRAIN_SINGLETONS : N_TRAIN_SINGLETONS + N_EVAL_SINGLETONS
+    ]
+    train_pool = build_pool(resolver, by_id, gold_pairs, train_ids)
+
+    # Balance the held-out set to ~1:EVAL_NEG_RATIO so per-slice error rates are not
+    # drowned by the easy-negative majority (a diagnostic view, not a deployment F1).
+    eval_full = build_pool(resolver, by_id, gold_pairs, eval_ids)
+    eval_pos = [p for p in eval_full if p[1]]
+    eval_neg = [p for p in eval_full if not p[1]]
+    eval_pool = eval_pos + random.Random(SEED).sample(
+        eval_neg, min(len(eval_neg), EVAL_NEG_RATIO * len(eval_pos))
+    )
+    eval_candidates = [c for c, _ in eval_pool]
+    records: dict[str, dict[str, object]] = {}
+    for candidate, _ in eval_pool:
+        records[candidate.left.id] = candidate.left.model_dump()
+        records[candidate.right.id] = candidate.right.model_dump()
+    print(
+        f"\nEval set: {len(eval_candidates)} pairs "
+        f"({len(eval_pos)} matches, balanced to ~1:{EVAL_NEG_RATIO})"
+    )
+
+    with tempfile.TemporaryDirectory(prefix="langres-curation-") as tmp:
+        log_dir = Path(tmp)
+
+        # --- Round 0: naive matcher (random draw from the imbalanced pool) -----------
+        initial_draw = random.Random(1000).sample(train_pool, min(INITIAL_BUDGET, len(train_pool)))
+        initial = fit(initial_draw, feature_specs)
+        before = profile_matcher(
+            initial, eval_candidates, gold_pairs, records, log_dir / "before.jsonl"
+        )
+        print(f"\n[before] naive matcher trained on {len(initial_draw)} random pairs")
+        print(
+            f"  overall error rate {_pct(before.error_rate)}  "
+            f"(FP={before.n_false_positive}, FN={before.n_false_negative})"
+        )
+        target = worst_stable_slice(before)
+        if target is None:
+            print("  no stable failing slice surfaced; nothing to target.")
+            return
+        print(
+            f"  worst slice: {target.dimension} = '{target.value}'  "
+            f"error rate {_pct(target.error_rate)} (lift {target.lift:.2f}, {target.n} pairs)"
+        )
+
+        # --- Curate targeting the failure, retrain, re-profile -----------------------
+        recipe = curate(train_pool, comparator)
+        curated = fit(recipe, feature_specs)
+        after = profile_matcher(
+            curated, eval_candidates, gold_pairs, records, log_dir / "after.jsonl"
+        )
+        print(f"\n[after] curated matcher trained on {len(recipe)} mined+augmented+balanced pairs")
+        print(
+            f"  overall error rate {_pct(after.error_rate)}  "
+            f"(FP={after.n_false_positive}, FN={after.n_false_negative})"
+        )
+        after_rate = slice_error(after, target.dimension, target.value)
+        print(
+            f"  targeted slice {target.dimension} = '{target.value}': "
+            f"error rate {_pct(target.error_rate)} -> {_pct(after_rate)}"
+        )
+
+    dropped = (
+        after_rate is not None and target.error_rate is not None and after_rate < target.error_rate
+    )
+    print(
+        f"\n=> The targeted slice's error rate {'DROPPED' if dropped else 'did not drop'} "
+        f"({_pct(target.error_rate)} -> {_pct(after_rate)}); "
+        f"overall {_pct(before.error_rate)} -> {_pct(after.error_rate)}, "
+        f"false negatives {before.n_false_negative} -> {after.n_false_negative}."
+    )
+    print(
+        "   The naive matcher missed matches (its errors are false negatives); mining\n"
+        "   those misses back in -- as hard positives + missing-field augmentations --\n"
+        "   is the curation round the failure-mode profile told us to run."
+    )
+
+
+def _pct(value: float | None) -> str:
+    """A rate as a percentage, or ``n/a`` when the slice was absent."""
+    return "n/a" if value is None else f"{value * 100:.1f}%"
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/recipe_lift_proof.py
+++ b/examples/recipe_lift_proof.py
@@ -1,0 +1,217 @@
+"""Proof: a curated training recipe beats random pairs at an equal label budget.
+
+This is the acceptance demonstration for the data-preparation layer. It asks one
+question and answers it with numbers, on a real benchmark, for $0:
+
+    Given a fixed budget of N training pairs drawn from a blocked candidate pool,
+    does *curating* those N (balance + hard positives + denoise + augmentation)
+    beat drawing them at random?
+
+Why it works -- honestly. A blocked entity-resolution pool is dominated by
+non-matches (here an all-pairs blocked pool runs ~1:500 positive:negative). A
+random draw of N pairs is therefore almost all negatives and usually contains
+*no* matches at all, so the trained matcher never learns what a match looks like
+and its held-out F1 collapses. The recipe spends the SAME N-pair budget
+deliberately: it mines the hard positives, drops likely-mislabeled pairs,
+augments the positives, and balances the negatives to 2:1 -- so the matcher
+trains on a set that actually contains matches.
+
+To keep the comparison fair and low-variance, the baseline is the **mean over
+several random draws** at the same N (a single lucky draw that happens to catch a
+few matches can approach the recipe -- see how many draws the recipe beats). The
+recipe and every draw come from the SAME pool and are trained by the SAME
+:class:`~langres.core.matchers.random_forest_judge.RandomForestMatcher`, then
+scored on the SAME held-out, entity-disjoint test split with the existing
+:func:`~langres.core.benchmark.evaluate_judge_on_candidates` (best-F1 threshold on
+a fixed grid). No LLM, no network, no spend.
+
+Run it (self-contained -- sets the macOS OpenMP guard itself):
+    uv run python examples/recipe_lift_proof.py
+"""
+
+import os
+
+# On macOS, importing the abt_buy loader pulls faiss + torch (its default blocker
+# is a VectorBlocker); the guard avoids their OpenMP double-load crash. Set before
+# any heavy import. This example never runs the VectorBlocker -- it blocks with the
+# core AllPairsBlocker -- so it stays $0 and offline.
+os.environ.setdefault("OMP_NUM_THREADS", "1")
+os.environ.setdefault("KMP_DUPLICATE_LIB_OK", "TRUE")
+
+import random
+from statistics import mean, pstdev
+
+from langres.core.benchmark import evaluate_judge_on_candidates
+from langres.core.comparator import StringComparator
+from langres.core.finetune import LabeledCandidate
+from langres.core.matchers.random_forest_judge import RandomForestMatcher
+from langres.core.models import ERCandidate
+from langres.core.resolver import Resolver
+from langres.data.mining import (
+    augment_by_attribute,
+    denoise_pairs,
+    mine_misclassified_pairs,
+    sample_negative_pairs,
+)
+from langres.data.registry import get_benchmark
+
+BENCHMARK = "abt_buy"
+SEED = 0
+#: Held-out pair-level F1 threshold grid (0.05 .. 1.00) -- the same operating-point
+#: sweep for the recipe and every baseline draw, so neither is handed a better cut.
+GRID = [i / 20 for i in range(1, 21)]
+
+#: Pool size knobs. A modest slice of the benchmark keeps the run a few seconds
+#: while preserving the heavy imbalance the mechanism needs.
+N_TRAIN_CLUSTERS = 80  # matched entity clusters whose records seed the TRAIN pool
+N_TEST_CLUSTERS = 60  # entity-disjoint clusters for the held-out TEST pool
+N_TRAIN_SINGLETONS = 120  # extra unmatched records -> negatives in the TRAIN pool
+N_TEST_SINGLETONS = 120
+POS_CAP = 40  # positives the recipe mines/augments (the label budget's match half)
+N_BASELINE_DRAWS = 10  # random draws averaged for the honest baseline
+
+
+def build_pool(
+    resolver: Resolver,
+    by_id: dict[str, object],
+    gold_pairs: set[frozenset[str]],
+    ids: list[str],
+) -> list[LabeledCandidate]:
+    """Block a set of records all-pairs and label each pair against gold.
+
+    ``resolver.candidates`` runs the AllPairsBlocker + StringComparator, so every
+    candidate carries the ``comparison`` vector the featurizing miners and the
+    RandomForest need. A pair is a positive iff its id-set is a gold match.
+    """
+    records = [by_id[i].model_dump() for i in ids]  # type: ignore[attr-defined]
+    candidates = resolver.candidates(records)
+    return [(c, frozenset({c.left.id, c.right.id}) in gold_pairs) for c in candidates]
+
+
+def assemble_recipe(
+    train_pool: list[LabeledCandidate], comparator: StringComparator[object]
+) -> tuple[list[LabeledCandidate], int]:
+    """Curate the same-budget training set from the imbalanced pool.
+
+    Four Wave-A miners compose into one training set:
+      1. ``denoise_pairs``          -- drop likely-mislabeled pairs.
+      2. ``mine_misclassified_pairs`` -- the AnyMatch hard positives (out-of-fold).
+      3. ``augment_by_attribute``   -- blank one field at a time (missing-field
+         robustness); it resets ``comparison`` to ``None``, so re-run the
+         comparator over the augmented pairs before they are usable.
+      4. ``sample_negative_pairs``  -- balance the negatives to 2:1.
+
+    Returns ``(recipe, n_flagged)`` -- the assembled pairs and how many the
+    denoiser dropped.
+    """
+    clean, flagged = denoise_pairs(train_pool, seed=SEED)
+    hard = mine_misclassified_pairs(clean, cap=POS_CAP, seed=SEED)
+    augmented = [
+        (c.model_copy(update={"comparison": comparator.compare(c.left, c.right)}), label)
+        for c, label in augment_by_attribute(hard, cap=POS_CAP, seed=SEED)
+    ]
+    positives = list(hard) + augmented
+    negatives = sample_negative_pairs(
+        positives + [pair for pair in clean if not pair[1]], ratio=2.0, seed=SEED
+    )
+    return positives + negatives, len(flagged)
+
+
+def fit_and_score(
+    labeled: list[LabeledCandidate],
+    feature_specs: list[object],
+    test_candidates: list[ERCandidate[object]],
+    gold_pairs: set[frozenset[str]],
+) -> float:
+    """Fit a RandomForest on ``labeled`` and return its best-F1 on the held-out set."""
+    matcher: RandomForestMatcher[object] = RandomForestMatcher(
+        feature_specs=feature_specs,  # type: ignore[arg-type]
+        random_state=SEED,
+    )
+    matcher.fit(iter([c for c, _ in labeled]), [label for _, label in labeled])
+    result, _ = evaluate_judge_on_candidates(matcher, test_candidates, gold_pairs, GRID)
+    return result.pair.f1
+
+
+def main() -> None:
+    print("Recipe-lift proof: curated pairs vs random pairs at an equal budget")
+    print("=" * 70)
+
+    bench = get_benchmark(BENCHMARK)
+    corpus, clusters, gold_pairs = bench.load()
+    by_id = {record.id: record for record in corpus}
+    multi = sorted((sorted(c) for c in clusters if len(c) >= 2), key=lambda c: c[0])
+    singletons = sorted(next(iter(c)) for c in clusters if len(c) == 1)
+
+    resolver = Resolver.from_schema(bench.schema)  # AllPairsBlocker + StringComparator
+    comparator = resolver.comparator
+    feature_specs = list(comparator.feature_specs)
+
+    train_ids = [i for c in multi[:N_TRAIN_CLUSTERS] for i in c] + singletons[:N_TRAIN_SINGLETONS]
+    test_slice = multi[N_TRAIN_CLUSTERS : N_TRAIN_CLUSTERS + N_TEST_CLUSTERS]
+    test_ids = [i for c in test_slice for i in c] + singletons[
+        N_TRAIN_SINGLETONS : N_TRAIN_SINGLETONS + N_TEST_SINGLETONS
+    ]
+    train_pool = build_pool(resolver, by_id, gold_pairs, train_ids)
+    test_candidates = [c for c, _ in build_pool(resolver, by_id, gold_pairs, test_ids)]
+
+    n_pos = sum(1 for _, label in train_pool if label)
+    n_neg = len(train_pool) - n_pos
+    print(f"\nDataset: {BENCHMARK} (all-pairs blocked)")
+    print(
+        f"Train pool: {len(train_pool):,} pairs "
+        f"({n_pos} positive / {n_neg:,} negative -> 1:{n_neg / max(n_pos, 1):.0f} imbalance)"
+    )
+    print(f"Held-out test pool: {len(test_candidates):,} candidate pairs (entity-disjoint)")
+
+    recipe, n_flagged = assemble_recipe(train_pool, comparator)
+    budget = len(recipe)
+    recipe_pos = sum(1 for _, label in recipe if label)
+    print(f"\nBudget N = {budget} pairs (the recipe's size; every baseline draws the same N).")
+    print(
+        f"  recipe   : {recipe_pos} positives (hard-mined + augmented) + "
+        f"{budget - recipe_pos} negatives (2:1); denoiser dropped {n_flagged}"
+    )
+
+    recipe_f1 = fit_and_score(recipe, feature_specs, test_candidates, gold_pairs)
+
+    baseline_f1s: list[float] = []
+    baseline_pos: list[int] = []
+    for k in range(N_BASELINE_DRAWS):
+        draw = random.Random(1000 + k).sample(train_pool, min(budget, len(train_pool)))
+        baseline_pos.append(sum(1 for _, label in draw if label))
+        baseline_f1s.append(fit_and_score(draw, feature_specs, test_candidates, gold_pairs))
+    avg_draw_pos = mean(baseline_pos)
+    baseline_mean = mean(baseline_f1s)
+    margin = recipe_f1 - baseline_mean
+    beats = sum(1 for f1 in baseline_f1s if recipe_f1 > f1)
+
+    print(
+        f"  baseline : ~{avg_draw_pos:.1f} positives on average per random draw "
+        f"(the rest negatives)"
+    )
+    print("\nHeld-out pair F1")
+    print("-" * 70)
+    print(
+        f"  BASELINE (mean of {N_BASELINE_DRAWS} random draws) : "
+        f"{baseline_mean:.4f}  (+/- {pstdev(baseline_f1s):.4f}, best draw {max(baseline_f1s):.4f})"
+    )
+    print(f"  RECIPE  (curated, same N)                : {recipe_f1:.4f}")
+    print(f"  MARGIN  (recipe - baseline mean)         : {margin:+.4f}")
+    print(f"  Recipe beats {beats}/{N_BASELINE_DRAWS} individual random draws.")
+
+    verdict = "LIFT" if margin > 0 else "NO LIFT"
+    print(
+        f"\n=> {verdict}: at an equal {budget}-pair budget, curation "
+        f"{'beats' if margin > 0 else 'does not beat'} random by {margin:+.4f} F1."
+    )
+    print(
+        "   The lift is the balance + hard positives paying for themselves: a random\n"
+        "   draw from a 1:%d pool is mostly non-matches, so the matcher barely sees a\n"
+        "   match to learn from. A single lucky draw can approach the recipe, which is\n"
+        "   why the honest baseline is the MEAN over draws." % (n_neg / max(n_pos, 1))
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/src/langres/data/data_profile/__init__.py
+++ b/src/langres/data/data_profile/__init__.py
@@ -41,6 +41,11 @@ from langres.data.data_profile.embedding_source import (
     NpySource,
     cosine_signal,
 )
+from langres.data.data_profile.failure_mode import (
+    FailureModeSection,
+    FailureSlice,
+    profile_failure_mode,
+)
 from langres.data.data_profile.hero import HeroSection, build_hero
 from langres.data.data_profile.label_structure import (
     LabelStructureSection,
@@ -65,6 +70,8 @@ __all__ = [
     "HeroSection",
     "LabelStructureSection",
     "MiningReadinessSection",
+    "FailureModeSection",
+    "FailureSlice",
     "CorpusFieldSection",
     "FieldStat",
     "SeparabilitySection",
@@ -74,6 +81,7 @@ __all__ = [
     "build_hero",
     "profile_label_structure",
     "profile_mining_readiness",
+    "profile_failure_mode",
     "profile_corpus_fields",
     "profile_separability",
     "profile_embedding",

--- a/src/langres/data/data_profile/builders.py
+++ b/src/langres/data/data_profile/builders.py
@@ -8,14 +8,13 @@ entry points converge on one internal assembler (:func:`_assemble`) so the two
 paths return the *same* pinned section layout:
 
     hero -> label-structure -> separability -> [mining-readiness] ->
-    corpus-fields -> embeddings -> embedding-comparison
+    [failure-mode] -> corpus-fields -> embeddings -> embedding-comparison
 
 Each section is included only when its input is present; omitting an input drops
-that section silently (never a raise). Mining readiness is the one section this
-package does not *compute* -- it is a precomputed
-:class:`~langres.data.data_profile.mining_readiness.MiningReadinessSection` the
-caller assembles from the miners (which need scikit-learn) and passes in, keeping
-this package import-light. ``include=`` narrows the set further -- it
+that section silently (never a raise). Mining readiness and failure mode are the
+two sections this package does not *compute* -- each is a precomputed section the
+caller assembles from the miners / a matcher's judgement log (both needing
+scikit-learn or a matcher run) and passes in, keeping this package import-light. ``include=`` narrows the set further -- it
 is a **selector of section kinds** (it validates its keys and raises on an unknown
 one, because a typo there means "select nothing you meant to"), never a data
 input.
@@ -48,6 +47,7 @@ from langres.data.data_profile.embedding_source import (
     NpySource,
     cosine_signal,
 )
+from langres.data.data_profile.failure_mode import FailureModeSection
 from langres.data.data_profile.hero import build_hero
 from langres.data.data_profile.label_structure import profile_label_structure
 from langres.data.data_profile.mining_readiness import MiningReadinessSection
@@ -72,6 +72,7 @@ _KNOWN_KINDS: frozenset[str] = frozenset(
         "hero",
         "label_structure",
         "mining_readiness",
+        "failure_mode",
         "separability",
         "corpus_field",
         "embedding",
@@ -99,6 +100,7 @@ def from_benchmark(
     include: Collection[str] | None = None,
     embeddings: Sequence[EmbeddingSource] | None = None,
     mining_readiness: MiningReadinessSection | None = None,
+    failure_mode: FailureModeSection | None = None,
     negatives_cap: int = _DEFAULT_NEGATIVES_CAP,
     top_n_fields: int = 50,
     seed: int = _NEGATIVES_SEED,
@@ -127,6 +129,10 @@ def from_benchmark(
             :class:`~langres.data.data_profile.mining_readiness.MiningReadinessSection`
             (built by the caller from the miners -- this package runs no matcher).
             Omitting it drops the mining-readiness section.
+        failure_mode: Optional precomputed
+            :class:`~langres.data.data_profile.failure_mode.FailureModeSection`
+            (built by the caller from a matcher's judgement log + gold -- this
+            package runs no matcher). Omitting it drops the failure-mode section.
         negatives_cap: Cap on sampled non-matching pairs for the separability
             chart (logged when it truncates).
         top_n_fields: Row cap for the corpus-field table.
@@ -162,6 +168,7 @@ def from_benchmark(
         seed=seed,
         id_key="id",
         mining_readiness=mining_readiness,
+        failure_mode=failure_mode,
     )
 
 
@@ -172,6 +179,7 @@ def from_records(
     schema: "type[BaseModel] | None" = None,
     embeddings: Sequence[EmbeddingSource] | None = None,
     mining_readiness: MiningReadinessSection | None = None,
+    failure_mode: FailureModeSection | None = None,
     include: Collection[str] | None = None,
     id_key: str = "id",
     negatives_cap: int = _DEFAULT_NEGATIVES_CAP,
@@ -198,6 +206,9 @@ def from_records(
         mining_readiness: Optional precomputed
             :class:`~langres.data.data_profile.mining_readiness.MiningReadinessSection`
             (see :func:`from_benchmark`).
+        failure_mode: Optional precomputed
+            :class:`~langres.data.data_profile.failure_mode.FailureModeSection`
+            (see :func:`from_benchmark`).
         include: Optional selector of section *kinds* (see :func:`from_benchmark`).
         id_key: The record field holding the id used for pairs / embedding
             alignment (default ``"id"``).
@@ -222,6 +233,7 @@ def from_records(
         seed=seed,
         id_key=id_key,
         mining_readiness=mining_readiness,
+        failure_mode=failure_mode,
     )
 
 
@@ -332,14 +344,16 @@ def _assemble(
     seed: int,
     id_key: str,
     mining_readiness: MiningReadinessSection | None = None,
+    failure_mode: FailureModeSection | None = None,
 ) -> DataProfileReport:
     """Compose the pinned default section set; ``include=`` narrows it.
 
     Builds each section only when its input is present, in the pinned order, then
-    prepends the derived hero and applies the ``include=`` kind filter. A
-    ``mining_readiness`` section, when supplied, is a **precomputed** input the
-    caller assembled from the miners (this package never runs a matcher), inserted
-    after the label-structure / separability blocks.
+    prepends the derived hero and applies the ``include=`` kind filter. The
+    ``mining_readiness`` and ``failure_mode`` sections, when supplied, are
+    **precomputed** inputs the caller assembled from the miners / a matcher's
+    judgement log (this package never runs a matcher), inserted after the
+    label-structure / separability blocks.
     """
     sources = list(embeddings or [])
     id_map = _index_by_id(records, id_key)
@@ -364,6 +378,9 @@ def _assemble(
 
     if mining_readiness is not None:
         body.append(mining_readiness)
+
+    if failure_mode is not None:
+        body.append(failure_mode)
 
     fields = profile_corpus_fields(records, top_n=top_n_fields)
     if fields is not None:

--- a/src/langres/data/data_profile/failure_mode.py
+++ b/src/langres/data/data_profile/failure_mode.py
@@ -1,0 +1,615 @@
+"""Failure-mode profile section: where a matcher's errors concentrate.
+
+The post-hoc, error-analysis companion to mining readiness. Where mining
+readiness profiles a labeled set *before* training, this section profiles a
+matcher's *judgements after* it ran: it joins a precomputed
+:class:`~langres.core.judgement_log.JudgementLog` against gold, splits the
+confident verdicts into correct / false-positive / false-negative, and then asks
+the question that drives the next curation round -- **which slice of the data do
+the errors concentrate in?**
+
+It answers that two ways, both a *diff of the error distribution against the
+success distribution*:
+
+- a **score-band overlay** -- the density histogram of error scores vs correct
+  scores, so the uncertain middle band (where errors pile up) is visible;
+- a **slice table** -- error rate + *lift* (slice error rate / overall error
+  rate) per data slice: each score band, each content field's emptiness, and the
+  cross- vs same-source split. A lift well above ``1.0`` names a slice the next
+  mining round should target.
+
+Like :class:`~langres.data.data_profile.mining_readiness.MiningReadinessSection`
+it is a **pure consumer of precomputed inputs**: it runs no matcher and pulls no
+scikit-learn (keeping ``data_profile`` import-light). The caller runs the matcher
+(logging to a :class:`JudgementLog`), reads the rows back, and hands them plus the
+gold pairs (and, for the field/source slices, the id->record mapping) to
+:func:`profile_failure_mode`. Every input beyond the judgements + gold is optional
+and degrades to fewer slices -- the same graceful-degradation contract the rest of
+the report keeps.
+"""
+
+from __future__ import annotations
+
+import html
+import logging
+import math
+from collections.abc import Collection, Hashable, Mapping, Sequence
+from typing import Any, Literal
+
+from pydantic import BaseModel, ConfigDict
+
+from langres.core import _report_html, _svg
+from langres.data.data_profile.base import ProfileSection
+
+logger = logging.getLogger(__name__)
+
+#: Error / success series colors for the score overlay (explicit for light+dark;
+#: the eval_report palette -- errors warm, successes cool).
+_COLOR_ERROR = "#e76f51"
+_COLOR_SUCCESS = "#2a9d8f"
+
+#: Default number of equal-width score bands over ``[0, 1]`` (histogram + slices).
+_DEFAULT_SCORE_BANDS = 5
+
+#: Default cap on how many slices the table shows (the most concentrated first).
+_DEFAULT_MAX_SLICES = 12
+
+
+class FailureSlice(BaseModel):
+    """Error concentration in one data slice -- one row of the failure table.
+
+    A frozen record: how a single slice of the judged pairs (a score band, a
+    field's emptiness, the source split) fares against the overall error rate.
+
+    Attributes:
+        dimension: The slicing axis (e.g. ``"score_band"``, ``"empty:price"``,
+            ``"source"``).
+        value: The human label of this slice's bucket (e.g. ``"0.40-0.60"``,
+            ``"either side empty"``, ``"cross-source"``).
+        n: Confident (non-abstain) judged pairs in this slice -- the error-rate
+            denominator.
+        n_errors: Errors (verdict != gold) among those ``n`` pairs.
+        error_rate: ``n_errors / n``; ``None`` for an empty slice.
+        lift: ``error_rate`` relative to the overall error rate -- ``> 1`` means
+            errors concentrate here. ``None`` when the overall rate is ``0`` (no
+            errors anywhere) or the slice is empty.
+    """
+
+    model_config = ConfigDict(frozen=True)
+
+    dimension: str
+    value: str
+    n: int
+    n_errors: int
+    error_rate: float | None
+    lift: float | None
+
+
+class FailureModeSection(ProfileSection):
+    """Where a matcher's errors concentrate: FP/FN split + sliced error rates.
+
+    A frozen :class:`ProfileSection` holding the confusion headline (correct /
+    false-positive / false-negative / abstain), the error-vs-success score
+    histogram, and the per-slice :class:`FailureSlice` table. Build it with
+    :func:`profile_failure_mode`; it computes nothing that needs a model.
+
+    Attributes:
+        n_judged: Judged pairs joined against gold (all rows).
+        n_correct: Confident verdicts that matched gold.
+        n_errors: Confident verdicts that disagreed with gold.
+        n_abstain: Rows with no confident verdict (``verdict`` null) -- excluded
+            from the error rate (an abstain is not a wrong answer).
+        n_false_positive: Predicted match, gold non-match.
+        n_false_negative: Predicted non-match, gold match.
+        score_edges: Bin edges (``B + 1``) of the score overlay; empty when no
+            confident pair carried a score.
+        error_counts: Error scores per band (``B`` values).
+        success_counts: Correct scores per band (``B`` values).
+        slices: Failure slices, most concentrated (highest lift) first.
+        n_slices_hidden: Slices dropped by the display cap (0 when none).
+    """
+
+    kind: Literal["failure_mode"] = "failure_mode"
+
+    n_judged: int
+    n_correct: int
+    n_errors: int
+    n_abstain: int
+    n_false_positive: int
+    n_false_negative: int
+    score_edges: list[float]
+    error_counts: list[float]
+    success_counts: list[float]
+    slices: list[FailureSlice]
+    n_slices_hidden: int
+
+    # ------------------------------------------------------------- derived stats
+    @property
+    def n_confident(self) -> int:
+        """Confident verdicts (correct + errors) -- the error-rate denominator."""
+        return self.n_correct + self.n_errors
+
+    @property
+    def error_rate(self) -> float | None:
+        """Overall error rate over confident verdicts; ``None`` when none are confident."""
+        return self.n_errors / self.n_confident if self.n_confident else None
+
+    @property
+    def abstain_rate(self) -> float | None:
+        """Fraction of judged pairs with no confident verdict; ``None`` for an empty set."""
+        return self.n_abstain / self.n_judged if self.n_judged else None
+
+    # ------------------------------------------------------------- shared render
+    def _metrics_kv(self) -> list[tuple[str, str]]:
+        """The headline metrics as ``(label, display)`` pairs (markdown + HTML share this)."""
+        return [
+            ("judged pairs", f"{self.n_judged:,}"),
+            ("confident verdicts", f"{self.n_confident:,}"),
+            ("errors", _fmt_count_share(self.n_errors, self.error_rate)),
+            ("false positives", f"{self.n_false_positive:,}"),
+            ("false negatives", f"{self.n_false_negative:,}"),
+            ("abstentions", _fmt_count_share(self.n_abstain, self.abstain_rate)),
+        ]
+
+    # ------------------------------------------------------------ text surfaces
+    def to_markdown(self) -> str:
+        """Markdown: the confusion headline, then the concentrated-slice table."""
+        lines = [f"## {self.title}", "", "| metric | value |", "|---|---|"]
+        lines += [
+            f"| {_report_html._md_cell(k)} | {_report_html._md_cell(v)} |"
+            for k, v in self._metrics_kv()
+        ]
+        if self.n_judged == 0:
+            lines += ["", "_No judged pairs: nothing to analyze yet._"]
+            return "\n".join(lines)
+        lines += [
+            "",
+            "### Error concentration by slice",
+            "",
+            "| slice | value | pairs | errors | error rate | lift |",
+            "|---|---|---|---|---|---|",
+        ]
+        if self.slices:
+            for s in self.slices:
+                lines.append(
+                    f"| {_report_html._md_cell(s.dimension)} "
+                    f"| {_report_html._md_cell(s.value)} | {s.n:,} | {s.n_errors:,} "
+                    f"| {_fmt_pct(s.error_rate)} | {_report_html._num(s.lift, 2)} |"
+                )
+        else:
+            lines.append("| _(no slices)_ | | 0 | 0 | n/a | n/a |")
+        if self.n_slices_hidden:
+            lines += ["", f"_+{self.n_slices_hidden} more slice(s) below the display cap._"]
+        return "\n".join(lines)
+
+    @property
+    def summary(self) -> dict[str, Any]:
+        """Headline numbers as a flat, title-namespaced dict (collision-free per report)."""
+        return {
+            f"{self.title}.n_judged": self.n_judged,
+            f"{self.title}.n_errors": self.n_errors,
+            f"{self.title}.error_rate": self.error_rate,
+            f"{self.title}.n_false_positive": self.n_false_positive,
+            f"{self.title}.n_false_negative": self.n_false_negative,
+            f"{self.title}.n_abstain": self.n_abstain,
+        }
+
+    def rows(self) -> list[dict[str, Any]]:
+        """One row per failure slice -- ``pd.DataFrame(section.rows())``-ready."""
+        return [
+            {
+                "dimension": s.dimension,
+                "value": s.value,
+                "n": s.n,
+                "n_errors": s.n_errors,
+                "error_rate": s.error_rate,
+                "lift": s.lift,
+            }
+            for s in self.slices
+        ]
+
+    # -------------------------------------------------------------- html panel
+    def panels(self) -> list[str]:
+        """A single ``<section>``: the KV headline, the score overlay, the slice table."""
+        kv = "".join(
+            f"<tr><th>{html.escape(k)}</th><td>{html.escape(v)}</td></tr>"
+            for k, v in self._metrics_kv()
+        )
+        body = f'<table class="kv">{kv}</table>'
+        if self.error_counts or self.success_counts:
+            body += _svg.bar_chart(
+                self.score_edges,
+                [
+                    ("errors", _COLOR_ERROR, self.error_counts),
+                    ("correct", _COLOR_SUCCESS, self.success_counts),
+                ],
+                x_label="score",
+                y_label="density",
+                normalize="density",
+            )
+        body += self._slices_table_html()
+        return [_report_html.section(self.title, body)]
+
+    def _slices_table_html(self) -> str:
+        """The per-slice error-concentration table as an HTML ``<table>``."""
+        if not self.slices:
+            return '<p class="empty">No slices to report.</p>'
+        head = (
+            "<tr><th>slice</th><th>value</th><th>pairs</th><th>errors</th>"
+            "<th>error rate</th><th>lift</th></tr>"
+        )
+        body_rows = "".join(
+            f"<tr><td>{html.escape(s.dimension)}</td><td>{html.escape(s.value)}</td>"
+            f"<td>{s.n:,}</td><td>{s.n_errors:,}</td>"
+            f"<td>{html.escape(_fmt_pct(s.error_rate))}</td>"
+            f"<td>{html.escape(_report_html._num(s.lift, 2))}</td></tr>"
+            for s in self.slices
+        )
+        return f'<table class="errors">{head}{body_rows}</table>'
+
+
+# ---------------------------------------------------------------------------
+# One joined + labeled judged pair (internal working shape)
+# ---------------------------------------------------------------------------
+
+
+class _Judged:
+    """A judgement row joined to its gold label -- the working unit of the profiler."""
+
+    __slots__ = ("key", "left_id", "right_id", "score", "verdict", "gold")
+
+    def __init__(
+        self,
+        *,
+        left_id: str,
+        right_id: str,
+        score: float | None,
+        verdict: bool | None,
+        gold: bool,
+    ) -> None:
+        self.key = frozenset({left_id, right_id})
+        self.left_id = left_id
+        self.right_id = right_id
+        self.score = score
+        self.verdict = verdict
+        self.gold = gold
+
+    @property
+    def confident(self) -> bool:
+        """A confident verdict is a real match/non-match call (not an abstention)."""
+        return self.verdict is not None
+
+    @property
+    def error(self) -> bool:
+        """A confident verdict that disagrees with gold."""
+        return self.verdict is not None and self.verdict != self.gold
+
+
+def profile_failure_mode(
+    judgements: Sequence[Mapping[str, Any]],
+    *,
+    gold_pairs: Collection[Collection[Hashable]] | None,
+    records: Mapping[Hashable, Mapping[str, Any]] | None = None,
+    id_key: str = "id",
+    source_key: str | None = "source",
+    n_score_bands: int = _DEFAULT_SCORE_BANDS,
+    max_slices: int = _DEFAULT_MAX_SLICES,
+    title: str = "Failure modes",
+) -> FailureModeSection | None:
+    """Profile where a matcher's logged errors concentrate.
+
+    Joins each logged judgement to its gold label, splits the confident verdicts
+    into correct / false-positive / false-negative, and diffs the error
+    distribution against the success distribution -- a score overlay plus a
+    slice table (error rate + lift per score band, per content-field emptiness,
+    and the cross- vs same-source split).
+
+    Pure assembly over inputs the caller already produced -- it runs no matcher
+    and pulls no scikit-learn (keeping ``data_profile`` import-light).
+
+    Args:
+        judgements: Logged judge calls as mappings with at least ``left_id``,
+            ``right_id``, ``score`` and ``verdict`` keys -- e.g.
+            :meth:`JudgementLog.read() <langres.core.judgement_log.JudgementLog.read>`.
+            ``verdict`` is the caller's predicted-match decision (``None`` for an
+            abstention); ``score`` may be ``None`` for a decision-only judge.
+        gold_pairs: The gold positive pairs -- a collection of 2-id collections
+            (order-independent). A judged pair is a true match iff it is in this
+            set (closed-world: any pair not listed is a true non-match). ``None``
+            means no gold is available, and the profiler returns ``None`` (the
+            section is omitted, logged) -- errors cannot be identified without it.
+        records: Optional ``id -> field mapping`` for the two records of each
+            pair. Enables the field-emptiness and source slices; omit it and only
+            the score-band slices are produced.
+        id_key: Record field holding the id (default ``"id"``); excluded from the
+            field-emptiness slices.
+        source_key: Record field naming the linkage side for the cross/same-source
+            slice (default ``"source"``); pass ``None`` to skip that slice, and it
+            is skipped automatically when the field is absent. Excluded from the
+            field-emptiness slices.
+        n_score_bands: Equal-width score bands over ``[0, 1]`` for the overlay and
+            the score-band slices.
+        max_slices: Cap on how many slices the table shows (most concentrated
+            first); the remainder are counted in ``n_slices_hidden``.
+        title: Section heading; also the report lookup key and the namespace for
+            this section's :attr:`~FailureModeSection.summary` keys.
+
+    Returns:
+        A :class:`FailureModeSection`, or ``None`` when there is nothing to
+        analyze (no judgements, or no gold) -- logged, never raised.
+    """
+    if not judgements:
+        logger.warning("profile_failure_mode: no judgements to analyze; returning None.")
+        return None
+    if gold_pairs is None:
+        logger.warning(
+            "profile_failure_mode: gold_pairs is None; cannot identify errors without gold. "
+            "Returning None."
+        )
+        return None
+
+    gold = _normalize_gold(gold_pairs)
+    judged = _join_gold(judgements, gold)
+    confident = [j for j in judged if j.confident]
+
+    n_false_positive = sum(1 for j in confident if j.verdict and not j.gold)
+    n_false_negative = sum(1 for j in confident if not j.verdict and j.gold)
+    n_errors = sum(1 for j in confident if j.error)
+    n_correct = len(confident) - n_errors
+    overall_rate = n_errors / len(confident) if confident else None
+
+    score_edges, error_counts, success_counts = _score_overlay(confident, n_score_bands)
+
+    all_slices = _build_slices(
+        confident,
+        overall_rate,
+        records=records,
+        id_key=id_key,
+        source_key=source_key,
+        n_score_bands=n_score_bands,
+    )
+    ranked = _rank_slices(all_slices)
+    shown = ranked[:max_slices]
+
+    return FailureModeSection(
+        title=title,
+        n_judged=len(judged),
+        n_correct=n_correct,
+        n_errors=n_errors,
+        n_abstain=len(judged) - len(confident),
+        n_false_positive=n_false_positive,
+        n_false_negative=n_false_negative,
+        score_edges=score_edges,
+        error_counts=error_counts,
+        success_counts=success_counts,
+        slices=shown,
+        n_slices_hidden=len(ranked) - len(shown),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Join + slice helpers
+# ---------------------------------------------------------------------------
+
+
+def _normalize_gold(gold_pairs: Collection[Collection[Hashable]]) -> set[frozenset[str]]:
+    """Normalize any gold-pair collection to a set of 2-id ``frozenset``\\ s of strings.
+
+    Accepts the ``set[frozenset[str]]`` shape :func:`evaluate` uses as well as a
+    plain sequence of ``(left, right)`` tuples, keying ids as strings so the join
+    matches the judgement log (which logs ids as strings). Malformed pairs (not
+    exactly two distinct ids) are dropped.
+    """
+    normalized: set[frozenset[str]] = set()
+    for pair in gold_pairs:
+        key = frozenset(str(identifier) for identifier in pair)
+        if len(key) == 2:
+            normalized.add(key)
+    return normalized
+
+
+def _join_gold(judgements: Sequence[Mapping[str, Any]], gold: set[frozenset[str]]) -> list[_Judged]:
+    """Join each judgement row to its gold label (in the log's row order)."""
+    joined: list[_Judged] = []
+    for row in judgements:
+        left_id = str(row["left_id"])
+        right_id = str(row["right_id"])
+        raw_score = row.get("score")
+        joined.append(
+            _Judged(
+                left_id=left_id,
+                right_id=right_id,
+                score=None if raw_score is None else float(raw_score),
+                verdict=row.get("verdict"),
+                gold=frozenset({left_id, right_id}) in gold,
+            )
+        )
+    return joined
+
+
+def _score_overlay(
+    confident: Sequence[_Judged], n_bands: int
+) -> tuple[list[float], list[float], list[float]]:
+    """Bin error vs correct scores into ``[0, 1]`` bands; ``([], [], [])`` when no scores.
+
+    The diff of the error distribution against the success distribution along the
+    score axis: two histograms sharing fixed ``[0, 1]`` edges so the bands line up
+    (density normalization happens at render time). Confident pairs without a
+    score (a decision-only judge) contribute to neither.
+    """
+    error_scores = [j.score for j in confident if j.error and j.score is not None]
+    success_scores = [j.score for j in confident if not j.error and j.score is not None]
+    if not error_scores and not success_scores:
+        return [], [], []
+    edges = [i / n_bands for i in range(n_bands + 1)]
+    error_counts = _report_html._histogram([s for s in error_scores if s is not None], edges)
+    success_counts = _report_html._histogram([s for s in success_scores if s is not None], edges)
+    return edges, error_counts, success_counts
+
+
+def _build_slices(
+    confident: Sequence[_Judged],
+    overall_rate: float | None,
+    *,
+    records: Mapping[Hashable, Mapping[str, Any]] | None,
+    id_key: str,
+    source_key: str | None,
+    n_score_bands: int,
+) -> list[FailureSlice]:
+    """Build every failure slice: score bands, then (with records) field / source."""
+    slices: list[FailureSlice] = []
+    slices += _score_band_slices(confident, overall_rate, n_score_bands)
+    if records is not None:
+        slices += _field_empty_slices(
+            confident, overall_rate, records=records, id_key=id_key, source_key=source_key
+        )
+        if source_key is not None:
+            slices += _source_slices(
+                confident, overall_rate, records=records, source_key=source_key
+            )
+    return slices
+
+
+def _slice(
+    dimension: str, value: str, bucket: Sequence[_Judged], overall_rate: float | None
+) -> FailureSlice:
+    """Aggregate one bucket of confident pairs into a :class:`FailureSlice`."""
+    n = len(bucket)
+    n_errors = sum(1 for j in bucket if j.error)
+    rate = n_errors / n if n else None
+    lift = rate / overall_rate if (rate is not None and overall_rate) else None
+    return FailureSlice(
+        dimension=dimension, value=value, n=n, n_errors=n_errors, error_rate=rate, lift=lift
+    )
+
+
+def _score_band_slices(
+    confident: Sequence[_Judged], overall_rate: float | None, n_bands: int
+) -> list[FailureSlice]:
+    """One slice per score band (pairs with a score); empty bands are dropped."""
+    scored = [j for j in confident if j.score is not None]
+    if not scored:
+        return []
+    buckets: dict[int, list[_Judged]] = {b: [] for b in range(n_bands)}
+    for j in scored:
+        assert j.score is not None  # narrowed by the filter above
+        band = min(int(j.score * n_bands), n_bands - 1)  # score==1.0 lands in the last band
+        buckets[band].append(j)
+    out: list[FailureSlice] = []
+    for b in range(n_bands):
+        if not buckets[b]:
+            continue
+        label = f"{b / n_bands:.2f}-{(b + 1) / n_bands:.2f}"
+        out.append(_slice("score_band", label, buckets[b], overall_rate))
+    return out
+
+
+def _field_empty_slices(
+    confident: Sequence[_Judged],
+    overall_rate: float | None,
+    *,
+    records: Mapping[Hashable, Mapping[str, Any]],
+    id_key: str,
+    source_key: str | None,
+) -> list[FailureSlice]:
+    """One slice per content field: error rate among pairs missing that field on either side.
+
+    A field is "empty on either side" when at least one of the pair's two records
+    has no non-empty value for it (absent, ``None``, or blank string). Fields never
+    empty across the confident pairs contribute no slice (nothing to concentrate).
+    ``id_key`` and ``source_key`` are structural, not content, so both are skipped.
+    """
+    skip = {id_key} | ({source_key} if source_key is not None else set())
+    fields = _content_fields(records, skip)
+    out: list[FailureSlice] = []
+    for field in fields:
+        bucket = [j for j in confident if _either_empty(j, field, records)]
+        if bucket:
+            out.append(_slice(f"empty:{field}", "either side empty", bucket, overall_rate))
+    return out
+
+
+def _source_slices(
+    confident: Sequence[_Judged],
+    overall_rate: float | None,
+    *,
+    records: Mapping[Hashable, Mapping[str, Any]],
+    source_key: str,
+) -> list[FailureSlice]:
+    """Cross-source vs same-source slices (skipped when no pair carries the source key)."""
+    buckets: dict[str, list[_Judged]] = {"cross-source": [], "same-source": []}
+    for j in confident:
+        left = records.get(j.left_id)
+        right = records.get(j.right_id)
+        if left is None or right is None:
+            continue
+        if source_key not in left or source_key not in right:
+            continue
+        same = left.get(source_key) == right.get(source_key)
+        buckets["same-source" if same else "cross-source"].append(j)
+    return [
+        _slice("source", value, bucket, overall_rate) for value, bucket in buckets.items() if bucket
+    ]
+
+
+def _content_fields(records: Mapping[Hashable, Mapping[str, Any]], skip: set[str]) -> list[str]:
+    """The sorted union of the records' field names, minus the structural ``skip`` set."""
+    names: set[str] = set()
+    for record in records.values():
+        names.update(record.keys())
+    return sorted(names - skip)
+
+
+def _either_empty(
+    judged: _Judged, field: str, records: Mapping[Hashable, Mapping[str, Any]]
+) -> bool:
+    """``True`` if ``field`` is empty on either record of the pair (or a record is absent)."""
+    left = records.get(judged.left_id)
+    right = records.get(judged.right_id)
+    if left is None or right is None:
+        return True
+    return _is_empty(left.get(field)) or _is_empty(right.get(field))
+
+
+def _is_empty(value: Any) -> bool:
+    """A field value counts as empty when absent, ``None``, or a blank/whitespace string."""
+    if value is None:
+        return True
+    if isinstance(value, str):
+        return not value.strip()
+    return False
+
+
+def _rank_slices(slices: Sequence[FailureSlice]) -> list[FailureSlice]:
+    """Sort slices most-concentrated first: by lift (then error rate, then size), desc.
+
+    A slice with an undefined lift (no errors anywhere, or an empty overall rate)
+    sorts last -- there is no concentration to surface.
+    """
+    return sorted(
+        slices,
+        key=lambda s: (
+            s.lift if s.lift is not None else -1.0,
+            s.error_rate if s.error_rate is not None else -1.0,
+            s.n,
+        ),
+        reverse=True,
+    )
+
+
+def _fmt_pct(value: float | None) -> str:
+    """A fraction as a scannable percentage (3 sig figs); ``None``/NaN/Inf -> ``"n/a"``.
+
+    ``%.3g`` (not ``%.2g``) so a full ``100%`` error rate -- common in a small
+    slice -- renders as ``"100%"`` rather than ``.2g``'s scientific ``"1e+02%"``.
+    """
+    if value is None or not math.isfinite(value):
+        return "n/a"
+    return f"{value * 100:.3g}%"
+
+
+def _fmt_count_share(count: int, share: float | None) -> str:
+    """``"<count> (<pct>)"`` when a share is defined, else the bare count."""
+    if share is None:
+        return f"{count:,}"
+    return f"{count:,} ({_fmt_pct(share)})"

--- a/src/langres/data/mining.py
+++ b/src/langres/data/mining.py
@@ -421,8 +421,10 @@ def augment_by_attribute(
 def _nonempty_string_fields(record: Any) -> set[str]:
     """Names of the record's non-empty string fields, excluding ``id``.
 
-    These are exactly the attributes a string comparator compares and a text
-    serializer renders, so blanking one is a meaningful "missing field" signal.
+    These are the record's content attributes -- what a string comparator
+    compares -- so blanking one is a meaningful "missing field" signal. ``id``
+    is excluded because it is a primary key, never a content field to blank
+    (a text serializer may still render it).
     """
     return {
         field

--- a/tests/data/data_profile/test_failure_mode.py
+++ b/tests/data/data_profile/test_failure_mode.py
@@ -1,0 +1,463 @@
+"""Tests for the ``FailureModeSection`` + ``profile_failure_mode``.
+
+Covers the log<->gold join and the FP/FN/abstain split, the score-band /
+field-emptiness / source slicing (error rate + lift), the error-vs-success score
+overlay, slice ranking + the display cap, the render ladder (markdown / summary /
+rows / panels), graceful degrade on missing judgements / gold / records, empty
+and degenerate inputs (all-correct, all-abstain), and the section's wiring into
+``DataProfileReport`` (``from_records(failure_mode=...)`` + the ``include=``
+filter).
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from langres.data.data_profile import (
+    DataProfileReport,
+    FailureModeSection,
+    FailureSlice,
+    from_records,
+    profile_failure_mode,
+)
+
+
+def _row(left: str, right: str, score: float | None, verdict: bool | None) -> dict[str, Any]:
+    """One JudgementLog-shaped row."""
+    return {"left_id": left, "right_id": right, "score": score, "verdict": verdict}
+
+
+def _records(*items: tuple[str, dict[str, Any]]) -> dict[str, dict[str, Any]]:
+    """An id -> field-mapping table for the field/source slices."""
+    return dict(items)
+
+
+def _basic() -> FailureModeSection:
+    """A small, deterministic profile exercising every branch (FP, FN, TP, TN, abstain)."""
+    judgements = [
+        _row("a1", "b1", 0.90, True),  # gold match, predicted match  -> correct
+        _row("a2", "b2", 0.55, True),  # gold non-match, predicted match -> FP
+        _row("a3", "b3", 0.45, False),  # gold match, predicted non-match -> FN
+        _row("a4", "b4", 0.10, False),  # gold non-match, predicted non-match -> correct
+        _row("a5", "b5", None, None),  # abstain
+    ]
+    gold = {frozenset({"a1", "b1"}), frozenset({"a3", "b3"})}
+    records = _records(
+        ("a1", {"id": "a1", "name": "Acme", "price": "10", "source": "abt"}),
+        ("b1", {"id": "b1", "name": "Acme Inc", "price": "10", "source": "buy"}),
+        ("a2", {"id": "a2", "name": "Zephyr", "price": "", "source": "abt"}),  # price empty
+        ("b2", {"id": "b2", "name": "Zephyr Co", "price": "5", "source": "buy"}),
+        ("a3", {"id": "a3", "name": "Nimbus", "price": None, "source": "abt"}),  # price empty
+        ("b3", {"id": "b3", "name": "Nimbus LLC", "price": "8", "source": "buy"}),
+        ("a4", {"id": "a4", "name": "Vertex", "price": "3", "source": "abt"}),
+        ("b4", {"id": "b4", "name": "Orion", "price": "9", "source": "abt"}),  # same-source
+        ("a5", {"id": "a5", "name": "Titan", "price": "1", "source": "abt"}),
+        ("b5", {"id": "b5", "name": "Nova", "price": "2", "source": "buy"}),
+    )
+    section = profile_failure_mode(judgements, gold_pairs=gold, records=records, n_score_bands=5)
+    assert section is not None
+    return section
+
+
+class TestJoinAndSplit:
+    def test_confusion_counts(self) -> None:
+        section = _basic()
+        assert section.n_judged == 5
+        assert section.n_correct == 2  # a1/b1, a4/b4
+        assert section.n_errors == 2  # a2/b2 (FP), a3/b3 (FN)
+        assert section.n_false_positive == 1
+        assert section.n_false_negative == 1
+        assert section.n_abstain == 1
+
+    def test_derived_rates(self) -> None:
+        section = _basic()
+        assert section.n_confident == 4
+        assert section.error_rate == 0.5  # 2 errors / 4 confident
+        assert section.abstain_rate == 0.2  # 1 / 5
+
+    def test_gold_normalizes_from_tuples_and_ignores_order(self) -> None:
+        # gold given as (left, right) tuples in the *opposite* order to the log.
+        judgements = [_row("a", "b", 0.9, True)]
+        section = profile_failure_mode(judgements, gold_pairs=[("b", "a")])
+        assert section is not None
+        assert section.n_correct == 1 and section.n_errors == 0
+
+    def test_gold_drops_malformed_pairs(self) -> None:
+        # A self-pair (one distinct id) is not a valid gold pair and is dropped.
+        judgements = [_row("a", "b", 0.9, True)]
+        section = profile_failure_mode(judgements, gold_pairs=[("a", "a"), ("x", "y")])
+        assert section is not None
+        assert section.n_false_positive == 1  # (a,b) not gold -> predicted match is a FP
+
+    def test_int_ids_are_stringified_on_join(self) -> None:
+        # Log ids may arrive as ints; the join keys them as strings (like the log).
+        judgements = [_row("1", "2", 0.9, True)]
+        section = profile_failure_mode(judgements, gold_pairs=[(1, 2)])
+        assert section is not None
+        assert section.n_correct == 1
+
+
+class TestScoreSlicesAndOverlay:
+    def test_score_band_slice_rates_and_lift(self) -> None:
+        section = _basic()
+        bands = {s.value: s for s in section.slices if s.dimension == "score_band"}
+        # the two errors (0.55 and 0.45) both fall in the 0.40-0.60 band -> 100% error
+        mid = bands["0.40-0.60"]
+        assert mid.n == 2 and mid.n_errors == 2
+        assert mid.error_rate == 1.0
+        assert mid.lift == 2.0  # 1.0 / overall 0.5
+
+    def test_score_one_lands_in_last_band(self) -> None:
+        judgements = [_row("a", "b", 1.0, True)]  # correct, score exactly 1.0
+        section = profile_failure_mode(judgements, gold_pairs=[("a", "b")], n_score_bands=5)
+        assert section is not None
+        bands = {s.value for s in section.slices if s.dimension == "score_band"}
+        assert "0.80-1.00" in bands
+
+    def test_overlay_counts_split_error_vs_success(self) -> None:
+        section = _basic()
+        assert len(section.score_edges) == 6  # n_bands + 1
+        assert sum(section.error_counts) == 2  # the 2 errors carried a score
+        assert sum(section.success_counts) == 2  # the 2 correct verdicts carried a score
+
+    def test_deciders_have_no_score_overlay(self) -> None:
+        # Decision-only rows (score=None, verdict set) -> no scores to bin, no bands.
+        judgements = [_row("a", "b", None, True), _row("c", "d", None, False)]
+        section = profile_failure_mode(judgements, gold_pairs=[("a", "b")])
+        assert section is not None
+        assert section.score_edges == []
+        assert section.error_counts == [] and section.success_counts == []
+        assert not any(s.dimension == "score_band" for s in section.slices)
+
+
+class TestCategoricalSlices:
+    def test_field_empty_slice(self) -> None:
+        section = _basic()
+        empty_price = next(s for s in section.slices if s.dimension == "empty:price")
+        # a2/b2 (empty) and a3/b3 (None) both have an empty price and are both errors
+        assert empty_price.value == "either side empty"
+        assert empty_price.n == 2 and empty_price.n_errors == 2
+        assert empty_price.error_rate == 1.0 and empty_price.lift == 2.0
+
+    def test_source_cross_vs_same(self) -> None:
+        section = _basic()
+        by_value = {s.value: s for s in section.slices if s.dimension == "source"}
+        assert set(by_value) == {"cross-source", "same-source"}
+        # a4/b4 is the only same-source confident pair, and it is correct.
+        assert by_value["same-source"].n == 1 and by_value["same-source"].n_errors == 0
+
+    def test_id_and_source_excluded_from_field_slices(self) -> None:
+        section = _basic()
+        dims = {s.dimension for s in section.slices}
+        assert "empty:id" not in dims  # id is structural, never a content field
+        assert "empty:source" not in dims  # source has its own dimension
+
+    def test_no_records_yields_only_score_slices(self) -> None:
+        judgements = [_row("a", "b", 0.9, True), _row("c", "d", 0.4, False)]
+        section = profile_failure_mode(judgements, gold_pairs=[("c", "d")], records=None)
+        assert section is not None
+        assert {s.dimension for s in section.slices} == {"score_band"}
+
+    def test_source_key_none_skips_source_slice(self) -> None:
+        section = _basic_with(source_key=None)
+        assert not any(s.dimension == "source" for s in section.slices)
+
+    def test_source_absent_from_records_skips_source_slice(self) -> None:
+        judgements = [_row("a", "b", 0.9, True)]
+        records = _records(("a", {"id": "a", "name": "x"}), ("b", {"id": "b", "name": "y"}))
+        section = profile_failure_mode(judgements, gold_pairs=[("a", "b")], records=records)
+        assert section is not None
+        assert not any(s.dimension == "source" for s in section.slices)
+
+
+def _basic_with(**kwargs: Any) -> FailureModeSection:
+    """A ``_basic``-shaped profile with overridable ``profile_failure_mode`` kwargs."""
+    judgements = [
+        _row("a1", "b1", 0.9, True),
+        _row("a2", "b2", 0.55, True),
+        _row("a3", "b3", 0.45, False),
+    ]
+    gold = {frozenset({"a1", "b1"}), frozenset({"a3", "b3"})}
+    records = _records(
+        ("a1", {"id": "a1", "name": "Acme", "source": "abt"}),
+        ("b1", {"id": "b1", "name": "Acme Inc", "source": "buy"}),
+        ("a2", {"id": "a2", "name": "Zephyr", "source": "abt"}),
+        ("b2", {"id": "b2", "name": "Zephyr Co", "source": "buy"}),
+        ("a3", {"id": "a3", "name": "Nimbus", "source": "abt"}),
+        ("b3", {"id": "b3", "name": "Nimbus LLC", "source": "buy"}),
+    )
+    section = profile_failure_mode(judgements, gold_pairs=gold, records=records, **kwargs)
+    assert section is not None
+    return section
+
+
+class TestRankingAndCap:
+    def test_slices_ranked_by_lift_descending(self) -> None:
+        section = _basic()
+        lifts = [s.lift for s in section.slices if s.lift is not None]
+        assert lifts == sorted(lifts, reverse=True)
+
+    def test_max_slices_caps_and_counts_hidden(self) -> None:
+        section = profile_failure_mode(
+            _basic_judgements(), gold_pairs=_basic_gold(), records=_basic_records(), max_slices=2
+        )
+        assert section is not None
+        assert len(section.slices) == 2
+        assert section.n_slices_hidden >= 1
+
+    def test_no_cap_hides_nothing(self) -> None:
+        section = _basic()
+        assert section.n_slices_hidden == 0
+
+
+def _basic_judgements() -> list[dict[str, Any]]:
+    return [
+        _row("a1", "b1", 0.90, True),
+        _row("a2", "b2", 0.55, True),
+        _row("a3", "b3", 0.45, False),
+        _row("a4", "b4", 0.10, False),
+    ]
+
+
+def _basic_gold() -> set[frozenset[str]]:
+    return {frozenset({"a1", "b1"}), frozenset({"a3", "b3"})}
+
+
+def _basic_records() -> dict[str, dict[str, Any]]:
+    return _records(
+        ("a1", {"id": "a1", "name": "Acme", "price": "10", "source": "abt"}),
+        ("b1", {"id": "b1", "name": "Acme Inc", "price": "10", "source": "buy"}),
+        ("a2", {"id": "a2", "name": "Zephyr", "price": "", "source": "abt"}),
+        ("b2", {"id": "b2", "name": "Zephyr Co", "price": "5", "source": "buy"}),
+        ("a3", {"id": "a3", "name": "Nimbus", "price": None, "source": "abt"}),
+        ("b3", {"id": "b3", "name": "Nimbus LLC", "price": "8", "source": "buy"}),
+        ("a4", {"id": "a4", "name": "Vertex", "price": "3", "source": "abt"}),
+        ("b4", {"id": "b4", "name": "Orion", "price": "9", "source": "abt"}),
+    )
+
+
+class TestGracefulDegradation:
+    def test_no_judgements_returns_none(self) -> None:
+        assert profile_failure_mode([], gold_pairs=[("a", "b")]) is None
+
+    def test_no_gold_returns_none(self) -> None:
+        assert profile_failure_mode([_row("a", "b", 0.9, True)], gold_pairs=None) is None
+
+    def test_all_correct_gives_zero_error_and_no_lift(self) -> None:
+        # Every verdict matches gold: error rate 0, and no slice can have a lift.
+        judgements = [_row("a", "b", 0.9, True), _row("c", "d", 0.1, False)]
+        section = profile_failure_mode(judgements, gold_pairs=[("a", "b")])
+        assert section is not None
+        assert section.n_errors == 0
+        assert section.error_rate == 0.0
+        assert all(s.lift is None for s in section.slices)  # overall rate 0 -> lift undefined
+
+    def test_all_abstain_gives_no_confident_and_no_slices(self) -> None:
+        judgements = [_row("a", "b", None, None), _row("c", "d", None, None)]
+        records = _records(
+            ("a", {"id": "a", "name": "x"}),
+            ("b", {"id": "b", "name": "y"}),
+            ("c", {"id": "c", "name": "z"}),
+            ("d", {"id": "d", "name": "w"}),
+        )
+        section = profile_failure_mode(judgements, gold_pairs=[("a", "b")], records=records)
+        assert section is not None
+        assert section.n_judged == 2
+        assert section.n_confident == 0
+        assert section.error_rate is None
+        assert section.abstain_rate == 1.0
+        assert section.slices == []
+        assert "_(no slices)_" in section.to_markdown()  # n_judged>0 but no slice rows
+
+    def test_record_missing_from_mapping_marks_field_empty_and_skips_source(self) -> None:
+        # The pair's ids are absent from `records`: every content field reads empty
+        # for the pair, and the source slice cannot classify a pair it has no records for.
+        judgements = [_row("x", "y", 0.9, False)]  # gold match, predicted non-match -> FN
+        records = _records(("z", {"id": "z", "name": "present", "source": "abt"}))
+        section = profile_failure_mode(judgements, gold_pairs=[("x", "y")], records=records)
+        assert section is not None
+        assert any(s.dimension == "empty:name" for s in section.slices)
+        assert not any(s.dimension == "source" for s in section.slices)
+
+    def test_non_string_field_value_is_never_empty(self) -> None:
+        # A present, non-string value (e.g. a number) is not "empty" -> no slice for it.
+        judgements = [_row("a", "b", 0.4, False)]  # FN error to slice on
+        records = _records(
+            ("a", {"id": "a", "name": "x", "year": 2020}),
+            ("b", {"id": "b", "name": "y", "year": 2021}),
+        )
+        section = profile_failure_mode(judgements, gold_pairs=[("a", "b")], records=records)
+        assert section is not None
+        assert not any(s.dimension == "empty:year" for s in section.slices)
+
+    def test_empty_field_detection_treats_blank_and_missing_alike(self) -> None:
+        # "", "   ", None, and an absent key all count as empty on that side.
+        judgements = [_row("a", "b", 0.4, False)]  # FN so it is an error to slice on
+        records = _records(
+            ("a", {"id": "a", "name": "x", "extra": "   "}),  # whitespace -> empty
+            ("b", {"id": "b", "name": "y"}),  # 'extra' absent -> empty
+        )
+        section = profile_failure_mode(judgements, gold_pairs=[("a", "b")], records=records)
+        assert section is not None
+        assert any(s.dimension == "empty:extra" for s in section.slices)
+
+
+class TestRenderLadder:
+    def test_markdown_headline_and_slice_table(self) -> None:
+        md = _basic().to_markdown()
+        assert md.startswith("## Failure modes")
+        assert "false negatives" in md
+        assert "Error concentration by slice" in md
+        assert "| score_band |" in md
+        assert "NaN" not in md and "Infinity" not in md
+
+    def test_markdown_full_error_rate_renders_100_not_scientific(self) -> None:
+        # A 100% slice error rate must render "100%", never ".2g" scientific "1e+02%".
+        assert "1e+02" not in _basic().to_markdown()
+        assert "100%" in _basic().to_markdown()
+
+    def test_summary_is_title_namespaced(self) -> None:
+        assert _basic().summary == {
+            "Failure modes.n_judged": 5,
+            "Failure modes.n_errors": 2,
+            "Failure modes.error_rate": 0.5,
+            "Failure modes.n_false_positive": 1,
+            "Failure modes.n_false_negative": 1,
+            "Failure modes.n_abstain": 1,
+        }
+
+    def test_rows_one_per_slice(self) -> None:
+        section = _basic()
+        rows = section.rows()
+        assert len(rows) == len(section.slices)
+        assert set(rows[0]) == {"dimension", "value", "n", "n_errors", "error_rate", "lift"}
+
+    def test_panels_render_kv_overlay_and_slice_table(self) -> None:
+        panel = _basic().panels()[0]
+        assert panel.startswith("<section><h2>Failure modes</h2>")
+        assert 'table class="kv"' in panel
+        assert "<svg" in panel  # error-vs-success score overlay
+        assert 'table class="errors"' in panel  # slice table
+        assert "NaN" not in panel and "Infinity" not in panel
+
+    def test_panels_without_scores_have_no_overlay(self) -> None:
+        judgements = [_row("a", "b", None, True)]  # decider: no score
+        section = profile_failure_mode(judgements, gold_pairs=[("a", "b")])
+        assert section is not None
+        panel = section.panels()[0]
+        assert "<svg" not in panel
+
+    def test_panels_without_slices_render_empty_note(self) -> None:
+        judgements = [_row("a", "b", None, None)]  # abstain -> no confident, no slices
+        section = profile_failure_mode(judgements, gold_pairs=[("a", "b")])
+        assert section is not None
+        panel = section.panels()[0]
+        assert "No slices to report." in panel
+
+    def test_zero_judged_section_renders_note(self) -> None:
+        # n_judged == 0 is unreachable via the profiler (it returns None), but the
+        # section's defensive branch still renders an honest note.
+        section = FailureModeSection(
+            title="Failure modes",
+            n_judged=0,
+            n_correct=0,
+            n_errors=0,
+            n_abstain=0,
+            n_false_positive=0,
+            n_false_negative=0,
+            score_edges=[],
+            error_counts=[],
+            success_counts=[],
+            slices=[],
+            n_slices_hidden=0,
+        )
+        assert "nothing to analyze" in section.to_markdown()
+        assert section.error_rate is None and section.abstain_rate is None
+
+    def test_hidden_slices_noted_in_markdown(self) -> None:
+        section = profile_failure_mode(
+            _basic_judgements(), gold_pairs=_basic_gold(), records=_basic_records(), max_slices=2
+        )
+        assert section is not None
+        assert "below the display cap" in section.to_markdown()
+
+    def test_markdown_renders_null_rate_slice_as_na(self) -> None:
+        # A null-rate slice (n=0) is unreachable via the profiler but the render
+        # guards it: the error rate renders "n/a" rather than crashing on None.
+        section = FailureModeSection(
+            title="Failure modes",
+            n_judged=3,
+            n_correct=3,
+            n_errors=0,
+            n_abstain=0,
+            n_false_positive=0,
+            n_false_negative=0,
+            score_edges=[],
+            error_counts=[],
+            success_counts=[],
+            slices=[
+                FailureSlice(
+                    dimension="score_band",
+                    value="0.00-0.20",
+                    n=0,
+                    n_errors=0,
+                    error_rate=None,
+                    lift=None,
+                )
+            ],
+            n_slices_hidden=0,
+        )
+        md = section.to_markdown()
+        assert "n/a" in md
+        assert "NaN" not in md and "Infinity" not in md
+
+    def test_failure_slice_is_frozen(self) -> None:
+        s = FailureSlice(dimension="d", value="v", n=1, n_errors=1, error_rate=1.0, lift=2.0)
+        assert isinstance(s, FailureSlice)
+
+
+class TestReportWiring:
+    def _records_and_gold(self) -> tuple[list[dict[str, str]], list[set[str]]]:
+        records = [
+            {"id": "1", "name": "Acme"},
+            {"id": "2", "name": "Acme Inc"},
+            {"id": "3", "name": "Zephyr"},
+        ]
+        gold = [{"1", "2"}, {"3"}]
+        return records, gold
+
+    def _section(self) -> FailureModeSection:
+        section = profile_failure_mode(
+            [_row("1", "2", 0.9, True), _row("1", "3", 0.6, True)],
+            gold_pairs=[("1", "2")],
+        )
+        assert section is not None
+        return section
+
+    def test_section_included_when_supplied(self) -> None:
+        records, gold = self._records_and_gold()
+        report = from_records(records, gold=gold, failure_mode=self._section())
+        assert isinstance(report["Failure modes"], FailureModeSection)
+
+    def test_section_absent_when_not_supplied(self) -> None:
+        records, gold = self._records_and_gold()
+        report = from_records(records, gold=gold)
+        assert "failure_mode" not in {s.kind for s in report.sections}
+
+    def test_include_selects_the_kind(self) -> None:
+        records, gold = self._records_and_gold()
+        report = from_records(
+            records, gold=gold, failure_mode=self._section(), include=["failure_mode"]
+        )
+        assert {s.kind for s in report.sections} == {"failure_mode"}
+
+    def test_report_renders_with_section(self) -> None:
+        records, gold = self._records_and_gold()
+        report = from_records(records, gold=gold, failure_mode=self._section())
+        assert "Failure modes" in report.to_markdown()
+        assert "<section><h2>Failure modes</h2>" in report.to_html()
+
+    def test_report_is_a_data_profile_report(self) -> None:
+        records, gold = self._records_and_gold()
+        report = from_records(records, gold=gold, failure_mode=self._section())
+        assert isinstance(report, DataProfileReport)

--- a/tests/data/test_recipe_lift.py
+++ b/tests/data/test_recipe_lift.py
@@ -1,0 +1,187 @@
+"""Behavior test for the recipe-lift claim: curation beats random at an equal budget.
+
+The seeded, synthetic-and-fast twin of ``examples/recipe_lift_proof.py``. It builds
+a heavily imbalanced fuzzy pair pool (near-duplicate matched clusters drowned in
+random non-matches -- the shape a real all-pairs blocked ER pool has), then checks
+that a *curated* training set (denoise + hard positives + attribute augmentation +
+2:1 balance, the four Wave-A miners) trains a matcher with a materially higher
+held-out pair-F1 than the **mean over several equal-size random draws** from the
+same pool.
+
+Why the mean-of-draws baseline: a random draw from a ~1:hundreds pool is almost
+all non-matches and usually contains *no* match at all, so its matcher never
+learns what a match is and its F1 collapses. A single lucky draw can catch a match
+and approach the recipe, so the honest comparison is the average draw, not the
+worst. This mirrors the example's mechanism exactly, at a size that runs in a
+couple of seconds on CPU with no network or spend (needs the ``[trained]`` extra
+for the RandomForest behind the featurizing miners + the served matcher).
+"""
+
+from __future__ import annotations
+
+import random
+
+import pytest
+from pydantic import BaseModel
+
+from langres.core.benchmark import evaluate_judge_on_candidates
+from langres.core.comparator import StringComparator
+from langres.core.finetune import LabeledCandidate
+from langres.core.matchers.random_forest_judge import RandomForestMatcher
+from langres.core.models import ERCandidate
+from langres.core.resolver import Resolver
+from langres.data.mining import (
+    augment_by_attribute,
+    denoise_pairs,
+    mine_misclassified_pairs,
+    sample_negative_pairs,
+)
+
+SEED = 0
+GRID = [i / 20 for i in range(1, 21)]  # 0.05 .. 1.00 best-F1 threshold sweep
+POS_CAP = 30
+N_BASELINE_DRAWS = 5
+
+_CONSONANTS = "bcdfghjklmnpqrstvwxz"
+_VOWELS = "aeiou"
+
+
+class _Org(BaseModel):
+    """A tiny two-content-field entity so the comparator emits >1 feature."""
+
+    id: str
+    name: str
+    city: str
+
+
+def _word(rng: random.Random, syllables: int = 4) -> str:
+    """A distinct pronounceable pseudo-word (consonant-vowel syllables)."""
+    return "".join(rng.choice(_CONSONANTS) + rng.choice(_VOWELS) for _ in range(syllables))
+
+
+def _typo(rng: random.Random, word: str) -> str:
+    """A near-duplicate of ``word``: one character substituted (a high-similarity dup)."""
+    i = rng.randrange(len(word))
+    return word[:i] + rng.choice(_CONSONANTS + _VOWELS) + word[i + 1 :]
+
+
+def _make_corpus(
+    n_clusters: int, n_singletons: int, seed: int
+) -> tuple[list[dict[str, str]], set[frozenset[str]]]:
+    """A fuzzy corpus: ``n_clusters`` near-duplicate pairs + ``n_singletons`` loners.
+
+    Each matched cluster is two records whose name and city are one-character typos
+    of a shared, distinct base (high within-pair similarity); every singleton and
+    every base is a fresh pseudo-word, so cross-entity similarity stays low. Returns
+    the records (as field dicts) and the gold positive pairs (matched id-sets).
+    """
+    rng = random.Random(seed)
+    records: list[dict[str, str]] = []
+    gold: set[frozenset[str]] = set()
+    for c in range(n_clusters):
+        name, city = _word(rng), _word(rng)
+        left = {"id": f"m{c}a", "name": name.title(), "city": city.title()}
+        right = {"id": f"m{c}b", "name": _typo(rng, name).title(), "city": _typo(rng, city).title()}
+        records += [left, right]
+        gold.add(frozenset({left["id"], right["id"]}))
+    for s in range(n_singletons):
+        records.append({"id": f"s{s}", "name": _word(rng).title(), "city": _word(rng).title()})
+    return records, gold
+
+
+def _build_pool(
+    resolver: Resolver, records: list[dict[str, str]], gold: set[frozenset[str]]
+) -> list[LabeledCandidate]:
+    """Block records all-pairs (comparison attached) and label each pair against gold."""
+    return [(c, frozenset({c.left.id, c.right.id}) in gold) for c in resolver.candidates(records)]
+
+
+def _assemble_recipe(
+    train_pool: list[LabeledCandidate], comparator: StringComparator[object]
+) -> list[LabeledCandidate]:
+    """The four-miner curation recipe (identical composition to the example)."""
+    clean, _flagged = denoise_pairs(train_pool, seed=SEED)
+    hard = mine_misclassified_pairs(clean, cap=POS_CAP, seed=SEED)
+    augmented = [
+        (c.model_copy(update={"comparison": comparator.compare(c.left, c.right)}), label)
+        for c, label in augment_by_attribute(hard, cap=POS_CAP, seed=SEED)
+    ]
+    positives = list(hard) + augmented
+    negatives = sample_negative_pairs(
+        positives + [pair for pair in clean if not pair[1]], ratio=2.0, seed=SEED
+    )
+    return positives + negatives
+
+
+def _fit_and_score(
+    labeled: list[LabeledCandidate],
+    feature_specs: list[object],
+    test_candidates: list[ERCandidate[object]],
+    gold: set[frozenset[str]],
+) -> float:
+    """Fit a RandomForest on ``labeled`` and return its best-F1 on the held-out set."""
+    matcher: RandomForestMatcher[object] = RandomForestMatcher(
+        feature_specs=feature_specs,  # type: ignore[arg-type]
+        random_state=SEED,
+    )
+    matcher.fit(iter([c for c, _ in labeled]), [label for _, label in labeled])
+    result, _ = evaluate_judge_on_candidates(matcher, test_candidates, gold, GRID)
+    return result.pair.f1
+
+
+@pytest.fixture(scope="module")
+def _lift() -> dict[str, float]:
+    """Run the proof once (module-scoped: the RF fits are the expensive part)."""
+    train_records, train_gold = _make_corpus(n_clusters=12, n_singletons=70, seed=SEED)
+    test_records, test_gold = _make_corpus(n_clusters=8, n_singletons=40, seed=SEED + 1)
+
+    resolver = Resolver.from_schema(_Org)  # AllPairsBlocker + StringComparator
+    comparator = resolver.comparator
+    feature_specs = list(comparator.feature_specs)
+
+    train_pool = _build_pool(resolver, train_records, train_gold)
+    test_candidates = [c for c, _ in _build_pool(resolver, test_records, test_gold)]
+
+    n_pos = sum(1 for _, label in train_pool if label)
+    n_neg = len(train_pool) - n_pos
+
+    recipe = _assemble_recipe(train_pool, comparator)
+    budget = len(recipe)
+    recipe_f1 = _fit_and_score(recipe, feature_specs, test_candidates, test_gold)
+
+    draws = [
+        _fit_and_score(
+            random.Random(1000 + k).sample(train_pool, min(budget, len(train_pool))),
+            feature_specs,
+            test_candidates,
+            test_gold,
+        )
+        for k in range(N_BASELINE_DRAWS)
+    ]
+    baseline_mean = sum(draws) / len(draws)
+    return {
+        "recipe_f1": recipe_f1,
+        "baseline_mean": baseline_mean,
+        "beats": sum(1 for f1 in draws if recipe_f1 > f1),
+        "imbalance": n_neg / max(n_pos, 1),
+        "budget": float(budget),
+    }
+
+
+class TestRecipeLift:
+    def test_pool_is_heavily_imbalanced(self, _lift: dict[str, float]) -> None:
+        # The mechanism needs the genuine blocked-pool imbalance; guard it holds.
+        assert _lift["imbalance"] > 20.0
+
+    def test_recipe_learns_a_real_matcher(self, _lift: dict[str, float]) -> None:
+        # Curation trains a matcher that actually separates matches on held-out data.
+        assert _lift["recipe_f1"] > 0.5
+
+    def test_recipe_beats_random_mean_by_a_clear_margin(self, _lift: dict[str, float]) -> None:
+        # The headline claim: curated pairs beat the mean random draw at an equal budget.
+        assert _lift["recipe_f1"] > _lift["baseline_mean"] + 0.15
+
+    def test_recipe_beats_the_majority_of_draws(self, _lift: dict[str, float]) -> None:
+        # Tolerates a couple of lucky draws that happen to catch a match; the point
+        # is that most equal-budget random draws contain none and score zero.
+        assert _lift["beats"] >= N_BASELINE_DRAWS // 2 + 1


### PR DESCRIPTION
**Wave B** (final) of the data-preparation layer — the failure-mode curation loop and the **$0 recipe-lift proof** that is the layer's primary acceptance. Stacked on #162 + #163 (merged).

## Headline — the recipe lifts F1 (honest, $0, CPU)
`examples/recipe_lift_proof.py` on **abt_buy**, seed 0, equal budget **N=240**:
- **Baseline** (mean of 10 random 240-pair draws): **0.204 F1**
- **Recipe** (mine hard positives + denoise + attribute-augment + 2:1 balance, same N): **0.583 F1**
- **+0.379 F1**, beats **10/10** random draws.

Mechanism is the honest one: the blocked train pool is 1:487 imbalanced (39,060 pairs), so a random 240-draw averages ~0.6 positives and its matcher never learns a match; the recipe spends the same budget deliberately. Baseline is the **mean** of draws (not a cherry-picked worst). The fast seeded `tests/data/test_recipe_lift.py` guards the lift on a synthetic separable pool; the abt_buy example is the headline.

## FailureModeSection (`src/langres/data/data_profile/failure_mode.py`)
Pure consumer of a **precomputed** `JudgementLog` + gold (no matcher run, import-light). Joins by id-set, splits correct / FP / FN (abstentions excluded), and diffs errors vs successes two ways: a score-density overlay and a **lift-ranked slice table** (score bands · per-field emptiness · cross- vs same-source). Graceful degrade on every missing input (logged). Wired into the report assembler like `MiningReadinessSection`. **100% line+branch coverage.**

## curation_loop (`examples/curation_loop.py`)
End-to-end: profile → find the worst slice (cross-source, 22.3% error) → mine/augment it → retrain → re-profile: slice **22.3% → 3.0%**, false negatives **49 → 3**.

## Verification (local, `uv sync --all-extras`, $0)
- both examples run at $0 (recipe +0.379; curation slice 22.3%→3.0%)
- `test_failure_mode.py`: 41 passed, 100% cov; `test_recipe_lift.py`: 4 passed
- `test_import_budget`: passed (data_profile import-light); ruff + mypy strict: clean

## Summary by Sourcery

Add a failure-mode profiling section to the data-preparation report and demonstrate/verify the curated training recipe’s lift over random draws, including an end-to-end curation loop example.

New Features:
- Introduce FailureModeSection and profile_failure_mode to analyze where a matcher’s errors concentrate, including score overlays and slice-level error rates.
- Expose failure-mode profiling through the data_profile package and wire it into DataProfileReport builders as an optional precomputed section.
- Add recipe_lift_proof.py example to show curated training data outperforming equal-budget random draws on abt_buy.
- Add curation_loop.py example to demonstrate a full failure-mode-driven curation flywheel from judgement logging to retraining.

Enhancements:
- Clarify data_profile builders documentation about precomputed mining-readiness and failure-mode sections and extend include-filter support to the new section.
- Slightly refine mining attribute selection comments to better describe content fields vs structural ids.

Tests:
- Add comprehensive tests for FailureModeSection and profile_failure_mode, covering joins, slicing, rendering, and report wiring.
- Add a fast synthetic test (test_recipe_lift.py) that behaviorally validates the curated training recipe’s F1 lift over the mean of equal-budget random draws.