### PR TITLE
fix(data): harden failure-mode diagnostic + denoise feature_specs parity + honest framing

### DIFF
--- a/examples/recipe_lift_proof.py
+++ b/examples/recipe_lift_proof.py
@@ -1,4 +1,4 @@
-"""Proof: a curated training recipe beats random pairs at an equal label budget.
+"""Proof: a curated training recipe beats random pairs at an equal training budget.
 
 This is the acceptance demonstration for the data-preparation layer. It asks one
 question and answers it with numbers, on a real benchmark, for $0:
@@ -6,6 +6,10 @@ question and answers it with numbers, on a real benchmark, for $0:
     Given a fixed budget of N training pairs drawn from a blocked candidate pool,
     does *curating* those N (balance + hard positives + denoise + augmentation)
     beat drawing them at random?
+
+Both arms draw the same N pairs from the *same fully-labeled pool*: the budget is
+training size N, not a labeling budget, and the arms differ only in how those N are
+*selected*.
 
 Why it works -- honestly. A blocked entity-resolution pool is dominated by
 non-matches (here an all-pairs blocked pool runs ~1:500 positive:negative). A
@@ -104,6 +108,8 @@ def assemble_recipe(
     Returns ``(recipe, n_flagged)`` -- the assembled pairs and how many the
     denoiser dropped.
     """
+    # Denoise-before-mine can strip genuine hard positives (denoise and hard-positive
+    # mining compete); the recipe accepts that here because the class-balance lift dominates.
     clean, flagged = denoise_pairs(train_pool, seed=SEED)
     hard = mine_misclassified_pairs(clean, cap=POS_CAP, seed=SEED)
     augmented = [
@@ -202,7 +208,7 @@ def main() -> None:
 
     verdict = "LIFT" if margin > 0 else "NO LIFT"
     print(
-        f"\n=> {verdict}: at an equal {budget}-pair budget, curation "
+        f"\n=> {verdict}: at an equal {budget}-pair training budget, curation "
         f"{'beats' if margin > 0 else 'does not beat'} random by {margin:+.4f} F1."
     )
     print(

--- a/src/langres/data/data_profile/failure_mode.py
+++ b/src/langres/data/data_profile/failure_mode.py
@@ -360,10 +360,14 @@ def profile_failure_mode(
 
     score_edges, error_counts, success_counts = _score_overlay(confident, n_score_bands)
 
+    # Normalize record keys to str ONCE here (symmetric with _normalize_gold), so
+    # the slice lookups -- keyed by the stringified judgement ids -- hit even when
+    # the caller passed an int-keyed map.
+    slice_records = _normalize_records(records) if records is not None else None
     all_slices = _build_slices(
         confident,
         overall_rate,
-        records=records,
+        records=slice_records,
         id_key=id_key,
         source_key=source_key,
         n_score_bands=n_score_bands,
@@ -401,10 +405,37 @@ def _normalize_gold(gold_pairs: Collection[Collection[Hashable]]) -> set[frozens
     exactly two distinct ids) are dropped.
     """
     normalized: set[frozenset[str]] = set()
+    n_dropped = 0
     for pair in gold_pairs:
         key = frozenset(str(identifier) for identifier in pair)
         if len(key) == 2:
             normalized.add(key)
+        else:
+            n_dropped += 1
+    if n_dropped:
+        logger.warning(
+            "profile_failure_mode: dropped %d malformed gold pair(s) (not exactly two "
+            "distinct ids); this section logs omissions, never drops silently.",
+            n_dropped,
+        )
+    return normalized
+
+
+def _normalize_records(
+    records: Mapping[Hashable, Mapping[str, Any]],
+) -> dict[Hashable, Mapping[str, Any]]:
+    """Re-key a records map by ``str`` id, symmetric with :func:`_normalize_gold`.
+
+    The join stringifies judgement ids (the log stores ids as strings), so the
+    slice lookups (:func:`_either_empty`, :func:`_source_slices`) must find each
+    record by that same string key. A caller passing an ``int``-keyed map would
+    otherwise miss every lookup silently -- reporting every field-emptiness slice
+    as all-empty and skipping the source slice. Normalizing keys once at entry
+    keeps the str-conversion out of every per-pair helper.
+    """
+    normalized: dict[Hashable, Mapping[str, Any]] = {
+        str(key): value for key, value in records.items()
+    }
     return normalized
 
 
@@ -427,6 +458,18 @@ def _join_gold(judgements: Sequence[Mapping[str, Any]], gold: set[frozenset[str]
     return joined
 
 
+def _in_unit_range(score: float | None) -> bool:
+    """Whether a score is a real number in ``[0, 1]`` -- the only binnable range.
+
+    The overlay counts (via :func:`~langres.core._report_html._histogram`) drop
+    scores outside the ``[0, 1]`` edges, and a raw/signed-score judge can emit
+    such values. Both the overlay and the score-band slices exclude out-of-range
+    (and ``None``) scores through this one predicate, so the two views stay
+    consistent and a negative score can never index a negative band.
+    """
+    return score is not None and 0.0 <= score <= 1.0
+
+
 def _score_overlay(
     confident: Sequence[_Judged], n_bands: int
 ) -> tuple[list[float], list[float], list[float]]:
@@ -435,10 +478,11 @@ def _score_overlay(
     The diff of the error distribution against the success distribution along the
     score axis: two histograms sharing fixed ``[0, 1]`` edges so the bands line up
     (density normalization happens at render time). Confident pairs without a
-    score (a decision-only judge) contribute to neither.
+    score (a decision-only judge) or with an out-of-``[0, 1]`` score contribute to
+    neither -- consistent with the score-band slices (see :func:`_in_unit_range`).
     """
-    error_scores = [j.score for j in confident if j.error and j.score is not None]
-    success_scores = [j.score for j in confident if not j.error and j.score is not None]
+    error_scores = [j.score for j in confident if j.error and _in_unit_range(j.score)]
+    success_scores = [j.score for j in confident if not j.error and _in_unit_range(j.score)]
     if not error_scores and not success_scores:
         return [], [], []
     edges = [i / n_bands for i in range(n_bands + 1)]
@@ -486,13 +530,15 @@ def _slice(
 def _score_band_slices(
     confident: Sequence[_Judged], overall_rate: float | None, n_bands: int
 ) -> list[FailureSlice]:
-    """One slice per score band (pairs with a score); empty bands are dropped."""
-    scored = [j for j in confident if j.score is not None]
+    """One slice per score band; empty bands and out-of-``[0, 1]`` scores are dropped."""
+    # Exclude out-of-range scores (consistent with the overlay), so a negative
+    # score cannot produce a negative band index -> buckets[-1] KeyError.
+    scored = [j for j in confident if _in_unit_range(j.score)]
     if not scored:
         return []
     buckets: dict[int, list[_Judged]] = {b: [] for b in range(n_bands)}
     for j in scored:
-        assert j.score is not None  # narrowed by the filter above
+        assert j.score is not None  # narrowed by the _in_unit_range filter above
         band = min(int(j.score * n_bands), n_bands - 1)  # score==1.0 lands in the last band
         buckets[band].append(j)
     out: list[FailureSlice] = []

--- a/src/langres/data/mining.py
+++ b/src/langres/data/mining.py
@@ -235,6 +235,7 @@ def denoise_pairs(
     labeled: Sequence[LabeledCandidate],
     *,
     method: str = "confident_learning",
+    feature_specs: Sequence[FeatureSpec] | None = None,
     cv: int = 5,
     seed: int = 0,
 ) -> tuple[list[LabeledCandidate], list[LabeledCandidate]]:
@@ -248,9 +249,17 @@ def denoise_pairs(
     given label. Robust to class imbalance because the threshold is per-class, not
     a global 0.5.
 
+    Caveat -- confident learning cannot perfectly separate label noise from
+    *genuinely hard* positives (both look alike to the model), so it may flag a
+    real hard positive as suspected noise. Running :func:`denoise_pairs` *before*
+    :func:`mine_misclassified_pairs` therefore competes with hard-positive mining:
+    it can strip the very boundary positives mining targets. Order accordingly.
+
     Args:
         labeled: Comparison-attached labeled candidates. Must contain both classes.
         method: Denoise strategy; only ``"confident_learning"`` is supported.
+        feature_specs: Features to featurize with; when ``None``, derived from the
+            union of the candidates' comparison levels (see module docs).
         cv: Requested out-of-fold folds (reduced when a class is small; when a
             fold cannot hold both classes, nothing is flagged and the split is
             ``(all, [])``, logged).
@@ -270,7 +279,7 @@ def denoise_pairs(
         )
     materialized = list(labeled)
     _require_both_classes(materialized, fn="denoise_pairs")
-    specs = _resolve_feature_specs(materialized, feature_specs=None)
+    specs = _resolve_feature_specs(materialized, feature_specs=feature_specs)
     x = _feature_matrix(materialized, specs)
     y = [int(label) for _, label in materialized]
 

--- a/tests/data/data_profile/test_failure_mode.py
+++ b/tests/data/data_profile/test_failure_mode.py
@@ -11,7 +11,10 @@ filter).
 
 from __future__ import annotations
 
+import logging
 from typing import Any
+
+import pytest
 
 from langres.data.data_profile import (
     DataProfileReport,
@@ -300,6 +303,74 @@ class TestGracefulDegradation:
         section = profile_failure_mode(judgements, gold_pairs=[("a", "b")], records=records)
         assert section is not None
         assert any(s.dimension == "empty:extra" for s in section.slices)
+
+
+class TestReviewHardening:
+    """Cross-model review fixes: record-key normalization, score-band clamping, gold logging."""
+
+    def test_int_keyed_records_match_str_keyed_slices(self) -> None:
+        # The join stringifies judgement ids; a raw INT-keyed `records` map would
+        # miss every lookup, silently reporting `empty:name` as n=2 lift=1.0 and
+        # dropping the source slice. The str-keyed truth is n=1 lift=2.0 --
+        # normalizing the records keys once at entry makes both agree.
+        judgements = [
+            _row("1", "2", 0.90, True),  # gold match, predicted match -> correct
+            _row("3", "4", 0.40, False),  # gold match, predicted non-match -> FN error
+        ]
+        gold = [("1", "2"), ("3", "4")]
+        fields = {
+            "1": {"id": "1", "name": "Acme", "source": "abt"},
+            "2": {"id": "2", "name": "Acme Inc", "source": "buy"},
+            "3": {"id": "3", "name": "", "source": "abt"},  # name empty -> the error slice
+            "4": {"id": "4", "name": "Nimbus LLC", "source": "buy"},
+        }
+        str_records: dict[Any, dict[str, Any]] = {k: dict(v) for k, v in fields.items()}
+        int_records: dict[Any, dict[str, Any]] = {int(k): dict(v) for k, v in fields.items()}
+
+        str_section = profile_failure_mode(judgements, gold_pairs=gold, records=str_records)
+        int_section = profile_failure_mode(judgements, gold_pairs=gold, records=int_records)
+        assert str_section is not None and int_section is not None
+
+        # The str-keyed truth: empty:name concentrates the single error (n=1, lift=2.0).
+        str_empty = next(s for s in str_section.slices if s.dimension == "empty:name")
+        assert str_empty.n == 1
+        assert str_empty.error_rate == 1.0
+        assert str_empty.lift == 2.0
+        # Int-keyed lookups now hit the same records -> byte-identical slices.
+        assert int_section.rows() == str_section.rows()
+        assert any(s.dimension == "source" for s in int_section.slices)
+
+    def test_out_of_range_scores_do_not_crash_and_match_overlay(self) -> None:
+        # A raw/signed-score judge can emit scores outside [0, 1]. The score-band
+        # slice path must not crash on a negative band (buckets[-1] KeyError), and
+        # must exclude out-of-range scores consistently with the overlay (which
+        # drops them via _histogram).
+        judgements = [
+            _row("a", "b", -0.5, True),  # gold match, correct; score below 0
+            _row("c", "d", 1.5, False),  # gold non-match, correct; score above 1
+            _row("e", "f", 0.40, False),  # gold match -> FN error; in-range
+        ]
+        gold = [("a", "b"), ("e", "f")]
+        section = profile_failure_mode(judgements, gold_pairs=gold, n_score_bands=5)
+        assert section is not None
+        # Overlay drops the two out-of-range scores; only the in-range 0.4 error remains.
+        assert sum(section.error_counts) == 1
+        assert sum(section.success_counts) == 0
+        # Score-band slices cover only the in-range score (no negative-band crash).
+        band_pairs = sum(s.n for s in section.slices if s.dimension == "score_band")
+        assert band_pairs == 1
+
+    def test_malformed_gold_pairs_are_logged(self, caplog: pytest.LogCaptureFixture) -> None:
+        # This section's contract is "omissions logged, never silent": dropped
+        # malformed gold pairs (not exactly two distinct ids) must be counted+logged.
+        judgements = [_row("a", "b", 0.9, True)]
+        with caplog.at_level(logging.WARNING, logger="langres.data.data_profile.failure_mode"):
+            section = profile_failure_mode(
+                judgements, gold_pairs=[("a",), ("x", "y", "z"), ("a", "b")]
+            )
+        assert section is not None
+        messages = [r.getMessage() for r in caplog.records]
+        assert any("malformed gold" in m.lower() and "2" in m for m in messages)
 
 
 class TestRenderLadder:

--- a/tests/data/test_mining.py
+++ b/tests/data/test_mining.py
@@ -356,8 +356,33 @@ class TestDenoisePairs:
         assert len(cleaned) == 11
         assert flagged == []
 
+    def test_honours_feature_specs(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """feature_specs pins denoise's feature space (parity with mine_misclassified_pairs).
+
+        Without it, a matcher trained on a custom feature SUBSET would be denoised
+        in the full default feature space -- a mismatch. Spy on _feature_matrix to
+        assert the explicit subset is threaded through, not the derived default.
+        """
+        import langres.data.mining as mining_mod
+
+        labeled = _separable_dataset(n_positive=20, n_negative=20)
+        subset = [FeatureSpec(name="name")]
+        captured: list[list[FeatureSpec]] = []
+        real_feature_matrix = mining_mod._feature_matrix
+
+        def spy(labeled_arg: list[LabeledCandidate], specs: list[FeatureSpec]) -> list[list[float]]:
+            captured.append(list(specs))
+            return real_feature_matrix(labeled_arg, specs)
+
+        monkeypatch.setattr(mining_mod, "_feature_matrix", spy)
+        denoise_pairs(labeled, feature_specs=subset, cv=4, seed=0)
+        assert captured and captured[0] == subset
+
     def test_agrees_with_cleanlab_on_same_probabilities(self) -> None:
-        """Cross-check: our confident-joint flags match cleanlab on the same OOF probs."""
+        """Cross-check: our confident-joint (Northcutt et al.) core overlaps cleanlab
+        on the same OOF probs -- partial overlap (jaccard >= 0.5), not byte-parity:
+        we run the confident-joint core, not Cleanlab's full prune-by-noise-rate pipeline.
+        """
         cleanlab_filter = pytest.importorskip("cleanlab.filter")
 
         clean = _separable_dataset(n_positive=40, n_negative=40)


### PR DESCRIPTION
Six verified findings from a cross-model code review (Codex gpt-5.5 + a fresh Claude adversarial pass) of the langres data-preparation layer. Each fix is surgical and traces to a reproduced finding. The recipe-lift proof (`examples/recipe_lift_proof.py`) itself was verified **valid** by both reviewers and is **unchanged** — it still prints recipe 0.5833 / baseline 0.2043 / margin +0.3790, beats 10/10 draws.

## Fixes

**A — record-key str-normalization (`failure_mode.py`)** — the join stringifies judgement ids, but the `records` map was looked up with those stringified ids against the caller's raw-keyed map. An int-keyed map missed every lookup silently: field-emptiness read all-empty and source slices were skipped, corrupting the headline diagnostic (reproduced: `empty:name` reported n=2 lift=1.0 vs the str-keyed truth n=1 lift=2.0). Fix: normalize the records keys to `str` once at entry (`_normalize_records`, symmetric with `_normalize_gold`).

**B — score-band lower clamp (`failure_mode.py`)** — `min(int(j.score * n_bands), n_bands - 1)` clamped only the upper bound, so `score < 0` produced `buckets[-1]` → KeyError crash (reproduced). Meanwhile the overlay's `_histogram` silently drops out-of-`[0,1]` scores. Fix: a shared `_in_unit_range` predicate excludes out-of-range (and `None`) scores from **both** the slices and the overlay, keeping the two views consistent and impossible to crash.

**C — malformed-gold logging (`failure_mode.py`)** — `_normalize_gold` silently dropped gold pairs without exactly two distinct ids. This section's contract is "omissions logged, never silent." Fix: count drops and `logger.warning` the count when > 0.

**D — `feature_specs` on `denoise_pairs` (`mining.py`)** — `mine_misclassified_pairs` accepts `feature_specs` but `denoise_pairs` hardcoded the full default, so a matcher trained on a feature SUBSET was denoised in a different space. Fix: add `feature_specs` (mirroring `mine_misclassified_pairs`) and thread it through `_resolve_feature_specs`.

**E — denoise-before-mine caveat (doc)** — confident learning cannot perfectly separate label noise from genuine hard positives, so denoise-before-mine competes with hard-positive mining. Added an honest caveat to `denoise_pairs`'s docstring and a one-line comment in the recipe's `assemble_recipe` (which accepts the tension because class balance dominates the lift). No behavior/order change.

**F — honest Cleanlab framing (doc)** — the denoiser is the confident-JOINT core (Northcutt et al.), not Cleanlab's full prune pipeline. Reworded the test cross-check docstring to "confident-joint core, partial overlap (jaccard ≥ 0.5), not byte-parity." Also tightened the example's "equal label budget" → "equal training budget" (both arms sit on the same fully-labeled pool; they differ in selection at equal training size N).

## Gates
- TDD: tests written first (red) for A/B/C/D in `test_failure_mode.py` + `test_mining.py`, then implemented.
- Coverage: `failure_mode.py` **100%** (225 stmts / 60 branches), `mining.py` **100%** (121 stmts / 38 branches).
- `tests/data/` + `tests/test_import_budget.py`: 664 passed, import-light budget green (sklearn stays lazy).
- `ruff format` + `ruff check` clean; `mypy src/` clean on touched files.
- `examples/recipe_lift_proof.py` prints the same numbers — proof unchanged.

## Summary by Sourcery

Harden failure-mode diagnostics and denoising behavior in the data-preparation layer, and align documentation and tests with the intended semantics.

Bug Fixes:
- Normalize record keys to strings in failure-mode profiling so field-emptiness and source slices work correctly with non-string ids.
- Exclude out-of-[0,1] and missing scores from score-band slices and overlays to prevent crashes and keep the two views consistent.
- Log and count malformed gold pairs that are dropped during normalization instead of silently omitting them.
- Ensure denoise_pairs respects the caller-provided feature_specs so denoising happens in the same feature space as training.

Enhancements:
- Add a shared score-range predicate to unify score handling between overlays and score-band slices.
- Improve docstrings and comments around denoise_pairs, Cleanlab cross-checking, and the recipe proof to more accurately describe budgets, caveats, and method scope.

Documentation:
- Clarify denoise_pairs caveats about trading off label denoising against hard-positive mining.
- Reframe Cleanlab comparison docs to emphasize confident-joint core overlap rather than exact parity.
- Tighten recipe_lift_proof wording to describe an equal training budget drawn from a fully labeled pool and note the denoise-before-mine tradeoff.

Tests:
- Add targeted tests for record-key normalization, score-band handling of out-of-range scores, malformed-gold logging, and denoise_pairs feature_specs propagation.