### PR TITLE
docs: drop the un-built "TrainedLMMatcher" name; point at the shipped finetune()/serve path

### DIFF
--- a/docs/plans/20260715_data_layer_plan.md
+++ b/docs/plans/20260715_data_layer_plan.md
@@ -299,7 +299,7 @@ langres`.
   `denoise_pairs`, `MiningReadinessSection`. *Exit:* mine hard positives + random
   negatives on one benchmark, denoise, profile the mined set in the tearsheet.
 - **Stage 3 (north-star, separate epic):** `attribute_examples` + `flipped` + `ColVal`
-  schema-free serializer → `TrainedLMMatcher` → the **leave-one-out generalist harness**
+  schema-free serializer → the existing `finetune()`/serve seam (an unbuilt classification-head trainer variant for AnyMatch fidelity) → the **leave-one-out generalist harness**
   (pool mined pairs across the 10-dataset registry, hold one out, zero-shot eval) — the
   AnyMatch "one ER model across all benchmarks" payoff (F1 81.96 reference). Consumes
   Waves 1–3; scoped in its own plan.

--- a/docs/research/20260714_training_surface_design.md
+++ b/docs/research/20260714_training_surface_design.md
@@ -95,7 +95,7 @@ report = resolver.fit(records, pairs="corrections.jsonl")
 
 The maintainer's criterion: over-simplification that hides what happens underneath *adds* cognitive load. PyTorch's virtue — you know what you're training — is restored inside a one-call API by:
 
-1. **Declared-at-construction**: nothing trains that you didn't name. `TrainedLMMatcher(base="Qwen/Qwen3-1.7B", method=QLoRA(r=16), serializer=ColVal(mode=1))` states the architecture, the method, and the rank in the user's own code.
+1. **Declared-at-construction**: nothing trains that you didn't name. `finetune(pairs, method=QLoRA(base="Qwen/Qwen3-1.7B", r=16), record_serializer="colval")` states the base, the method, and the rank in the user's own code.
 2. **`resolver.describe()`** — pre-fit: which slots *would* train (and how), which are frozen.
 3. **`FitReport`** — post-fit, returned from every `fit`: per-slot what trained (mechanism, learned-param summary), on how much data (train/valid split sizes, label provenance incl. silver-teacher identity), at what cost (tokens/$ for paid fits, GPU time for local), thresholds/bands derived, and validation metrics. Doubles as the lineage record (feeds RunRecord and the hub model card: base model, data recipe, license chain, eval provenance).
 
@@ -132,7 +132,7 @@ Deferred, doors kept open (nothing in the surface forecloses them): `partial_fit
 The training-loop plan's targets ride these; note **UC-AnyMatch never touches the Resolver** — it is a matcher + eval harness, so this A-layer *is* the AnyMatch tooling gap:
 
 1. **Miners as plain functions**, not strategy objects: `mine_misclassified(dataset, miner=…, cap=…)` (AnyMatch hard-positives), `sample_negatives(dataset, ratio=…, seed=…)`, `attribute_examples(pool, cap=…)`, `flipped(pairs)`, `mine_hard_negatives(blocker_log, …)` (the #86 blocking-derived strategy). All produce `LabeledPair`s — printable, inspectable data prep (the label-noise inspection the #86 survey demands). Hard-positive and hard-negative mining stay **separate functions** (opposite failure modes), routed by consumer (fine-tune wants hard; DSPy demo pools want easy-correct).
-2. **`TrainedLMMatcher`** — the trainable-LM matcher: `base=` (HF id), `method=` (`QLoRA(r, alpha)` | `FullFinetune()` — AnyMatch fidelity needs full-FT GPT-2), `head=` (`"classification"` | generative), `serializer=`, epochs/lr. Implements the fit protocol; checkpoint to `state_dir` sidecar (safetensors, no pickle); lazy heavy imports; training-only deps (unsloth/trl/peft) stay dev-group-only.
+2. **`finetune()` verb** — the trainable-LM path shipped as a standalone **function**, not a matcher class: `finetune(pairs, method=QLoRA(base=…, r=…), record_serializer="colval")` fine-tunes the base LM and returns a weightless `ModelRef` (base + adapter) that the existing `LLMMatcher(model=ref)` serves in-process, or `vllm serve` behind `LLMMatcher(api_base=…)`; `Resolver.fit(records, pairs=…, method=QLoRA(…))` wraps it into the canonical sequence + a `FitReport`. Lazy heavy imports; training-only deps (peft/trl/bitsandbytes) live in the `[finetune]` extra. *(As built: the standalone matcher-class name proposed here was rejected — "trained" is vacuous, every model is trained — and never built; the path is this function. AnyMatch's full-FT-GPT-2 / classification-head route stays an **unbuilt classification-head finetune-trainer variant** — a future extension of the finetune seam — distinct from the shipped generative QLoRA fine-tune.)*
 3. **`ColVal` serializer** — one Ditto-style `COL <val>…` textualizer (AnyMatch modes 1–4; `N/A` for missing), shared by trained matchers, LLM prompts, and the replication.
 4. **`CrossEncoderMatcher`** — the Ditto-method-class baseline (sentence-transformers), same fit protocol; completeness yardstick per the training plan's LLM-native framing.
 5. **Local student serving** — per the training plan §3.3 Option A: fine-tuned checkpoints served behind `LLMMatcher` via a local OpenAI-compatible `api_base` (same seam as the paid teacher), with the in-process matcher as fallback.
@@ -167,9 +167,9 @@ report = resolver.fit(records, pairs=silver)                      # report: demo
 
 **QLoRA fine-tune**
 ```python
-student = TrainedLMMatcher(base="Qwen/Qwen3-1.7B", method=QLoRA(r=16),
-                           serializer=ColVal(mode=1), epochs=3)   # NEW component
-student.fit(train_cands, silver)                                  # GPU; safetensors sidecar
+ref = finetune(train_pairs, method=QLoRA(base="Qwen/Qwen3-1.7B", r=16, epochs=3),
+               record_serializer="colval")                       # GPU -> weightless ModelRef
+matcher = LLMMatcher(model=ref)                                  # served in-process (or `vllm serve`)
 ```
 
 **AnyMatch replication (core layer; no Resolver)**
@@ -178,8 +178,11 @@ pool  = [get_benchmark(n) for n in NINE if n != holdout]
 pairs = concat(mine_misclassified(d, miner="random_forest", cap=400)   # NEW miners
                + sample_negatives(d, ratio=2, seed=42) for d in pool)
 pairs += attribute_examples(pool, cap=600) + flipped(pairs)
-matcher = TrainedLMMatcher(base="gpt2", head="classification", serializer=ColVal(mode=1))
-matcher.fit(pairs)
+# Paper-faithful AnyMatch = full-FT GPT-2 with a classification head — UNBUILT:
+# a classification-head finetune-trainer variant of the finetune() seam.
+# Shipped generative-QLoRA path today:
+ref = finetune(pairs, method=QLoRA(base="gpt2"), record_serializer="colval")
+matcher = LLMMatcher(model=ref)
 f1 = evaluate(matcher, get_benchmark(holdout).candidates("test"), threshold=0.5)
 ```
 
@@ -205,7 +208,7 @@ result = resolver.resolve(records)         # result.matches / result.review_queu
 |---|---|---|
 | **0a — rename** | the Matcher rename (§1.3), one mechanical PR incl. docs sweep | before hub ids + new components ossify "judge" |
 | **0b — seams** | `align_pairs` bridge; fit protocols beyond the matcher; `FitReport` + `describe()` + `Resolver.fit` canonical sequence; `budget_usd` plumbing | serves every shape and use case |
-| **0c — training components** | miners (misclassified, random-neg, attribute, flipped, blocking-derived hard-neg); `ColVal`; `TrainedLMMatcher` scaffold (CI dry-run on `tiny_fixture`); GPU smoke (Unsloth QLoRA Qwen3-0.6B overfits 100 pairs on the 3070) | = training plan Wave 0, re-expressed |
+| **0c — training components** | miners (misclassified, random-neg, attribute, flipped, blocking-derived hard-neg); `ColVal`; `finetune()` verb + `QLoRATrainer` (CI dry-run on `tiny_fixture`); GPU smoke (Unsloth QLoRA Qwen3-0.6B overfits 100 pairs on the 3070) | = training plan Wave 0, re-expressed |
 | **1 — AnyMatch (T2)** | LOO harness over the registry pool; native run (Qwen3-0.6B QLoRA + sklearn miner) first, paper-faithful (GPT-2 full-FT, AutoGluon) as ablation if numbers disappoint | maintainer decision 2026-07-13: AnyMatch leads |
 | **2+** | T1 gold ladder → teacher tune + silver (≤$5 gate) → silver students → T4-H1 blocking probes | per the training plan; unchanged |
 | later | calibrator slot + Bands; `TrainableVectorBlocker` (T4-H2 material); `CrossEncoderMatcher` baseline | classical-gap items, sequenced behind the program |

--- a/docs/research/20260715_data_prep_architecture.md
+++ b/docs/research/20260715_data_prep_architecture.md
@@ -240,7 +240,7 @@ candidate, here is the existing seam it plugs into and the **only** delta to wri
 | **BADGE** (`acquire`) | `select_for_review` already ranks by margin; `VectorBlocker` already produces per-record embeddings | pair-embedding features + **k-means++ seeding** over (margin-scaled) embeddings. ≈ one function; no new dep (numpy) |
 | **Blocking-derived hard-neg** (`select`) | `Blocker.candidates` + their scores; `JudgementLog` verdicts | filter: `score ≥ threshold ∧ label = non-match`. Pure reuse |
 | **EL2N difficulty** (`select`) | `JudgementLog.score` is `p(match)` | compute `\|1 − p(gold)\|`, sort. No training |
-| **Matcher→blocker distillation** (`relabel`→embedder) | `CascadeMatcher`/`LLMMatcher` already score pairs into `JudgementLog`; `[semantic]` has sentence-transformers | wrap those margins as `MarginMSELoss` targets; a `TrainedEmbedder` sibling to `TrainedLMMatcher` |
+| **Matcher→blocker distillation** (`relabel`→embedder) | `CascadeMatcher`/`LLMMatcher` already score pairs into `JudgementLog`; `[semantic]` has sentence-transformers | wrap those margins as `MarginMSELoss` targets; a `TrainedEmbedder` sibling to the `finetune()` path |
 | **Confident-learning denoise** (`relabel`) | `RandomForestMatcher` / sklearn already in `[trained]` | k-fold CV → confident joint. The planned `denoise_pairs` |
 | **Snorkel label model** (`relabel`) | `StringComparator` sims, blocking keys, cheap judge are all cheap labeling functions | a light label-model aggregator (or FlyingSquid closed-form) over their votes |
 | **Coreset / SemDeDup / prototypicality** (`select`) | `VectorBlocker` embeddings | k-center-greedy / near-dup / centroid-distance over existing vectors |
@@ -350,7 +350,7 @@ value-per-effort.
    — it operates on *sources*, not `LabeledPair`s, so it's a different currency and a
    different epic (Stage-3 LOO harness / autoresearch).
 4. **The blocker-embedding training home.** A `TrainedEmbedder` sibling to
-   `TrainedLMMatcher` (same fit protocol), fed by the distillation `relabel` step. Confirm
+   the `finetune()` path (same fit protocol), fed by the distillation `relabel` step. Confirm
    the fit-protocol shape covers both a classification head (matcher) and a contrastive
    objective (embedder).
 5. **Cleanlab as a dep.** Built-in confident-learning first (sklearn, no new dep); Cleanlab

--- a/docs/research/README.md
+++ b/docs/research/README.md
@@ -32,7 +32,7 @@ on. It is the answer to *"where do we write down everything we find in research?
 | [`20260710_dx_audit_examples_we_wish_we_had.md`](20260710_dx_audit_examples_we_wish_we_had.md) | audit | DX audit: the examples we wish we had (every claim run/verified against `main`). |
 | [`20260710_logprob_credence_probe.md`](20260710_logprob_credence_probe.md) | results | The logprob-credence probe — does an LLM judge know when it's wrong? A **gate** run before adding `confidence` to `PairwiseJudgement`. |
 | [`20260713_model_identity_and_hub.md`](20260713_model_identity_and_hub.md) | design | Model identity + a publishing seam — the "HF-transformers moment": tie the verbs to which model is used. |
-| [`20260714_training_surface_design.md`](20260714_training_surface_design.md) | design | The training surface — judge→`Matcher` rename, one-verb `fit`, the **miner contract** (plain functions → `LabeledPair`), `TrainedLMMatcher`, `ColVal`. |
+| [`20260714_training_surface_design.md`](20260714_training_surface_design.md) | design | The training surface — judge→`Matcher` rename, one-verb `fit`, the **miner contract** (plain functions → `LabeledPair`), the `finetune()`/serve path, `ColVal`. |
 | [`20260715_data_prep_architecture.md`](20260715_data_prep_architecture.md) ⭐ | design | **Data-preparation architecture** — the method-*shape* taxonomy, the failure-mode-driven curation loop (profile → diagnose → fix → train), the existing-code reuse map, AnyMatch-first build order, and the experiment backlog. The *design* over the #86 survey. |
 
 **Related, elsewhere:** `docs/plans/20260715_data_layer_plan.md` (the buildable profiler +


### PR DESCRIPTION
## Why

David rejected the name **`TrainedLMMatcher`** — "trained" is vacuous (every
model is trained) — **and** the class was never built. The fine-tune → serve
path already exists as a **function**, not a component:

- `langres.core.finetune.finetune(pairs, method=QLoRA(base=<hf-id>, r=…), record_serializer="colval") -> ModelRef`
  — a standalone function whose own docstring says it is "**NOT a Resolver, NOT
  a new component**". `base` lives on the `QLoRA` method object, not a separate
  arg.
- You serve the returned weightless `ModelRef` via `LLMMatcher(model=ref)`
  in-process, or `vllm serve` / `LLMMatcher(api_base=<url>)` for a served
  OpenAI-compatible endpoint.
- The full-suite `Resolver.fit(records, pairs=…, method=QLoRA(…))` surface wraps
  it and builds a `FitReport`.

This PR rewords every doc occurrence of the un-built name to the as-built
reality, **preserving each doc's dated historical design narrative** (surgical
rewords, not section rewrites).

## What changed (doc-only)

- **`docs/research/20260714_training_surface_design.md`** (5 occ)
  - §3.3 declared-at-construction example → `finetune(pairs, method=QLoRA(base=…, r=16), record_serializer="colval")`.
  - §5 component definition → the **`finetune()` verb** (function → `ModelRef` → served via `LLMMatcher`), with a one-clause note that the standalone matcher-class name was rejected and never built; the AnyMatch full-FT/classification-head route stays an **unbuilt classification-head finetune-trainer variant**.
  - §6 "QLoRA fine-tune" example → `ref = finetune(...)` then `LLMMatcher(model=ref)`.
  - §6 "AnyMatch replication" example → classification-head route marked `UNBUILT` (comment, not a call); shipped generative-QLoRA path shown via `finetune()`.
  - §7 build-order row → `finetune()` verb + `QLoRATrainer`.
- **`docs/plans/20260715_data_layer_plan.md`** (1 occ) — Stage-3 pipeline → the existing `finetune()`/serve seam (unbuilt classification-head variant for AnyMatch fidelity).
- **`docs/research/20260715_data_prep_architecture.md`** (2 occ, post-dated the original task snapshot) — reuse-map row + open-item: the `TrainedEmbedder` **sibling** reference re-pointed at the `finetune()` path. `TrainedEmbedder` itself is a separate coined name, out of this change's scope, and left intact.
- **`docs/research/README.md`** (1 occ) — index row for the training-surface doc.

## Verification

- Gate: `grep -rn "TrainedLM" docs/ src/ tests/ examples/` returns **nothing**.
- `uv run --no-dev --group docs mkdocs build --strict` builds clean (no broken links / warnings introduced).
- Every reworded code example checked against the real API (`QLoRA(base, r, lora_alpha, epochs, …)`, `finetune(pairs, method, *, record_serializer=…)`, `LLMMatcher(model=ref)`, `record_serializer="colval"` in `RECORD_SERIALIZERS`).

No `.py` source, tests, or non-doc files touched.

## Summary by Sourcery

Update documentation to reflect the shipped finetune()/serve path instead of the unbuilt TrainedLMMatcher component.

Documentation:
- Revise training-surface design doc examples and narrative to describe the finetune() function returning ModelRef and serving via LLMMatcher, marking the AnyMatch classification-head trainer as unbuilt.
- Update data prep architecture and data layer plan docs to reference the finetune()/serve seam as the sibling path for TrainedEmbedder and the Stage-3 pipeline, rather than TrainedLMMatcher.
- Adjust the research README index entry to describe the training-surface doc in terms of the finetune()/serve path instead of TrainedLMMatcher.

Chores:
- Remove remaining TrainedLMMatcher/TrainedLM references from docs to align terminology with the actual API surface.