### PR TITLE
feat(trackers): local-first Trackio ExperimentTracker adapter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,10 @@
 A `propose → run → evaluate → keep-if-better` hill-climber that tunes a pipeline
 against a **loss-like** objective instead of a saturated F1. M1 proves the loop on
 the **blocking** vertical; the matching vertical (`log_loss` / AUC-PR steering) and
-small-LM fine-tuning are deferred, as is a durable off-laptop **Trackio + Hugging
-Face** dashboard (an optional `tracker=` hook is wired but no-op by default) and an
-Optuna/LLAMBO proposer swap.
+small-LM fine-tuning are deferred, as is an Optuna/LLAMBO proposer swap. A durable
+off-laptop dashboard is no longer deferred: `tracker=resolve_tracker("trackio")`
+(local-first; an HF Space/Dataset sync is a `space_id`/`HF_TOKEN` opt-in) plugs
+straight into `optimize`/`run_loop` via the existing `tracker=` hook (see below).
 
 #### Added
 
@@ -718,10 +719,14 @@ still pulls no `mlflow`/`wandb`).
   exit, and sets the `current_run` contextvar. **`store=None` writes nothing.**
 - **`ExperimentTracker` Protocol + adapters** (`langres.core.trackers`) — an
   Accelerate-style seam (`NoOpTracker` null default, `MultiTracker` fan-out to run
-  MLflow *and* W&B at once, `resolve_tracker` dispatch) with lazy **MLflow** and **W&B**
-  adapters behind the `[mlflow]` / `[wandb]` extras (a missing extra raises a helpful
-  `pip install 'langres[<backend>]'` `ImportError`). MLflow defaults to a local file
-  store out of the box; W&B supports keyless `offline`/`disabled` runs for CI/no-key use.
+  MLflow *and* W&B at once, `resolve_tracker` dispatch) with lazy **MLflow**, **W&B**,
+  and **Trackio** adapters behind the `[mlflow]` / `[wandb]` / `[trackio]` extras (a
+  missing extra raises a helpful `pip install 'langres[<backend>]'` `ImportError`).
+  MLflow defaults to a local file store out of the box; W&B supports keyless
+  `offline`/`disabled` runs for CI/no-key use; **Trackio is local-first** (a local
+  SQLite store, zero credentials) with an opt-in HF Space/Dataset sync
+  (`space_id`/`dataset_id`) gated behind an actionable `ValueError` when no
+  `HF_TOKEN` is available — verified against the installed trackio 0.20.2 API.
 - **LLM trace correlation** — `capture_run` sets `current_run`; `JudgementLog` records
   the active `run_id`, and `LLMJudge` injects litellm `metadata` (`langres_attempt_id`
   + pair ids + decision step) on **both** the sync (`forward`) and async
@@ -733,7 +738,9 @@ still pulls no `mlflow`/`wandb`).
   later eval run threads it into `parent_run_id` (compile → eval lineage).
 - **`Settings`** — `RUN_STORE_PATH`, `MLFLOW_TRACKING_URI`, `MLFLOW_EXPERIMENT` (the
   MLflow ones consumed by `MlflowTracker`; a zero-config default `store` from
-  `RUN_STORE_PATH` is deferred to the benchmark wrap — pass `store=` explicitly today).
+  `RUN_STORE_PATH` is deferred to the benchmark wrap — pass `store=` explicitly today),
+  and `HF_TOKEN` / `TRACKIO_SPACE_ID` / `TRACKIO_DATASET_ID` (consumed by
+  `TrackioTracker` / `create_trackio_tracker`; all optional -- local runs need none).
   Docs: `docs/EXPERIMENTS.md`; runnable zero-spend
   `examples/research/experiment_tracking_demo.py`.
 

--- a/docs/EXPERIMENTS.md
+++ b/docs/EXPERIMENTS.md
@@ -373,13 +373,25 @@ records = RunStore("tmp/autoresearch/ag_blocking.jsonl").read()   # last-wins pe
 accepted = [r for r in records if (r.metrics or {}).get("accepted") == 1.0]
 ```
 
-This persistence is **local-only for now.** A durable, off-laptop dashboard
-(Trackio + Hugging Face, with the winning artifact pushed to the Hub) is
-**deferred** — an optional `tracker=` hook is wired into `optimize`/`run_loop` but
-defaults to a no-op. Also deferred: swapping the exhaustive grid proposer for an
-Optuna/LLAMBO one, and the **matching vertical** (steering a judge on `log_loss` /
-AUC-PR) plus small-LM fine-tuning. **M1 proves the loop on the blocking vertical
-only** (epic #145).
+The `RunStore` JSONL is the durable local record; `store=None` skips it entirely
+(the offline path). For a durable, off-laptop **dashboard**, pass a tracker:
+
+```python
+from langres.core.trackers import resolve_tracker
+
+# Local-first: no credentials, no network -- writes to a local trackio SQLite store.
+result = optimize(space, objective, "amazon_google", tracker=resolve_tracker("trackio"))
+```
+
+Set `HF_TOKEN` and configure a `space_id` (`TrackioTracker(space_id="user/space")` or
+`TRACKIO_SPACE_ID`) to additionally sync the dashboard to a Hugging Face Space (and
+`TRACKIO_DATASET_ID`/`dataset_id` for a persistent HF Dataset) — omitted, this stays
+local-only. Every trial the loop already logs to `RunStore` (accepted, over-budget
+rejects, and scorer failures alike) also streams to the tracker via the same
+`capture_run` call, so nothing needs to be wired twice. Also deferred: swapping the
+exhaustive grid proposer for an Optuna/LLAMBO one, and the **matching vertical**
+(steering a judge on `log_loss` / AUC-PR) plus small-LM fine-tuning. **M1 proves the
+loop on the blocking vertical only** (epic #145).
 
 ### Worked proof — climbing blocking recall@budget on amazon_google
 

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -397,9 +397,11 @@ persisted to a local `RunStore` JSONL.
   and `examples/research/blocking_recall_autoresearch.py`.
 - **Deferred (do not reference as existing):** the **matching** vertical (steering a
   judge on `log_loss` / AUC-PR) and small-LM fine-tuning; an Optuna/LLAMBO proposer
-  swap; and a durable off-laptop **Trackio + Hugging Face** dashboard with the
-  winning artifact pushed to the Hub (an optional `tracker=` hook is wired but
-  defaults to a no-op — persistence is **local JSONL only** today).
+  swap; and pushing the winning artifact to the Hub.
+- **Shipped:** a durable off-laptop dashboard via the **Trackio** tracker
+  (`tracker=resolve_tracker("trackio")`, local-first — no credentials unless an HF
+  Space is configured). Local `RunStore` JSONL persistence (`store=`) remains the
+  default and is independent of the tracker.
 
 ---
 

--- a/docs/TECHNICAL_OVERVIEW.md
+++ b/docs/TECHNICAL_OVERVIEW.md
@@ -910,7 +910,8 @@ across every `k`), and drives the loop over `space.configs()`.
 - `embedder: EmbeddingProvider | None` — optional pre-built embedder (a fake keeps
   tests offline); production leaves it `None` to load the real SentenceTransformer.
 - `tracker: ExperimentTracker | None` — optional experiment tracker; defaults to a
-  no-op (the deferred Trackio/HF hook).
+  no-op. `resolve_tracker("trackio")` is local-first (no credentials/network); an HF
+  Space/Dataset sync is an opt-in `space_id`/`HF_TOKEN` config on top.
 
 ### score_blocking (the one-config scorer)
 
@@ -999,9 +1000,10 @@ Every trial (including over-budget rejects and scorer failures) is appended to t
 `store` path's `RunStore` JSONL (the `core.runs` spine, §2). `store=None` writes
 nothing; read a trail back with `RunStore(path).read()` (each `RunRecord`'s
 `metrics["accepted"]` is `1.0`/`0.0`, so the incumbent timeline is reconstructable
-from the store alone). This is **local-only for now**: a durable off-laptop
-dashboard (Trackio + Hugging Face + models-on-Hub) is deferred behind the optional
-`tracker=` hook (a no-op by default), as are an Optuna/LLAMBO proposer and the
-matching vertical (`log_loss` / AUC-PR steering) + fine-tuning. See
+from the store alone). `RunStore` is local-only by design; a durable off-laptop
+dashboard is available via `tracker=resolve_tracker("trackio")` (local-first; an
+HF Space/Dataset sync is a `space_id`/`HF_TOKEN` opt-in) -- models-on-Hub is not
+built. Still deferred: an Optuna/LLAMBO proposer and the matching vertical
+(`log_loss` / AUC-PR steering) + fine-tuning. See
 [EXPERIMENTS.md](EXPERIMENTS.md#self-tuning-the-autoresearch-loop-langresoptimize)
 for the worked amazon_google proof and `examples/research/blocking_recall_autoresearch.py`.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -107,14 +107,21 @@ finetune = [
     # path; install unsloth yourself (`pip install unsloth`) for its speedups.
 ]
 # Experiment-tracking backends for the ExperimentTracker seam (core/trackers/).
-# Each is loaded lazily by its adapter (mlflow_tracker.py / wandb_tracker.py) so
-# `import langres` never pulls them -- installing the extra names the fix that
-# resolve_tracker's ImportError points at (`pip install 'langres[mlflow]'`).
+# Each is loaded lazily by its adapter (mlflow_tracker.py / wandb_tracker.py /
+# trackio_tracker.py) so `import langres` never pulls them -- installing the
+# extra names the fix that resolve_tracker's ImportError points at
+# (`pip install 'langres[mlflow]'`).
 mlflow = [
     "mlflow>=2.9",
 ]
 wandb = [
     "wandb>=0.16",
+]
+# trackio is pre-1.0 and actively renaming params (dataset_id -> bucket_id,
+# etc.) -- pinned to the installed 0.20 minor (allowing 1.0 is unverified;
+# bump deliberately after re-verifying the API against a new major).
+trackio = [
+    "trackio>=0.20,<1",
 ]
 
 [build-system]
@@ -178,6 +185,7 @@ dev = [
     "ruff>=0.15.2",
     "scikit-learn>=1.7.2",
     "testcontainers[qdrant]>=4.13.2",
+    "trackio>=0.20,<1",
     "types-networkx>=3.5.0.20251001",
     "wandb>=0.22.3",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -117,9 +117,10 @@ mlflow = [
 wandb = [
     "wandb>=0.16",
 ]
-# trackio is pre-1.0 and actively renaming params (dataset_id -> bucket_id,
-# etc.) -- pinned to the installed 0.20 minor (allowing 1.0 is unverified;
-# bump deliberately after re-verifying the API against a new major).
+# trackio is pre-1.0; the adapter is coded against the verified 0.20.2 API
+# (`trackio.init(..., space_id=, dataset_id=, config=)` -> a Run handle;
+# `Run.log`/`Run.finish`). Capped below 1.0 (that major is unverified) -- bump
+# deliberately after re-verifying the API, since a pre-1.0 rename could move it.
 trackio = [
     "trackio>=0.20,<1",
 ]

--- a/src/langres/clients/__init__.py
+++ b/src/langres/clients/__init__.py
@@ -5,16 +5,20 @@ This module provides centralized configuration and client factories for:
 - LLM providers (OpenAI, LiteLLM with Langfuse tracing)
 - Experiment tracking (wandb)
 
-W0.4: ``create_llm_client``/``create_wandb_tracker`` are resolved lazily (PEP
-562) -- ``langres.clients.llm`` imports ``litellm`` at module level, and
-litellm's own import runs ``load_dotenv()`` as a side effect, silently
-populating ``OPENROUTER_API_KEY``/etc. from any ``.env`` on the path (the
-SPEND-SAFETY footgun this branch closes). Eager-importing it here (a side
+W0.4: ``create_llm_client``/``create_wandb_tracker``/``create_trackio_tracker``
+are resolved lazily (PEP 562) -- ``langres.clients.llm`` imports ``litellm`` at
+module level, and litellm's own import runs ``load_dotenv()`` as a side effect,
+silently populating ``OPENROUTER_API_KEY``/etc. from any ``.env`` on the path
+(the SPEND-SAFETY footgun this branch closes). Eager-importing it here (a side
 effect of importing ANY submodule of this package, e.g.
 ``langres.clients.settings``) meant plain ``import langres`` triggered that
-side effect unconditionally. ``create_wandb_tracker`` (``wandb``, dev-only)
-gets the same treatment for consistency and import weight. ``Settings`` stays
-eager -- it's pydantic-settings only.
+side effect unconditionally. ``create_wandb_tracker`` (``wandb``, dev-only) and
+``create_trackio_tracker`` (``trackio``) get the same treatment for consistency
+and import weight -- both resolve through ``langres.clients.tracking``, but
+``create_trackio_tracker`` only imports ``trackio`` inside its own function
+body (see that module's docstring), so accessing either name here never
+requires the other backend's dependency. ``Settings`` stays eager -- it's
+pydantic-settings only.
 """
 
 import importlib
@@ -24,17 +28,19 @@ from langres.clients.settings import Settings
 
 if TYPE_CHECKING:
     from langres.clients.llm import create_llm_client
-    from langres.clients.tracking import create_wandb_tracker
+    from langres.clients.tracking import create_trackio_tracker, create_wandb_tracker
 
 __all__ = [
     "Settings",
     "create_llm_client",
+    "create_trackio_tracker",
     "create_wandb_tracker",
 ]
 
 _LAZY: dict[str, str] = {
     "create_llm_client": "langres.clients.llm",
     "create_wandb_tracker": "langres.clients.tracking",
+    "create_trackio_tracker": "langres.clients.tracking",
 }
 
 

--- a/src/langres/clients/settings.py
+++ b/src/langres/clients/settings.py
@@ -63,6 +63,18 @@ class Settings(BaseSettings):
             file store; MlflowTracker enables it out of the box).
         MLFLOW_EXPERIMENT: MLflow experiment name (default: "langres"). Read by
             the MLflow tracker (MlflowTracker.start_run), not by capture_run.
+        HF_TOKEN: Hugging Face write token. Only needed by the Trackio tracker
+            (TrackioTracker / resolve_tracker("trackio")) when syncing to an HF
+            Space (TRACKIO_SPACE_ID set) -- a purely local Trackio run needs no
+            token. huggingface_hub itself also reads HF_TOKEN (and the legacy
+            HUGGING_FACE_HUB_TOKEN) directly, so this field is mainly for
+            explicit construction (Settings(hf_token=...)); either source
+            satisfies TrackioTracker's credential guard.
+        TRACKIO_SPACE_ID: HF Space ("user/space") to sync Trackio runs to
+            (optional). Unset -> local-first, no credentials/network. Read by
+            TrackioTracker.start_run, not by capture_run.
+        TRACKIO_DATASET_ID: HF Dataset to additionally sync Trackio metrics to
+            (optional; requires TRACKIO_SPACE_ID). Read by TrackioTracker.start_run.
 
     Example:
         # Load from environment variables
@@ -122,6 +134,11 @@ class Settings(BaseSettings):
     run_store_path: str | None = None
     mlflow_tracking_uri: str | None = None
     mlflow_experiment: str = "langres"
+
+    # Trackio (experiment tracking, local-first): HF Space/Dataset sync is opt-in.
+    hf_token: str | None = None
+    trackio_space_id: str | None = None
+    trackio_dataset_id: str | None = None
 
     @field_validator("langres_offline", mode="before")
     @classmethod

--- a/src/langres/clients/tracking.py
+++ b/src/langres/clients/tracking.py
@@ -1,7 +1,8 @@
-"""wandb tracking client factory."""
+"""Experiment-tracker client factories (wandb, trackio)."""
 
 import logging
 import os
+from collections.abc import Mapping
 from typing import Any
 
 import wandb
@@ -83,3 +84,56 @@ def create_wandb_tracker(settings: Settings | None = None, job_type: str = "opti
     )
 
     return run
+
+
+def create_trackio_tracker(
+    settings: Settings | None = None,
+    *,
+    project: str | None = None,
+    space_id: str | None = None,
+    dataset_id: str | None = None,
+    config: Mapping[str, Any] | None = None,
+) -> Any:
+    """Build a (not-yet-started) :class:`TrackioTracker` from settings + overrides.
+
+    Mirrors :func:`create_wandb_tracker`'s settings-driven construction, with
+    two differences forced by trackio's shape: ``trackio.init`` is not called
+    here (deferred to ``TrackioTracker.start_run``, matching
+    :class:`~langres.core.trackers.mlflow_tracker.MlflowTracker`'s
+    init-on-start-run pattern -- there is no live "run" object to configure
+    before a run starts), so the missing-HF-token guard also fires there, not
+    in this factory; and the import of :class:`TrackioTracker` (and therefore
+    ``trackio``) is local to this function body, not this module's top level --
+    this file already has an unconditional top-level ``import wandb`` (needed
+    so ``wandb_tracker.py``'s missing-extra ``ImportError`` surfaces correctly),
+    and importing ``trackio`` there too would make a ``langres[wandb]``-only
+    install fail merely by loading this module. Calling this factory always
+    requires the ``trackio`` extra; ``resolve_tracker("trackio")`` and
+    constructing :class:`TrackioTracker` directly do not need this factory at all.
+
+    Args:
+        settings: Source of ``trackio_space_id``/``trackio_dataset_id``/
+            ``hf_token`` fallbacks when the matching keyword is ``None``.
+            ``None`` -> :class:`Settings` from the environment.
+        project: The trackio project name. ``None`` -> resolved from the run's
+            experiment name at ``start_run`` time.
+        space_id: HF Space to sync to. ``None`` (default) -> local-first, no
+            credentials/network. Overrides ``settings.trackio_space_id``.
+        dataset_id: HF Dataset to additionally sync to (requires ``space_id``).
+            Overrides ``settings.trackio_dataset_id``.
+        config: Extra config merged with the run context at ``start_run``.
+
+    Returns:
+        An unstarted ``TrackioTracker`` -- call ``.start_run(...)`` to open it.
+    """
+    from langres.core.trackers.trackio_tracker import TrackioTracker
+
+    if settings is None:
+        settings = Settings()
+    return TrackioTracker(
+        settings,
+        project=project,
+        space_id=space_id if space_id is not None else settings.trackio_space_id,
+        dataset_id=dataset_id if dataset_id is not None else settings.trackio_dataset_id,
+        config=config,
+    )

--- a/src/langres/clients/tracking.py
+++ b/src/langres/clients/tracking.py
@@ -1,11 +1,17 @@
-"""Experiment-tracker client factories (wandb, trackio)."""
+"""Experiment-tracker client factories (wandb, trackio).
+
+``wandb`` and ``trackio`` are each pulled in only by the factory that needs it
+(``import wandb`` inside :func:`create_wandb_tracker`, the ``TrackioTracker``
+import inside :func:`create_trackio_tracker`), so importing this module -- which
+``from langres.clients import create_trackio_tracker`` does -- never requires the
+*other* backend's extra to be installed. A trackio-only install can therefore
+call ``create_trackio_tracker`` without ``wandb`` present, and vice versa.
+"""
 
 import logging
 import os
 from collections.abc import Mapping
 from typing import Any
-
-import wandb
 
 from langres.clients.settings import Settings
 
@@ -62,6 +68,17 @@ def create_wandb_tracker(settings: Settings | None = None, job_type: str = "opti
         - wandb.log({"metric_name": value})
         - wandb.log({"trial": trial_num, "f1": f1_score, "cost": cost_usd})
     """
+    # Lazy import so this module (and therefore create_trackio_tracker) is
+    # importable in a wandb-less install. A missing extra surfaces the same
+    # branded fix as resolve_tracker's other backends.
+    try:
+        import wandb
+    except ImportError as exc:
+        raise ImportError(
+            "the 'wandb' tracker requires the 'wandb' extra: "
+            "pip install 'langres[wandb]' (or uv add 'langres[wandb]')"
+        ) from exc
+
     if settings is None:
         settings = Settings()
 

--- a/src/langres/core/trackers/__init__.py
+++ b/src/langres/core/trackers/__init__.py
@@ -10,14 +10,15 @@ module carries only the seam: the :class:`ExperimentTracker` Protocol, the
 mirroring :func:`langres.core.presets.resolve_judge`).
 
 The concrete backend adapters (``MlflowTracker`` in ``mlflow_tracker.py``,
-``WandbTracker`` in ``wandb_tracker.py``) are added by later streams and pull
-their heavy dependency (``mlflow`` / ``wandb``) lazily. They are exposed here via
-a PEP 562 module ``__getattr__`` so ``from langres.core.trackers import
-MlflowTracker`` works, but importing this package -- and therefore ``import
-langres`` -- never pulls ``mlflow``/``wandb`` into ``sys.modules``. Until those
-adapter modules exist, accessing the name (or ``resolve_tracker("mlflow")``)
-raises a clear :class:`ImportError` naming the ``pip install 'langres[<backend>]'``
-extra to install -- which is the correct, testable behavior now.
+``WandbTracker`` in ``wandb_tracker.py``, ``TrackioTracker`` in
+``trackio_tracker.py``) pull their heavy dependency (``mlflow`` / ``wandb`` /
+``trackio``) lazily. They are exposed here via a PEP 562 module ``__getattr__``
+so ``from langres.core.trackers import MlflowTracker`` works, but importing this
+package -- and therefore ``import langres`` -- never pulls
+``mlflow``/``wandb``/``trackio`` into ``sys.modules``. When an adapter's extra
+isn't installed, accessing the name (or ``resolve_tracker("mlflow")``) raises a
+clear :class:`ImportError` naming the ``pip install 'langres[<backend>]'`` extra
+to install.
 """
 
 from __future__ import annotations
@@ -48,6 +49,7 @@ __all__ = [
 _ADAPTERS: dict[str, tuple[str, str]] = {
     "mlflow": ("langres.core.trackers.mlflow_tracker", "MlflowTracker"),
     "wandb": ("langres.core.trackers.wandb_tracker", "WandbTracker"),
+    "trackio": ("langres.core.trackers.trackio_tracker", "TrackioTracker"),
 }
 
 
@@ -217,13 +219,16 @@ def resolve_tracker(
     Mirrors :func:`langres.core.presets.resolve_judge`:
 
     * ``None`` -> :class:`NoOpTracker` (no persistence, zero overhead).
-    * ``"mlflow"`` / ``"wandb"`` -> the lazily-loaded backend adapter (a helpful
-      :class:`ImportError` when the extra is absent).
+    * ``"mlflow"`` / ``"wandb"`` / ``"trackio"`` -> the lazily-loaded backend
+      adapter (a helpful :class:`ImportError` when the extra is absent).
+      ``"trackio"`` is local-first: no credentials/network unless the caller
+      also configures an HF Space (``TRACKIO_SPACE_ID`` / ``TrackioTracker``).
     * an ``ExperimentTracker`` instance -> returned as-is (dependency injection).
     * a sequence of specs -> a :class:`MultiTracker` over the resolved children.
 
     Raises:
-        ImportError: A ``"mlflow"``/``"wandb"`` spec whose extra is not installed.
+        ImportError: A ``"mlflow"``/``"wandb"``/``"trackio"`` spec whose extra is
+            not installed.
         ValueError: An unrecognized backend string.
     """
     if spec is None:
@@ -232,7 +237,8 @@ def resolve_tracker(
         if spec not in _ADAPTERS:
             raise ValueError(
                 f"unknown tracker backend {spec!r}; choose 'mlflow', 'wandb', "
-                "pass an ExperimentTracker instance, or a sequence of these"
+                "'trackio', pass an ExperimentTracker instance, or a sequence of "
+                "these"
             )
         return _load_adapter_class(spec)()  # type: ignore[no-any-return]
     if isinstance(spec, ExperimentTracker):
@@ -246,15 +252,17 @@ def resolve_tracker(
 
 
 def __getattr__(name: str) -> Any:
-    """PEP 562: expose ``MlflowTracker``/``WandbTracker`` via lazy adapter import.
+    """PEP 562: expose ``MlflowTracker``/``WandbTracker``/``TrackioTracker`` lazily.
 
-    Keeps ``mlflow``/``wandb`` out of ``sys.modules`` on a bare ``import
-    langres`` -- the class object is only resolved on first attribute access,
-    and surfaces the missing-extra ``ImportError`` if the backend isn't
-    installed (or its adapter module isn't added yet).
+    Keeps ``mlflow``/``wandb``/``trackio`` out of ``sys.modules`` on a bare
+    ``import langres`` -- the class object is only resolved on first attribute
+    access, and surfaces the missing-extra ``ImportError`` if the backend isn't
+    installed.
     """
     if name == "MlflowTracker":
         return _load_adapter_class("mlflow")
     if name == "WandbTracker":
         return _load_adapter_class("wandb")
+    if name == "TrackioTracker":
+        return _load_adapter_class("trackio")
     raise AttributeError(f"module {__name__!r} has no attribute {name!r}")

--- a/src/langres/core/trackers/trackio_tracker.py
+++ b/src/langres/core/trackers/trackio_tracker.py
@@ -1,0 +1,233 @@
+"""Trackio :class:`ExperimentTracker` adapter -- the local-first, HF-optional backend.
+
+Lazily loaded by :func:`langres.core.trackers.resolve_tracker` and
+``from langres.core.trackers import TrackioTracker`` -- ``trackio`` (and its own
+transitive ``huggingface_hub`` dependency) is only pulled in when this module is
+actually imported, so a bare ``import langres`` never touches either (asserted
+by ``tests/test_import_budget.py``). Install with ``pip install 'langres[trackio]'``.
+
+Unlike :class:`~langres.core.trackers.wandb_tracker.WandbTracker` (which
+delegates ``wandb.init`` to :func:`langres.clients.tracking.create_wandb_tracker`),
+this adapter calls ``trackio.init`` directly, mirroring
+:class:`~langres.core.trackers.mlflow_tracker.MlflowTracker`'s self-contained
+shape. That keeps ``trackio``'s import fully scoped to *this* module -- the
+factory in ``langres.clients.tracking`` (``create_trackio_tracker``) still
+exists for settings-driven construction, but only imports this module lazily
+inside its own function body, so a ``langres[wandb]``-only install (that file's
+existing unconditional ``import wandb``) never needs ``trackio`` importable, and
+vice versa.
+
+Local-first by design: with no ``space_id`` configured, ``trackio.init`` writes
+to a local SQLite store only -- no credentials, no network, no HF account. A
+``space_id`` opts into syncing the run to a Hugging Face Space (and optionally a
+persistent Dataset via ``dataset_id`` -- verified against the installed trackio
+0.20.2 API; NOT ``bucket_id``, an unconfirmed name floated before installing).
+Since HF Space sync requires a *write* token, :func:`_require_hf_token` fails
+fast with an actionable :class:`ValueError` naming exactly what to set --
+mirroring :func:`~langres.clients.tracking.create_wandb_tracker`'s missing-cred
+guard -- rather than letting the (still correct, but less actionable) exception
+surface deep inside ``huggingface_hub``. This adapter never deploys or names a
+Space itself; the caller opts in explicitly via ``space_id``.
+"""
+
+from __future__ import annotations
+
+import os
+from collections.abc import Mapping
+from typing import TYPE_CHECKING, Any
+
+import huggingface_hub
+import trackio
+
+from langres.clients.settings import Settings
+
+if TYPE_CHECKING:
+    # Type-only: the adapter receives a RunContext but never imports runs at
+    # runtime (runs imports the trackers package -- keep the dependency acyclic).
+    from langres.core.runs import RunContext
+
+__all__ = ["TrackioTracker"]
+
+#: HF Spaces' stable URL convention (matches ``trackio.deploy.SPACE_HOST_URL``,
+#: not imported directly since that submodule is deploy-only internals) -- used
+#: to build a real deep link, since ``trackio.Run.url`` on a Space run is just
+#: the raw ``"user/space"`` id, not a browsable URL.
+_SPACE_URL = "https://{user}-{space}.hf.space/"
+
+
+def _flatten(obj: Any, prefix: str = "") -> dict[str, Any]:
+    """Flatten a nested mapping/sequence into dotted-key scalars (dropping ``None``).
+
+    Mirrors :func:`langres.core.trackers.wandb_tracker._flatten` (trackio's
+    ``Run.config`` is, like W&B's, a flat scalar dict fed straight to
+    ``trackio.init(config=...)``).
+    """
+    flat: dict[str, Any] = {}
+    if isinstance(obj, Mapping):
+        for key, value in obj.items():
+            child = f"{prefix}.{key}" if prefix else str(key)
+            flat.update(_flatten(value, child))
+    elif isinstance(obj, (list, tuple)):
+        for index, value in enumerate(obj):
+            flat.update(_flatten(value, f"{prefix}[{index}]"))
+    elif obj is not None:
+        flat[prefix] = obj
+    return flat
+
+
+def _has_hf_token(settings: Settings) -> bool:
+    """True if a Hugging Face *write* token is available from any source.
+
+    Checks, in order: an explicit ``settings.hf_token`` (constructor override),
+    then ``huggingface_hub.get_token()`` -- which itself checks the ``HF_TOKEN``
+    env var, the legacy ``HUGGING_FACE_HUB_TOKEN`` env var, and the token file
+    written by ``hf auth login`` (verified against huggingface_hub 0.36).
+    """
+    return bool(settings.hf_token) or huggingface_hub.get_token() is not None
+
+
+def _require_hf_token(space_id: str, settings: Settings) -> None:
+    """Fail fast with an actionable error when ``space_id`` has no token to use.
+
+    Raised BEFORE ``trackio.init`` is ever called -- ``trackio`` itself would
+    eventually raise ``huggingface_hub.errors.LocalTokenNotFoundError`` for the
+    same condition, but only after already resolving/creating Space state; this
+    guard mirrors ``create_wandb_tracker``'s missing-cred ``ValueError`` so the
+    failure is immediate and names the fix.
+    """
+    if not _has_hf_token(settings):
+        raise ValueError(
+            f"space_id={space_id!r} requires a Hugging Face token to sync this "
+            "Trackio run to the Hub: set HF_TOKEN (or the legacy "
+            "HUGGING_FACE_HUB_TOKEN), or run `hf auth login`, before configuring "
+            "an HF-synced Trackio run. Leave space_id unset for a local-only run "
+            "(no credentials needed)."
+        )
+
+
+class TrackioTracker:
+    """Push langres runs into Trackio (the ``"trackio"`` backend) -- local by default.
+
+    One :class:`~langres.core.runs.RunContext` becomes one Trackio run: the
+    context is flattened into ``run.config`` (passed to ``trackio.init`` up
+    front, so it is captured even for a single-``log`` run), metrics stream via
+    ``run.log``, and ``log_artifact``/``set_tags`` do the closest honest mapping
+    given trackio 0.20.2 has no dedicated artifact or tag API -- both fold into
+    ``run.log``/``run.config`` respectively. :attr:`run_url` deep-links the HF
+    Space dashboard when ``space_id`` is configured (``None`` for local runs, which
+    have no static browsable URL outside a notebook embed); :attr:`native` is the
+    escape hatch to the underlying ``trackio.Run``.
+    """
+
+    name = "trackio"
+
+    def __init__(
+        self,
+        settings: Settings | None = None,
+        *,
+        project: str | None = None,
+        space_id: str | None = None,
+        dataset_id: str | None = None,
+        config: Mapping[str, Any] | None = None,
+    ) -> None:
+        """Configure the adapter; ``trackio.init`` is deferred to :meth:`start_run`.
+
+        Args:
+            settings: Source of ``trackio_space_id``/``trackio_dataset_id``/
+                ``hf_token`` fallbacks when the matching keyword is ``None``.
+                ``None`` -> :class:`~langres.clients.settings.Settings` from the
+                environment.
+            project: The trackio project name. ``None`` -> the run's
+                ``context.experiment`` at :meth:`start_run` time.
+            space_id: HF Space to sync to (``"user/space"``), e.g. for durable
+                off-laptop persistence. ``None`` (the default) -> a pure local
+                run: no credentials, no network. Overrides
+                ``settings.trackio_space_id`` when given.
+            dataset_id: HF Dataset to additionally sync metrics to (requires
+                ``space_id``). Overrides ``settings.trackio_dataset_id``.
+            config: Extra config merged with the flattened
+                :class:`~langres.core.runs.RunContext` at :meth:`start_run`.
+        """
+        self._settings = settings
+        self._project = project
+        self._space_id = space_id
+        self._dataset_id = dataset_id
+        self._extra_config = dict(config) if config is not None else {}
+        self._run: Any = None
+
+    def start_run(self, context: RunContext, *, run_name: str | None = None) -> None:
+        """Open a trackio run, seeding its config from the flattened ``context``.
+
+        Resolves ``space_id``/``dataset_id`` (constructor arg, else
+        ``settings``), guards HF credentials when ``space_id`` is set (see
+        :func:`_require_hf_token`), and defaults ``project`` to
+        ``context.experiment``.
+        """
+        settings = self._settings or Settings()
+        space_id = self._space_id if self._space_id is not None else settings.trackio_space_id
+        dataset_id = (
+            self._dataset_id if self._dataset_id is not None else settings.trackio_dataset_id
+        )
+        if space_id is not None:
+            if settings.hf_token:
+                # setdefault: an explicit user-exported HF_TOKEN always wins.
+                os.environ.setdefault("HF_TOKEN", settings.hf_token)
+            _require_hf_token(space_id, settings)
+
+        config = {**_flatten(context.model_dump(mode="json")), **self._extra_config}
+        self._run = trackio.init(
+            project=self._project or context.experiment,
+            name=run_name,
+            config=config,
+            space_id=space_id,
+            dataset_id=dataset_id,
+        )
+        self._space_id = space_id
+
+    def log_params(self, params: Mapping[str, Any]) -> None:
+        """Merge extra (flattened) params into the run config."""
+        if self._run is not None:
+            self._run.config.update(_flatten(dict(params)))
+
+    def log_metrics(self, metrics: Mapping[str, float], *, step: int | None = None) -> None:
+        """Stream metrics to *this* run (``run.log``). A no-op before :meth:`start_run`."""
+        if self._run is not None:
+            self._run.log(dict(metrics), step=step)
+
+    def log_artifact(self, key: str, value: str) -> None:
+        """Record an artifact path/URL as a log entry (no dedicated artifact API)."""
+        if self._run is not None:
+            self._run.log({key: value})
+
+    def set_tags(self, tags: Mapping[str, str]) -> None:
+        """Fold ``key:value`` labels into the run config (no dedicated tags API).
+
+        Prefixed ``tag.<key>`` so a tag never silently overwrites a same-named
+        config entry from :meth:`start_run`/:meth:`log_params`.
+        """
+        if self._run is not None:
+            self._run.config.update({f"tag.{key}": value for key, value in tags.items()})
+
+    def finish(self, *, status: str) -> None:
+        """Record the terminal ``status`` then close *this* run (``run.finish``).
+
+        Trackio's ``Run.finish()`` takes no status argument, so the langres
+        status is stamped as a ``langres_status`` log entry first (mirrors
+        MLflow's ``langres.status`` tag). A no-op before :meth:`start_run`.
+        """
+        if self._run is not None:
+            self._run.log({"langres_status": status})
+            self._run.finish()
+
+    @property
+    def run_url(self) -> str | None:
+        """Deep link to the HF Space dashboard, or ``None`` for a local run."""
+        if self._run is None or self._space_id is None:
+            return None
+        user, space = self._space_id.split("/", 1)
+        return _SPACE_URL.format(user=user, space=space)
+
+    @property
+    def native(self) -> Any:
+        """The underlying ``trackio.Run`` object (escape hatch), or ``None``."""
+        return self._run

--- a/src/langres/core/trackers/trackio_tracker.py
+++ b/src/langres/core/trackers/trackio_tracker.py
@@ -110,13 +110,16 @@ class TrackioTracker:
 
     One :class:`~langres.core.runs.RunContext` becomes one Trackio run: the
     context is flattened into ``run.config`` (passed to ``trackio.init`` up
-    front, so it is captured even for a single-``log`` run), metrics stream via
-    ``run.log``, and ``log_artifact``/``set_tags`` do the closest honest mapping
-    given trackio 0.20.2 has no dedicated artifact or tag API -- both fold into
-    ``run.log``/``run.config`` respectively. :attr:`run_url` deep-links the HF
-    Space dashboard when ``space_id`` is configured (``None`` for local runs, which
-    have no static browsable URL outside a notebook embed); :attr:`native` is the
-    escape hatch to the underlying ``trackio.Run``.
+    front, so it is captured even for a single-``log`` run) and metrics stream via
+    ``run.log``. trackio 0.20.2 has no dedicated artifact or tag API, so
+    ``log_artifact``/``log_params``/``set_tags`` all persist through ``run.log``
+    (``log_artifact`` as a raw entry, ``log_params``/``set_tags`` under
+    ``param.``/``tag.`` prefixes) -- ``run.config`` alone is flushed only on the
+    first ``run.log``, so log entries are what make post-first-metric params/tags
+    durable. :attr:`run_url` deep-links the HF Space dashboard when a namespaced
+    ``space_id`` is configured (``None`` for local runs, which have no static
+    browsable URL outside a notebook embed); :attr:`native` is the escape hatch to
+    the underlying ``trackio.Run``.
     """
 
     name = "trackio"
@@ -168,6 +171,15 @@ class TrackioTracker:
         dataset_id = (
             self._dataset_id if self._dataset_id is not None else settings.trackio_dataset_id
         )
+        if dataset_id is not None and space_id is None:
+            # trackio.init raises the same condition itself, but only after other
+            # setup -- fail fast here so the misconfiguration names its own fix.
+            raise ValueError(
+                f"dataset_id={dataset_id!r} requires a space_id: a persistent HF "
+                "Dataset is only synced alongside an HF Space. Set a space_id "
+                "(constructor arg or TRACKIO_SPACE_ID), or drop dataset_id for a "
+                "local-only run."
+            )
         if space_id is not None:
             if settings.hf_token:
                 # setdefault: an explicit user-exported HF_TOKEN always wins.
@@ -185,9 +197,20 @@ class TrackioTracker:
         self._space_id = space_id
 
     def log_params(self, params: Mapping[str, Any]) -> None:
-        """Merge extra (flattened) params into the run config."""
+        """Persist extra (flattened) params on the run, under a ``param.<k>`` prefix.
+
+        trackio flushes ``run.config`` to its store only on the *first* ``run.log``
+        (a one-way latch), and ``finish()`` never flushes it -- so a config-only
+        update after the first metric would be silently dropped. We therefore
+        *also* emit the params as a ``run.log`` entry (``param.<key>``), which
+        always persists regardless of call order; ``config`` is updated too so
+        the in-memory :attr:`native` view (and the pre-first-log flush) stay
+        coherent.
+        """
         if self._run is not None:
-            self._run.config.update(_flatten(dict(params)))
+            flat = _flatten(dict(params))
+            self._run.config.update(flat)
+            self._run.log({f"param.{key}": value for key, value in flat.items()})
 
     def log_metrics(self, metrics: Mapping[str, float], *, step: int | None = None) -> None:
         """Stream metrics to *this* run (``run.log``). A no-op before :meth:`start_run`."""
@@ -200,13 +223,17 @@ class TrackioTracker:
             self._run.log({key: value})
 
     def set_tags(self, tags: Mapping[str, str]) -> None:
-        """Fold ``key:value`` labels into the run config (no dedicated tags API).
+        """Persist ``key:value`` labels on the run (no dedicated tags API).
 
-        Prefixed ``tag.<key>`` so a tag never silently overwrites a same-named
-        config entry from :meth:`start_run`/:meth:`log_params`.
+        Prefixed ``tag.<key>`` so a tag never collides with a config/param entry.
+        Emitted via ``run.log`` (not only ``run.config``) for the same
+        persistence reason as :meth:`log_params`: a config-only update after the
+        first ``run.log`` would never reach trackio's store.
         """
         if self._run is not None:
-            self._run.config.update({f"tag.{key}": value for key, value in tags.items()})
+            prefixed = {f"tag.{key}": value for key, value in tags.items()}
+            self._run.config.update(prefixed)
+            self._run.log(prefixed)
 
     def finish(self, *, status: str) -> None:
         """Record the terminal ``status`` then close *this* run (``run.finish``).
@@ -221,8 +248,14 @@ class TrackioTracker:
 
     @property
     def run_url(self) -> str | None:
-        """Deep link to the HF Space dashboard, or ``None`` for a local run."""
-        if self._run is None or self._space_id is None:
+        """Deep link to the HF Space dashboard, or ``None`` for a local run.
+
+        Returns ``None`` for a bare (namespace-less) ``space_id`` too -- the
+        ``user/space`` URL can't be built from it, and trackio would have created
+        the Space in the logged-in user's namespace, whose name we don't resolve
+        here.
+        """
+        if self._run is None or self._space_id is None or "/" not in self._space_id:
             return None
         user, space = self._space_id.split("/", 1)
         return _SPACE_URL.format(user=user, space=space)

--- a/tests/clients/test_tracking.py
+++ b/tests/clients/test_tracking.py
@@ -1,6 +1,7 @@
 """Tests for langres.clients.tracking module."""
 
 import os
+import sys
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -26,7 +27,8 @@ class TestCreateWandbTracker:
             azure_api_endpoint="https://test.openai.azure.com",
         )
 
-        with patch("langres.clients.tracking.wandb") as mock_wandb:
+        mock_wandb = MagicMock()
+        with patch.dict(sys.modules, {"wandb": mock_wandb}):
             mock_run = MagicMock()
             mock_wandb.init.return_value = mock_run
 
@@ -59,7 +61,8 @@ class TestCreateWandbTracker:
             ),
             patch("pydantic_settings.sources.DotEnvSettingsSource.__call__", return_value={}),
         ):
-            with patch("langres.clients.tracking.wandb") as mock_wandb:
+            mock_wandb = MagicMock()
+            with patch.dict(sys.modules, {"wandb": mock_wandb}):
                 mock_run = MagicMock()
                 mock_wandb.init.return_value = mock_run
 
@@ -82,7 +85,8 @@ class TestCreateWandbTracker:
             azure_api_endpoint="https://test.openai.azure.com",
         )
 
-        with patch("langres.clients.tracking.wandb") as mock_wandb:
+        mock_wandb = MagicMock()
+        with patch.dict(sys.modules, {"wandb": mock_wandb}):
             create_wandb_tracker(settings)
 
             # Verify default job_type is "optimization"
@@ -102,7 +106,8 @@ class TestCreateWandbTracker:
             azure_api_endpoint="https://test.openai.azure.com",
         )
 
-        with patch("langres.clients.tracking.wandb") as mock_wandb:
+        mock_wandb = MagicMock()
+        with patch.dict(sys.modules, {"wandb": mock_wandb}):
             create_wandb_tracker(settings)
 
             # Verify entity=None passed to wandb.init
@@ -118,6 +123,14 @@ class TestCreateWandbTracker:
         with pytest.raises(ValueError, match="WANDB_API_KEY environment variable is required"):
             create_wandb_tracker(settings)
 
+    def test_create_wandb_tracker_raises_branded_import_error_without_extra(
+        self, monkeypatch: pytest.MonkeyPatch
+    ):
+        """The now-lazy wandb import surfaces the branded langres[wandb] fix at call time."""
+        monkeypatch.setitem(sys.modules, "wandb", None)  # a fresh `import wandb` now fails
+        with pytest.raises(ImportError, match=r"langres\[wandb\]"):
+            create_wandb_tracker(Settings(wandb_api_key="k"))
+
     @pytest.mark.parametrize("mode", ["offline", "disabled", "OFFLINE", " offline "])
     def test_create_wandb_tracker_skips_api_key_when_offline(
         self, monkeypatch: pytest.MonkeyPatch, mode: str
@@ -126,7 +139,8 @@ class TestCreateWandbTracker:
         monkeypatch.setenv("WANDB_MODE", mode)
         settings = Settings(wandb_api_key=None, wandb_project="offline-proj")
 
-        with patch("langres.clients.tracking.wandb") as mock_wandb:
+        mock_wandb = MagicMock()
+        with patch.dict(sys.modules, {"wandb": mock_wandb}):
             mock_run = MagicMock()
             mock_wandb.init.return_value = mock_run
 
@@ -154,7 +168,25 @@ class TestCreateTrackioTracker:
 
     def test_default_settings_loaded_when_none_given(self, monkeypatch: pytest.MonkeyPatch) -> None:
         monkeypatch.delenv("TRACKIO_SPACE_ID", raising=False)
+        monkeypatch.delenv("TRACKIO_DATASET_ID", raising=False)
         tracker = create_trackio_tracker()
+        assert isinstance(tracker, TrackioTracker)
+
+    def test_needs_no_wandb_extra(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """create_trackio_tracker must work in a trackio-only (wandb-less) install.
+
+        Co-located with create_wandb_tracker, but the wandb import is lazy inside
+        that factory's body -- so importing/calling create_trackio_tracker never
+        needs the wandb extra. Simulate wandb's absence and prove the call still
+        succeeds (while a fresh ``import wandb`` genuinely fails).
+        """
+        import importlib
+
+        monkeypatch.setitem(sys.modules, "wandb", None)
+        with pytest.raises(ImportError):
+            importlib.import_module("wandb")  # the simulation is real
+
+        tracker = create_trackio_tracker(Settings())  # must NOT raise
         assert isinstance(tracker, TrackioTracker)
 
     def test_explicit_project_and_config_passed_through(self) -> None:
@@ -180,8 +212,14 @@ class TestCreateTrackioTracker:
         tracker = create_trackio_tracker(settings, space_id="explicit/space")
         assert tracker._space_id == "explicit/space"
 
-    def test_local_first_when_nothing_configured(self) -> None:
-        """No space_id anywhere (kwarg or settings) -> a pure local tracker."""
+    def test_local_first_when_nothing_configured(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """No space_id anywhere (kwarg or settings) -> a pure local tracker.
+
+        Hermetic: drop any ambient TRACKIO_SPACE_ID/TRACKIO_DATASET_ID so the
+        assertion doesn't depend on the runner's environment.
+        """
+        monkeypatch.delenv("TRACKIO_SPACE_ID", raising=False)
+        monkeypatch.delenv("TRACKIO_DATASET_ID", raising=False)
         tracker = create_trackio_tracker(Settings())
         assert tracker._space_id is None
         assert tracker._dataset_id is None

--- a/tests/clients/test_tracking.py
+++ b/tests/clients/test_tracking.py
@@ -6,7 +6,8 @@ from unittest.mock import MagicMock, patch
 import pytest
 
 from langres.clients.settings import Settings
-from langres.clients.tracking import create_wandb_tracker
+from langres.clients.tracking import create_trackio_tracker, create_wandb_tracker
+from langres.core.trackers.trackio_tracker import TrackioTracker
 
 
 class TestCreateWandbTracker:
@@ -135,3 +136,52 @@ class TestCreateWandbTracker:
             mock_wandb.init.assert_called_once_with(
                 project="offline-proj", entity=None, job_type="optimization"
             )
+
+
+class TestCreateTrackioTracker:
+    """Tests for create_trackio_tracker factory function.
+
+    Unlike create_wandb_tracker (which calls wandb.init eagerly and returns the
+    live run), create_trackio_tracker builds and returns an UNSTARTED
+    TrackioTracker -- trackio.init is deferred to .start_run(), so these tests
+    never touch the network/trackio.init and don't need to mock trackio.
+    """
+
+    def test_returns_unstarted_trackio_tracker(self) -> None:
+        tracker = create_trackio_tracker(Settings())
+        assert isinstance(tracker, TrackioTracker)
+        assert tracker.native is None
+
+    def test_default_settings_loaded_when_none_given(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.delenv("TRACKIO_SPACE_ID", raising=False)
+        tracker = create_trackio_tracker()
+        assert isinstance(tracker, TrackioTracker)
+
+    def test_explicit_project_and_config_passed_through(self) -> None:
+        tracker = create_trackio_tracker(Settings(), project="ar-smoke", config={"k": "v"})
+        assert tracker._project == "ar-smoke"
+        assert tracker._extra_config == {"k": "v"}
+
+    def test_space_id_and_dataset_id_from_explicit_kwargs(self) -> None:
+        tracker = create_trackio_tracker(
+            Settings(), space_id="acme/runs", dataset_id="acme/runs_dataset"
+        )
+        assert tracker._space_id == "acme/runs"
+        assert tracker._dataset_id == "acme/runs_dataset"
+
+    def test_space_id_and_dataset_id_fall_back_to_settings(self) -> None:
+        settings = Settings(trackio_space_id="acme/runs", trackio_dataset_id="acme/ds")
+        tracker = create_trackio_tracker(settings)
+        assert tracker._space_id == "acme/runs"
+        assert tracker._dataset_id == "acme/ds"
+
+    def test_explicit_space_id_overrides_settings(self) -> None:
+        settings = Settings(trackio_space_id="settings/space")
+        tracker = create_trackio_tracker(settings, space_id="explicit/space")
+        assert tracker._space_id == "explicit/space"
+
+    def test_local_first_when_nothing_configured(self) -> None:
+        """No space_id anywhere (kwarg or settings) -> a pure local tracker."""
+        tracker = create_trackio_tracker(Settings())
+        assert tracker._space_id is None
+        assert tracker._dataset_id is None

--- a/tests/test_import_budget.py
+++ b/tests/test_import_budget.py
@@ -51,9 +51,14 @@ _HEAVY_MODULES = [
     "sentence_transformers",
     "sklearn",
     # Tracking backends (S1): the ExperimentTracker adapters must load mlflow/
-    # wandb lazily, never on a bare `import langres`.
+    # wandb/trackio lazily, never on a bare `import langres`. huggingface_hub
+    # is trackio's own transitive dependency and was absent from the eager
+    # import graph before trackio_tracker.py -- listed here so it can't
+    # silently become eager either.
     "mlflow",
     "wandb",
+    "trackio",
+    "huggingface_hub",
     # Fine-tune stack ([finetune], PR-F): peft/trl/bitsandbytes import lazily
     # inside core.finetune's QLoRATrainer.train, never on a bare `import langres`.
     "peft",

--- a/tests/test_trackers.py
+++ b/tests/test_trackers.py
@@ -275,6 +275,28 @@ class TestResolveTracker:
         with pytest.raises(ImportError, match=r"langres\[wandb\]"):
             resolve_tracker("wandb")
 
+    def test_trackio_string_raises_helpful_import_error_when_absent(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A missing ``trackio`` extra -> a helpful ``langres[trackio]`` ImportError.
+
+        ``trackio`` is a real dev dependency in this env, so genuine absence
+        doesn't occur here. Simulate it by forcing the adapter import to fail
+        (mirrors the mlflow/wandb twins above).
+        """
+        import langres.core.trackers as trackers_mod
+
+        real_import = trackers_mod.importlib.import_module
+
+        def _fail_trackio_import(path: str, *a: Any, **k: Any) -> Any:
+            if path == "langres.core.trackers.trackio_tracker":
+                raise ImportError("No module named 'trackio'")
+            return real_import(path, *a, **k)
+
+        monkeypatch.setattr(trackers_mod.importlib, "import_module", _fail_trackio_import)
+        with pytest.raises(ImportError, match=r"langres\[trackio\]"):
+            resolve_tracker("trackio")
+
     def test_unknown_backend_string_raises_value_error(self) -> None:
         with pytest.raises(ValueError, match="unknown"):
             resolve_tracker("not-a-backend")
@@ -346,6 +368,23 @@ class TestLazyAdapterGetattr:
         monkeypatch.setattr(trackers.importlib, "import_module", _fail_wandb_import)
         with pytest.raises(ImportError, match=r"langres\[wandb\]"):
             trackers.WandbTracker  # noqa: B018
+
+    def test_trackio_tracker_attribute_raises_helpful_import_error(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """``trackers.TrackioTracker`` -> helpful ImportError when the extra is absent."""
+        import langres.core.trackers as trackers
+
+        real_import = trackers.importlib.import_module
+
+        def _fail_trackio_import(path: str, *a: Any, **k: Any) -> Any:
+            if path == "langres.core.trackers.trackio_tracker":
+                raise ImportError("No module named 'trackio'")
+            return real_import(path, *a, **k)
+
+        monkeypatch.setattr(trackers.importlib, "import_module", _fail_trackio_import)
+        with pytest.raises(ImportError, match=r"langres\[trackio\]"):
+            trackers.TrackioTracker  # noqa: B018
 
     def test_unknown_attribute_raises_attribute_error(self) -> None:
         import langres.core.trackers as trackers

--- a/tests/test_trackio_tracker.py
+++ b/tests/test_trackio_tracker.py
@@ -231,6 +231,32 @@ class TestHfSyncCredentialGuard:
 
         assert fake_trackio.init_kwargs["space_id"] == "explicit/space"
 
+    def test_preexisting_hf_token_env_wins_over_settings_token(
+        self, fake_trackio: _FakeTrackio, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A user-exported HF_TOKEN is never clobbered by settings.hf_token.
+
+        Locks in the ``os.environ.setdefault`` precedence: the explicit ambient
+        token wins, and trackio's own huggingface_hub calls keep seeing it.
+        """
+        monkeypatch.setenv("HF_TOKEN", "preexisting-token")
+        tracker = TrackioTracker(Settings(hf_token="hf_explicit"), space_id="acme/langres-runs")
+        tracker.start_run(_context())  # must not raise (token present)
+
+        assert os.environ["HF_TOKEN"] == "preexisting-token"
+
+    def test_dataset_id_without_space_id_raises(
+        self, fake_trackio: _FakeTrackio, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A dataset_id with no space_id is a misconfiguration -- fail fast, no init."""
+        monkeypatch.delenv("TRACKIO_SPACE_ID", raising=False)
+        tracker = TrackioTracker(Settings(), dataset_id="acme/ds")
+
+        with pytest.raises(ValueError, match=r"dataset_id.*requires a space_id"):
+            tracker.start_run(_context())
+
+        assert fake_trackio.init_kwargs is None
+
 
 class TestLogging:
     def test_log_metrics_routes_to_run_log(self, fake_trackio: _FakeTrackio) -> None:
@@ -251,12 +277,25 @@ class TestLogging:
         TrackioTracker().log_metrics({"f1": 0.5})
         assert fake_trackio.run.log_calls == []
 
-    def test_log_params_merges_into_config(self, fake_trackio: _FakeTrackio) -> None:
+    def test_log_params_merges_into_config_and_logs(self, fake_trackio: _FakeTrackio) -> None:
         tracker = TrackioTracker(Settings())
         tracker.start_run(_context())
         tracker.log_params({"extra": {"nested": 1}})
 
+        # Kept in config (in-memory / pre-first-log flush) AND emitted via run.log
+        # under a param. prefix (the durable path -- see below).
         assert fake_trackio.run.config["extra.nested"] == 1
+        assert fake_trackio.run.log_calls[-1] == ({"param.extra.nested": 1}, None)
+
+    def test_log_params_persists_after_a_metric(self, fake_trackio: _FakeTrackio) -> None:
+        """trackio flushes config only on the first run.log, so a param logged
+        AFTER a metric must still reach the store -- via its own run.log entry."""
+        tracker = TrackioTracker(Settings())
+        tracker.start_run(_context())
+        tracker.log_metrics({"f1": 0.9})  # first log latches config
+        tracker.log_params({"late": 1})
+
+        assert ({"param.late": 1}, None) in fake_trackio.run.log_calls
 
     def test_log_params_noop_before_start(self) -> None:
         TrackioTracker().log_params({"a": 1})  # must not raise
@@ -271,13 +310,26 @@ class TestLogging:
     def test_log_artifact_noop_before_start(self) -> None:
         TrackioTracker().log_artifact("k", "v")  # must not raise
 
-    def test_set_tags_folds_into_config_with_prefix(self, fake_trackio: _FakeTrackio) -> None:
+    def test_set_tags_folds_into_config_with_prefix_and_logs(
+        self, fake_trackio: _FakeTrackio
+    ) -> None:
         tracker = TrackioTracker(Settings())
         tracker.start_run(_context())
         tracker.set_tags({"env": "ci", "team": "er"})
 
         assert fake_trackio.run.config["tag.env"] == "ci"
         assert fake_trackio.run.config["tag.team"] == "er"
+        assert fake_trackio.run.log_calls[-1] == ({"tag.env": "ci", "tag.team": "er"}, None)
+
+    def test_set_tags_persists_after_a_metric(self, fake_trackio: _FakeTrackio) -> None:
+        """Same one-way-config-latch reason as params: a tag set after a metric
+        must still persist via run.log, not only the (already-flushed) config."""
+        tracker = TrackioTracker(Settings())
+        tracker.start_run(_context())
+        tracker.log_metrics({"f1": 0.9})
+        tracker.set_tags({"env": "ci"})
+
+        assert ({"tag.env": "ci"}, None) in fake_trackio.run.log_calls
 
     def test_set_tags_noop_before_start(self) -> None:
         TrackioTracker().set_tags({"a": "b"})  # must not raise
@@ -319,6 +371,16 @@ class TestRunUrlAndNative:
         tracker.start_run(_context())
 
         assert tracker.run_url == "https://acme-langres-runs.hf.space/"
+
+    def test_run_url_none_for_namespaceless_space_id(
+        self, fake_trackio: _FakeTrackio, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A bare (no ``/``) space_id can't build a user-space URL -> None, no crash."""
+        monkeypatch.setattr(huggingface_hub, "get_token", lambda: "cached-login-token")
+        tracker = TrackioTracker(Settings(), space_id="justareponame")
+        tracker.start_run(_context())
+
+        assert tracker.run_url is None
 
     def test_native_returns_underlying_run(self, fake_trackio: _FakeTrackio) -> None:
         tracker = TrackioTracker(Settings())

--- a/tests/test_trackio_tracker.py
+++ b/tests/test_trackio_tracker.py
@@ -1,0 +1,372 @@
+"""Tests for the Trackio ``ExperimentTracker`` adapter.
+
+Behavior/smoke tier: ``trackio`` is fully mocked (a fake module patched over
+``langres.core.trackers.trackio_tracker.trackio``), so no test touches the
+network or a real HF login. We assert that start_run -> log -> finish call the
+right trackio APIs with the flattened context, that ``run_url``/``native``
+derive from the underlying run, that the HF-sync credential guard fires
+before ``trackio.init`` (and never fires for a local-only run), and that
+``resolve_tracker("trackio")`` returns a real :class:`TrackioTracker`. One
+``@pytest.mark.slow`` test drives the REAL, uninstalled-mock trackio against a
+local (no ``space_id``) run to prove the adapter works end to end offline.
+"""
+
+from __future__ import annotations
+
+import os
+from typing import Any
+
+import huggingface_hub
+import pytest
+
+from langres.clients.settings import Settings
+from langres.core.runs import RunContext
+from langres.core.trackers import ExperimentTracker, resolve_tracker
+from langres.core.trackers.trackio_tracker import TrackioTracker, _flatten
+
+
+class _FakeRun:
+    """Stand-in for a ``trackio.Run`` -- records ``log``/``finish`` on itself.
+
+    ``config`` is a plain ``dict`` (unlike wandb's special config object), since
+    that is what the real ``trackio.Run.config`` is -- ``.update()`` is the
+    built-in ``dict`` method.
+    """
+
+    def __init__(self) -> None:
+        self.config: dict[str, Any] = {}
+        self.name: str | None = None
+        self.log_calls: list[tuple[dict[str, Any], int | None]] = []
+        self.finish_calls: int = 0
+
+    def log(self, data: dict[str, Any], step: int | None = None) -> None:
+        self.log_calls.append((dict(data), step))
+
+    def finish(self) -> None:
+        self.finish_calls += 1
+
+
+class _FakeTrackio:
+    """Minimal fake ``trackio`` module: ``init`` records kwargs and returns the run."""
+
+    def __init__(self, run: _FakeRun | None = None) -> None:
+        self.run = run if run is not None else _FakeRun()
+        self.init_kwargs: dict[str, Any] | None = None
+
+    def init(self, **kwargs: Any) -> _FakeRun:
+        self.init_kwargs = kwargs
+        return self.run
+
+
+@pytest.fixture
+def fake_trackio(monkeypatch: pytest.MonkeyPatch) -> _FakeTrackio:
+    """Patch the fake over ``trackio_tracker.trackio`` (the module-level import)."""
+    fake = _FakeTrackio()
+    import langres.core.trackers.trackio_tracker as tracker_mod
+
+    monkeypatch.setattr(tracker_mod, "trackio", fake)
+    return fake
+
+
+@pytest.fixture(autouse=True)
+def _no_ambient_hf_token(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Isolate tests from a real local HF login / env token on the dev machine.
+
+    Every test that touches the credential guard controls
+    ``huggingface_hub.get_token`` (or ``settings.hf_token``) explicitly; this
+    fixture just guarantees the *ambient* environment can't leak in and flip a
+    "no token" test green (or a "has token" test's isolation) depending on
+    whoever's machine runs the suite.
+    """
+    monkeypatch.delenv("HF_TOKEN", raising=False)
+    monkeypatch.delenv("HUGGING_FACE_HUB_TOKEN", raising=False)
+
+
+def _context() -> RunContext:
+    return RunContext(
+        experiment="dedupe-ag",
+        tags={"env": "ci"},
+        git_sha="deadbeef",
+        llm_model="deepseek/deepseek-chat",
+        cascade_band=(0.3, 0.7),
+        blocking_k=5,
+        dataset_name="amazon-google",
+        seeds={"split": 42},
+        resolver_config={"type_name": "Resolver", "seed": 7},
+    )
+
+
+class TestFlatten:
+    def test_dots_nested_and_drops_none(self) -> None:
+        flat = _flatten({"a": {"b": 1}, "c": None, "d": 2})
+        assert flat == {"a.b": 1, "d": 2}
+
+    def test_indexes_sequences(self) -> None:
+        assert _flatten({"band": [0.3, 0.7]}) == {"band[0]": 0.3, "band[1]": 0.7}
+
+    def test_empty_mapping_yields_nothing(self) -> None:
+        assert _flatten({"tags": {}}) == {}
+
+
+class TestProtocolAndConstruction:
+    def test_satisfies_protocol(self) -> None:
+        assert isinstance(TrackioTracker(), ExperimentTracker)
+
+    def test_name_is_trackio(self) -> None:
+        assert TrackioTracker().name == "trackio"
+
+    def test_no_run_before_start(self) -> None:
+        tracker = TrackioTracker()
+        assert tracker.native is None
+        assert tracker.run_url is None
+
+
+class TestStartRunLocal:
+    def test_local_run_needs_no_token(self, fake_trackio: _FakeTrackio) -> None:
+        """The default (no space_id) path never touches the HF-token guard."""
+        tracker = TrackioTracker(Settings())
+        tracker.start_run(_context(), run_name="dedupe-ag")  # must not raise
+
+        assert fake_trackio.init_kwargs is not None
+        assert fake_trackio.init_kwargs["space_id"] is None
+        assert fake_trackio.init_kwargs["dataset_id"] is None
+
+    def test_project_defaults_to_experiment(self, fake_trackio: _FakeTrackio) -> None:
+        tracker = TrackioTracker(Settings())
+        tracker.start_run(_context())
+
+        assert fake_trackio.init_kwargs is not None
+        assert fake_trackio.init_kwargs["project"] == "dedupe-ag"
+
+    def test_explicit_project_overrides_experiment(self, fake_trackio: _FakeTrackio) -> None:
+        tracker = TrackioTracker(Settings(), project="my-project")
+        tracker.start_run(_context())
+
+        assert fake_trackio.init_kwargs is not None
+        assert fake_trackio.init_kwargs["project"] == "my-project"
+
+    def test_run_name_passed_through(self, fake_trackio: _FakeTrackio) -> None:
+        tracker = TrackioTracker(Settings())
+        tracker.start_run(_context(), run_name="dedupe-ag-run")
+
+        assert fake_trackio.init_kwargs is not None
+        assert fake_trackio.init_kwargs["name"] == "dedupe-ag-run"
+
+    def test_flattens_context_into_config(self, fake_trackio: _FakeTrackio) -> None:
+        tracker = TrackioTracker(Settings())
+        tracker.start_run(_context())
+
+        config = fake_trackio.init_kwargs["config"]
+        assert config["experiment"] == "dedupe-ag"
+        assert config["llm_model"] == "deepseek/deepseek-chat"
+        assert config["blocking_k"] == 5
+        assert config["seeds.split"] == 42
+        assert config["tags.env"] == "ci"
+        assert config["git_sha"] == "deadbeef"
+        assert config["cascade_band[0]"] == 0.3
+        assert config["cascade_band[1]"] == 0.7
+        assert config["resolver_config.seed"] == 7
+        # None-valued context fields are dropped, not surfaced as "None".
+        assert "group" not in config
+
+    def test_extra_config_merged_in(self, fake_trackio: _FakeTrackio) -> None:
+        tracker = TrackioTracker(Settings(), config={"extra": 1})
+        tracker.start_run(_context())
+
+        assert fake_trackio.init_kwargs["config"]["extra"] == 1
+
+
+class TestHfSyncCredentialGuard:
+    def test_space_id_without_token_raises_actionable_value_error(
+        self, fake_trackio: _FakeTrackio, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setattr(huggingface_hub, "get_token", lambda: None)
+        tracker = TrackioTracker(Settings(), space_id="acme/langres-runs")
+
+        with pytest.raises(ValueError, match=r"acme/langres-runs.*HF_TOKEN"):
+            tracker.start_run(_context())
+
+        # The guard fired before trackio.init was ever called.
+        assert fake_trackio.init_kwargs is None
+
+    def test_space_id_with_settings_hf_token_succeeds_and_exports_env(
+        self, fake_trackio: _FakeTrackio, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setattr(huggingface_hub, "get_token", lambda: None)
+        tracker = TrackioTracker(Settings(hf_token="hf_explicit"), space_id="acme/langres-runs")
+        tracker.start_run(_context())  # must not raise
+
+        assert fake_trackio.init_kwargs["space_id"] == "acme/langres-runs"
+        # Propagated so trackio's own internal huggingface_hub calls see it too.
+        assert os.environ["HF_TOKEN"] == "hf_explicit"
+
+    def test_space_id_with_ambient_hf_token_succeeds_without_settings(
+        self, fake_trackio: _FakeTrackio, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setattr(huggingface_hub, "get_token", lambda: "cached-login-token")
+        tracker = TrackioTracker(Settings(), space_id="acme/langres-runs")
+        tracker.start_run(_context())  # must not raise
+
+        assert fake_trackio.init_kwargs["space_id"] == "acme/langres-runs"
+
+    def test_space_id_from_settings_fallback(
+        self, fake_trackio: _FakeTrackio, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A space_id configured only via Settings (not the constructor) also works."""
+        monkeypatch.setattr(huggingface_hub, "get_token", lambda: "cached-login-token")
+        settings = Settings(trackio_space_id="acme/langres-runs", trackio_dataset_id="acme/ds")
+        tracker = TrackioTracker(settings)
+        tracker.start_run(_context())
+
+        assert fake_trackio.init_kwargs["space_id"] == "acme/langres-runs"
+        assert fake_trackio.init_kwargs["dataset_id"] == "acme/ds"
+
+    def test_constructor_space_id_overrides_settings(
+        self, fake_trackio: _FakeTrackio, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setattr(huggingface_hub, "get_token", lambda: "cached-login-token")
+        settings = Settings(trackio_space_id="settings/space")
+        tracker = TrackioTracker(settings, space_id="explicit/space")
+        tracker.start_run(_context())
+
+        assert fake_trackio.init_kwargs["space_id"] == "explicit/space"
+
+
+class TestLogging:
+    def test_log_metrics_routes_to_run_log(self, fake_trackio: _FakeTrackio) -> None:
+        tracker = TrackioTracker(Settings())
+        tracker.start_run(_context())
+        tracker.log_metrics({"f1": 0.91, "recall": 0.88}, step=3)
+
+        assert fake_trackio.run.log_calls == [({"f1": 0.91, "recall": 0.88}, 3)]
+
+    def test_log_metrics_defaults_step_to_none(self, fake_trackio: _FakeTrackio) -> None:
+        tracker = TrackioTracker(Settings())
+        tracker.start_run(_context())
+        tracker.log_metrics({"f1": 0.5})
+
+        assert fake_trackio.run.log_calls == [({"f1": 0.5}, None)]
+
+    def test_log_metrics_noop_before_start(self, fake_trackio: _FakeTrackio) -> None:
+        TrackioTracker().log_metrics({"f1": 0.5})
+        assert fake_trackio.run.log_calls == []
+
+    def test_log_params_merges_into_config(self, fake_trackio: _FakeTrackio) -> None:
+        tracker = TrackioTracker(Settings())
+        tracker.start_run(_context())
+        tracker.log_params({"extra": {"nested": 1}})
+
+        assert fake_trackio.run.config["extra.nested"] == 1
+
+    def test_log_params_noop_before_start(self) -> None:
+        TrackioTracker().log_params({"a": 1})  # must not raise
+
+    def test_log_artifact_logs_as_metadata_entry(self, fake_trackio: _FakeTrackio) -> None:
+        tracker = TrackioTracker(Settings())
+        tracker.start_run(_context())
+        tracker.log_artifact("report_md", "runs/report.md")
+
+        assert fake_trackio.run.log_calls[-1] == ({"report_md": "runs/report.md"}, None)
+
+    def test_log_artifact_noop_before_start(self) -> None:
+        TrackioTracker().log_artifact("k", "v")  # must not raise
+
+    def test_set_tags_folds_into_config_with_prefix(self, fake_trackio: _FakeTrackio) -> None:
+        tracker = TrackioTracker(Settings())
+        tracker.start_run(_context())
+        tracker.set_tags({"env": "ci", "team": "er"})
+
+        assert fake_trackio.run.config["tag.env"] == "ci"
+        assert fake_trackio.run.config["tag.team"] == "er"
+
+    def test_set_tags_noop_before_start(self) -> None:
+        TrackioTracker().set_tags({"a": "b"})  # must not raise
+
+
+class TestFinish:
+    def test_finish_logs_status_then_closes_run(self, fake_trackio: _FakeTrackio) -> None:
+        tracker = TrackioTracker(Settings())
+        tracker.start_run(_context())
+        tracker.finish(status="completed")
+
+        assert fake_trackio.run.log_calls[-1] == ({"langres_status": "completed"}, None)
+        assert fake_trackio.run.finish_calls == 1
+
+    @pytest.mark.parametrize("status", ["failed", "budget_exceeded"])
+    def test_finish_logs_any_status(self, fake_trackio: _FakeTrackio, status: str) -> None:
+        tracker = TrackioTracker(Settings())
+        tracker.start_run(_context())
+        tracker.finish(status=status)
+
+        assert fake_trackio.run.log_calls[-1] == ({"langres_status": status}, None)
+
+    def test_finish_before_start_is_noop(self, fake_trackio: _FakeTrackio) -> None:
+        TrackioTracker().finish(status="completed")
+        assert fake_trackio.run.finish_calls == 0
+
+
+class TestRunUrlAndNative:
+    def test_run_url_none_for_local_run(self, fake_trackio: _FakeTrackio) -> None:
+        tracker = TrackioTracker(Settings())
+        tracker.start_run(_context())
+        assert tracker.run_url is None
+
+    def test_run_url_deep_links_hf_space(
+        self, fake_trackio: _FakeTrackio, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setattr(huggingface_hub, "get_token", lambda: "cached-login-token")
+        tracker = TrackioTracker(Settings(), space_id="acme/langres-runs")
+        tracker.start_run(_context())
+
+        assert tracker.run_url == "https://acme-langres-runs.hf.space/"
+
+    def test_native_returns_underlying_run(self, fake_trackio: _FakeTrackio) -> None:
+        tracker = TrackioTracker(Settings())
+        tracker.start_run(_context())
+        assert tracker.native is fake_trackio.run
+
+
+class TestResolveTracker:
+    def test_resolve_tracker_trackio_returns_real_trackio_tracker(
+        self, fake_trackio: _FakeTrackio
+    ) -> None:
+        resolved = resolve_tracker("trackio")
+        assert isinstance(resolved, TrackioTracker)
+        assert resolved.name == "trackio"
+
+    def test_resolve_tracker_trackio_is_local_first_by_default(
+        self, fake_trackio: _FakeTrackio
+    ) -> None:
+        """No creds/env configured -> resolve_tracker("trackio") still starts a run."""
+        tracker = resolve_tracker("trackio")
+        tracker.start_run(_context())  # must not raise: no space_id configured
+        assert fake_trackio.init_kwargs["space_id"] is None
+
+
+@pytest.mark.slow
+class TestRealLocalSmoke:
+    """One real (unmocked) local trackio.init -- proves the adapter works offline.
+
+    No ``space_id`` -> no network, no HF login required. Skips cleanly if a real
+    local trackio init cannot complete offline (kept mocked above for everything
+    else specifically so this env-dependent edge doesn't gate the fast suite).
+    """
+
+    def test_real_local_run_writes_to_local_store(self, tmp_path: Any) -> None:
+        import trackio
+
+        from langres.core.trackers.trackio_tracker import TrackioTracker as RealTracker
+
+        project = f"langres-test-{os.getpid()}"
+        tracker = RealTracker(Settings(), project=project)
+        tracker.start_run(_context(), run_name="smoke-run")
+        try:
+            tracker.log_metrics({"f1": 0.5}, step=0)
+            tracker.log_metrics({"f1": 0.6}, step=1)
+        finally:
+            tracker.finish(status="completed")
+
+        assert tracker.native is not None
+        assert tracker.run_url is None  # local run: no HF Space configured
+        runs = trackio.SQLiteStorage.get_runs(project)
+        assert "smoke-run" in runs

--- a/tests/test_wandb_tracker.py
+++ b/tests/test_wandb_tracker.py
@@ -11,6 +11,7 @@ the underlying run, that status maps to an exit code, and that
 
 from __future__ import annotations
 
+import sys
 from typing import Any
 
 import pytest
@@ -79,14 +80,15 @@ class _FakeWandb:
 def fake_wandb(monkeypatch: pytest.MonkeyPatch) -> _FakeWandb:
     """Patch the fake over the ``wandb`` the reused ``create_wandb_tracker`` init uses.
 
-    The adapter itself no longer references a module-global ``wandb`` (log/finish
-    route through ``self._run``), so only ``langres.clients.tracking.wandb`` -- the
-    ``wandb.init`` seam -- needs patching.
+    ``create_wandb_tracker`` now imports ``wandb`` lazily inside its own body (so
+    ``langres.clients.tracking`` -- and therefore ``create_trackio_tracker`` -- is
+    importable without the ``wandb`` extra), so the ``wandb.init`` seam is patched
+    at ``sys.modules["wandb"]``: an in-body ``import wandb`` binds to whatever is
+    there. The adapter itself never references a module-global ``wandb`` (log/finish
+    route through ``self._run``).
     """
     fake = _FakeWandb()
-    import langres.clients.tracking as tracking_mod
-
-    monkeypatch.setattr(tracking_mod, "wandb", fake)
+    monkeypatch.setitem(sys.modules, "wandb", fake)
     return fake
 
 
@@ -272,9 +274,7 @@ class TestRunUrlAndNative:
         self, monkeypatch: pytest.MonkeyPatch, settings: Settings
     ) -> None:
         fake = _FakeWandb(_FakeRun(url=None))
-        import langres.clients.tracking as tracking_mod
-
-        monkeypatch.setattr(tracking_mod, "wandb", fake)
+        monkeypatch.setitem(sys.modules, "wandb", fake)
 
         tracker = WandbTracker(settings)
         tracker.start_run(_context())


### PR DESCRIPTION
## Summary

Adds `TrackioTracker`, a third `ExperimentTracker` backend alongside `MlflowTracker`/`WandbTracker`, giving the autoresearch loop (`langres.optimize`) durable, off-laptop persistence via [Trackio](https://github.com/gradio-app/trackio).

- **Local-first by default.** `resolve_tracker("trackio")` / `TrackioTracker()` writes to a local trackio SQLite store — no credentials, no network, works out of the box.
- **HF Space sync is opt-in, not built-in.** Setting `space_id` (constructor arg, or `TRACKIO_SPACE_ID`) additionally syncs the run to a Hugging Face Space (+ optional `dataset_id`/`TRACKIO_DATASET_ID` for a persistent Dataset). This is **gated**: if `space_id` is set but no HF write token is available (`HF_TOKEN`/`HUGGING_FACE_HUB_TOKEN` env, or a stored `hf auth login`), `start_run` raises an actionable `ValueError` *before* `trackio.init` is ever called. Nothing is deployed or hardcoded — no Space is created unless the caller explicitly configures one with valid credentials.
- **Registered in the existing seam**: `core/trackers/__init__.py`'s `_ADAPTERS`/`__getattr__`, so `resolve_tracker("trackio")` and `from langres.core.trackers import TrackioTracker` both work, with the same "missing extra" `ImportError` pattern as `mlflow`/`wandb`.
- **`create_trackio_tracker()`** in `clients/tracking.py` mirrors `create_wandb_tracker`'s settings-driven construction (builds an unstarted `TrackioTracker` from `Settings`/explicit overrides — trackio's own `import` stays local to that function body so a `langres[wandb]`-only install never needs `trackio` importable, and vice versa).
- New `[trackio]` extra (pinned `trackio>=0.20,<1`) + dev-group entry; `trackio`/`huggingface_hub` added to the import-budget heavy-module list (both confirmed absent from a bare `import langres`).

## Real installed trackio API (verified, not assumed — 0.20.2)

- `trackio.init(project, name=None, space_id=None, dataset_id=None, config=None, ...) -> Run`. **`dataset_id` is the real, current param name — not `bucket_id`** (no trace of `bucket_id` anywhere in 0.20.2; that was an unverified guess going in).
- `Run` has `.config` (a plain flat `dict`), `.name`, `.url`, and exactly four methods: `log(metrics, step=None)`, `log_system`, `alert`, `finish()` — **no tags API, no artifact API, `finish()` takes no status argument.** `log_artifact`/`set_tags` fold into `run.log`/`run.config` (closest honest mapping); the langres terminal `status` is stamped as a `langres_status` log entry before `finish()`.
- `Run.url` on a Space run is literally the raw `"user/space"` id, not a browsable URL — `run_url` builds `https://{user}-{space}.hf.space/` itself (matches trackio's own internal `deploy.SPACE_HOST_URL` format). `None` for local runs (no static URL outside a notebook embed).
- `trackio.init(space_id=...)` internally raises `huggingface_hub.errors.LocalTokenNotFoundError` for a missing token — the adapter's own `_require_hf_token` guard preempts that with an actionable, project-branded `ValueError` first.
- Both `trackio` and `huggingface_hub` ship `py.typed`, so no `[[tool.mypy.overrides]]` entry was needed (unlike mlflow/litellm/etc.).

## Run-it evidence ($0, offline, real local trackio)

Ran `optimize(space, objective, "amazon_google", tracker=TrackioTracker(project="ar-trackio-smoke"))` over a 3-config k-sweep (k=5/40/80, same RR-budget objective as `examples/research/blocking_recall_autoresearch.py`):

- Local storage: `~/.cache/huggingface/trackio/ar-trackio-smoke.db` (trackio's own default `TRACKIO_DIR`).
- 3 trials -> 3 distinct trackio runs (`optimize_blocking:amazon_google`, `dainty-sunset-0`, `brave-forest-1` — trackio auto-renames on a same-name collision since every trial in one loop shares `context.experiment`).
- **Rejected trials confirmed durable in trackio itself** (not just the in-memory `LoopResult`): `brave-forest-1` (k=80) landed with `"accepted": 0.0, "reduction_ratio": 0.9776` (< the 0.985 budget) read straight back out of trackio's SQLite log table — a genuine over-budget reject, captured end to end through `capture_run` -> `TrackioTracker`.

## Test plan

- [x] `uv run pytest tests/test_trackio_tracker.py tests/test_trackers.py tests/clients/test_tracking.py tests/test_import_budget.py -q` — green (78 fast + 1 slow real-local smoke).
- [x] `uv run pytest --cov=src/langres/core/trackers --cov=src/langres/clients ...` — 100% on `trackio_tracker.py` and `clients/tracking.py`.
- [x] `uv run ruff check .` / `uv run ruff format --check .` / `uv run mypy src` — all clean.
- [x] Full fast suite (`pytest -m "not slow and not integration"`) — 3462 passed, no regressions.
- [x] Import-budget subprocess check — bare `import langres` pulls neither `trackio` nor `huggingface_hub`.
- [x] Docs updated in the same change: `CHANGELOG.md`, `docs/ROADMAP.md`, `docs/EXPERIMENTS.md` (usage snippet), `docs/TECHNICAL_OVERVIEW.md`.

## Known trade-off (flagged, not silently accepted)

`create_trackio_tracker()` lives in `clients/tracking.py` alongside the pre-existing `create_wandb_tracker` (per spec — this keeps the two factories symmetric and in one place). That file has an unconditional top-level `import wandb`, which is load-bearing for `wandb`'s existing "helpful missing-extra `ImportError`" behavior (removing it would regress that). `trackio`'s own import is kept function-local inside `create_trackio_tracker` to avoid the reverse problem for wandb-only installs — but a hypothetical `pip install langres[trackio]`-only (no `[wandb]`, no dev group) caller of `create_trackio_tracker()` specifically (not `resolve_tracker("trackio")` or constructing `TrackioTracker` directly, both of which never touch this file) would still need `wandb` importable. This is documented in the module's docstring. Not a regression for this repo (wandb/mlflow/trackio are all in the dev group together already), but worth knowing about for a future backend-isolation pass.

## Out of scope (confirmed not built)

- No Space deployment, no hardcoded Space name — HF sync is purely a caller opt-in.
- No models-on-Hub / artifact upload beyond the `log_artifact` metadata-entry mapping.

## Summary by Sourcery

Add Trackio as a local-first experiment tracking backend and wire it into the existing ExperimentTracker seam and client factory system, with optional HF Space/Dataset sync and maintained lazy-import behavior.

New Features:
- Introduce TrackioTracker adapter implementing the ExperimentTracker protocol with local SQLite persistence and optional Hugging Face Space/Dataset sync.
- Add create_trackio_tracker factory to build TrackioTracker instances from Settings and explicit overrides, parallel to create_wandb_tracker.
- Expose resolve_tracker("trackio") and TrackioTracker via the trackers package, and add HF/Trackio-related settings fields for token and Space/Dataset configuration.

Enhancements:
- Extend client and tracker lazy-loading infrastructure to include Trackio while preserving import-budget guarantees.
- Update experiment-tracking docs (EXPERIMENTS, TECHNICAL_OVERVIEW, ROADMAP, CHANGELOG) to document Trackio usage and the new off-laptop dashboard option.

Build:
- Define a new [trackio] extra and include trackio in the dev dependency group with version pinning aligned to the verified API.

Tests:
- Add comprehensive tests for the TrackioTracker adapter, including credential-guard behavior, logging semantics, resolve_tracker integration, and a real local smoke test.
- Add tests for the create_trackio_tracker factory and for helpful ImportError behavior when the Trackio extra is missing.
- Extend import-budget tests to ensure trackio and huggingface_hub remain lazily imported.