### PR TITLE
feat(trackers): accept a tracker spec on optimize()/run_loop()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,9 +8,9 @@ A `propose → run → evaluate → keep-if-better` hill-climber that tunes a pi
 against a **loss-like** objective instead of a saturated F1. M1 proves the loop on
 the **blocking** vertical; the matching vertical (`log_loss` / AUC-PR steering) and
 small-LM fine-tuning are deferred, as is an Optuna/LLAMBO proposer swap. A durable
-off-laptop dashboard is no longer deferred: `tracker=resolve_tracker("trackio")`
-(local-first; an HF Space/Dataset sync is a `space_id`/`HF_TOKEN` opt-in) plugs
-straight into `optimize`/`run_loop` via the existing `tracker=` hook (see below).
+off-laptop dashboard is no longer deferred: `tracker="trackio"` (local-first; an HF
+Space/Dataset sync is a `space_id`/`HF_TOKEN` opt-in) plugs straight into
+`optimize`/`run_loop` via the existing `tracker=` hook (see below).
 
 #### Added
 
@@ -23,6 +23,13 @@ straight into `optimize`/`run_loop` via the existing `tracker=` hook (see below)
   persists **every** trial (accepted, over-budget reject, and scorer failure) to a
   local `RunStore` JSONL at `store=` (`store=None` writes nothing). **Local-only
   persistence today.**
+- **DX: `tracker=` on `optimize`/`run_loop` takes a spec, not a resolved
+  instance** — a backend name (`tracker="trackio"`), an already-built
+  `ExperimentTracker`, a sequence of either (fan-out), or `None` (default,
+  no-op). Both resolve it internally via `core.trackers.resolve_tracker`
+  (mirrors the `matcher="..."` preset convention), so the boilerplate
+  `tracker=resolve_tracker("trackio")` is no longer needed on the happy path;
+  `resolve_tracker` stays public for advanced/explicit use.
 - **`langres.score_blocking(config, benchmark, *, embedder=None, index=None) ->
   dict[str, float]`** — the concrete one-config blocking scorer `optimize` wraps,
   returning `candidate_recall` / `reduction_ratio` / `candidate_precision` /

--- a/docs/EXPERIMENTS.md
+++ b/docs/EXPERIMENTS.md
@@ -374,13 +374,20 @@ accepted = [r for r in records if (r.metrics or {}).get("accepted") == 1.0]
 ```
 
 The `RunStore` JSONL is the durable local record; `store=None` skips it entirely
-(the offline path). For a durable, off-laptop **dashboard**, pass a tracker:
+(the offline path). For a durable, off-laptop **dashboard**, pass a `tracker=`
+**spec** — a backend name, an already-built instance, a sequence of either
+(fan-out), or `None` (the default, no-op) — and `optimize` resolves it internally
+via `resolve_tracker`, mirroring the `matcher="..."` string dispatch:
 
 ```python
-from langres.core.trackers import resolve_tracker
-
 # Local-first: no credentials, no network -- writes to a local trackio SQLite store.
-result = optimize(space, objective, "amazon_google", tracker=resolve_tracker("trackio"))
+result = optimize(space, objective, "amazon_google", tracker="trackio")
+
+# An instance configures the backend (e.g. HF-Space sync); a sequence fans out
+# to several backends at once.
+from langres.core.trackers import TrackioTracker
+result = optimize(space, objective, "amazon_google",
+                   tracker=[TrackioTracker(space_id="user/space"), "mlflow"])
 ```
 
 Set `HF_TOKEN` and configure a `space_id` (`TrackioTracker(space_id="user/space")` or

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -399,9 +399,9 @@ persisted to a local `RunStore` JSONL.
   judge on `log_loss` / AUC-PR) and small-LM fine-tuning; an Optuna/LLAMBO proposer
   swap; and pushing the winning artifact to the Hub.
 - **Shipped:** a durable off-laptop dashboard via the **Trackio** tracker
-  (`tracker=resolve_tracker("trackio")`, local-first — no credentials unless an HF
-  Space is configured). Local `RunStore` JSONL persistence (`store=`) remains the
-  default and is independent of the tracker.
+  (`tracker="trackio"`, local-first — no credentials unless an HF Space is
+  configured). Local `RunStore` JSONL persistence (`store=`) remains the default
+  and is independent of the tracker.
 
 ---
 

--- a/docs/TECHNICAL_OVERVIEW.md
+++ b/docs/TECHNICAL_OVERVIEW.md
@@ -909,9 +909,13 @@ across every `k`), and drives the loop over `space.configs()`.
   whole loaded corpus).
 - `embedder: EmbeddingProvider | None` — optional pre-built embedder (a fake keeps
   tests offline); production leaves it `None` to load the real SentenceTransformer.
-- `tracker: ExperimentTracker | None` — optional experiment tracker; defaults to a
-  no-op. `resolve_tracker("trackio")` is local-first (no credentials/network); an HF
-  Space/Dataset sync is an opt-in `space_id`/`HF_TOKEN` config on top.
+- `tracker: TrackerSpec` (`str | ExperimentTracker | Sequence[str | ExperimentTracker] | None`)
+  — a backend name (`"trackio"`/`"mlflow"`/`"wandb"`), an already-built instance, a
+  sequence of either (fan-out), or `None` (default, no-op). `run_loop` resolves the
+  spec internally via `resolve_tracker`, mirroring the `matcher="..."` string
+  dispatch — write `tracker="trackio"`, not `tracker=resolve_tracker("trackio")`.
+  `"trackio"` is local-first (no credentials/network); an HF Space/Dataset sync
+  needs a `TrackioTracker(space_id=...)` instance or `TRACKIO_SPACE_ID`/`HF_TOKEN`.
 
 ### score_blocking (the one-config scorer)
 
@@ -1001,9 +1005,8 @@ Every trial (including over-budget rejects and scorer failures) is appended to t
 nothing; read a trail back with `RunStore(path).read()` (each `RunRecord`'s
 `metrics["accepted"]` is `1.0`/`0.0`, so the incumbent timeline is reconstructable
 from the store alone). `RunStore` is local-only by design; a durable off-laptop
-dashboard is available via `tracker=resolve_tracker("trackio")` (local-first; an
-HF Space/Dataset sync is a `space_id`/`HF_TOKEN` opt-in) -- models-on-Hub is not
-built. Still deferred: an Optuna/LLAMBO proposer and the matching vertical
+dashboard is available via `tracker="trackio"` (local-first; an HF Space/Dataset
+sync is a `space_id`/`HF_TOKEN` opt-in) -- models-on-Hub is not built. Still deferred: an Optuna/LLAMBO proposer and the matching vertical
 (`log_loss` / AUC-PR steering) + fine-tuning. See
 [EXPERIMENTS.md](EXPERIMENTS.md#self-tuning-the-autoresearch-loop-langresoptimize)
 for the worked amazon_google proof and `examples/research/blocking_recall_autoresearch.py`.

--- a/src/langres/core/autoresearch/loop.py
+++ b/src/langres/core/autoresearch/loop.py
@@ -28,7 +28,7 @@ from typing import Any
 
 from langres.core.autoresearch.objective import Objective
 from langres.core.runs import RunContext, capture_run, compute_recipe_id
-from langres.core.trackers import ExperimentTracker, NoOpTracker
+from langres.core.trackers import TrackerSpec, resolve_tracker
 
 logger = logging.getLogger(__name__)
 
@@ -93,7 +93,7 @@ def run_loop(
     split_id: str | None = None,
     seeds: dict[str, int] | None = None,
     store: str | Any | None = None,
-    tracker: ExperimentTracker | None = None,
+    tracker: TrackerSpec = None,
     dedup: bool = True,
 ) -> LoopResult:
     """Run the ``propose → run → evaluate → keep-if-better`` loop over ``configs``.
@@ -140,16 +140,20 @@ def run_loop(
         store: Where to persist run records — a path / ``RunStore`` / ``None``.
             ``None`` writes **nothing** (the offline path); the loop still returns
             the same ``LoopResult``.
-        tracker: Experiment tracker forwarded to ``capture_run``; ``None``
-            (default) uses a fresh :class:`~langres.core.trackers.NoOpTracker`
-            rather than a shared instance.
+        tracker: Experiment tracker spec forwarded to ``capture_run`` --
+            a backend name (``"trackio"``/``"mlflow"``/``"wandb"``), an
+            ``ExperimentTracker`` instance, a sequence of either (fan-out via
+            :class:`~langres.core.trackers.MultiTracker`), or ``None``
+            (default; resolves to a fresh
+            :class:`~langres.core.trackers.NoOpTracker`). Resolved once via
+            :func:`~langres.core.trackers.resolve_tracker`.
         dedup: When ``True`` (default), skip a config whose ``recipe_id`` was
             already scored this run.
 
     Returns:
         A :class:`LoopResult` with the best incumbent and the full trial trail.
     """
-    tracker = tracker or NoOpTracker()
+    tracker = resolve_tracker(tracker)
     best_config: dict[str, Any] | None = None
     best_metrics: dict[str, float] | None = None
     best_attempt_id: str | None = None

--- a/src/langres/core/trackers/__init__.py
+++ b/src/langres/core/trackers/__init__.py
@@ -39,6 +39,7 @@ __all__ = [
     "ExperimentTracker",
     "MultiTracker",
     "NoOpTracker",
+    "TrackerSpec",
     "resolve_tracker",
 ]
 
@@ -192,6 +193,14 @@ class MultiTracker:
         return self.trackers
 
 
+#: The tracker spec accepted at every ``tracker=`` seam (``run_loop``,
+#: ``optimize``): a backend name, an already-built instance, a sequence of
+#: either (fan-out), or ``None`` (no-op). Mirrors the judge/matcher spec
+#: convention -- callers write ``tracker="trackio"``, not
+#: ``tracker=resolve_tracker("trackio")``.
+TrackerSpec = str | ExperimentTracker | Sequence[str | ExperimentTracker] | None
+
+
 def _load_adapter_class(backend: str) -> type[Any]:
     """Import a backend adapter class, or raise a helpful missing-extra ImportError.
 
@@ -211,9 +220,7 @@ def _load_adapter_class(backend: str) -> type[Any]:
     return getattr(module, class_name)  # type: ignore[no-any-return]
 
 
-def resolve_tracker(
-    spec: None | str | ExperimentTracker | Sequence[Any],
-) -> ExperimentTracker:
+def resolve_tracker(spec: TrackerSpec) -> ExperimentTracker:
     """Resolve a tracker spec to a concrete :class:`ExperimentTracker`.
 
     Mirrors :func:`langres.core.presets.resolve_judge`:

--- a/src/langres/optimize.py
+++ b/src/langres/optimize.py
@@ -37,7 +37,7 @@ if TYPE_CHECKING:
     from langres.core.embeddings import EmbeddingProvider
     from langres.core.indexes.vector_index import VectorIndex
     from langres.core.runs import RunStore
-    from langres.core.trackers import ExperimentTracker
+    from langres.core.trackers import TrackerSpec
 
 
 def _resolve_benchmark(benchmark: str | Benchmark[Any]) -> Benchmark[Any]:
@@ -196,7 +196,7 @@ def optimize(
     dedup: bool = True,
     split: str = "full",
     embedder: EmbeddingProvider | None = None,
-    tracker: ExperimentTracker | None = None,
+    tracker: TrackerSpec = None,
 ) -> LoopResult:
     """Search ``space`` for the blocking config ``objective`` prefers on ``benchmark``.
 
@@ -226,7 +226,12 @@ def optimize(
             ``"full"`` — M1 measures blocking over the whole loaded corpus.
         embedder: Optional pre-built embedder for the vector index (a
             ``FakeEmbedder`` keeps tests offline); production leaves it ``None``.
-        tracker: Optional experiment tracker; defaults to a no-op.
+        tracker: Experiment tracker spec -- a backend name (``"trackio"``/
+            ``"mlflow"``/``"wandb"``), an ``ExperimentTracker`` instance, a
+            sequence of either (fan-out), or ``None`` (default; no-op).
+            Forwarded to :func:`~langres.core.autoresearch.loop.run_loop`,
+            which resolves it via
+            :func:`~langres.core.trackers.resolve_tracker`.
 
     Returns:
         The :class:`~langres.core.autoresearch.loop.LoopResult` (best incumbent +
@@ -234,7 +239,6 @@ def optimize(
     """
     from langres.core.autoresearch.loop import run_loop
     from langres.core.runs import dataset_fingerprint
-    from langres.core.trackers import NoOpTracker
 
     bench = _resolve_benchmark(benchmark)
     dataset_name = benchmark if isinstance(benchmark, str) else bench.name
@@ -270,6 +274,6 @@ def optimize(
         split_id=split,
         seeds={"optimize": seed} if seed is not None else None,
         store=store,
-        tracker=tracker or NoOpTracker(),
+        tracker=tracker,
         dedup=dedup,
     )

--- a/tests/core/test_autoresearch_loop.py
+++ b/tests/core/test_autoresearch_loop.py
@@ -222,3 +222,147 @@ def test_trial_is_a_frozen_dataclass() -> None:
     trial = Trial({"blocker": "vector"}, {"r": 1.0}, True, "rid", "aid", "completed")
     with pytest.raises((AttributeError, TypeError)):
         trial.accepted = False  # type: ignore[misc]
+
+
+# ---------------------------------------------------------------------------
+# Tracker spec (DX: ``tracker="trackio"`` resolved internally via
+# ``core.trackers.resolve_tracker`` -- mirrors ``judge="..."`` presets).
+# ---------------------------------------------------------------------------
+
+
+class _SpyTracker:
+    """Minimal in-memory ``ExperimentTracker`` double -- records every call it gets."""
+
+    name = "spy"
+
+    def __init__(self) -> None:
+        self.calls: list[str] = []
+
+    def start_run(self, context: Any, *, run_name: str | None = None) -> None:
+        self.calls.append("start_run")
+
+    def log_params(self, params: Any) -> None:
+        self.calls.append("log_params")
+
+    def log_metrics(self, metrics: Any, *, step: int | None = None) -> None:
+        self.calls.append("log_metrics")
+
+    def log_artifact(self, key: str, value: str) -> None:
+        self.calls.append("log_artifact")
+
+    def set_tags(self, tags: Any) -> None:
+        self.calls.append("set_tags")
+
+    def finish(self, *, status: str) -> None:
+        self.calls.append("finish")
+
+    @property
+    def run_url(self) -> str | None:
+        return None
+
+    @property
+    def native(self) -> Any:
+        return self
+
+
+def test_tracker_none_default_never_raises() -> None:
+    result = run_loop(
+        [_cfg("a")],
+        _scorer({"a": {"r": 1.0}}),
+        Objective.maximize("r"),
+        experiment="e",
+        dataset_name="d",
+        tracker=None,
+    )
+    assert result.best_config == _cfg("a")
+
+
+def test_tracker_instance_is_driven_through_the_loop() -> None:
+    spy = _SpyTracker()
+    run_loop(
+        [_cfg("a")],
+        _scorer({"a": {"r": 1.0}}),
+        Objective.maximize("r"),
+        experiment="e",
+        dataset_name="d",
+        tracker=spy,
+    )
+    assert spy.calls == ["start_run", "log_metrics", "finish"]
+
+
+def test_tracker_string_resolves_to_the_named_backend_and_is_driven(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """``tracker="trackio"`` resolves to a real ``TrackioTracker`` end to end.
+
+    ``trackio`` is mocked exactly like ``tests/test_trackio_tracker.py``'s
+    ``fake_trackio`` fixture -- no network, no real HF login -- so this proves
+    the spec resolved AND the resulting tracker actually got driven by
+    ``capture_run``, not just that ``resolve_tracker`` returns the right type.
+    """
+    import langres.core.trackers.trackio_tracker as trackio_mod
+
+    class _FakeRun:
+        def __init__(self) -> None:
+            self.log_calls: list[Any] = []
+
+        def log(self, data: Any, step: int | None = None) -> None:
+            self.log_calls.append((data, step))
+
+        def finish(self) -> None:
+            pass
+
+    class _FakeTrackio:
+        def __init__(self) -> None:
+            self.init_kwargs: dict[str, Any] | None = None
+            self.run = _FakeRun()
+
+        def init(self, **kwargs: Any) -> Any:
+            self.init_kwargs = kwargs
+            return self.run
+
+    fake = _FakeTrackio()
+    monkeypatch.setattr(trackio_mod, "trackio", fake)
+
+    run_loop(
+        [_cfg("a")],
+        _scorer({"a": {"r": 1.0}}),
+        Objective.maximize("r"),
+        experiment="e",
+        dataset_name="d",
+        tracker="trackio",
+    )
+    assert fake.init_kwargs is not None  # TrackioTracker.start_run really fired
+
+
+def test_tracker_sequence_fans_out_to_every_child() -> None:
+    a, b = _SpyTracker(), _SpyTracker()
+    run_loop(
+        [_cfg("x")],
+        _scorer({"x": {"r": 1.0}}),
+        Objective.maximize("r"),
+        experiment="e",
+        dataset_name="d",
+        tracker=[a, b],
+    )
+    assert a.calls == ["start_run", "log_metrics", "finish"]
+    assert b.calls == ["start_run", "log_metrics", "finish"]
+
+
+def test_tracker_unknown_backend_string_raises_before_any_config_is_scored() -> None:
+    scored: list[str] = []
+
+    def scorer(config: Mapping[str, Any]) -> dict[str, float]:
+        scored.append(config["id"])
+        return {"r": 1.0}
+
+    with pytest.raises(ValueError, match="unknown"):
+        run_loop(
+            [_cfg("a")],
+            scorer,
+            Objective.maximize("r"),
+            experiment="e",
+            dataset_name="d",
+            tracker="not-a-backend",
+        )
+    assert scored == []  # the spec is resolved before the loop scores anything

--- a/tests/test_optimize.py
+++ b/tests/test_optimize.py
@@ -213,6 +213,56 @@ def test_optimize_records_seed_when_given(tmp_path: Any) -> None:
 
 
 # ---------------------------------------------------------------------------
+# Tracker spec DX -- ``optimize(..., tracker="trackio")`` instead of
+# ``tracker=resolve_tracker("trackio")``. ``optimize`` just forwards the spec
+# into ``run_loop``, which is the one place it's resolved (see
+# ``tests/core/test_autoresearch_loop.py`` for the resolution-branch coverage).
+# ---------------------------------------------------------------------------
+
+
+def test_optimize_tracker_none_default_never_raises() -> None:
+    space = SearchSpace(blocker=("all_pairs",), text_field=("name",), k_neighbors=(5,))
+    result = optimize(
+        space, Objective.maximize("candidate_recall"), _MemoryBenchmark(), tracker=None
+    )
+    assert isinstance(result, LoopResult)
+
+
+def test_optimize_tracker_string_resolves_to_the_named_backend_and_is_driven(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """``tracker="trackio"`` end-to-end through ``optimize`` -- mocked like
+    ``tests/test_trackio_tracker.py``'s ``fake_trackio`` fixture (no network)."""
+    import langres.core.trackers.trackio_tracker as trackio_mod
+
+    class _FakeRun:
+        def __init__(self) -> None:
+            self.log_calls: list[Any] = []
+
+        def log(self, data: Any, step: int | None = None) -> None:
+            self.log_calls.append((data, step))
+
+        def finish(self) -> None:
+            pass
+
+    class _FakeTrackio:
+        def __init__(self) -> None:
+            self.init_kwargs: dict[str, Any] | None = None
+            self.run = _FakeRun()
+
+        def init(self, **kwargs: Any) -> Any:
+            self.init_kwargs = kwargs
+            return self.run
+
+    fake = _FakeTrackio()
+    monkeypatch.setattr(trackio_mod, "trackio", fake)
+
+    space = SearchSpace(blocker=("all_pairs",), text_field=("name",), k_neighbors=(5,))
+    optimize(space, Objective.maximize("candidate_recall"), _MemoryBenchmark(), tracker="trackio")
+    assert fake.init_kwargs is not None  # TrackioTracker.start_run really fired
+
+
+# ---------------------------------------------------------------------------
 # Slow: real embedder + FAISS on a registered benchmark
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary

Small DX follow-on to the Trackio adapter (#167): `tracker=` on `langres.optimize()` and `core.autoresearch.loop.run_loop()` now accepts a **spec** instead of requiring a pre-resolved instance — mirrors the existing `judge=`/`matcher=` string-preset convention.

- `tracker="trackio"` (or `"mlflow"`/`"wandb"`) — resolved lazily via `resolve_tracker`
- `tracker=<ExperimentTracker instance>` — passed through unchanged
- `tracker=["trackio", <instance>]` — fans out via `MultiTracker`
- `tracker=None` (default) — resolves to `NoOpTracker`, zero overhead

**Change is surgical and localized to the resolution choke point:**
- `core/trackers/__init__.py`: adds the `TrackerSpec` type alias (`str | ExperimentTracker | Sequence[str | ExperimentTracker] | None`), used by `resolve_tracker`'s own signature too.
- `core/autoresearch/loop.py::run_loop`: `tracker = tracker or NoOpTracker()` → `tracker = resolve_tracker(tracker)` — the one place the spec is resolved.
- `optimize.py::optimize`: just forwards the spec straight through to `run_loop` (dropped the `or NoOpTracker()`).
- `core/runs.py::capture_run` is untouched — it stays instance-based (the low-level API), by design.

Docs updated in the same change: `docs/EXPERIMENTS.md`, `docs/TECHNICAL_OVERVIEW.md`, `docs/ROADMAP.md` (had the same stale pattern), `CHANGELOG.md`.

## Test plan

- [x] `uv run ruff check .` / `uv run ruff format --check .` — clean
- [x] `uv run mypy src` (with `--all-extras` synced, matching CI) — clean
- [x] `uv run pytest tests/ -k "loop or optimize or tracker or import_budget" -q` — 250 passed, 4 skipped, 0 failed
- [x] New tests: `tracker=None`/instance/string/sequence/unknown-string across `run_loop` and `optimize`, using the same trackio-mock pattern as `tests/test_trackio_tracker.py` (no network)
- [x] `core/trackers/__init__.py` and `core/autoresearch/loop.py` at 100% coverage in the touched-file tier; `optimize.py` at 93% (3 pre-existing uncovered lines unrelated to this change)
- [x] Manually verified `optimize(..., tracker="trackio")` drives a real (mocked) `TrackioTracker` end-to-end
- [x] `import langres` import-budget test confirms no new heavy imports leak in

## Summary by Sourcery

Simplify experiment tracking ergonomics by making tracker= on optimize() and run_loop() accept a high-level spec instead of requiring a pre-resolved ExperimentTracker instance, with corresponding documentation and tests updated.

New Features:
- Allow optimize() and run_loop() to accept flexible tracker specs (backend name, instance, sequence, or None) that are resolved internally.

Enhancements:
- Introduce a TrackerSpec type and centralize tracker resolution via resolve_tracker at the loop entry point.

Documentation:
- Update experiments, technical overview, roadmap, and changelog docs to describe tracker specs and the simplified tracker="trackio" usage.

Tests:
- Add tests for tracker spec handling in run_loop and optimize, covering None, instances, backend strings, sequences, and unknown backends.