### PR TITLE
refactor(core): split __init__ exports into per-domain fragments

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,32 @@
+# Merge policy for the per-domain export fragments (W-1a).
+#
+# langres/__init__.py and langres/core/__init__.py used to carry one sorted
+# ~100-name __all__ plus a shared eager import block -- the single worst
+# merge-conflict hotspot in the repo (21 touches in 30 days). A sorted list is
+# the exact shape git cannot auto-merge: N concurrent streams each inserting a
+# name at its sorted position = N guaranteed conflicts. The list now lives in
+# per-domain fragments so streams edit disjoint FILES.
+#
+# `merge=union` (a built-in git driver) closes the remaining case: two streams
+# appending to the SAME fragment. Instead of a conflict, git keeps both sides'
+# lines -- which is correct here precisely because the fragments are
+# append-mostly and the aggregation is order-insensitive and de-duplicating
+# (`sorted({...})` over every fragment's NAMES).
+#
+# The trade-off, stated honestly: union merge is not semantic. If one stream
+# REMOVES an export while another edits the same fragment, union resurrects the
+# removed __all__ entry without its import -- and `from ._x import *` then
+# raises AttributeError on import. That failure is immediate and loud (every
+# test collection dies; tests/test_import_budget.py is the gate), never silent
+# corruption -- which is what makes the trade acceptable for append-mostly
+# files. Removals are rare; additions are the hot path.
+src/langres/_exports/_*.py             merge=union
+src/langres/core/_exports/_*.py        merge=union
+
+# The `_*.py` globs above also match `__init__.py`. The aggregators are NOT
+# append-mostly -- they carry import blocks and the PEP-562 __getattr__, where
+# keeping both sides' lines would duplicate imports or split a function body.
+# Reset them to git's default 3-way text merge (conflict markers, human
+# resolves).
+src/langres/_exports/__init__.py       !merge
+src/langres/core/_exports/__init__.py  !merge

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -49,7 +49,9 @@ langres/
 │   ├── optimize.py     # langres.optimize / score_blocking: import-light autoresearch facade over blocking search
 │   ├── eval.py         # Curated evaluation facade (lazy): evaluate, list_benchmarks/get_benchmark, ER metrics
 │   ├── cli.py          # langres CLI: review / export-csv / import-csv (labeling loop)
+│   ├── _exports/       # per-domain fragments composing the ROOT __all__ + lazy maps (add a root export HERE, not in __init__.py)
 │   ├── core/           # Low-level primitives + the Resolver
+│   │   ├── _exports/       # same, for langres.core (add a core export HERE, not in core/__init__.py)
 │   │   ├── resolver.py     # Resolver.from_schema / resolve / save / load
 │   │   ├── presets.py      # judge presets ("auto" fail-fast/string/embedding/zero_shot_llm/prompt_llm), DEFAULT_AUTO_MODEL, NoJudgeAvailableError, spend cap
 │   │   ├── method_registry.py  # ONE MethodSpec registry: judge/method name -> builder + identity (all three dispatch paths resolve here)
@@ -87,7 +89,7 @@ modules, a general `Optimizer`, a synthetic data generator.
 - `[trained]` — scikit-learn (`RandomForestJudge`, the W1.2 trained-family judge, and `core.calibration.derive_threshold`).
 - `[eval]` — ranx (ranking metrics MRR/NDCG/MAP in `core.metrics.evaluate_blocking_with_ranking`). Imported lazily, so the rest of `core.metrics`/`core.benchmark` (BCubed/pairwise metrics, `evaluate()`) stays importable without it.
 
-These heavy/optional symbols resolve lazily (PEP 562 `__getattr__` in `langres/core/__init__.py` and `langres/clients/__init__.py`) so a bare `import langres` never pulls torch/litellm/faiss/scikit-learn/ranx into `sys.modules` — see `tests/test_import_budget.py`. Optuna/wandb/langfuse are dev-only (`[dependency-groups] dev`), for eval tooling, not the production `link()`/`dedupe()` path. ranx backs the `[eval]` extra but is duplicated in the dev group too (like scikit-learn / `[trained]`), so the repo's own test suite doesn't need `--all-extras` for a bare `uv sync`.
+These heavy/optional symbols resolve lazily (PEP 562 `__getattr__` in `langres/core/__init__.py` and `langres/clients/__init__.py`) so a bare `import langres` never pulls torch/litellm/faiss/scikit-learn/ranx into `sys.modules` — see `tests/test_import_budget.py`. **Adding a public symbol?** The two package `__init__.py` files are thin aggregators holding no per-name content: add the export (eager import, or the lazy `name -> module` + `[extra]` entry) to the per-domain fragment that owns its domain under `langres/_exports/` or `langres/core/_exports/` — never to the sorted `__all__` itself. A heavy dep must go in `LAZY_SYMBOLS`, never a fragment's module scope: fragments are eagerly imported, so an import there lands in every bare `import langres`. Optuna/wandb/langfuse are dev-only (`[dependency-groups] dev`), for eval tooling, not the production `link()`/`dedupe()` path. ranx backs the `[eval]` extra but is duplicated in the dev group too (like scikit-learn / `[trained]`), so the repo's own test suite doesn't need `--all-extras` for a bare `uv sync`.
 
 **Dev tools**: ruff (format + lint), pytest + pytest-cov (tests), mypy (strict-mode type checking).
 

--- a/docs/TECHNICAL_OVERVIEW.md
+++ b/docs/TECHNICAL_OVERVIEW.md
@@ -61,6 +61,17 @@ seam in `langres/core/__init__.py` and `langres/clients/__init__.py`, so a bare
 `import langres` never drags torch / litellm / faiss / scikit-learn / ranx into
 `sys.modules`. `tests/test_import_budget.py` guards this.
 
+**Where the exports live.** `langres/__init__.py` and `langres/core/__init__.py`
+are thin aggregators: they keep the `__getattr__` seam but hold no per-*name*
+content. Each export — its eager import or its lazy `name -> module` + `[extra]`
+entry — lives in a per-domain fragment under `langres/_exports/` and
+`langres/core/_exports/` (see those packages' docstrings for the contract). To
+add a public symbol, edit the one fragment that owns its domain; the aggregator
+composes `__all__` and the lazy maps from whatever the fragments declare. This
+split exists because a single sorted ~100-name `__all__` is unmergeable: N
+parallel work-streams each inserting a name at its sorted position produce N
+guaranteed conflicts.
+
 ### core.review.ReviewQueue (Human-in-the-Loop)
 
 The HITL system splits a storage backend from a labeling surface:

--- a/src/langres/__init__.py
+++ b/src/langres/__init__.py
@@ -30,87 +30,39 @@ inside their fit paths). ``EvalReport``, ``gold_pairs_from_clusters``,
 never pulls the eval-report/benchmark modules -- or scikit-learn
 (``derive_threshold``, the ``[trained]`` extra) or litellm (``LLMMatcher``, the
 ``[llm]`` extra) -- into ``sys.modules``. See ``tests/test_import_budget.py``.
+
+**This module is a thin aggregator.** The exports -- eager imports included --
+live in per-domain fragments under :mod:`langres._exports`, one file per
+work-stream (verbs, optimize, core, flywheel, training, data). Both the sorted
+``__all__`` and the eager import block were merge-conflict hotspots: their lines
+belong to different streams, so any two streams collided on this file.
+
+**To add an export, edit the owning fragment, not this file.** Nothing below is
+per-*name*; only a brand new domain touches this module. See
+``langres/_exports/__init__.py`` for the fragment contract.
 """
 
 import importlib
 from importlib.metadata import PackageNotFoundError
 from importlib.metadata import version as _metadata_version
-from typing import TYPE_CHECKING, Any
+from typing import Any
 
-from langres.clients.openrouter import BudgetExceeded
-from langres.core import (
-    Bootstrap,
-    CompanySchema,
-    Correction,
-    CorrectionLog,
-    ERCandidate,
-    FitReport,
-    GEPA,
-    Isotonic,
-    JudgementLog,
-    MIPRO,
-    Method,
-    PairwiseJudgement,
-    Platt,
-    Resolver,
-    ReviewQueue,
-    align_pairs,
-    derive_threshold_from_pairs,
-    harvest_labeled_pairs,
-    select_for_review,
-)
-from langres.core.models import MatcherAbstainedError
-from langres.core.presets import DEFAULT_AUTO_MODEL, NoMatcherAvailableError
-from langres.optimize import optimize, score_blocking
-from langres.verbs import LinkVerdict, dedupe, link
+from langres import _exports
 
-if TYPE_CHECKING:
-    # Only reached by mypy (never at runtime) -- keeps the lazy names visible
-    # to `mypy --strict` without executing the imports below on a bare import.
-    from langres.core.benchmark import gold_pairs_from_clusters
-    from langres.core.calibration import derive_threshold
-    from langres.data.data_profile import DataProfileReport
-    from langres.core.eval_report import EvalReport
-    from langres.core.matchers.llm_judge import LLMMatcher
+# Bind each fragment's EAGER names into this namespace. Every star-import is
+# bounded by that fragment's own `__all__`, so this imports exactly the names
+# the fragment declares -- and nothing lazy (a lazy name is deliberately not
+# defined at runtime; see the _exports contract).
+from langres._exports._core import *  # noqa: F403
+from langres._exports._data import *  # noqa: F403
+from langres._exports._flywheel import *  # noqa: F403
+from langres._exports._optimize import *  # noqa: F403
+from langres._exports._training import *  # noqa: F403
+from langres._exports._verbs import *  # noqa: F403
 
-__all__ = [
-    "Bootstrap",
-    "BudgetExceeded",
-    "CompanySchema",
-    "DEFAULT_AUTO_MODEL",
-    "Correction",
-    "CorrectionLog",
-    "DataProfileReport",
-    "ERCandidate",
-    "EvalReport",
-    "FitReport",
-    "GEPA",
-    "Isotonic",
-    "MatcherAbstainedError",
-    "Method",
-    "MIPRO",
-    "JudgementLog",
-    "LinkVerdict",
-    "LLMMatcher",
-    "NoMatcherAvailableError",
-    "PairwiseJudgement",
-    "Platt",
-    "QLoRA",
-    "Resolver",
-    "ReviewQueue",
-    "align_pairs",
-    "dedupe",
-    "derive_threshold",
-    "derive_threshold_from_pairs",
-    "finetune",
-    "gold_pairs_from_clusters",
-    "harvest_labeled_pairs",
-    "link",
-    "optimize",
-    "run_finetune",
-    "score_blocking",
-    "select_for_review",
-]
+#: The composed public surface -- every fragment's slice, deduplicated and
+#: sorted (see :data:`langres._exports.NAMES`).
+__all__ = list(_exports.NAMES)
 
 # Single source of truth is pyproject.toml; resolved from installed metadata so
 # a version bump can never miss this string again. Falls back for source trees
@@ -121,36 +73,13 @@ except PackageNotFoundError:  # pragma: no cover - only hit on uninstalled sourc
     __version__ = "0.0.0.dev0"
 
 #: ``name -> owning module`` for root exports resolved on first access (PEP
-#: 562, mirroring ``langres.core.__getattr__``). ``EvalReport`` and
-#: ``gold_pairs_from_clusters`` are import-light but live in modules kept out
-#: of the eager import graph on purpose (``core.eval_report`` pulls
-#: ``core.benchmark``/``core.metrics``); ``derive_threshold`` imports
-#: scikit-learn at module scope (the ``[trained]`` extra).
-_LAZY_SYMBOLS: dict[str, str] = {
-    "EvalReport": "langres.core.eval_report",
-    "DataProfileReport": "langres.data.data_profile",
-    "derive_threshold": "langres.core.calibration",
-    "gold_pairs_from_clusters": "langres.core.benchmark",
-    # The LLM matcher (serve a fine-tuned model_ref, a vLLM api_base, or a paid
-    # judge). Importing the class pulls litellm -> the [llm] extra, so it stays
-    # lazy: a bare `import langres` never touches litellm.
-    "LLMMatcher": "langres.core.matchers.llm_judge",
-    # The finetune surface: the module is import-light (peft/trl/torch import
-    # lazily inside QLoRATrainer.train), so these symbols carry no [finetune] extra
-    # here -- an ImportError from importing the symbols is a genuine bug. The
-    # actionable "pip install langres[finetune]" hint is raised at train time.
-    "QLoRA": "langres.core.finetune",
-    "finetune": "langres.core.finetune",
-    "run_finetune": "langres.core.finetune",
-}
+#: 562, mirroring ``langres.core.__getattr__``).
+_LAZY_SYMBOLS: dict[str, str] = _exports.LAZY_SYMBOLS
 
 #: ``name -> extra`` for the lazy symbols where a missing dependency has a
 #: ``pip install langres[<extra>]`` fix. Symbols absent here need no extra --
 #: an ImportError from them is a genuine bug and propagates unchanged.
-_EXTRA_BY_SYMBOL: dict[str, str] = {
-    "derive_threshold": "trained",
-    "LLMMatcher": "llm",
-}
+_EXTRA_BY_SYMBOL: dict[str, str] = _exports.EXTRA_BY_SYMBOL
 
 
 def __getattr__(name: str) -> Any:

--- a/src/langres/_exports/__init__.py
+++ b/src/langres/_exports/__init__.py
@@ -1,0 +1,72 @@
+"""Per-domain export fragments composed by ``langres.__init__``.
+
+Same motivation and contract as :mod:`langres.core._exports` (read that first),
+applied to the root package -- where the **eager import block** was the sharper
+edge: its lines split across four different work-streams (verbs/presets,
+optimize, the flywheel, training), so any two of them touching the root
+``__init__`` collided. Each fragment below owns one of those streams.
+
+**The contract.** Every fragment declares exactly these four names::
+
+    __all__: list[str]                 # EAGER names -- `import *` binds these
+    LAZY_SYMBOLS: dict[str, str]       # name -> owning module (resolved on access)
+    EXTRA_BY_SYMBOL: dict[str, str]    # name -> pip extra, for the ImportError hint
+    NAMES: tuple[str, ...]             # this fragment's slice of langres.__all__
+
+``__all__`` holds only the *eager* names because that is what
+``from ._exports._x import *`` actually binds -- a lazy name is deliberately not
+defined at runtime (it lives under ``TYPE_CHECKING`` for mypy only). ``NAMES``
+is therefore always *derived*, never hand-maintained::
+
+    NAMES = (*__all__, *LAZY_SYMBOLS)
+
+Unlike ``core``'s, this contract has no ``LAZY_SUBMODULES`` (the root resolves
+no submodules lazily), and ``EXTRA_BY_SYMBOL`` is a *subset* of
+``LAZY_SYMBOLS``: a lazy symbol absent from it needs no extra, and an
+ImportError from it is a genuine bug that propagates unchanged.
+
+**Adding an export**: edit the one fragment that owns its domain. **Adding a
+domain** (rare): add the fragment here (import + the three merges below) and one
+star-import line in ``langres/__init__.py``.
+"""
+
+from langres._exports import _core, _data, _flywheel, _optimize, _training, _verbs
+
+#: The composed public surface: every fragment's slice, deduplicated and sorted
+#: case-insensitively (the dominant convention of the hand-maintained list this
+#: replaced). Order is cosmetic -- ``__all__`` is only ever read as a set.
+NAMES: tuple[str, ...] = tuple(
+    sorted(
+        {
+            *_core.NAMES,
+            *_data.NAMES,
+            *_flywheel.NAMES,
+            *_optimize.NAMES,
+            *_training.NAMES,
+            *_verbs.NAMES,
+        },
+        key=str.lower,
+    )
+)
+
+#: ``name -> owning module`` for root exports resolved on first access.
+LAZY_SYMBOLS: dict[str, str] = {
+    **_core.LAZY_SYMBOLS,
+    **_data.LAZY_SYMBOLS,
+    **_flywheel.LAZY_SYMBOLS,
+    **_optimize.LAZY_SYMBOLS,
+    **_training.LAZY_SYMBOLS,
+    **_verbs.LAZY_SYMBOLS,
+}
+
+#: ``name -> extra`` for the lazy symbols where a missing dependency has a
+#: ``pip install langres[<extra>]`` fix. Symbols absent here need no extra --
+#: an ImportError from them is a genuine bug and propagates unchanged.
+EXTRA_BY_SYMBOL: dict[str, str] = {
+    **_core.EXTRA_BY_SYMBOL,
+    **_data.EXTRA_BY_SYMBOL,
+    **_flywheel.EXTRA_BY_SYMBOL,
+    **_optimize.EXTRA_BY_SYMBOL,
+    **_training.EXTRA_BY_SYMBOL,
+    **_verbs.EXTRA_BY_SYMBOL,
+}

--- a/src/langres/_exports/__init__.py
+++ b/src/langres/_exports/__init__.py
@@ -23,7 +23,24 @@ is therefore always *derived*, never hand-maintained::
 Unlike ``core``'s, this contract has no ``LAZY_SUBMODULES`` (the root resolves
 no submodules lazily), and ``EXTRA_BY_SYMBOL`` is a *subset* of
 ``LAZY_SYMBOLS``: a lazy symbol absent from it needs no extra, and an
-ImportError from it is a genuine bug that propagates unchanged.
+ImportError from it is a genuine bug that propagates unchanged. (``core``'s
+must be *total* -- its ``__getattr__`` indexes the map rather than ``.get()``
+-ing it; ``tests/test_export_fragments.py`` locks both rules.)
+
+**Root fragments vs. their ``core`` namesakes.** Several names appear in both
+trees (``_training``, ``_flywheel``) -- this is re-export, not duplication, and
+the two have distinct jobs:
+
+* ``langres/core/_exports/*`` **owns** the export: it imports from the
+  implementation module (``langres.core.harvest``, ``langres.core.fit_report``,
+  ...) and decides eager-vs-lazy for ``langres.core``.
+* ``langres/_exports/*`` **re-surfaces** a curated subset at the root, mostly
+  importing from ``langres.core`` itself (already-eager names come for free).
+  The root is a smaller, opinionated front door -- ``langres.core`` exports 103
+  names, the root 36 -- so it is deliberately NOT a mirror.
+
+A name therefore lives in a root fragment only if it is part of the paved-road
+surface. Adding one to ``core`` does not imply adding it here.
 
 **Adding an export**: edit the one fragment that owns its domain. **Adding a
 domain** (rare): add the fragment here (import + the three merges below) and one

--- a/src/langres/_exports/_core.py
+++ b/src/langres/_exports/_core.py
@@ -1,0 +1,33 @@
+"""The core primitives surfaced at the root: the ``Resolver`` + its data contracts.
+
+See ``langres._exports`` for the fragment contract.
+"""
+
+from typing import TYPE_CHECKING
+
+from langres.core import CompanySchema, ERCandidate, PairwiseJudgement, Resolver
+
+if TYPE_CHECKING:
+    # Never executed at runtime -- keeps the lazy name visible to `mypy --strict`
+    # without pulling litellm into a bare `import langres`.
+    from langres.core.matchers.llm_judge import LLMMatcher
+
+__all__ = [
+    "CompanySchema",
+    "ERCandidate",
+    "PairwiseJudgement",
+    "Resolver",
+]
+
+#: The LLM matcher (serve a fine-tuned model_ref, a vLLM api_base, or a paid
+#: judge). Importing the class pulls litellm -> the [llm] extra, so it stays
+#: lazy: a bare `import langres` never touches litellm.
+LAZY_SYMBOLS: dict[str, str] = {
+    "LLMMatcher": "langres.core.matchers.llm_judge",
+}
+
+EXTRA_BY_SYMBOL: dict[str, str] = {
+    "LLMMatcher": "llm",
+}
+
+NAMES: tuple[str, ...] = (*__all__, *LAZY_SYMBOLS)

--- a/src/langres/_exports/_data.py
+++ b/src/langres/_exports/_data.py
@@ -1,0 +1,28 @@
+"""The data-prep surface at the root.
+
+``DataProfileReport`` is import-light (stdlib + numpy + the import-light
+``core.metrics``; it consumes precomputed embeddings and never generates them)
+but lives outside the eager import graph on purpose, so it stays lazy and needs
+no extra -- an ImportError from it is a genuine bug and must propagate
+unchanged.
+
+See ``langres._exports`` for the fragment contract.
+"""
+
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    # Never executed at runtime -- keeps the lazy name visible to `mypy --strict`
+    # without pulling the data-profile module into a bare `import langres`.
+    from langres.data.data_profile import DataProfileReport
+
+#: Nothing is eager here by design -- see the module docstring.
+__all__: list[str] = []
+
+LAZY_SYMBOLS: dict[str, str] = {
+    "DataProfileReport": "langres.data.data_profile",
+}
+
+EXTRA_BY_SYMBOL: dict[str, str] = {}
+
+NAMES: tuple[str, ...] = (*__all__, *LAZY_SYMBOLS)

--- a/src/langres/_exports/_flywheel.py
+++ b/src/langres/_exports/_flywheel.py
@@ -1,0 +1,58 @@
+"""The flywheel loop, end to end at the root.
+
+``JudgementLog`` (the inlet -- wire via ``log=`` on ``link``/``dedupe``),
+``select_for_review`` / ``ReviewQueue`` (pick the uncertain margin),
+``Correction`` / ``CorrectionLog`` (the human labels the ``langres import-csv``
+CLI writes), ``harvest_labeled_pairs`` + ``derive_threshold_from_pairs``
+(labels -> a tuned threshold), and ``gold_pairs_from_clusters`` +
+``EvalReport`` (grade a run against gold at $0). See
+``examples/flywheel_min.py`` for the whole loop in one script.
+
+The harvest surface is already in the eager import graph (via ``langres.core``)
+so it is eager here for free. ``EvalReport`` / ``gold_pairs_from_clusters`` are
+import-light but live in modules kept out of the eager graph on purpose
+(``core.eval_report`` pulls ``core.benchmark``/``core.metrics``), so they stay
+lazy -- they need no extra, and an ImportError from them is a genuine bug that
+must propagate unchanged.
+
+See ``langres._exports`` for the fragment contract.
+"""
+
+from typing import TYPE_CHECKING
+
+from langres.core import (
+    Correction,
+    CorrectionLog,
+    JudgementLog,
+    ReviewQueue,
+    derive_threshold_from_pairs,
+    harvest_labeled_pairs,
+    select_for_review,
+)
+
+if TYPE_CHECKING:
+    # Never executed at runtime -- keeps the lazy names visible to `mypy --strict`
+    # without pulling the eval-report/benchmark modules into a bare
+    # `import langres`.
+    from langres.core.benchmark import gold_pairs_from_clusters
+    from langres.core.eval_report import EvalReport
+
+__all__ = [
+    "Correction",
+    "CorrectionLog",
+    "derive_threshold_from_pairs",
+    "harvest_labeled_pairs",
+    "JudgementLog",
+    "ReviewQueue",
+    "select_for_review",
+]
+
+LAZY_SYMBOLS: dict[str, str] = {
+    "EvalReport": "langres.core.eval_report",
+    "gold_pairs_from_clusters": "langres.core.benchmark",
+}
+
+#: Neither needs an extra -- see the module docstring.
+EXTRA_BY_SYMBOL: dict[str, str] = {}
+
+NAMES: tuple[str, ...] = (*__all__, *LAZY_SYMBOLS)

--- a/src/langres/_exports/_optimize.py
+++ b/src/langres/_exports/_optimize.py
@@ -1,0 +1,22 @@
+"""The autoresearch facade (``langres.optimize`` / ``score_blocking``).
+
+Eager on purpose, and import-light by construction: ``langres/optimize.py``'s
+module top is stdlib/typing only (every factory / data / metrics / faiss import
+is lazy inside a function body), so pulling it into the eager graph must not
+drag torch / faiss / sentence-transformers / litellm / scikit-learn into
+``sys.modules``. ``tests/test_import_budget.py`` locks both halves.
+
+See ``langres._exports`` for the fragment contract.
+"""
+
+from langres.optimize import optimize, score_blocking
+
+__all__ = [
+    "optimize",
+    "score_blocking",
+]
+
+LAZY_SYMBOLS: dict[str, str] = {}
+EXTRA_BY_SYMBOL: dict[str, str] = {}
+
+NAMES: tuple[str, ...] = (*__all__, *LAZY_SYMBOLS)

--- a/src/langres/_exports/_training.py
+++ b/src/langres/_exports/_training.py
@@ -1,0 +1,57 @@
+"""The training surface at the root: the pieces that make ``Resolver.fit`` legible.
+
+The method objects ``Method`` / ``Bootstrap`` / ``MIPRO`` / ``GEPA`` (prompt)
+and ``Platt`` / ``Isotonic`` (calibrate), the ``align_pairs``
+pairs->candidates bridge, and the ``FitReport`` digest are all import-light
+config/primitives (dspy/scikit-learn stay lazy inside their fit paths), so they
+are eager.
+
+See ``langres._exports`` for the fragment contract.
+"""
+
+from typing import TYPE_CHECKING
+
+from langres.core import (
+    Bootstrap,
+    FitReport,
+    GEPA,
+    Isotonic,
+    MIPRO,
+    Method,
+    Platt,
+    align_pairs,
+)
+
+if TYPE_CHECKING:
+    # Never executed at runtime -- keeps the lazy names visible to `mypy --strict`
+    # without pulling scikit-learn into a bare `import langres`.
+    from langres.core.calibration import derive_threshold
+
+__all__ = [
+    "align_pairs",
+    "Bootstrap",
+    "FitReport",
+    "GEPA",
+    "Isotonic",
+    "Method",
+    "MIPRO",
+    "Platt",
+]
+
+#: ``derive_threshold`` imports scikit-learn at module scope (the ``[trained]``
+#: extra). The finetune surface is import-light instead (peft/trl/torch import
+#: lazily inside ``QLoRATrainer.train``), so those symbols carry no extra here
+#: -- an ImportError from importing them is a genuine bug, and the actionable
+#: "pip install langres[finetune]" hint is raised at train time.
+LAZY_SYMBOLS: dict[str, str] = {
+    "derive_threshold": "langres.core.calibration",
+    "QLoRA": "langres.core.finetune",
+    "finetune": "langres.core.finetune",
+    "run_finetune": "langres.core.finetune",
+}
+
+EXTRA_BY_SYMBOL: dict[str, str] = {
+    "derive_threshold": "trained",
+}
+
+NAMES: tuple[str, ...] = (*__all__, *LAZY_SYMBOLS)

--- a/src/langres/_exports/_verbs.py
+++ b/src/langres/_exports/_verbs.py
@@ -1,0 +1,24 @@
+"""The front door: the two verbs, their presets, and the exceptions to catch.
+
+See ``langres._exports`` for the fragment contract.
+"""
+
+from langres.clients.openrouter import BudgetExceeded
+from langres.core.models import MatcherAbstainedError
+from langres.core.presets import DEFAULT_AUTO_MODEL, NoMatcherAvailableError
+from langres.verbs import LinkVerdict, dedupe, link
+
+__all__ = [
+    "BudgetExceeded",
+    "DEFAULT_AUTO_MODEL",
+    "dedupe",
+    "link",
+    "LinkVerdict",
+    "MatcherAbstainedError",
+    "NoMatcherAvailableError",
+]
+
+LAZY_SYMBOLS: dict[str, str] = {}
+EXTRA_BY_SYMBOL: dict[str, str] = {}
+
+NAMES: tuple[str, ...] = (*__all__, *LAZY_SYMBOLS)

--- a/src/langres/core/__init__.py
+++ b/src/langres/core/__init__.py
@@ -19,284 +19,63 @@ fast and never touches ``sys.modules`` for a dependency the caller hasn't
 asked for. Accessing a ``[semantic]``/``[llm]``/``[trained]`` symbol without
 that extra installed raises a clear ``ImportError`` naming the extra to
 install.
+
+**This module is a thin aggregator.** The exports themselves live in
+per-domain fragments under :mod:`langres.core._exports` -- one file per domain,
+each owning its own eager imports, its ``__all__`` slice, and its slice of the
+three lazy maps. A single sorted ~100-name ``__all__`` was the repo's worst
+merge-conflict hotspot (21 touches in 30 days): N concurrent streams each
+inserting a name at its sorted position = N guaranteed conflicts. Fragments
+make those streams edit disjoint files instead.
+
+**To add an export, edit the owning fragment, not this file.** Nothing below is
+per-*name*; only a brand new domain touches this module. See
+``langres/core/_exports/__init__.py`` for the fragment contract.
 """
 
 import importlib
-from typing import TYPE_CHECKING, Any
+from typing import Any
 
-from langres.core.adapters.glinker import GLinkerAdapter
-from langres.core.anchor_store import AnchorStore, ClusterDelta
-from langres.core.blocker import Blocker
-from langres.core.blockers.all_pairs import AllPairsBlocker
-from langres.core.blockers.composite import CompositeBlocker
-from langres.core.blockers.key import KeyBlocker
-from langres.core.canonicalizer import Canonicalizer
-from langres.core.clusterer import Clusterer
-from langres.core.clusterers.correlation import CorrelationClusterer
-from langres.core.comparator import Comparator, StringComparator
-from langres.core.debugging import (
-    CandidateStats,
-    ClusterStats,
-    ErrorExample,
-    PipelineDebugger,
-    ScoreStats,
-)
-from langres.core.feature import ComparisonLevel, ComparisonVector, FeatureSpec
-from langres.core.fit import SupervisedFitMixin, UnsupervisedFitMixin
-from langres.core.groups import ERCandidateGroup, derive_groups_from_pairs
-from langres.core.fit_report import FitReport
-from langres.core.harvest import (
-    Correction,
-    CorrectionLog,
-    LabeledPair,
-    align_pairs,
-    derive_threshold_from_pairs,
-    harvest_labeled_pairs,
-)
-from langres.core.judgement_log import JudgementLog, LoggingMatcher
-from langres.core.matchers.embedding_score import EmbeddingScoreMatcher
-from langres.core.matchers.fellegi_sunter import FellegiSunterMatcher
-from langres.core.matchers.weighted_average import WeightedAverageMatcher
-from langres.core.method_registry import (
-    DEFAULT_EMBEDDING_MODEL,
-    MethodSpec,
-    UnknownMethodError,
-    get_method,
-    list_methods,
-    register_method,
-)
-from langres.core.methods_api import Method
-from langres.core.methods_calibrate import Isotonic, Platt
-from langres.core.methods_prompt import Bootstrap, GEPA, MIPRO
-from langres.core.models import (
-    CompanySchema,
-    EntityProtocol,
-    ERCandidate,
-    MatcherAbstainedError,
-    PairwiseJudgement,
-    predicted_match,
-)
-from langres.core.matcher import GroupwiseMatcher, Matcher, stamp_group_cost
-from langres.core.matchers.cascade_judge import CascadeMatcher
-from langres.core.registry import (
-    SchemaNotRegistered,
-    UnknownComponentType,
-    get_component,
-    get_schema,
-    register,
-    register_schema,
-)
-from langres.core.resolver import Resolver
-from langres.core.review import ReviewItem, ReviewQueue, select_for_review
-from langres.core.runs import (
-    RunContext,
-    RunRecord,
-    RunStore,
-    capture_run,
-    compute_recipe_id,
-    resolve_store,
-)
-from langres.core.serialization import (
-    ARTIFACT_VERSION,
-    ArtifactManifest,
-    ComponentSpec,
-    SerializableState,
-)
-from langres.core.trackers import (
-    ExperimentTracker,
-    MultiTracker,
-    NoOpTracker,
-    resolve_tracker,
-)
+from langres.core import _exports
 
-if TYPE_CHECKING:
-    # Only reached by mypy (never at runtime) -- keeps every lazy name visible
-    # to `mypy --strict` without executing the heavy imports below.
-    from langres.core import benchmark, metrics, optimizers
-    from langres.core.blockers.vector import VectorBlocker
-    from langres.core.embeddings import (
-        EmbeddingProvider,
-        FakeEmbedder,
-        FakeSparseEmbedder,
-        FastEmbedSparseEmbedder,
-        SentenceTransformerEmbedder,
-        SparseEmbeddingProvider,
-    )
-    from langres.core.indexes import (
-        FAISSIndex,
-        FakeHybridVectorIndex,
-        FakeVectorIndex,
-        QdrantHybridIndex,
-        VectorIndex,
-    )
-    from langres.core.calibration import Calibrator
-    from langres.core.matchers.llm_judge import LLMMatcher
-    from langres.core.matchers.random_forest_judge import RandomForestMatcher
-    from langres.core.matchers.select_judge import SelectMatcher
-    from langres.core.trackers import MlflowTracker, WandbTracker
+# Bind each fragment's EAGER names into this namespace. Every star-import is
+# bounded by that fragment's own `__all__`, so this imports exactly the names
+# the fragment declares -- and nothing lazy (a lazy name is deliberately not
+# defined at runtime; see the _exports contract).
+from langres.core._exports._blocking import *  # noqa: F403
+from langres.core._exports._clustering import *  # noqa: F403
+from langres.core._exports._eval import *  # noqa: F403
+from langres.core._exports._flywheel import *  # noqa: F403
+from langres.core._exports._matchers import *  # noqa: F403
+from langres.core._exports._methods import *  # noqa: F403
+from langres.core._exports._models import *  # noqa: F403
+from langres.core._exports._resolver import *  # noqa: F403
+from langres.core._exports._semantic import *  # noqa: F403
+from langres.core._exports._tracking import *  # noqa: F403
+from langres.core._exports._training import *  # noqa: F403
 
-__all__ = [
-    "ARTIFACT_VERSION",
-    "AllPairsBlocker",
-    "AnchorStore",
-    "ArtifactManifest",
-    "benchmark",
-    "Blocker",
-    "Calibrator",
-    "CandidateStats",
-    "Canonicalizer",
-    "CascadeMatcher",
-    "ClusterDelta",
-    "ClusterStats",
-    "Clusterer",
-    "CompanySchema",
-    "Comparator",
-    "ComparisonLevel",
-    "ComparisonVector",
-    "ComponentSpec",
-    "CompositeBlocker",
-    "Correction",
-    "CorrectionLog",
-    "CorrelationClusterer",
-    "DEFAULT_EMBEDDING_MODEL",
-    "derive_groups_from_pairs",
-    "derive_threshold_from_pairs",
-    "EmbeddingProvider",
-    "EmbeddingScoreMatcher",
-    "EntityProtocol",
-    "ERCandidate",
-    "ERCandidateGroup",
-    "ErrorExample",
-    "FAISSIndex",
-    "FakeEmbedder",
-    "FakeHybridVectorIndex",
-    "FakeSparseEmbedder",
-    "FakeVectorIndex",
-    "FastEmbedSparseEmbedder",
-    "FeatureSpec",
-    "FellegiSunterMatcher",
-    "get_component",
-    "get_method",
-    "get_schema",
-    "GLinkerAdapter",
-    "GroupwiseMatcher",
-    "harvest_labeled_pairs",
-    "MatcherAbstainedError",
-    "JudgementLog",
-    "KeyBlocker",
-    "LabeledPair",
-    "LLMMatcher",
-    "list_methods",
-    "LoggingMatcher",
-    "MethodSpec",
-    "metrics",
-    "Matcher",
-    "optimizers",
-    "PairwiseJudgement",
-    "PipelineDebugger",
-    "predicted_match",
-    "QdrantHybridIndex",
-    "register",
-    "register_method",
-    "register_schema",
-    "Resolver",
-    "ReviewItem",
-    "ReviewQueue",
-    "RandomForestMatcher",
-    "ScoreStats",
-    "SchemaNotRegistered",
-    "select_for_review",
-    "SelectMatcher",
-    "SentenceTransformerEmbedder",
-    "SerializableState",
-    "SparseEmbeddingProvider",
-    "stamp_group_cost",
-    "StringComparator",
-    "SupervisedFitMixin",
-    "UnknownComponentType",
-    "UnknownMethodError",
-    "UnsupervisedFitMixin",
-    "VectorBlocker",
-    "VectorIndex",
-    "WeightedAverageMatcher",
-    # Experiment tracking (S1): run identity + persistence + pluggable trackers.
-    "capture_run",
-    "compute_recipe_id",
-    "ExperimentTracker",
-    "MlflowTracker",
-    "MultiTracker",
-    "NoOpTracker",
-    "resolve_store",
-    "resolve_tracker",
-    "RunContext",
-    "RunRecord",
-    "RunStore",
-    "WandbTracker",
-    # Training surface: the pairs->candidates bridge, the fit digest, and the
-    # method objects passed to Resolver.fit(method=...) (import-light config;
-    # dspy/sklearn stay lazy in dspy_judge/calibration).
-    "align_pairs",
-    "Bootstrap",
-    "FitReport",
-    "GEPA",
-    "Isotonic",
-    "Method",
-    "MIPRO",
-    "Platt",
-]
+#: The composed public surface -- every fragment's slice, deduplicated and
+#: sorted (see :data:`langres.core._exports.NAMES`).
+__all__ = list(_exports.NAMES)
 
 #: Names resolved to a *submodule of this package* on first access -- unlike
 #: :data:`_LAZY_SYMBOLS`, the value ``__getattr__`` binds is the imported
-#: module itself (``langres.core.benchmark``, not an attribute of it). All
-#: three eventually need ranx (``metrics``, and ``benchmark`` which imports
-#: it) or optuna/wandb (``optimizers``) -- dev/eval tooling, not part of the
-#: link()/dedupe() runtime path.
-_LAZY_SUBMODULES: frozenset[str] = frozenset({"benchmark", "metrics", "optimizers"})
+#: module itself (``langres.core.benchmark``, not an attribute of it).
+_LAZY_SUBMODULES: frozenset[str] = _exports.LAZY_SUBMODULES
 
 #: ``name -> owning module`` for symbols resolved on first access. Each entry
 #: needs an optional extra installed; see :data:`_EXTRA_BY_SYMBOL` for the
 #: ``pip install langres[<extra>]`` hint a missing dependency should surface.
-_LAZY_SYMBOLS: dict[str, str] = {
-    "Calibrator": "langres.core.calibration",
-    "VectorBlocker": "langres.core.blockers.vector",
-    "EmbeddingProvider": "langres.core.embeddings",
-    "FakeEmbedder": "langres.core.embeddings",
-    "FakeSparseEmbedder": "langres.core.embeddings",
-    "FastEmbedSparseEmbedder": "langres.core.embeddings",
-    "SentenceTransformerEmbedder": "langres.core.embeddings",
-    "SparseEmbeddingProvider": "langres.core.embeddings",
-    "FAISSIndex": "langres.core.indexes",
-    "FakeHybridVectorIndex": "langres.core.indexes",
-    "FakeVectorIndex": "langres.core.indexes",
-    "QdrantHybridIndex": "langres.core.indexes",
-    "VectorIndex": "langres.core.indexes",
-    "LLMMatcher": "langres.core.matchers.llm_judge",
-    "RandomForestMatcher": "langres.core.matchers.random_forest_judge",
-    "SelectMatcher": "langres.core.matchers.select_judge",
-    # Backend tracker adapters (S3/S4): the package's own __getattr__ pulls the
-    # concrete adapter -- and its mlflow/wandb dependency -- only on access.
-    "MlflowTracker": "langres.core.trackers",
-    "WandbTracker": "langres.core.trackers",
-}
+_LAZY_SYMBOLS: dict[str, str] = _exports.LAZY_SYMBOLS
 
 #: ``name -> extra`` for the lazy symbols a ``pip install langres[<extra>]``
-#: actually fixes -- everything in :data:`_LAZY_SYMBOLS` except the three
-#: submodules (dev/eval tooling, not distributed as a pip extra; see
-#: :data:`_LAZY_SUBMODULES`'s docstring). ``RandomForestMatcher`` needs scikit-learn (the
-#: ``[trained]`` extra, W1.2's trained-family judge); ``LLMMatcher``/
-#: ``SelectMatcher`` need ``[llm]`` (litellm/dspy-ai); everything else needs
-#: ``[semantic]`` (embeddings/vector index/VectorBlocker).
-_EXTRA_BY_SYMBOL: dict[str, str] = {
-    name: {
-        "LLMMatcher": "llm",
-        "SelectMatcher": "llm",
-        "RandomForestMatcher": "trained",
-        "Calibrator": "trained",
-        "MlflowTracker": "mlflow",
-        "WandbTracker": "wandb",
-    }.get(name, "semantic")
-    for name in _LAZY_SYMBOLS
-}
+#: actually fixes -- everything in :data:`_LAZY_SYMBOLS` except the submodules
+#: (dev/eval tooling, not distributed as a pip extra; see
+#: :data:`_LAZY_SUBMODULES`). ``RandomForestMatcher``/``Calibrator`` need
+#: scikit-learn (``[trained]``); ``LLMMatcher``/``SelectMatcher`` need
+#: ``[llm]`` (litellm/dspy-ai); the embedding/vector names need
+#: ``[semantic]``; the tracker adapters name their own backend.
+_EXTRA_BY_SYMBOL: dict[str, str] = _exports.EXTRA_BY_SYMBOL
 
 
 def __getattr__(name: str) -> Any:

--- a/src/langres/core/_exports/__init__.py
+++ b/src/langres/core/_exports/__init__.py
@@ -30,8 +30,11 @@ an export to an existing domain touches one fragment and nothing else.
 
 **Adding an export**: edit the one fragment that owns its domain -- add the
 import + the ``__all__`` entry (eager), or the ``LAZY_SYMBOLS`` +
-``EXTRA_BY_SYMBOL`` entry and a ``TYPE_CHECKING`` import (lazy). Only a brand
-new *domain* requires touching ``core/__init__.py``.
+``EXTRA_BY_SYMBOL`` entry and a ``TYPE_CHECKING`` import (lazy). Nothing else
+changes: this module composes whatever the fragments declare.
+
+**Adding a domain** (rare): add the fragment here (import + the four merges
+below) and one star-import line in ``langres/core/__init__.py``.
 
 **Keep lazy names lazy**: a symbol pulling an optional/heavy dependency
 (torch/litellm/faiss/scikit-learn/mlflow/wandb) must go in ``LAZY_SYMBOLS``, never
@@ -39,3 +42,87 @@ be imported at a fragment's module scope -- fragments are eagerly imported by
 ``langres.core``, so an import here lands in every bare ``import langres``.
 ``tests/test_import_budget.py`` is the gate.
 """
+
+from langres.core._exports import (
+    _blocking,
+    _clustering,
+    _eval,
+    _flywheel,
+    _matchers,
+    _methods,
+    _models,
+    _resolver,
+    _semantic,
+    _tracking,
+    _training,
+)
+
+#: The composed public surface: every fragment's slice, deduplicated and sorted
+#: case-insensitively (the dominant convention of the hand-maintained list this
+#: replaced). Order is cosmetic -- ``__all__`` is only ever read as a set.
+NAMES: tuple[str, ...] = tuple(
+    sorted(
+        {
+            *_blocking.NAMES,
+            *_clustering.NAMES,
+            *_eval.NAMES,
+            *_flywheel.NAMES,
+            *_matchers.NAMES,
+            *_methods.NAMES,
+            *_models.NAMES,
+            *_resolver.NAMES,
+            *_semantic.NAMES,
+            *_tracking.NAMES,
+            *_training.NAMES,
+        },
+        key=str.lower,
+    )
+)
+
+#: Names resolved to a *submodule of* ``langres.core`` on first access.
+LAZY_SUBMODULES: frozenset[str] = frozenset(
+    (
+        *_blocking.LAZY_SUBMODULES,
+        *_clustering.LAZY_SUBMODULES,
+        *_eval.LAZY_SUBMODULES,
+        *_flywheel.LAZY_SUBMODULES,
+        *_matchers.LAZY_SUBMODULES,
+        *_methods.LAZY_SUBMODULES,
+        *_models.LAZY_SUBMODULES,
+        *_resolver.LAZY_SUBMODULES,
+        *_semantic.LAZY_SUBMODULES,
+        *_tracking.LAZY_SUBMODULES,
+        *_training.LAZY_SUBMODULES,
+    )
+)
+
+#: ``name -> owning module`` for symbols resolved on first access.
+LAZY_SYMBOLS: dict[str, str] = {
+    **_blocking.LAZY_SYMBOLS,
+    **_clustering.LAZY_SYMBOLS,
+    **_eval.LAZY_SYMBOLS,
+    **_flywheel.LAZY_SYMBOLS,
+    **_matchers.LAZY_SYMBOLS,
+    **_methods.LAZY_SYMBOLS,
+    **_models.LAZY_SYMBOLS,
+    **_resolver.LAZY_SYMBOLS,
+    **_semantic.LAZY_SYMBOLS,
+    **_tracking.LAZY_SYMBOLS,
+    **_training.LAZY_SYMBOLS,
+}
+
+#: ``name -> extra`` for the lazy symbols a ``pip install langres[<extra>]``
+#: actually fixes.
+EXTRA_BY_SYMBOL: dict[str, str] = {
+    **_blocking.EXTRA_BY_SYMBOL,
+    **_clustering.EXTRA_BY_SYMBOL,
+    **_eval.EXTRA_BY_SYMBOL,
+    **_flywheel.EXTRA_BY_SYMBOL,
+    **_matchers.EXTRA_BY_SYMBOL,
+    **_methods.EXTRA_BY_SYMBOL,
+    **_models.EXTRA_BY_SYMBOL,
+    **_resolver.EXTRA_BY_SYMBOL,
+    **_semantic.EXTRA_BY_SYMBOL,
+    **_tracking.EXTRA_BY_SYMBOL,
+    **_training.EXTRA_BY_SYMBOL,
+}

--- a/src/langres/core/_exports/__init__.py
+++ b/src/langres/core/_exports/__init__.py
@@ -1,0 +1,41 @@
+"""Per-domain export fragments composed by ``langres.core.__init__``.
+
+**Why this package exists.** ``langres/core/__init__.py`` used to carry one
+alphabetically sorted ~100-name ``__all__`` plus the three lazy maps. A sorted
+list is the one shape git cannot auto-merge: N concurrent work-streams each
+inserting a name at its sorted position produce N guaranteed conflicts, and the
+file was touched 21 times in 30 days. Splitting the list into per-domain
+fragments makes those streams edit **disjoint files**, so they merge cleanly.
+
+**The contract.** Every fragment module in this package declares exactly these
+five module-level names, and ``langres.core.__init__`` composes them::
+
+    __all__: list[str]                 # EAGER names -- `import *` binds these
+    LAZY_SUBMODULES: tuple[str, ...]   # resolved to a submodule of langres.core
+    LAZY_SYMBOLS: dict[str, str]       # name -> owning module (resolved on access)
+    EXTRA_BY_SYMBOL: dict[str, str]    # name -> pip extra, for the ImportError hint
+    NAMES: tuple[str, ...]             # this fragment's slice of langres.core.__all__
+
+``__all__`` holds only the *eager* names because that is what
+``from ._exports._x import *`` actually binds -- a lazy name is deliberately not
+defined at runtime (it lives under ``TYPE_CHECKING`` for mypy only), so listing
+it in ``__all__`` would make the star-import raise ``AttributeError``. ``NAMES``
+is therefore always *derived*, never hand-maintained::
+
+    NAMES = (*__all__, *LAZY_SUBMODULES, *LAZY_SYMBOLS)
+
+All five are declared by every fragment even when empty. That uniformity is the
+whole point: it keeps ``core/__init__.py`` free of per-*name* content, so adding
+an export to an existing domain touches one fragment and nothing else.
+
+**Adding an export**: edit the one fragment that owns its domain -- add the
+import + the ``__all__`` entry (eager), or the ``LAZY_SYMBOLS`` +
+``EXTRA_BY_SYMBOL`` entry and a ``TYPE_CHECKING`` import (lazy). Only a brand
+new *domain* requires touching ``core/__init__.py``.
+
+**Keep lazy names lazy**: a symbol pulling an optional/heavy dependency
+(torch/litellm/faiss/scikit-learn/mlflow/wandb) must go in ``LAZY_SYMBOLS``, never
+be imported at a fragment's module scope -- fragments are eagerly imported by
+``langres.core``, so an import here lands in every bare ``import langres``.
+``tests/test_import_budget.py`` is the gate.
+"""

--- a/src/langres/core/_exports/_blocking.py
+++ b/src/langres/core/_exports/_blocking.py
@@ -1,0 +1,38 @@
+"""Candidate generation: the ``Blocker`` family + the ``Comparator`` feeding it.
+
+See ``langres.core._exports`` for the fragment contract.
+"""
+
+from typing import TYPE_CHECKING
+
+from langres.core.blocker import Blocker
+from langres.core.blockers.all_pairs import AllPairsBlocker
+from langres.core.blockers.composite import CompositeBlocker
+from langres.core.blockers.key import KeyBlocker
+from langres.core.comparator import Comparator, StringComparator
+
+if TYPE_CHECKING:
+    # Never executed at runtime -- keeps the lazy names visible to `mypy --strict`
+    # without pulling faiss/torch into a bare `import langres`.
+    from langres.core.blockers.vector import VectorBlocker
+
+__all__ = [
+    "AllPairsBlocker",
+    "Blocker",
+    "Comparator",
+    "CompositeBlocker",
+    "KeyBlocker",
+    "StringComparator",
+]
+
+LAZY_SUBMODULES: tuple[str, ...] = ()
+
+LAZY_SYMBOLS: dict[str, str] = {
+    "VectorBlocker": "langres.core.blockers.vector",
+}
+
+EXTRA_BY_SYMBOL: dict[str, str] = {
+    "VectorBlocker": "semantic",
+}
+
+NAMES: tuple[str, ...] = (*__all__, *LAZY_SUBMODULES, *LAZY_SYMBOLS)

--- a/src/langres/core/_exports/_clustering.py
+++ b/src/langres/core/_exports/_clustering.py
@@ -1,0 +1,25 @@
+"""Clustering, canonicalization, and the incremental anchor store.
+
+See ``langres.core._exports`` for the fragment contract.
+"""
+
+from langres.core.adapters.glinker import GLinkerAdapter
+from langres.core.anchor_store import AnchorStore, ClusterDelta
+from langres.core.canonicalizer import Canonicalizer
+from langres.core.clusterer import Clusterer
+from langres.core.clusterers.correlation import CorrelationClusterer
+
+__all__ = [
+    "AnchorStore",
+    "Canonicalizer",
+    "ClusterDelta",
+    "Clusterer",
+    "CorrelationClusterer",
+    "GLinkerAdapter",
+]
+
+LAZY_SUBMODULES: tuple[str, ...] = ()
+LAZY_SYMBOLS: dict[str, str] = {}
+EXTRA_BY_SYMBOL: dict[str, str] = {}
+
+NAMES: tuple[str, ...] = (*__all__, *LAZY_SUBMODULES, *LAZY_SYMBOLS)

--- a/src/langres/core/_exports/_eval.py
+++ b/src/langres/core/_exports/_eval.py
@@ -1,0 +1,41 @@
+"""Evaluation + debugging tooling: the pipeline debugger and the eval submodules.
+
+See ``langres.core._exports`` for the fragment contract.
+"""
+
+from typing import TYPE_CHECKING
+
+from langres.core.debugging import (
+    CandidateStats,
+    ClusterStats,
+    ErrorExample,
+    PipelineDebugger,
+    ScoreStats,
+)
+
+if TYPE_CHECKING:
+    # Never executed at runtime -- keeps the lazy submodules visible to
+    # `mypy --strict` without pulling ranx/optuna/wandb into a bare
+    # `import langres`.
+    from langres.core import benchmark, metrics, optimizers
+
+__all__ = [
+    "CandidateStats",
+    "ClusterStats",
+    "ErrorExample",
+    "PipelineDebugger",
+    "ScoreStats",
+]
+
+#: Unlike ``LAZY_SYMBOLS``, the value ``__getattr__`` binds for these is the
+#: imported *module* itself (``langres.core.benchmark``, not an attribute of
+#: it). All three eventually need ranx (``metrics``, and ``benchmark`` which
+#: imports it) or optuna/wandb (``optimizers``) -- dev/eval tooling, not part
+#: of the link()/dedupe() runtime path, and not distributed as a pip extra
+#: (hence no ``EXTRA_BY_SYMBOL`` entries).
+LAZY_SUBMODULES: tuple[str, ...] = ("benchmark", "metrics", "optimizers")
+
+LAZY_SYMBOLS: dict[str, str] = {}
+EXTRA_BY_SYMBOL: dict[str, str] = {}
+
+NAMES: tuple[str, ...] = (*__all__, *LAZY_SUBMODULES, *LAZY_SYMBOLS)

--- a/src/langres/core/_exports/_flywheel.py
+++ b/src/langres/core/_exports/_flywheel.py
@@ -1,0 +1,33 @@
+"""The flywheel loop: log every call -> pick the margin -> harvest the labels.
+
+See ``langres.core._exports`` for the fragment contract.
+"""
+
+from langres.core.harvest import (
+    Correction,
+    CorrectionLog,
+    LabeledPair,
+    derive_threshold_from_pairs,
+    harvest_labeled_pairs,
+)
+from langres.core.judgement_log import JudgementLog, LoggingMatcher
+from langres.core.review import ReviewItem, ReviewQueue, select_for_review
+
+__all__ = [
+    "Correction",
+    "CorrectionLog",
+    "derive_threshold_from_pairs",
+    "harvest_labeled_pairs",
+    "JudgementLog",
+    "LabeledPair",
+    "LoggingMatcher",
+    "ReviewItem",
+    "ReviewQueue",
+    "select_for_review",
+]
+
+LAZY_SUBMODULES: tuple[str, ...] = ()
+LAZY_SYMBOLS: dict[str, str] = {}
+EXTRA_BY_SYMBOL: dict[str, str] = {}
+
+NAMES: tuple[str, ...] = (*__all__, *LAZY_SUBMODULES, *LAZY_SYMBOLS)

--- a/src/langres/core/_exports/_matchers.py
+++ b/src/langres/core/_exports/_matchers.py
@@ -1,0 +1,45 @@
+"""The ``Matcher`` (judge) ABC and the concrete matcher family.
+
+See ``langres.core._exports`` for the fragment contract.
+"""
+
+from typing import TYPE_CHECKING
+
+from langres.core.matcher import GroupwiseMatcher, Matcher, stamp_group_cost
+from langres.core.matchers.cascade_judge import CascadeMatcher
+from langres.core.matchers.embedding_score import EmbeddingScoreMatcher
+from langres.core.matchers.fellegi_sunter import FellegiSunterMatcher
+from langres.core.matchers.weighted_average import WeightedAverageMatcher
+
+if TYPE_CHECKING:
+    # Never executed at runtime -- keeps the lazy names visible to `mypy --strict`
+    # without pulling litellm/dspy/scikit-learn into a bare `import langres`.
+    from langres.core.matchers.llm_judge import LLMMatcher
+    from langres.core.matchers.random_forest_judge import RandomForestMatcher
+    from langres.core.matchers.select_judge import SelectMatcher
+
+__all__ = [
+    "CascadeMatcher",
+    "EmbeddingScoreMatcher",
+    "FellegiSunterMatcher",
+    "GroupwiseMatcher",
+    "Matcher",
+    "stamp_group_cost",
+    "WeightedAverageMatcher",
+]
+
+LAZY_SUBMODULES: tuple[str, ...] = ()
+
+LAZY_SYMBOLS: dict[str, str] = {
+    "LLMMatcher": "langres.core.matchers.llm_judge",
+    "RandomForestMatcher": "langres.core.matchers.random_forest_judge",
+    "SelectMatcher": "langres.core.matchers.select_judge",
+}
+
+EXTRA_BY_SYMBOL: dict[str, str] = {
+    "LLMMatcher": "llm",
+    "RandomForestMatcher": "trained",
+    "SelectMatcher": "llm",
+}
+
+NAMES: tuple[str, ...] = (*__all__, *LAZY_SUBMODULES, *LAZY_SYMBOLS)

--- a/src/langres/core/_exports/_methods.py
+++ b/src/langres/core/_exports/_methods.py
@@ -1,0 +1,28 @@
+"""The single method/matcher-name registry (``core.method_registry``).
+
+See ``langres.core._exports`` for the fragment contract.
+"""
+
+from langres.core.method_registry import (
+    DEFAULT_EMBEDDING_MODEL,
+    MethodSpec,
+    UnknownMethodError,
+    get_method,
+    list_methods,
+    register_method,
+)
+
+__all__ = [
+    "DEFAULT_EMBEDDING_MODEL",
+    "get_method",
+    "list_methods",
+    "MethodSpec",
+    "register_method",
+    "UnknownMethodError",
+]
+
+LAZY_SUBMODULES: tuple[str, ...] = ()
+LAZY_SYMBOLS: dict[str, str] = {}
+EXTRA_BY_SYMBOL: dict[str, str] = {}
+
+NAMES: tuple[str, ...] = (*__all__, *LAZY_SUBMODULES, *LAZY_SYMBOLS)

--- a/src/langres/core/_exports/_models.py
+++ b/src/langres/core/_exports/_models.py
@@ -1,0 +1,35 @@
+"""Data contracts: the records, the judgement, the comparison feature bag.
+
+See ``langres.core._exports`` for the fragment contract.
+"""
+
+from langres.core.feature import ComparisonLevel, ComparisonVector, FeatureSpec
+from langres.core.groups import ERCandidateGroup, derive_groups_from_pairs
+from langres.core.models import (
+    CompanySchema,
+    EntityProtocol,
+    ERCandidate,
+    MatcherAbstainedError,
+    PairwiseJudgement,
+    predicted_match,
+)
+
+__all__ = [
+    "CompanySchema",
+    "ComparisonLevel",
+    "ComparisonVector",
+    "derive_groups_from_pairs",
+    "EntityProtocol",
+    "ERCandidate",
+    "ERCandidateGroup",
+    "FeatureSpec",
+    "MatcherAbstainedError",
+    "PairwiseJudgement",
+    "predicted_match",
+]
+
+LAZY_SUBMODULES: tuple[str, ...] = ()
+LAZY_SYMBOLS: dict[str, str] = {}
+EXTRA_BY_SYMBOL: dict[str, str] = {}
+
+NAMES: tuple[str, ...] = (*__all__, *LAZY_SUBMODULES, *LAZY_SYMBOLS)

--- a/src/langres/core/_exports/_resolver.py
+++ b/src/langres/core/_exports/_resolver.py
@@ -1,0 +1,40 @@
+"""The ``Resolver`` and the save/load seam it serializes through.
+
+See ``langres.core._exports`` for the fragment contract.
+"""
+
+from langres.core.registry import (
+    SchemaNotRegistered,
+    UnknownComponentType,
+    get_component,
+    get_schema,
+    register,
+    register_schema,
+)
+from langres.core.resolver import Resolver
+from langres.core.serialization import (
+    ARTIFACT_VERSION,
+    ArtifactManifest,
+    ComponentSpec,
+    SerializableState,
+)
+
+__all__ = [
+    "ARTIFACT_VERSION",
+    "ArtifactManifest",
+    "ComponentSpec",
+    "get_component",
+    "get_schema",
+    "register",
+    "register_schema",
+    "Resolver",
+    "SchemaNotRegistered",
+    "SerializableState",
+    "UnknownComponentType",
+]
+
+LAZY_SUBMODULES: tuple[str, ...] = ()
+LAZY_SYMBOLS: dict[str, str] = {}
+EXTRA_BY_SYMBOL: dict[str, str] = {}
+
+NAMES: tuple[str, ...] = (*__all__, *LAZY_SUBMODULES, *LAZY_SYMBOLS)

--- a/src/langres/core/_exports/_semantic.py
+++ b/src/langres/core/_exports/_semantic.py
@@ -1,0 +1,52 @@
+"""The embedding/vector stack (the ``[semantic]`` extra) -- lazy in its entirety.
+
+Every name here pulls torch / sentence-transformers / faiss / qdrant-client, so
+nothing in this fragment is imported at module scope: ``__all__`` is empty and
+all names resolve through ``langres.core.__getattr__`` on first access.
+
+See ``langres.core._exports`` for the fragment contract.
+"""
+
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    # Never executed at runtime -- keeps the lazy names visible to `mypy --strict`
+    # without pulling the [semantic] stack into a bare `import langres`.
+    from langres.core.embeddings import (
+        EmbeddingProvider,
+        FakeEmbedder,
+        FakeSparseEmbedder,
+        FastEmbedSparseEmbedder,
+        SentenceTransformerEmbedder,
+        SparseEmbeddingProvider,
+    )
+    from langres.core.indexes import (
+        FAISSIndex,
+        FakeHybridVectorIndex,
+        FakeVectorIndex,
+        QdrantHybridIndex,
+        VectorIndex,
+    )
+
+#: Nothing is eager here by design -- see the module docstring.
+__all__: list[str] = []
+
+LAZY_SUBMODULES: tuple[str, ...] = ()
+
+LAZY_SYMBOLS: dict[str, str] = {
+    "EmbeddingProvider": "langres.core.embeddings",
+    "FakeEmbedder": "langres.core.embeddings",
+    "FakeSparseEmbedder": "langres.core.embeddings",
+    "FastEmbedSparseEmbedder": "langres.core.embeddings",
+    "SentenceTransformerEmbedder": "langres.core.embeddings",
+    "SparseEmbeddingProvider": "langres.core.embeddings",
+    "FAISSIndex": "langres.core.indexes",
+    "FakeHybridVectorIndex": "langres.core.indexes",
+    "FakeVectorIndex": "langres.core.indexes",
+    "QdrantHybridIndex": "langres.core.indexes",
+    "VectorIndex": "langres.core.indexes",
+}
+
+EXTRA_BY_SYMBOL: dict[str, str] = dict.fromkeys(LAZY_SYMBOLS, "semantic")
+
+NAMES: tuple[str, ...] = (*__all__, *LAZY_SUBMODULES, *LAZY_SYMBOLS)

--- a/src/langres/core/_exports/_tracking.py
+++ b/src/langres/core/_exports/_tracking.py
@@ -1,0 +1,56 @@
+"""Experiment tracking (S1): run identity + persistence + pluggable trackers.
+
+See ``langres.core._exports`` for the fragment contract.
+"""
+
+from typing import TYPE_CHECKING
+
+from langres.core.runs import (
+    RunContext,
+    RunRecord,
+    RunStore,
+    capture_run,
+    compute_recipe_id,
+    resolve_store,
+)
+from langres.core.trackers import (
+    ExperimentTracker,
+    MultiTracker,
+    NoOpTracker,
+    resolve_tracker,
+)
+
+if TYPE_CHECKING:
+    # Never executed at runtime -- keeps the lazy names visible to `mypy --strict`
+    # without pulling mlflow/wandb into a bare `import langres`.
+    from langres.core.trackers import MlflowTracker, WandbTracker
+
+__all__ = [
+    "capture_run",
+    "compute_recipe_id",
+    "ExperimentTracker",
+    "MultiTracker",
+    "NoOpTracker",
+    "resolve_store",
+    "resolve_tracker",
+    "RunContext",
+    "RunRecord",
+    "RunStore",
+]
+
+LAZY_SUBMODULES: tuple[str, ...] = ()
+
+#: The backend tracker adapters (S3/S4): the ``trackers`` package's own
+#: ``__getattr__`` pulls the concrete adapter -- and its mlflow/wandb
+#: dependency -- only on access.
+LAZY_SYMBOLS: dict[str, str] = {
+    "MlflowTracker": "langres.core.trackers",
+    "WandbTracker": "langres.core.trackers",
+}
+
+EXTRA_BY_SYMBOL: dict[str, str] = {
+    "MlflowTracker": "mlflow",
+    "WandbTracker": "wandb",
+}
+
+NAMES: tuple[str, ...] = (*__all__, *LAZY_SUBMODULES, *LAZY_SYMBOLS)

--- a/src/langres/core/_exports/_training.py
+++ b/src/langres/core/_exports/_training.py
@@ -1,0 +1,47 @@
+"""The training surface: fit mixins, the fit digest, and the ``Method`` objects.
+
+The method objects passed to ``Resolver.fit(method=...)`` are import-light
+config -- dspy/scikit-learn stay lazy inside their fit paths (and behind
+``Calibrator`` below), so these names are safe to import eagerly.
+
+See ``langres.core._exports`` for the fragment contract.
+"""
+
+from typing import TYPE_CHECKING
+
+from langres.core.fit import SupervisedFitMixin, UnsupervisedFitMixin
+from langres.core.fit_report import FitReport
+from langres.core.harvest import align_pairs
+from langres.core.methods_api import Method
+from langres.core.methods_calibrate import Isotonic, Platt
+from langres.core.methods_prompt import Bootstrap, GEPA, MIPRO
+
+if TYPE_CHECKING:
+    # Never executed at runtime -- keeps the lazy name visible to `mypy --strict`
+    # without pulling scikit-learn into a bare `import langres`.
+    from langres.core.calibration import Calibrator
+
+__all__ = [
+    "align_pairs",
+    "Bootstrap",
+    "FitReport",
+    "GEPA",
+    "Isotonic",
+    "Method",
+    "MIPRO",
+    "Platt",
+    "SupervisedFitMixin",
+    "UnsupervisedFitMixin",
+]
+
+LAZY_SUBMODULES: tuple[str, ...] = ()
+
+LAZY_SYMBOLS: dict[str, str] = {
+    "Calibrator": "langres.core.calibration",
+}
+
+EXTRA_BY_SYMBOL: dict[str, str] = {
+    "Calibrator": "trained",
+}
+
+NAMES: tuple[str, ...] = (*__all__, *LAZY_SUBMODULES, *LAZY_SYMBOLS)

--- a/tests/test_export_fragments.py
+++ b/tests/test_export_fragments.py
@@ -1,0 +1,201 @@
+"""The export-fragment contract (W-1a): what keeps the split honest.
+
+``langres/__init__.py`` and ``langres/core/__init__.py`` are thin aggregators
+over per-domain fragments (``langres/_exports/``, ``langres/core/_exports/``).
+The split exists to let parallel work-streams edit disjoint files instead of
+one sorted ~100-name ``__all__``. But a contract enforced only by convention
+drifts -- and it drifts hardest under exactly the concurrent-edit pressure the
+split invites, especially since ``.gitattributes`` marks the fragments
+``merge=union`` (git keeps BOTH sides' lines rather than raising a conflict).
+
+So the contract is tested, not trusted. These are cheap, offline, structural
+checks that fail loudly in CI instead of surfacing as a confusing traceback or
+a silently wrong ``pip install`` hint months later.
+
+Fragments are DISCOVERED (``pkgutil``), never listed, so a newly added fragment
+is covered automatically -- including the case where someone adds a fragment
+file but forgets to wire it into its aggregator.
+"""
+
+from __future__ import annotations
+
+import importlib
+import pkgutil
+from types import ModuleType
+
+import pytest
+
+import langres
+import langres._exports
+import langres.core
+import langres.core._exports
+
+
+def _fragments(pkg: ModuleType) -> list[ModuleType]:
+    """Every ``_*.py`` fragment module in an ``_exports`` package."""
+    return [
+        importlib.import_module(f"{pkg.__name__}.{m.name}")
+        for m in pkgutil.iter_modules(pkg.__path__)
+        if m.name.startswith("_")
+    ]
+
+
+_CORE_FRAGMENTS = _fragments(langres.core._exports)
+_ROOT_FRAGMENTS = _fragments(langres._exports)
+_ALL_FRAGMENTS = _CORE_FRAGMENTS + _ROOT_FRAGMENTS
+
+
+def _lazy_submodules(frag: ModuleType) -> tuple[str, ...]:
+    """Root fragments declare no ``LAZY_SUBMODULES`` -- only ``core`` has any."""
+    return tuple(getattr(frag, "LAZY_SUBMODULES", ()))
+
+
+def _ids(frags: list[ModuleType]) -> list[str]:
+    return [f.__name__.removeprefix("langres.") for f in frags]
+
+
+def test_fragments_are_discovered() -> None:
+    """Guard the guard: these tests are worthless if discovery finds nothing."""
+    assert len(_CORE_FRAGMENTS) >= 10
+    assert len(_ROOT_FRAGMENTS) >= 5
+
+
+@pytest.mark.parametrize("frag", _ALL_FRAGMENTS, ids=_ids(_ALL_FRAGMENTS))
+class TestFragmentContract:
+    """Each fragment declares the contract in ``_exports/__init__.py``'s docstring."""
+
+    def test_declares_the_contract(self, frag: ModuleType) -> None:
+        for attr in ("__all__", "LAZY_SYMBOLS", "EXTRA_BY_SYMBOL", "NAMES"):
+            assert hasattr(frag, attr), f"{frag.__name__} is missing {attr}"
+
+    def test_names_is_derived_not_hand_maintained(self, frag: ModuleType) -> None:
+        """``NAMES == (*__all__, *LAZY_SUBMODULES, *LAZY_SYMBOLS)``.
+
+        Hand-editing ``NAMES`` is how a name silently drops out of (or sneaks
+        into) the public surface.
+        """
+        expected = (*frag.__all__, *_lazy_submodules(frag), *frag.LAZY_SYMBOLS)
+        assert tuple(frag.NAMES) == expected
+
+    def test_extras_only_describe_lazy_symbols(self, frag: ModuleType) -> None:
+        """An extra for a non-lazy name is dead config -- ``__getattr__`` never reads it."""
+        assert set(frag.EXTRA_BY_SYMBOL) <= set(frag.LAZY_SYMBOLS)
+
+    def test_eager_names_are_actually_defined(self, frag: ModuleType) -> None:
+        """``__all__`` drives ``from ._x import *`` -- an undefined entry is an AttributeError.
+
+        This is the loud failure mode ``merge=union`` trades for: if a removal
+        and an edit interleave, union can resurrect an ``__all__`` entry whose
+        import is gone. It must die here, at import, not in a user's process.
+        """
+        for name in frag.__all__:
+            assert hasattr(frag, name), f"{frag.__name__}.__all__ has undefined {name!r}"
+
+    def test_lazy_names_are_not_eagerly_defined(self, frag: ModuleType) -> None:
+        """A lazy name must NOT exist at fragment module scope.
+
+        Two failures at once if it does: the star-import would bind it eagerly
+        (blowing the import budget -- fragments are eagerly imported), and the
+        aggregator's ``__getattr__`` would never be consulted for it.
+        """
+        for name in frag.LAZY_SYMBOLS:
+            assert name not in vars(frag), (
+                f"{frag.__name__} defines lazy symbol {name!r} at module scope"
+            )
+
+
+@pytest.mark.parametrize(
+    ("frags", "pkg"),
+    [(_CORE_FRAGMENTS, langres.core._exports), (_ROOT_FRAGMENTS, langres._exports)],
+    ids=["core", "root"],
+)
+class TestNoCollisionsBetweenFragments:
+    """Exactly one fragment owns any given name.
+
+    ``**``-merging means a name declared by two fragments is silently
+    last-wins -- which would resolve it from the wrong module, or hint the
+    wrong extra. Nothing about the merge itself would complain.
+    """
+
+    def test_no_name_is_owned_by_two_fragments(
+        self, frags: list[ModuleType], pkg: ModuleType
+    ) -> None:
+        seen: dict[str, str] = {}
+        for frag in frags:
+            for name in frag.NAMES:
+                assert name not in seen, (
+                    f"{name!r} is declared by BOTH {seen[name]} and {frag.__name__}"
+                )
+                seen[name] = frag.__name__
+
+    def test_no_lazy_symbol_is_mapped_twice(self, frags: list[ModuleType], pkg: ModuleType) -> None:
+        seen: dict[str, str] = {}
+        for frag in frags:
+            for name in frag.LAZY_SYMBOLS:
+                assert name not in seen, (
+                    f"lazy {name!r} is mapped by BOTH {seen[name]} and {frag.__name__}"
+                )
+                seen[name] = frag.__name__
+
+    def test_every_fragment_is_wired_into_the_aggregate(
+        self, frags: list[ModuleType], pkg: ModuleType
+    ) -> None:
+        """A fragment file that no aggregator composes is invisible, silently."""
+        for frag in frags:
+            assert set(frag.NAMES) <= set(pkg.NAMES), (
+                f"{frag.__name__} is not composed by {pkg.__name__} -- forgot to wire it?"
+            )
+
+
+class TestAggregatesMatchTheirFragments:
+    """The composed surface is exactly the union of the fragments' slices."""
+
+    def test_core_all_is_the_union_of_fragment_names(self) -> None:
+        assert set(langres.core.__all__) == {n for f in _CORE_FRAGMENTS for n in f.NAMES}
+
+    def test_root_all_is_the_union_of_fragment_names(self) -> None:
+        assert set(langres.__all__) == {n for f in _ROOT_FRAGMENTS for n in f.NAMES}
+
+    @pytest.mark.parametrize("mod", [langres, langres.core], ids=["root", "core"])
+    def test_all_has_no_duplicates(self, mod: ModuleType) -> None:
+        assert len(mod.__all__) == len(set(mod.__all__))
+
+    @pytest.mark.parametrize("mod", [langres, langres.core], ids=["root", "core"])
+    def test_every_exported_name_actually_resolves(self, mod: ModuleType) -> None:
+        """The end-to-end promise: every ``__all__`` name is gettable.
+
+        Eager names resolve from the namespace; lazy ones go through
+        ``__getattr__``. A lazy name whose owning module needs an uninstalled
+        extra raises the actionable ImportError -- that IS the contract, so it
+        counts as resolving.
+        """
+        for name in mod.__all__:
+            try:
+                getattr(mod, name)
+            except ImportError:
+                pass  # missing optional extra -- the documented, actionable path
+            except AttributeError:  # pragma: no cover - a real regression
+                pytest.fail(f"{mod.__name__}.{name} is in __all__ but does not resolve")
+
+
+class TestCoreExtraBySymbolIsTotal:
+    """``core.__getattr__`` INDEXES ``_EXTRA_BY_SYMBOL[name]`` -- so it must be total.
+
+    The pre-split code built the map with a dict comprehension defaulting to
+    ``"semantic"``, which made totality automatic. The fragments declare extras
+    explicitly instead (clearer -- no magic default), which means a future lazy
+    symbol added WITHOUT an extra would raise ``KeyError`` from inside the
+    ``except ImportError`` handler: a confusing chained traceback in place of
+    the actionable "pip install langres[...]" hint. Locked here.
+
+    The root package needs no such rule -- its ``__getattr__`` uses ``.get()``
+    and deliberately re-raises unchanged for symbols that need no extra.
+    """
+
+    def test_every_core_lazy_symbol_has_an_extra(self) -> None:
+        missing = set(langres.core._LAZY_SYMBOLS) - set(langres.core._EXTRA_BY_SYMBOL)
+        assert not missing, f"core lazy symbols without a [extra] hint: {sorted(missing)}"
+
+    def test_core_submodules_are_not_given_extras(self) -> None:
+        """The lazy submodules are dev/eval tooling, not pip extras."""
+        assert not (langres.core._LAZY_SUBMODULES & set(langres.core._EXTRA_BY_SYMBOL))


### PR DESCRIPTION
## Why: the worst merge-conflict hotspot in the repo

`src/langres/core/__init__.py` was touched **21 times in the last 30 days**. It carried an alphabetically sorted **~100-name `__all__`** plus the `_LAZY_SUBMODULES` / `_LAZY_SYMBOLS` / `_EXTRA_BY_SYMBOL` dicts.

A sorted list is the exact shape git cannot auto-merge: N concurrent streams each inserting a name **at its sorted position** = N guaranteed conflicts. `src/langres/__init__.py` had the same disease **plus an eager import block whose lines belong to four different work-streams** (verbs/presets, optimize, flywheel, training) — so any two of them collided on one file.

This turns both into **thin aggregators** over per-domain fragments, so N parallel streams edit **disjoint files**.

## What changed

- **`src/langres/core/_exports/`** — 11 fragments (`_models`, `_blocking`, `_matchers`, `_semantic`, `_clustering`, `_resolver`, `_methods`, `_training`, `_tracking`, `_flywheel`, `_eval`), domains derived from the actual module structure.
- **`src/langres/_exports/`** — 6 fragments (`_verbs`, `_optimize`, `_core`, `_flywheel`, `_training`, `_data`), splitting the **eager import block** along work-stream lines.
- Each fragment owns its eager imports + `__all__`, and its slice of the lazy maps. `NAMES` is *derived* (`(*__all__, *LAZY_SUBMODULES, *LAZY_SYMBOLS)`), never hand-maintained.
- Both `__init__.py` keep the PEP-562 `__getattr__` **unchanged** and now hold **zero per-name content**: `core/__init__.py` 325 → 104 lines.
- `.gitattributes`: `merge=union` on the append-mostly fragments, with the aggregators explicitly reset to default 3-way merge (the `_*.py` glob would otherwise match `__init__.py`, where union would duplicate imports or split the `__getattr__` body). Verified with `git check-attr`.

- **`tests/test_export_fragments.py`** — the fragment contract, tested rather than trusted (added in response to the Sourcery review; see the review-response comment). Fragments are discovered via `pkgutil`, so new ones are covered automatically. **Every guard was verified by mutation** — each was seen to *fail* before being allowed to pass:

| Injected fault | Caught by |
|---|---|
| a name owned by two fragments (silent last-wins on `**`-merge) | `AssertionError: 'Resolver' is declared by BOTH ..._clustering and ..._resolver` |
| a core lazy symbol with no `[extra]` | `core lazy symbols without a [extra] hint: ['VectorBlocker']` |
| an `__all__` entry with no import | `AttributeError: module '..._blocking' has no attribute 'GhostBlocker'` (at import) |
| hand-edited `NAMES` | `test_names_is_derived_not_hand_maintained` |

  That last-but-one row matters: it's exactly the `merge=union` downside, and it dies **loudly at import**. The core-extra row closes a trap this refactor itself introduced — `core.__getattr__` does `_EXTRA_BY_SYMBOL[name]` (a direct index); the pre-split dict comprehension defaulted to `"semantic"` so totality was automatic, and explicit per-fragment extras removed that net.

**Adding an export now touches one fragment file.** Only a brand-new *domain* touches an aggregator.

## Zero behaviour change — the set-identity proof

A script captured the surface before and after (`__all__`, both lazy maps, the eager/lazy split, `dir()`) and diffed them:

```
IDENTICAL  core_all                 (103 names)
IDENTICAL  core_eager_names         <- the eager/lazy split is preserved exactly
IDENTICAL  core_extra_by_symbol
IDENTICAL  core_lazy_submodules
IDENTICAL  core_lazy_symbols
IDENTICAL  root_all                 (36 names)
IDENTICAL  root_eager_names
IDENTICAL  root_extra_by_symbol
IDENTICAL  root_lazy_symbols
DIFF       core_dir: only-before=['TYPE_CHECKING'] only-after=['_exports']
DIFF       root_dir: only-before=['TYPE_CHECKING'] only-after=['_exports']

PUBLIC SURFACE SET-IDENTICAL: True
```

The only movement is in `dir()`, and only in **private** names not in `__all__`:
- `-TYPE_CHECKING` — an accidental re-export of the `typing` helper (the `TYPE_CHECKING` blocks moved into the fragments). Verified nothing references `langres.core.TYPE_CHECKING`.
- `+_exports` — the new private fragment package.

`core_eager_names` being identical is the load-bearing one: **no lazy import silently became eager**, and no eager one became lazy.

## Verification

- **`tests/test_import_budget.py` + `tests/test_public_surface_dod.py`: 37 passed, 12 skipped** — identical to the pre-change baseline (skips are uninstalled extras). The import-budget test is subprocess-based and is exactly what a broken lazy seam or an import cycle would trip.
- **`uv run mypy src/`: `Success: no issues found in 147 source files`.** (A first pass showed 9 errors both before *and* after — diffed error-for-error, zero new; they turned out to be artifacts of the extras being absent from a fresh venv, and vanish once `--all-extras` is installed.)
- **`uv run ruff format src/ && uv run ruff check src/`**: clean.
- **Full local suite (`uv run pytest`, all extras): 3574 passed, 4 skipped, 0 failed** (16m29s).
- **Clean-room check** — built the wheel and installed it into a fresh **core-only** venv (no extras), i.e. the real user path the local suite can't exercise (it has extras installed):
  ```
  import langres            : OK
  langres.__all__           : 36 names
  langres.core.__all__      : 103 names
  heavy modules leaked      : none
  eager surface works       : AllPairsBlocker / Resolver / dedupe
  lazy [semantic] hint      : langres.core.VectorBlocker requires the 'semantic' extra: pip install 'langres[semantic]'
  lazy [trained] hint       : langres.derive_threshold requires the 'trained' extra: pip install 'langres[trained]'
  ```
  All 19 fragment files ship in the wheel (hatchling auto-discovers the new subpackages).
- **CI: green, 0 failing checks** — lint, CodeQL, Analyze, build, test (3.13), test-core-only, test-finetune, Sourcery.

### The mechanism actually works (simulated two concurrent streams)

| Scenario | Result |
|---|---|
| **Old** design — 2 streams insert into one sorted `__all__` | **CONFLICT** (2 markers) |
| **New** — 2 streams → *different* fragments | **clean merge** |
| **New** — 2 streams → *same* fragment (`merge=union`) | **clean merge**, both names kept |

Union merge is safe here precisely because the fragments are append-mostly and aggregation is order-insensitive and de-duplicating (`sorted({...})` over every fragment's `NAMES`).

**The honest trade-off**, also documented in `.gitattributes`: union merge is not semantic. If one stream *removes* an export while another edits the same fragment, union resurrects the `__all__` entry without its import — and `from ._x import *` then raises `AttributeError` at import. That failure is **immediate and loud** (collection dies; the import-budget test is the gate), never silent corruption. Removals are rare; additions are the hot path.

## Notes for the reviewer

- mypy's re-export rules were **probed, not assumed**: star-import re-exports under `--strict` (which implies `no_implicit_reexport`), so `from langres.core import AllPairsBlocker` keeps type-checking. A modules-as-`Protocol` variant to collapse the composition was tried and **rejected** — mypy rejects a tuple of modules against a Protocol.
- Docs updated in the same change (`CLAUDE.md`, `docs/TECHNICAL_OVERVIEW.md`): contributors are pointed at the fragments, not the sorted `__all__`.
