### PR TITLE
refactor(core): promote ModelRef to core/ with a re-export shim

### DIFF
--- a/src/langres/core/finetune.py
+++ b/src/langres/core/finetune.py
@@ -2,7 +2,7 @@
 
 The standalone training primitive of the training surface: given labeled candidate
 pairs, fine-tune a small base LM (LoRA / 4-bit QLoRA) to answer the yes/no match
-prompt, and return a :class:`~langres.core.matchers.model_ref.ModelRef` (base +
+prompt, and return a :class:`~langres.core.model_ref.ModelRef` (base +
 adapter) that the existing :class:`~langres.core.matchers.llm_judge.LLMMatcher`
 serves in-process — no new matcher class, no Resolver. ``Resolver.fit(...,
 method=QLoRA(...))`` wraps this (see ``Resolver._fit_finetune``).
@@ -32,7 +32,7 @@ from typing import TYPE_CHECKING, Any, Protocol
 
 from pydantic import Field
 
-from langres.core.matchers.model_ref import ModelRef, normalize_model_ref
+from langres.core.model_ref import ModelRef, normalize_model_ref
 from langres.core.methods_api import Method
 
 if TYPE_CHECKING:
@@ -289,7 +289,7 @@ def finetune(
     """Fine-tune ``method.base`` on labeled ``pairs`` → a weightless ``model_ref``.
 
     The standalone primitive (plan example 3): returns a
-    :class:`~langres.core.matchers.model_ref.ModelRef` you serve through
+    :class:`~langres.core.model_ref.ModelRef` you serve through
     ``LLMMatcher(model=ref)`` (in-process) or ``vllm serve`` — NOT a Resolver, NOT
     a new component. Use :func:`run_finetune` instead when you also want the cost
     digest (GPU-seconds / dollars / merge status); ``Resolver.fit(...,

--- a/src/langres/core/fit_report.py
+++ b/src/langres/core/fit_report.py
@@ -84,7 +84,7 @@ class FitReport(BaseModel):
         model_ref: The weightless model reference a fine-tune produced (a base id
             / local dir string, or a ``{base, adapter}`` dict whose shape also
             encodes merge status), else ``None``. Serialize with
-            :func:`~langres.core.matchers.model_ref.to_config`.
+            :func:`~langres.core.model_ref.to_config`.
         calibration: Before-vs-after Brier/ECE for a ``method="calibrate"`` fit
             (on the ``valid`` split), else ``None``.
         run_ref: The enclosing run's ``attempt_id`` (lineage reference to the

--- a/src/langres/core/matchers/llm_judge.py
+++ b/src/langres/core/matchers/llm_judge.py
@@ -26,7 +26,7 @@ except ImportError:
     RateLimitError = Exception
 
 from langres.clients.openrouter import parse_openrouter_billing
-from langres.core.matchers.model_ref import ModelRef, normalize_model_ref, to_config
+from langres.core.model_ref import ModelRef, normalize_model_ref, to_config
 from langres.core.models import ERCandidate, PairwiseJudgement
 from langres.core.matcher import Matcher, SchemaT
 from langres.core.registry import register
@@ -512,7 +512,7 @@ class LLMMatcher(Matcher[SchemaT]):
                 first use. Inject a client only as an escape hatch (e.g. tests
                 or a custom client); use :meth:`from_env` for the happy path.
             model: The model to run, as a *weightless reference* (see
-                :class:`~langres.core.matchers.model_ref.ModelRef`):
+                :class:`~langres.core.model_ref.ModelRef`):
 
                 - an API model name — ``"gpt-5-mini"``, ``"azure/gpt-5-mini"``,
                   ``"openrouter/..."`` — served over the wire via litellm;

--- a/src/langres/core/matchers/model_ref.py
+++ b/src/langres/core/matchers/model_ref.py
@@ -1,82 +1,11 @@
-"""``ModelRef``: normalize a model reference for the serve / finetune paths.
+"""Back-compat shim: ``ModelRef`` moved to :mod:`langres.core.model_ref`.
 
-A *model reference* names WHICH model an :class:`~langres.core.matchers.llm_judge.LLMMatcher`
-(and, later, ``finetune()``) should run, in one of three forms:
-
-- an **HF Hub id** (``"your-org/your-ft-model"``) or a **local directory path** —
-  a self-contained (base or already-merged) model, and
-- a **base + PEFT adapter** pair (``{"base": ..., "adapter": ...}``) — a QLoRA
-  fine-tune served *without* merging the adapter into the base weights.
-
-It is **weightless by construction**: a ``ModelRef`` is a small pair of
-*reference strings*, never weight bytes, so it round-trips through
-``Resolver.save`` / ``load`` as plain JSON config (:func:`to_config`). This
-module is deliberately import-light (stdlib only — no torch / transformers) so a
-bare ``import langres`` and the matcher's own import stay heavy-dependency free;
-the actual weights are loaded lazily by the in-process backend on first use.
+It is a weightless *contract* (stdlib-only, round-trips as JSON config), not a
+matcher -- so it now lives in ``core/`` beside the other contracts. This shim
+keeps the old import path working; it is removed in the architecture refactor's
+final wave.
 """
 
-from __future__ import annotations
+from langres.core.model_ref import ModelRef, normalize_model_ref, to_config
 
-from dataclasses import dataclass
-
-
-@dataclass(frozen=True)
-class ModelRef:
-    """A normalized, weightless reference to a served/local model.
-
-    ``base`` is the HF Hub id or local directory of the (base or merged) model;
-    ``adapter`` is an optional PEFT-adapter HF id / local dir applied on top of
-    ``base`` at load time (QLoRA served unmerged). ``adapter is None`` is the
-    self-contained case.
-    """
-
-    base: str
-    adapter: str | None = None
-
-
-def normalize_model_ref(model: str | dict[str, str] | ModelRef) -> ModelRef:
-    """Coerce a user-supplied model reference into a :class:`ModelRef`.
-
-    Accepts the three surface forms and validates them:
-
-    - ``str`` — an HF Hub id, a local dir, OR an API model name (e.g.
-      ``"gpt-5-mini"``, ``"openrouter/..."``). All become ``ModelRef(base=model)``;
-      the *routing* decision (in-process vs served API) is the matcher's, not
-      this normalizer's — here we only carve out a canonical shape.
-    - ``dict`` — must carry a non-empty ``"base"``; ``"adapter"`` is optional.
-    - :class:`ModelRef` — returned unchanged (idempotent).
-
-    Raises:
-        ValueError: An empty string, a dict missing/with an empty ``"base"``, or a
-            non-string ``"adapter"``.
-        TypeError: Any other type.
-    """
-    if isinstance(model, ModelRef):
-        return model
-    if isinstance(model, str):
-        if not model:
-            raise ValueError("model string must be non-empty")
-        return ModelRef(base=model)
-    if isinstance(model, dict):
-        base = model.get("base")
-        if not isinstance(base, str) or not base:
-            raise ValueError(f"model dict must carry a non-empty string 'base'; got {model!r}")
-        adapter = model.get("adapter")
-        if adapter is not None and not isinstance(adapter, str):
-            raise ValueError(f"model dict 'adapter' must be a string or absent; got {adapter!r}")
-        return ModelRef(base=base, adapter=adapter)
-    raise TypeError(f"model must be a str, dict, or ModelRef; got {type(model).__name__}")
-
-
-def to_config(ref: ModelRef) -> str | dict[str, str]:
-    """Serialize a :class:`ModelRef` for ``config`` (the inverse of :func:`normalize_model_ref`).
-
-    A self-contained ref (``adapter is None``) serializes to its bare ``base``
-    string — **byte-identical to the pre-model_ref string config**, so existing
-    saved artifacts and their round-trips are unchanged. Only the base+adapter
-    case widens to a ``{"base": ..., "adapter": ...}`` dict.
-    """
-    if ref.adapter is None:
-        return ref.base
-    return {"base": ref.base, "adapter": ref.adapter}
+__all__ = ["ModelRef", "normalize_model_ref", "to_config"]

--- a/src/langres/core/matchers/transformers_backend.py
+++ b/src/langres/core/matchers/transformers_backend.py
@@ -20,7 +20,7 @@ import threading
 from dataclasses import dataclass
 from typing import Any
 
-from langres.core.matchers.model_ref import ModelRef
+from langres.core.model_ref import ModelRef
 
 # ---------------------------------------------------------------------------
 # Minimal LiteLLM/OpenAI-shaped response objects.

--- a/src/langres/core/model_ref.py
+++ b/src/langres/core/model_ref.py
@@ -1,0 +1,82 @@
+"""``ModelRef``: normalize a model reference for the serve / finetune paths.
+
+A *model reference* names WHICH model an :class:`~langres.core.matchers.llm_judge.LLMMatcher`
+(and, later, ``finetune()``) should run, in one of three forms:
+
+- an **HF Hub id** (``"your-org/your-ft-model"``) or a **local directory path** —
+  a self-contained (base or already-merged) model, and
+- a **base + PEFT adapter** pair (``{"base": ..., "adapter": ...}``) — a QLoRA
+  fine-tune served *without* merging the adapter into the base weights.
+
+It is **weightless by construction**: a ``ModelRef`` is a small pair of
+*reference strings*, never weight bytes, so it round-trips through
+``Resolver.save`` / ``load`` as plain JSON config (:func:`to_config`). This
+module is deliberately import-light (stdlib only — no torch / transformers) so a
+bare ``import langres`` and the matcher's own import stay heavy-dependency free;
+the actual weights are loaded lazily by the in-process backend on first use.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class ModelRef:
+    """A normalized, weightless reference to a served/local model.
+
+    ``base`` is the HF Hub id or local directory of the (base or merged) model;
+    ``adapter`` is an optional PEFT-adapter HF id / local dir applied on top of
+    ``base`` at load time (QLoRA served unmerged). ``adapter is None`` is the
+    self-contained case.
+    """
+
+    base: str
+    adapter: str | None = None
+
+
+def normalize_model_ref(model: str | dict[str, str] | ModelRef) -> ModelRef:
+    """Coerce a user-supplied model reference into a :class:`ModelRef`.
+
+    Accepts the three surface forms and validates them:
+
+    - ``str`` — an HF Hub id, a local dir, OR an API model name (e.g.
+      ``"gpt-5-mini"``, ``"openrouter/..."``). All become ``ModelRef(base=model)``;
+      the *routing* decision (in-process vs served API) is the matcher's, not
+      this normalizer's — here we only carve out a canonical shape.
+    - ``dict`` — must carry a non-empty ``"base"``; ``"adapter"`` is optional.
+    - :class:`ModelRef` — returned unchanged (idempotent).
+
+    Raises:
+        ValueError: An empty string, a dict missing/with an empty ``"base"``, or a
+            non-string ``"adapter"``.
+        TypeError: Any other type.
+    """
+    if isinstance(model, ModelRef):
+        return model
+    if isinstance(model, str):
+        if not model:
+            raise ValueError("model string must be non-empty")
+        return ModelRef(base=model)
+    if isinstance(model, dict):
+        base = model.get("base")
+        if not isinstance(base, str) or not base:
+            raise ValueError(f"model dict must carry a non-empty string 'base'; got {model!r}")
+        adapter = model.get("adapter")
+        if adapter is not None and not isinstance(adapter, str):
+            raise ValueError(f"model dict 'adapter' must be a string or absent; got {adapter!r}")
+        return ModelRef(base=base, adapter=adapter)
+    raise TypeError(f"model must be a str, dict, or ModelRef; got {type(model).__name__}")
+
+
+def to_config(ref: ModelRef) -> str | dict[str, str]:
+    """Serialize a :class:`ModelRef` for ``config`` (the inverse of :func:`normalize_model_ref`).
+
+    A self-contained ref (``adapter is None``) serializes to its bare ``base``
+    string — **byte-identical to the pre-model_ref string config**, so existing
+    saved artifacts and their round-trips are unchanged. Only the base+adapter
+    case widens to a ``{"base": ..., "adapter": ...}`` dict.
+    """
+    if ref.adapter is None:
+        return ref.base
+    return {"base": ref.base, "adapter": ref.adapter}

--- a/src/langres/core/resolver.py
+++ b/src/langres/core/resolver.py
@@ -869,7 +869,7 @@ class Resolver:
         """
         from langres.core.finetune import FINETUNE_YES_NO_PROMPT, QLoRA, run_finetune
         from langres.core.matchers.llm_judge import LLMMatcher
-        from langres.core.matchers.model_ref import to_config
+        from langres.core.model_ref import to_config
 
         if not isinstance(method, QLoRA):
             raise TypeError(

--- a/tests/core/matchers/test_model_ref.py
+++ b/tests/core/matchers/test_model_ref.py
@@ -88,3 +88,20 @@ def test_config_round_trip_is_weightless_and_stable(model: str | dict[str, str])
     # strings -- no bytes -- and re-normalizes to the identical ref.
     json.dumps(config_value)
     assert normalize_model_ref(config_value) == ref
+
+
+def test_old_matchers_path_re_exports_the_same_objects() -> None:
+    """The back-compat shim is a pure re-export -- not a second, divergent copy.
+
+    ``ModelRef`` now lives in ``langres.core.model_ref`` (it is a weightless
+    contract, not a matcher). Everything above imports it through the old
+    ``langres.core.matchers.model_ref`` path, so this asserts the two paths hand
+    back the *identical* objects -- an ``==``-only check would pass even if the
+    shim redefined its own class, which would break isinstance/round-trips.
+    """
+    from langres.core import model_ref as new_path
+    from langres.core.matchers import model_ref as shim
+
+    assert shim.ModelRef is new_path.ModelRef
+    assert shim.normalize_model_ref is new_path.normalize_model_ref
+    assert shim.to_config is new_path.to_config


### PR DESCRIPTION
## What

Moves `ModelRef` from `core/matchers/model_ref.py` to `core/model_ref.py` (via `git mv`, so history follows), leaving a **pure re-export shim** at the old path.

`ModelRef` is the right primitive in the wrong place. It is a **contract, not a matcher**: a weightless, stdlib-only frozen dataclass (`base`, `adapter`) that round-trips through `Resolver.save`/`load` as plain JSON config. Nothing about it is matcher-specific — `finetune.py` produces one, `resolver.py` serializes one, and `LLMMatcher` merely consumes one. It belongs in `core/` beside the other contracts.

## Why now (sequencing)

This is a pre-wave item to **decouple two later waves that would otherwise collide**:

- one wave moves `finetune.py` into a `training/` package,
- a different wave rewrites `finetune.py`'s `model_ref` import.

Same line, two branches = a guaranteed conflict. Landing the promotion + shim on `main` now means each wave rebases onto a single settled import path instead of resolving the same conflict twice.

## Zero behaviour change

Both import paths work and hand back the **same objects** — the shim re-exports, it does not redefine:

```
old.ModelRef            is new.ModelRef            ->  True
old.normalize_model_ref is new.normalize_model_ref ->  True
old.to_config           is new.to_config           ->  True

canonical module of ModelRef: langres.core.model_ref
isinstance(old-built ref, new.ModelRef): True
heavy deps in sys.modules after importing model_ref: none
```

The existing tests still import the **old** path on purpose — they are the shim's regression test. One test is added (`test_old_matchers_path_re_exports_the_same_objects`) asserting `is`-identity across both paths; an `==`-only check would pass even if the shim redefined its own class, which would quietly break `isinstance` and the config round-trip.

## Changes

- `git mv src/langres/core/matchers/model_ref.py -> src/langres/core/model_ref.py` (module body unchanged).
- Old path becomes a re-export shim (`ModelRef`, `normalize_model_ref`, `to_config`), documented as removed in the refactor's final wave.
- Retargeted the 4 in-tree `src/` importers: `core/finetune.py`, `core/matchers/transformers_backend.py`, `core/matchers/llm_judge.py`, and `core/resolver.py` (kept **function-local**, path only).
- Retargeted 4 docstring cross-refs naming the old module path (`finetune.py` x2, `llm_judge.py`, `fit_report.py`) so they don't dangle when the shim is deleted.

## Constraints honoured

- **Import-light preserved** — `model_ref` stays stdlib-only (no torch/transformers/litellm); no imports added. `tests/test_import_budget.py` green.
- **`ModelRef` is not exported from `core/__init__.py`** — it isn't today, and adding it would collide with the concurrent wave rewriting that file. Neither `core/__init__.py` nor `langres/__init__.py` is touched by this PR.

## Verification

- `tests/core/matchers/test_model_ref.py`, `test_finetune.py`, `test_finetune_capstone.py`, `tests/core/modules/test_llm_judge_serve.py` — **50 passed**
- `tests/test_import_budget.py`, `tests/test_public_surface_dod.py` — **45 passed, 4 skipped** (incl. `test_dod3_capstone_public_imports_resolve`, which imports `to_config` through the shim)
- `uv run mypy src/` — clean, 129 files
- `uv run ruff format` / `ruff check` — clean, zero reformats

## Summary by Sourcery

Promote the ModelRef contract from the matchers package into core while preserving backward-compatible imports via a pure re-export shim.

Enhancements:
- Centralize ModelRef, normalize_model_ref, and to_config in a new langres.core.model_ref module treated as a core contract rather than a matcher.
- Update in-tree imports and docstring cross-references to target the new core.model_ref location instead of the old matchers path.
- Add a regression test ensuring the legacy matchers.model_ref path re-exports the exact same objects to guarantee zero behavioral change.