### PR TITLE
test(tools): drop the sys.path hack via pytest pythonpath

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -216,7 +216,10 @@ exclude-newer = "2026-07-08"
 minversion = "6.0"
 addopts = "-v --cov=langres --cov-report=term-missing --cov-report=html --cov-fail-under=90 -m 'not integration and not finetune'"
 testpaths = ["tests"]
-pythonpath = ["src"]
+# "tools" puts the repo's dev instruments (tools/import_graph.py) on the path so
+# tests/test_import_graph.py can import them without a sys.path hack. They are
+# tooling, not shipped library code, so they stay out of src/.
+pythonpath = ["src", "tools"]
 markers = [
     "slow: marks tests as slow running (e.g., embedding models, ML inference)",
     "integration: marks tests that require external API credentials or resources. DO NOT use for testcontainer database tests (fast enough for continuous testing).",

--- a/tests/test_import_graph.py
+++ b/tests/test_import_graph.py
@@ -11,15 +11,12 @@ from __future__ import annotations
 
 import json
 import re
-import sys
 from pathlib import Path
 
 import pytest
 
-TOOLS = Path(__file__).resolve().parent.parent / "tools"
-sys.path.insert(0, str(TOOLS))
-
-from import_graph import (  # noqa: E402
+# `tools` is on the path via [tool.pytest.ini_options] pythonpath in pyproject.toml.
+from import_graph import (
     DEFAULT_PACKAGE_ROOT,
     ImportKind,
     MappingError,
@@ -29,6 +26,8 @@ from import_graph import (  # noqa: E402
     counterfactual,
     main,
 )
+
+TOOLS = Path(__file__).resolve().parent.parent / "tools"
 
 
 @pytest.fixture(scope="module")


### PR DESCRIPTION
Follow-up to #171 (merged): the last open Sourcery finding on the import-graph tool.

## What

Sourcery flagged that `tests/test_import_graph.py` mutated `sys.path` to import from `tools/`. Uses pytest's own seam instead — `pythonpath = ["src", "tools"]` in `[tool.pytest.ini_options]` — and drops the path mutation plus its `noqa: E402`.

`tools/` holds dev instruments, not shipped library code, so it stays out of `src/`; `pythonpath` is the idiomatic way to make it importable from tests without a hack.

Verified: 46 tests pass, the CLI still runs standalone (`uv run python tools/import_graph.py fan`), ruff + mypy clean.

## One Sourcery finding deliberately not taken

> *"tools/import_graph.py has grown into a fairly large, multi-responsibility module; consider splitting the core graph/counterfactual logic into a separate library module and keeping the CLI thin."*

Skipped on purpose. It is a ~400-line single-purpose instrument with exactly one consumer, and the repo's own Simplicity First rule is explicit: *"No abstractions for single-use code… composability is earned by real reuse, not anticipated."* The CLI is already a clearly delimited section. Worth revisiting the moment a second consumer appears — e.g. if the W0 import-linter contract wants to import the graph builder directly.

The other two findings (the `ast.dump` TYPE_CHECKING substring match; `PackageMapping.from_json` validation) landed in #171 as `07aa65a`.

## Summary by Sourcery

Use pytest's pythonpath configuration to make the import_graph tool importable from tests without mutating sys.path.

Enhancements:
- Simplify test setup by relying on pytest's configured pythonpath instead of manual sys.path manipulation.

Build:
- Adjust pytest configuration in pyproject.toml to add the tools directory to pythonpath alongside src.

Tests:
- Update import_graph tests to import the tool module directly, removing the sys.path hack and related noqa comment.