### PR TITLE
test(arch): W0 import-tangle ratchet (SCC membership, not mutual pairs)

### DIFF
--- a/tests/test_import_tangle.py
+++ b/tests/test_import_tangle.py
@@ -3,23 +3,37 @@
 The architecture refactor's central risk is that a wave couples two more modules
 together and no gate notices. That is not hypothetical -- **PR #169** (the
 ``core/__init__`` fragment split) grew the module SCC from **29 to 43** and the
-package SCC from **8 to 9**, and CI stayed green the whole way. This file is the
+runtime SCC from **5 to 12**, and CI stayed green the whole way. This file is the
 gate that would have caught it.
 
 Why SCC membership, and not "mutual pairs"
 ------------------------------------------
 The obvious metric -- count the pairs of modules that import each other -- is
-**gameable by pure re-export indirection**, and PR #169 proves it. Across that
-same merge the mutual-pair count went *down* (4 -> 3) while nothing whatsoever was
-decoupled: the knot ``langres <-> langres.core`` "disappeared" only because
-``langres/__init__`` now reaches core via ``langres._exports``. A 2-cycle became a
-3-cycle. Same loop, one more relay on it -- and a mutual-pair ratchet would have
-scored that merge as an *improvement*.
+**worse than useless here**, and PR #169 proves it. Measured across that merge
+(``tools/import_graph.py`` run against ``858d605^1`` and ``858d605``):
+
+===========================  ==========  ===========
+metric                       pre #169    post #169
+===========================  ==========  ===========
+modules in a cycle (all)     34          48
+largest SCC (all edges)      29          43
+largest SCC (runtime)        5           12
+**mutual pairs**             **6**       **6**
+===========================  ==========  ===========
+
+The mutual-pair count did not merely go down -- it did not move *at all*. The
+same six pairs, before and after, while the runtime tangle more than doubled. The
+knot ``langres <-> langres.core`` stopped being a mutual pair only because
+``langres/__init__`` now reaches core via ``langres._exports``: a 2-cycle became a
+3-cycle. Same loop, one more relay on it. (At the *package* level the metric is
+actively perverse -- it improves, 4 -> 3.) A mutual-pair ratchet would have waved
+PR #169 through without a flicker.
 
 So this gate counts **membership of a strongly connected component**: the set of
 modules you cannot untangle from each other, however many hops the loop takes.
 Adding a relay module to a cycle makes that set *bigger*, never smaller. That is
-the property that makes the ratchet honest.
+the property that makes the ratchet honest, and it is why no metric here counts
+edges or pairs.
 
 The two views, and why both are pinned
 --------------------------------------

--- a/tests/test_import_tangle.py
+++ b/tests/test_import_tangle.py
@@ -107,14 +107,10 @@ per-PR ``test`` job (``.github/workflows/test.yml``), not just ``test-full``.
 
 from __future__ import annotations
 
-import sys
 from dataclasses import dataclass
-from pathlib import Path
 
-TOOLS = Path(__file__).resolve().parent.parent / "tools"
-sys.path.insert(0, str(TOOLS))
-
-from import_graph import ImportKind, build_graph  # noqa: E402
+# `tools` is on the path via [tool.pytest.ini_options] pythonpath in pyproject.toml.
+from import_graph import ImportKind, build_graph
 
 
 @dataclass(frozen=True, slots=True)

--- a/tests/test_import_tangle.py
+++ b/tests/test_import_tangle.py
@@ -1,0 +1,273 @@
+"""Import-tangle ratchet: the cyclic core of the import graph must not grow.
+
+The architecture refactor's central risk is that a wave couples two more modules
+together and no gate notices. That is not hypothetical -- **PR #169** (the
+``core/__init__`` fragment split) grew the module SCC from **29 to 43** and the
+package SCC from **8 to 9**, and CI stayed green the whole way. This file is the
+gate that would have caught it.
+
+Why SCC membership, and not "mutual pairs"
+------------------------------------------
+The obvious metric -- count the pairs of modules that import each other -- is
+**gameable by pure re-export indirection**, and PR #169 proves it. Across that
+same merge the mutual-pair count went *down* (4 -> 3) while nothing whatsoever was
+decoupled: the knot ``langres <-> langres.core`` "disappeared" only because
+``langres/__init__`` now reaches core via ``langres._exports``. A 2-cycle became a
+3-cycle. Same loop, one more relay on it -- and a mutual-pair ratchet would have
+scored that merge as an *improvement*.
+
+So this gate counts **membership of a strongly connected component**: the set of
+modules you cannot untangle from each other, however many hops the loop takes.
+Adding a relay module to a cycle makes that set *bigger*, never smaller. That is
+the property that makes the ratchet honest.
+
+The two views, and why both are pinned
+--------------------------------------
+``tools/import_graph.py`` classifies each import as toplevel / function-local /
+TYPE_CHECKING, which lets us gate two genuinely different graphs:
+
+* **runtime** (toplevel edges only) -- what actually executes on ``import
+  langres``. This is the graph ``tests/test_import_budget.py`` protects.
+* **all-edges** -- what grimp/import-linter would see. They cannot distinguish a
+  lazy function-body import from an eager one (grimp's ``DirectImport`` carries no
+  scope field), so every deliberate lazy-extras seam counts as a real edge here.
+
+The two numbers are far apart (12 vs 43) precisely *because* langres uses lazy
+imports on purpose. Pinning only one would hide half the tangle.
+
+Per view we pin two complementary facts, and both are load-bearing:
+
+* ``tangled`` -- every module in *any* cycle. Catches a module joining a cycle,
+  and catches a brand-new cycle appearing somewhere else entirely (which a
+  largest-SCC-only gate would miss).
+* ``largest_scc`` -- the biggest single component. Catches two existing cycles
+  *merging* (membership unchanged, structure worse), which ``tangled`` misses.
+
+Ratchet down, never up
+----------------------
+The assertion is **exact equality**, not ``<=``. That is deliberate and it is the
+asymmetry that makes this a ratchet:
+
+* **Lowering a baseline is a normal PR.** Decouple something, the test fails
+  telling you the new number, you commit it. Two lines in a diff.
+* **Raising a baseline is a deliberate act** that must be argued for in review,
+  with a comment saying why the coupling is worth it.
+
+``<=`` would quietly rot: an improvement to 40 that nobody records leaves the gate
+still accepting 43, so a later regression back to 43 sails through green. Exact
+equality keeps the committed number equal to the truth, always.
+
+Cost: pure AST parsing, no imports executed, no network, ~1s. It runs in the
+per-PR ``test`` job (``.github/workflows/test.yml``), not just ``test-full``.
+"""
+
+from __future__ import annotations
+
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+
+TOOLS = Path(__file__).resolve().parent.parent / "tools"
+sys.path.insert(0, str(TOOLS))
+
+from import_graph import ImportKind, build_graph  # noqa: E402
+
+
+@dataclass(frozen=True, slots=True)
+class TangleBaseline:
+    """The committed, measured shape of one view of the import graph.
+
+    `kinds` is the edge filter handed to ``ImportGraph.sccs`` -- ``None`` means
+    every edge (the grimp/import-linter view).
+    """
+
+    view: str
+    kinds: tuple[ImportKind, ...] | None
+    largest_scc: int
+    tangled: frozenset[str]
+
+
+# ---------------------------------------------------------------------------
+# THE BASELINES. Measured on ba4b1b7 (PR #171 merge) with:
+#     uv run python tools/import_graph.py kinds
+# Lower these freely when you decouple something -- that is the ratchet working.
+# RAISING either number means your change coupled the codebase further: say why,
+# in a comment, right here, and expect review to push back.
+# ---------------------------------------------------------------------------
+
+# Runtime view: 12 modules, one cycle. This is the export-fragment knot --
+# `langres/__init__` -> `_exports/*` -> `core` -> `core/_exports/*` -> `resolver`
+# -> `presets` and back up to `verbs`. Every one of these executes on a bare
+# `import langres`.
+RUNTIME = TangleBaseline(
+    view="runtime (toplevel edges only -- what `import langres` executes)",
+    kinds=(ImportKind.TOPLEVEL,),
+    largest_scc=12,
+    tangled=frozenset(
+        {
+            "langres",
+            "langres._exports",
+            "langres._exports._core",
+            "langres._exports._flywheel",
+            "langres._exports._training",
+            "langres._exports._verbs",
+            "langres.core",
+            "langres.core._exports",
+            "langres.core._exports._resolver",
+            "langres.core.presets",
+            "langres.core.resolver",
+            "langres.verbs",
+        }
+    ),
+)
+
+# All-edges view: 48 modules across three cycles, the largest being 43. The other
+# two are small and independent: {core.analysis, core.reports, plotting.blockers}
+# and {core.runs, core.trackers}. `tangled` covers all three; `largest_scc` pins
+# the 43 so those cycles cannot silently merge into it.
+ALL_EDGES = TangleBaseline(
+    view="all-edges (incl. lazy/TYPE_CHECKING -- what grimp/import-linter sees)",
+    kinds=None,
+    largest_scc=43,
+    tangled=frozenset(
+        {
+            "langres",
+            "langres._exports",
+            "langres._exports._core",
+            "langres._exports._data",
+            "langres._exports._flywheel",
+            "langres._exports._optimize",
+            "langres._exports._training",
+            "langres._exports._verbs",
+            "langres.clients.openrouter",
+            "langres.core",
+            "langres.core._exports",
+            "langres.core._exports._clustering",
+            "langres.core._exports._eval",
+            "langres.core._exports._flywheel",
+            "langres.core._exports._matchers",
+            "langres.core._exports._methods",
+            "langres.core._exports._resolver",
+            "langres.core.analysis",
+            "langres.core.anchor_store",
+            "langres.core.benchmark",
+            "langres.core.eval_report",
+            "langres.core.finetune",
+            "langres.core.judgement_log",
+            "langres.core.matchers.cascade",
+            "langres.core.matchers.cascade_judge",
+            "langres.core.matchers.llm_judge",
+            "langres.core.method_registry",
+            "langres.core.presets",
+            "langres.core.reports",
+            "langres.core.resolver",
+            "langres.core.runs",
+            "langres.core.trackers",
+            "langres.data.data_profile",
+            "langres.data.data_profile.base",
+            "langres.data.data_profile.builders",
+            "langres.data.data_profile.corpus_field",
+            "langres.data.data_profile.embedding_section",
+            "langres.data.data_profile.embedding_source",
+            "langres.data.data_profile.failure_mode",
+            "langres.data.data_profile.hero",
+            "langres.data.data_profile.label_structure",
+            "langres.data.data_profile.mining_readiness",
+            "langres.data.data_profile.separability",
+            "langres.data.registry",
+            "langres.methods",
+            "langres.optimize",
+            "langres.plotting.blockers",
+            "langres.verbs",
+        }
+    ),
+)
+
+
+def _bullet(modules: list[str]) -> str:
+    return "\n".join(f"      {m}" for m in modules)
+
+
+def _report(base: TangleBaseline, sccs: list[list[str]]) -> str | None:
+    """The failure report for `base`, or None if the graph still matches it.
+
+    Says which modules moved and in which direction, because "43 != 44" tells the
+    person who broke it nothing about what they broke.
+    """
+    tangled = frozenset(m for scc in sccs for m in scc)
+    largest = max((len(s) for s in sccs), default=0)
+    entered = sorted(tangled - base.tangled)
+    left = sorted(base.tangled - tangled)
+    if not entered and not left and largest == base.largest_scc:
+        return None
+
+    worse = len(tangled) > len(base.tangled) or largest > base.largest_scc
+    headline = "IMPORT TANGLE GREW" if worse else "IMPORT TANGLE CHANGED"
+    lines = [
+        f"{headline} -- view: {base.view}",
+        "",
+        f"  modules in a cycle : {len(base.tangled)} (baseline) -> {len(tangled)} (now)",
+        f"  largest SCC        : {base.largest_scc} (baseline) -> {largest} (now)",
+        f"  cycles now         : {sorted((len(s) for s in sccs), reverse=True)}",
+    ]
+    if entered:
+        lines += [
+            "",
+            f"  ENTERED the tangle ({len(entered)}) -- your change coupled these into a cycle:",
+            _bullet(entered),
+        ]
+    if left:
+        lines += [
+            "",
+            f"  LEFT the tangle ({len(left)}) -- these are now decoupled:",
+            _bullet(left),
+        ]
+    lines += [
+        "",
+        "  Trace any of them with:",
+        "      uv run python tools/import_graph.py cycles --toplevel-only"
+        if base.kinds
+        else "      uv run python tools/import_graph.py cycles",
+        f"      uv run python tools/import_graph.py importers {(entered or left or ['<module>'])[0]}",
+        "",
+    ]
+    if worse:
+        lines += [
+            "  This is the regression PR #169 shipped unnoticed. Prefer breaking the",
+            "  coupling over raising the baseline. If the coupling really is worth it,",
+            "  raise the number in tests/test_import_tangle.py AND say why in a comment.",
+        ]
+    else:
+        lines += [
+            "  You decoupled something -- nice. Ratchet it DOWN: update largest_scc /",
+            "  tangled in tests/test_import_tangle.py to the numbers above, so the gate",
+            "  holds the new ground.",
+        ]
+    return "\n".join(lines)
+
+
+def _check(base: TangleBaseline) -> None:
+    sccs = build_graph().sccs(base.kinds)
+    report = _report(base, sccs)
+    assert report is None, report
+
+
+def test_runtime_import_tangle_does_not_grow() -> None:
+    """The toplevel-only SCC -- the cycle a bare ``import langres`` really executes."""
+    _check(RUNTIME)
+
+
+def test_all_edges_import_tangle_does_not_grow() -> None:
+    """The SCC incl. lazy/TYPE_CHECKING edges -- what grimp/import-linter would see."""
+    _check(ALL_EDGES)
+
+
+def test_runtime_tangle_is_a_subset_of_the_all_edges_tangle() -> None:
+    """Sanity-check the two baselines against each other.
+
+    Every toplevel edge is also an all-edges edge, so a module tangled at runtime
+    is necessarily tangled under the wider view. If this ever fails, a baseline
+    above was hand-edited to something the tool never measured.
+    """
+    assert RUNTIME.tangled <= ALL_EDGES.tangled
+    assert RUNTIME.largest_scc <= ALL_EDGES.largest_scc

--- a/tests/test_import_tangle.py
+++ b/tests/test_import_tangle.py
@@ -71,6 +71,36 @@ asymmetry that makes this a ratchet:
 still accepting 43, so a later regression back to 43 sails through green. Exact
 equality keeps the committed number equal to the truth, always.
 
+Why not import-linter (yet)
+---------------------------
+Measured against import-linter 2.13 / grimp 3.15, not assumed:
+
+* **grimp cannot see the runtime view at all.** ``DirectImport``
+  (``grimp/domain/valueobjects.py``) carries only importer/imported/line -- no
+  scope field. ``exclude_type_checking_imports`` exists (top-level
+  ``[tool.importlinter]`` only), but there is **no equivalent for function-local
+  imports**: ``def build(): import faiss`` is recorded as a plain edge. langres
+  has 63 function-local edges and 102 edges that exist *only* lazily -- the
+  deliberate extras seam that ``tests/test_import_budget.py`` mandates. So a
+  ``forbidden`` contract on the heavy deps would fire on the architecture working
+  as designed, and import-linter could only ever gate the 43 view, never the 12.
+* **A ``layers`` contract is not writable today.** ``layers.py`` raises
+  ``ValueError: Missing layer ... does not exist`` -- a hard crash, not a report
+  -- and the target packages don't exist yet. Their order isn't decided either.
+* **The contracts that *are* true today are not useful.** Only ``cli``, ``eval``,
+  ``testing``, ``bootstrap`` and ``_method_names`` sit outside the package cycle;
+  an ``independence`` contract over those five would assert a regression nobody
+  could plausibly commit. Everything worth gating is already gated, and better:
+  cycles by this file (both views), eager-heavy-imports by
+  ``test_import_budget.py`` (which executes the import and reads ``sys.modules``
+  -- ground truth, zero false positives on lazy seams).
+
+import-linter earns its place when the refactor's target packages exist and their
+order is decided: a ``layers`` contract then asserts *direction*, which this gate
+deliberately does not. Until then ``tools/import_graph.py counterfactual
+--mapping ...`` answers "what would this split do to the cycles?" with no new
+dependency.
+
 Cost: pure AST parsing, no imports executed, no network, ~1s. It runs in the
 per-PR ``test`` job (``.github/workflows/test.yml``), not just ``test-full``.
 """


### PR DESCRIPTION
## Why

The refactor's central risk is that a wave makes the import tangle worse and no gate notices. **PR #169 did exactly that** — and CI was green the whole way.

Adds `tests/test_import_tangle.py`: a ratchet on **SCC membership**, built on the merged `tools/import_graph.py` (no second graph tool).

## The critical finding, verified independently

I ran `tools/import_graph.py` against `858d605^1` and `858d605` (the #169 merge) rather than restating the claim. At **module** level the mutual-pairs metric is not merely gameable — **it is blind**:

| metric | pre #169 | post #169 |
|---|---|---|
| modules in a cycle (all edges) | 34 | **48** |
| largest SCC (all edges) | 29 | **43** |
| largest SCC (runtime) | 5 | **12** |
| **mutual pairs** | **6** | **6** ← did not move |

The identical six pairs before and after, while the runtime tangle **more than doubled**. `langres <-> langres.core` stopped being a mutual pair only because `langres/__init__` now reaches core via `langres._exports` — a 2-cycle became a 3-cycle. Same loop, one more relay. At *package* level the metric is actively perverse (4 → 3, an "improvement"). A mutual-pair ratchet would have waved #169 through without a flicker.

Adding a relay to a cycle makes its SCC **bigger**, never smaller. That is why this gate counts SCC membership and no metric here counts edges or pairs.

> **Not previously recorded:** the runtime SCC went **5 → 12** across #169 — worse in relative terms than the headline 29 → 43, and it is the view that backs the import-budget/spend-safety guarantee.

## What it gates

Measured on `ba4b1b7`; **matches the reported 43/12 exactly**.

- **runtime** (toplevel-only) — largest SCC `12`, tangled `12`
- **all-edges** (grimp/import-linter view) — largest SCC `43`, tangled `48` (cycles `[43, 3, 2]`)

Per view it pins two complementary facts, both load-bearing:
- `tangled` — every module in *any* cycle. Catches a module joining a cycle, **and** a brand-new cycle appearing elsewhere (which a largest-SCC-only gate misses).
- `largest_scc` — catches two existing cycles **merging** (membership unchanged, structure worse), which `tangled` misses.

**Exact equality, not `<=`** — this is the ratchet asymmetry. `<=` rots: an unrecorded improvement to 40 leaves the gate accepting 43, so a later regression back to 43 stays green. Lowering a baseline is a normal two-line PR; raising one must be argued for in a comment.

## Proof it bites

One-line coupling (`clusterer.py` importing `langres.verbs`) — note it correctly reports **3** modules entering from a **1-line** edit:

```
IMPORT TANGLE GREW -- view: runtime (toplevel edges only -- what `import langres` executes)

  modules in a cycle : 12 (baseline) -> 15 (now)
  largest SCC        : 12 (baseline) -> 15 (now)
  cycles now         : [15]

  ENTERED the tangle (3) -- your change coupled these into a cycle:
      langres.core._exports._clustering
      langres.core.clusterer
      langres.core.clusterers.correlation

  Trace any of them with:
      uv run python tools/import_graph.py cycles --toplevel-only
      uv run python tools/import_graph.py importers langres.core._exports._clustering

  This is the regression PR #169 shipped unnoticed. Prefer breaking the
  coupling over raising the baseline. ...
```

The down direction reports `LEFT the tangle` + "Ratchet it DOWN". Breakage reverted; tree clean.

## Decision: do NOT add import-linter yet

Investigated against **import-linter 2.13 / grimp 3.15** (via `uv run --with`, pyproject untouched). The concern about `layers` being premature is correct, and there is a **stronger** reason:

1. **grimp cannot see the runtime view at all.** `DirectImport` (`grimp/domain/valueobjects.py:49-57`) carries only importer/imported/line — **no scope field**. `exclude_type_checking_imports` exists (top-level `[tool.importlinter]` only; setting it per-contract is **silently ignored**), but there is **no equivalent for function-local imports**. Verified end-to-end: `def build(): import faiss` under a `forbidden` contract with the flag on → `BROKEN`. langres has **63 function-local edges** / **102 lazy-only edges** — the seam `test_import_budget.py` *mandates*. import-linter would fight the architecture, and could only ever gate the 43 view, never the 12.
2. **`layers` is not writable today.** `layers.py:235-246` raises `ValueError: Missing layer ... does not exist` — a hard crash, not a contract report. Target packages don't exist; order undecided. (`(parens)` = optional exists, but an all-optional contract asserts nothing.)
3. **The contracts that *are* true today aren't useful.** Only 5 of 14 subpackages sit outside the cycle (`cli`, `eval`, `testing`, `bootstrap`, `_method_names`); an `independence` contract over them guards a regression nobody could plausibly commit. `testing` and `_method_names` are already covered by `test_import_budget.py`.

Everything worth gating is already gated, and **more precisely**: cycles by this file (both views), eager-heavy-imports by `test_import_budget.py` — which *executes* the import and reads `sys.modules` (ground truth, zero false positives on lazy seams) rather than statically approximating it.

**When it should land:** once the target packages exist and their order is decided — `layers` then asserts *direction*, which this gate deliberately does not. Until then `tools/import_graph.py counterfactual --mapping ...` already answers "what would this split do to the cycles?" with no new dependency.

## Cost / CI placement

Pure AST, `$0`, no network, **0.6s**. Unmarked → picked up by the per-PR **`test`** job (`pytest -m "not integration and not slow and not finetune"`), not just `test-full`. Verified.

## Verification

- `uv run pytest -m "not integration and not slow and not finetune"` → **3625 passed, 4 skipped**
- `uv run ruff check .` → clean · `uv run ruff format --check .` → 415 files formatted
- `uv run mypy src` → **Success: no issues in 148 source files**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Add a CI test that ratchets the size of the import-cycle core to prevent architecture refactors from worsening module tangling.

Tests:
- Introduce tests that assert the runtime and all-edges import strongly connected components do not grow beyond recorded baselines.
- Add detailed failure reporting for import-tangle regressions, including which modules entered or left cycles and guidance on adjusting baselines.
- Verify that the runtime tangle is always a subset of the broader all-edges tangle to keep the two baselines consistent.