### PR TITLE
ci: close the W0 gates for the architecture refactor

### DIFF
--- a/.claude/rules/testing.md
+++ b/.claude/rules/testing.md
@@ -33,15 +33,29 @@ code. Verify as you go.** Read before writing tests or running the suite.
 - Mark slow tests with `@pytest.mark.slow`, integration tests with `@pytest.mark.integration`
   - **Mark any heavy test `@pytest.mark.slow`** (loads embedding/ML models, runs
     torch inference, etc.). CI runs the **fast** subset (`not slow`) on every
-    PR; the **slow** tests + the coverage gate run on **every merge to main
+    PR; the **slow** tests + the coverage gates run on **every merge to main
     (push)** + **on demand** (`workflow_dispatch`) via the `test-full` job. So
     per-PR CI does not gate coverage or exercise slow ML paths — mislabeling a
-    heavy test as fast slows every PR, and the coverage floor is verified on
+    heavy test as fast slows every PR, and the coverage floors are verified on
     each merge to main, not per-PR. Run the full suite locally
     (`uv run pytest`) before merging a change to ML/embedding code.
+    (While the architecture refactor is in flight, `test-full` also runs on
+    every merge to the `feat/arch-refactor` integration branch.)
 - Run tests: `uv run pytest` (pre-push hook runs non-slow, non-integration tests automatically)
 - Check coverage: `uv run pytest --cov`; keep `core/**` in the 95–100% tier
   (the repo-wide gate is a relaxed 90% floor — see `pyproject.toml`)
+- **Two gates run on `test-full`, and they are not the same number as this
+  policy.** The repo-wide floor is 90% (`--cov-fail-under` in `pyproject.toml`).
+  The `core` contract additionally has its own path-scoped gate
+  (`coverage report --include="src/langres/core/*" --precision=2
+  --fail-under=98` in `.github/workflows/test.yml`). That 98 is a **regression
+  ratchet** pinned just under the measured value (98.84% at `ba4b1b7`), not the
+  policy — the *target* remains 95–100%. It exists because the repo-wide 90%
+  floor sits ~9 points below actual coverage, so the contract could be quietly
+  declassified with CI green throughout. Raise it as the real number climbs; if
+  it blocks legitimate work, lower it deliberately rather than deleting it.
+  **When the contract moves to a new package, extend that `--include` glob** or
+  the gate silently stops covering it.
 - Type-check as you go: `uv run mypy src/`
 
 ## Development Workflow (Human-Like Iteration)

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,10 +1,17 @@
 name: Lint
 
 on:
+  # NOTE: `pull_request.branches` filters by TARGET branch -- a PR into a branch
+  # not listed here runs NO lint at all (no ruff, no mypy). Each integration
+  # branch has had to be added below; `feat/arch-refactor` is the architecture
+  # refactor's. mypy is the gate that catches exactly what a package split
+  # breaks (moved symbols, stale re-exports, circular imports), so a sub-PR
+  # landing there unlinted is the failure this list exists to prevent.
+  # TEMPORARY: drop `feat/arch-refactor` from both lists once the refactor lands.
   push:
-    branches: [main]
+    branches: [main, feat/arch-refactor]
   pull_request:
-    branches: [main, feat/m4-foundation, feat/m5-foundation, feat/tracking-observability, feat/autoresearch]
+    branches: [main, feat/m4-foundation, feat/m5-foundation, feat/tracking-observability, feat/autoresearch, feat/arch-refactor]
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -182,6 +182,44 @@ jobs:
           files: ./coverage.xml
           fail_ci_if_error: false
 
+      # Second, PATH-SCOPED gate. The tiered policy (.claude/rules/testing.md)
+      # holds the `langres.core` library contract -- what users serialize against
+      # -- to a higher bar than the rest of the repo, but that tier was enforced
+      # by HUMAN REVIEW only: a path glob in a markdown rule, not a gate. The
+      # repo-wide floor is 90% while actual coverage is ~99%, so ~9 points of
+      # slack (order 1,000 statements) could go dark with CI green the whole way.
+      # The architecture refactor makes that concrete -- it moves most of `core/`
+      # into new packages, and nothing would notice the contract being quietly
+      # declassified on the way.
+      #
+      # Reads the .coverage data left by the run above (the FULL suite -- the
+      # slow ML tests are the only cover for some paths, so this number is only
+      # honest here). --fail-under applies to the --include subset alone.
+      #
+      # 98 = the measured `core/*` coverage (98.84% at ba4b1b7) rounded down.
+      # It is a REGRESSION RATCHET, not the policy: the policy target stays
+      # 95-100%, and a 95 floor here would let ~370 more units of the contract
+      # vanish before firing. Raise it as the real number climbs; if it ever
+      # blocks legitimate work, lower it deliberately rather than deleting it.
+      #
+      # !! KEEP THE GLOB IN SYNC !! As refactor waves relocate the contract out
+      # of `core/` (components/, architectures/, ... -- see the tier definition
+      # in .claude/rules/testing.md), ADD the new paths here. If the glob ever
+      # matches NOTHING, `coverage report` exits 1 ("No data to report.") and
+      # this step goes red rather than passing vacuously -- but a PARTIAL move
+      # still passes while silently covering less of the contract, so this is a
+      # real maintenance obligation, not a self-healing gate.
+      #
+      # Deliberately AFTER the Codecov upload: that upload is advisory, and when
+      # this gate fails you still want the data published to diagnose the drop.
+      #
+      # --precision=2 is LOAD-BEARING, not cosmetic: coverage compares the total
+      # ROUNDED to `precision`, which defaults to 0. Without it, round(97.6) = 98
+      # passes a --fail-under=98 gate -- the floor would silently mean 97.5.
+      # With it the comparison is exact and 98 means 98.
+      - name: Coverage gate -- langres.core contract
+        run: uv run coverage report --include="src/langres/core/*" --precision=2 --fail-under=98
+
   # The [finetune] extra's OWN job: install the QLoRA training stack (peft/trl/
   # bitsandbytes) that every other job deliberately excludes (`--no-extra
   # finetune`) and run the `finetune`-marked tests -- the CPU dry-run that actually

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,7 +1,7 @@
 name: Test
 
 # Per-PR: run the FAST suite only (slow ML tests excluded -- see the `test`
-# job). The full suite incl. slow tests + the 95% coverage gate runs on every
+# job). The full suite incl. slow tests + the coverage gates runs on every
 # merge to main (push) + on demand (workflow_dispatch) via the `test-full` job,
 # so slow embedding/ML tests don't cost ~10min on every PR. This repo is public,
 # so Actions minutes are free/unlimited -- per-merge coverage is worth it, while
@@ -9,11 +9,33 @@ name: Test
 on:
   pull_request:
   push:
-    branches: [main]
+    # TEMPORARY (architecture refactor): `feat/arch-refactor` is the integration
+    # branch the refactor's sub-PRs merge into. Without it here, `test-full` --
+    # the ONLY job that runs the slow tests and enforces the coverage gates --
+    # would not run for the entire refactor, and a regression would surface only
+    # at the final merge to main. REVERT THIS LIST TO `[main]` once the refactor
+    # has landed and the integration branch is deleted.
+    branches: [main, feat/arch-refactor]
   workflow_dispatch:
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  # `pull_request`: one group per PR ref, so a new push supersedes the previous
+  # run (`cancel-in-progress` below) -- the usual minute-saving behaviour.
+  #
+  # `push` / `workflow_dispatch`: one group PER COMMIT (`github.sha`). Runs on
+  # the same branch must NOT share a group: `test-full` is the only place the
+  # slow tests and the coverage gates run, and a cancelled run is not a green
+  # run. With a shared per-branch group, two merges in quick succession cancel
+  # the first commit's `test-full` outright, and -- because GitHub also evicts a
+  # *pending* run when a newer one queues ("any existing pending job or workflow
+  # in the same concurrency group will be canceled") -- merely setting
+  # `cancel-in-progress: false` would NOT fix it, it would only move the loss
+  # from "cancelled while running" to "cancelled while pending". Keying the
+  # group on the SHA gives every merge commit its own group, so each one is
+  # gated on its own merits. This has already bitten `main` (6 of the last 30
+  # push runs were cancelled), and matters more once sub-PRs land on the
+  # integration branch above.
+  group: ${{ github.workflow }}-${{ github.ref }}-${{ github.event_name == 'pull_request' && 'pr' || github.sha }}
   cancel-in-progress: true
 
 jobs:
@@ -21,7 +43,7 @@ jobs:
   # load heavy torch models and dominate wall-time). Coverage is collected but
   # NOT gated here (`--cov-fail-under=0` overrides the pyproject default),
   # because the excluded slow tests are the only cover for some ML paths -- the
-  # 95% floor is enforced on `test-full` below.
+  # coverage floors are enforced on `test-full` below.
   test:
     if: github.event_name == 'pull_request'
     runs-on: ubuntu-latest
@@ -99,10 +121,11 @@ jobs:
       - name: Verify the core-only flywheel loop (examples/flywheel_min.py) works
         run: uv run python examples/flywheel_min.py
 
-  # Full suite INCLUDING the slow embedding/ML tests, plus the 95% coverage gate
-  # (inherited from pyproject addopts). Runs on every merge to main (push) + on
+  # Full suite INCLUDING the slow embedding/ML tests, plus the coverage gates:
+  # the repo-wide floor (inherited from pyproject addopts) and the core-contract
+  # floor (a separate step). Runs on every merge to main (push) + on
   # demand (workflow_dispatch) -- NOT per PR -- so ML regressions and the
-  # coverage floor are enforced on every merge without paying ~10min on every
+  # coverage floors are enforced on every merge without paying ~10min on every
   # PR. Trigger an ad-hoc run before a release or a risky ML change with the
   # "Run workflow" button (workflow_dispatch). Do NOT mark this a required
   # status check (it is skipped on PR events).
@@ -134,7 +157,15 @@ jobs:
         # imports keep the full suite green without peft/trl/bitsandbytes here.
         run: uv sync --all-extras --no-extra finetune
 
-      - name: Run full suite incl. slow tests (95% coverage gate)
+      - name: Run full suite incl. slow tests (repo-wide coverage gate)
+        # The floor is `--cov-fail-under` in pyproject.toml (90% at time of
+        # writing) -- deliberately NOT restated here. This step was previously
+        # named "(95% coverage gate)" while actually enforcing 90: ba90aef
+        # lowered the floor 95 -> 90 when it adopted the tiered policy and left
+        # this name behind, and the stale name was later read as if it were the
+        # configuration. A name that duplicates a value owned by another file
+        # drifts from it; this one names the gate, not the number.
+        #
         # --cov-report=xml (on top of the pyproject default term/html reports)
         # emits coverage.xml for the Codecov upload below. This is the ONLY job
         # that runs the full suite, so it's the only place coverage is honest --

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -235,7 +235,16 @@ branch = true
 # and src/langres/data/mining.py coming next), behavior/smoke on
 # benchmark/experiment/harness code, so the blended whole-repo floor sits
 # below the core tier. Kept simple (one floor, no per-module omit lists).
-# Gated weekly by test-full, not per-PR.
+#
+# This floor is REPO-WIDE and deliberately relaxed; it is not the core tier's
+# floor. The core contract is gated separately (and higher) by the
+# "Coverage gate -- langres.core contract" step in .github/workflows/test.yml,
+# because a 90% repo-wide floor against ~99% actual coverage leaves enough slack
+# to let the contract go dark unnoticed.
+#
+# Enforced by test-full on every merge to main + on demand (workflow_dispatch),
+# not per-PR. (It was weekly when this comment was written; 2e46eae replaced the
+# weekly schedule with push-to-main and left the comment stale.)
 fail_under = 90
 exclude_lines = [
     "pragma: no cover",


### PR DESCRIPTION
Closes the **W0 CI gap** for the architecture refactor. Every claim below was re-measured on this branch; where a premise turned out to be wrong or imprecise, that is called out.

## 1. The integration branch would have run ungated

`test-full` — the only job that runs the slow tests and enforces the coverage gates — is gated on `push:` to `[main]`. The refactor's sub-PRs land on `feat/arch-refactor`, so the slow suite and the coverage gate would have gone dark for the whole refactor and surfaced only at the final merge of a change touching 148 of 202 test files.

Added `feat/arch-refactor` to that list, marked **TEMPORARY** (reverts to `[main]` when the refactor lands).

**Beyond the brief — `lint.yml` had the same hole, worse.** Its `pull_request.branches` filters by *target* branch, so a sub-PR into `feat/arch-refactor` would have run **no lint at all — no ruff, no mypy**. mypy is the gate that catches exactly what a package split breaks: moved symbols, stale re-exports, circular imports. The four `feat/*` entries already in that list show every prior integration branch was added this way; this one was simply forgotten. Added to both trigger lists.

## 2. The step name lied — and it is a fossil

The `test-full` step was **named** "(95% coverage gate)" while enforcing **90** (`--cov-fail-under=90`). Verified against today's CI log on main:

```
Required test coverage of 90% reached. Total coverage: 99.18%
```

Archaeology: **ba90aef** ("tiered coverage — high on core, behavior-focused on harness") lowered `fail_under` 95 → 90 when it adopted the tiered policy and left the name behind. The name was true when written; the value moved out from under it.

Renamed to **"Run full suite incl. slow tests (repo-wide coverage gate)"** — naming the gate rather than restating a number owned by another file. Restating "90" would rebuild the exact mechanism that produced the bug. The same false "95%" claim appeared twice more in the same file (header comment, `test` job comment); both fixed. Gate value unchanged, as instructed.

## 3. Path-scoped gate on the contract surface

The 95–100% `core/**` tier was enforced by **human review only** — a glob in a markdown rule, not a gate. Repo-wide floor 90 vs ~99 actual = ~9 points of slack.

**Measured (full suite incl. slow, at `ba4b1b7`):**

| path | coverage |
|---|---|
| whole repo | **99.18%** — reproduces CI's number exactly ✓ |
| **`src/langres/core/*`** | **98.84%** |
| `data/data_profile/*` | 100.00% |
| `data/mining.py` | 100.00% |

The whole-repo number matching CI's log exactly is what makes the `core/*` number trustworthy rather than a local artifact.

**Chose `--fail-under=98`** = measured value rounded down. A **regression ratchet, not the policy** (target stays 95–100%). A 95 floor would have left ~370 more units of contract free to vanish before firing — which defeats the stated point of catching a *decline*.

**`--precision=2` is load-bearing.** coverage compares the total **rounded to `precision`** (default **0**), so `--fail-under=98` alone silently means **97.5**. Verified at 98.84% actual:

| | result |
|---|---|
| `--precision=0 --fail-under=99` | **passes** (rc=0) ← wrong; `round(98.84)=99` |
| `--precision=2 --fail-under=99` | **fails** (rc=2) ← correct |

Without this the gate would have been decoration.

**Self-defending, partially.** If the glob ever matches nothing, `coverage report` exits 1 (`No data to report.`) → red, not vacuously green (verified). But a **partial** move still passes while covering less — hence the `!! KEEP THE GLOB IN SYNC !!` comment. Not a self-healing gate.

## 4. Concurrency — investigated, fixed

`cancel-in-progress: true` on a per-branch group means a merge cancels the previous merge's `test-full`. **Not hypothetical: 6 of the last 30 push runs on main were cancelled** (e.g. run 29514115708, `test-full: cancelled`).

**The intuitive fix does not work.** `cancel-in-progress: false` would only move the loss — GitHub docs: *"the queued job or workflow will be pending… any existing pending job or workflow in the same concurrency group will be canceled"*. Run 1 runs, run 2 pends, run 3 **evicts** run 2. It also serialises merges.

Fixed by keying the group on `github.sha` for push/dispatch so **every merge commit gets its own group**; PRs keep per-ref supersede behaviour:

```yaml
group: ${{ github.workflow }}-${{ github.ref }}-${{ github.event_name == 'pull_request' && 'pr' || github.sha }}
```

**Honest scoping of the severity:** the *tip* of a branch always does get gated eventually (the last push's run is not cancelled, and it contains the earlier commits' code). What cancellation actually destroys is **per-commit attribution** — which is precisely the "a wave is complete only when `test-full` was observed green" contract, and which sub-PR to blame when the tip goes red. Worth fixing (one line, free minutes on a public repo), but "coverage goes dark" overstates it.

## Verified vs. not

**Verified:** full suite green locally (3721 passed, 4 skipped, 21m, exit 0) with the exact `test-full` marker expression; whole-repo coverage reproduces CI's 99.18%; the gate command passes at 98 and fails (rc=2) on a decline; empty glob → rc=1; both YAML files and pyproject parse; the `--include` glob matches `core/` **recursively** into subdirs.

**Not verifiable pre-merge — stated plainly:** a `push:`-triggered change cannot be exercised from a PR. This PR's own run takes the `pull_request` branch of the ternary. The `push` behaviour for `main`/`feat/arch-refactor` and the SHA-keyed group only take effect **after merge**. To close as much of that gap as possible I will dispatch this workflow on this branch (`workflow_dispatch` runs `test-full` and takes the **non-PR** branch of the ternary), which exercises the new `core` gate for real in CI — result reported on the PR. No green is claimed that was not observed.

## Summary by Sourcery

Tighten CI protections around the architecture refactor and coverage policy, ensuring slow tests and coverage gates run on integration branches and that per-commit gating is preserved.

New Features:
- Introduce a path-scoped coverage gate for the langres.core contract to enforce a higher coverage tier than the repo-wide floor.

Enhancements:
- Clarify CI comments and documentation around coverage floors, slow test behaviour, and the tiered coverage policy, including accurate naming of the full-suite coverage gate step.
- Update pyproject coverage configuration commentary to reflect current enforcement via push-to-main and workflow_dispatch rather than the previous weekly schedule.

CI:
- Run the full test suite with coverage gates on the feat/arch-refactor integration branch in addition to main to avoid gaps during the refactor.
- Adjust test workflow concurrency to key push and workflow_dispatch runs by commit SHA so each merge’s full-suite run is gated independently without being canceled.
- Extend lint workflow triggers to cover the feat/arch-refactor integration branch for both push and pull_request events, ensuring ruff and mypy run on sub-PRs.

Documentation:
- Update testing guidance to describe the dual coverage gates (repo-wide and core-only) and their roles during the architecture refactor, including expectations for maintaining the core contract paths.