### PR TITLE
refactor(core): clear the two W4 fork blockers — fit() topology (B5) + save/load identity (B4)

### DIFF
--- a/docs/TECHNICAL_OVERVIEW.md
+++ b/docs/TECHNICAL_OVERVIEW.md
@@ -800,6 +800,33 @@ unchanged):
   map with pure NumPy). `Platt()`/`Isotonic()` are import-light (no scikit-learn
   until the fit runs).
 
+#### Which kinds a class accepts: `accepted_method_kinds`
+
+Note the fine-tune bullet above: `fit(method=QLoRA(...))` **repoints the matcher
+slot**. That is deliberate and correct for a plain `Resolver`, which claims no
+identity — "a resolver" is not a topology, so a topology change falsifies
+nothing. It stops being free the moment a *class* names an architecture: a
+`FuzzyString` that quietly became LLM-backed while still being class
+`FuzzyString` is a name that describes a pipeline it no longer is.
+
+So a Resolver subclass may declare the kinds it can absorb without ceasing to be
+itself:
+
+```python
+class FuzzyString(Resolver):
+    accepted_method_kinds = frozenset({"calibrate"})   # no prompt/finetune
+```
+
+`fit()` checks it at the boundary, before dispatch, and refuses anything else
+with `langres.core.UnsupportedMethodKind` (a `TypeError` — `Method.kind` is a
+`ClassVar`, i.e. strategy-*type* identity, so rejecting a kind is rejecting a
+type) naming the class, the kind, `method.describe()`, and the accepted kinds.
+The three real kinds are `"prompt"`, `"finetune"`, `"calibrate"`.
+
+The base `Resolver` leaves `accepted_method_kinds = None` — **permissive**, every
+kind accepted, every fit path unchanged. An empty `frozenset()` is the opposite
+extreme: a fully frozen topology that takes no `method=` at all.
+
 `Resolver.describe()` is the pre-fit honesty device: a per-component string
 tagging each pipeline role **TRAINABLE** (implements a `langres.core.fit`
 Protocol, or is a prompt-compilable `DSPyMatcher`) or **frozen**. A pure string

--- a/docs/TECHNICAL_OVERVIEW.md
+++ b/docs/TECHNICAL_OVERVIEW.md
@@ -204,6 +204,15 @@ It is **optional on purpose**, and the compatibility rules follow from that:
 - `config_dict()` still emits only `components`, so `model_class` stays **outside**
   `recipe_id`'s hash domain and no existing recipe hash forks.
 
+> **Constraint on a registered model:** `load` reconstructs by calling the class
+> with `Resolver.__init__`'s component keywords (`blocker=`, `comparator=`,
+> `matcher=`, `clusterer=`, `calibrator=`). An architecture that narrows
+> `__init__` to its own signature (e.g. `FuzzyString(threshold=0.8)`) raises
+> `TypeError: ... unexpected keyword argument 'blocker'` on load. It must keep
+> accepting the component keywords, or grow an explicit from-components hook.
+> This could not bite before `model_class`, since `load` always built the base
+> `Resolver`.
+
 All three name-dispatch paths — the verbs, `from_schema`, and the benchmark harness (`langres.methods`) — resolve judge names through the single **method registry** (`langres.core.method_registry`): one `MethodSpec` per name carrying its builder, `score_type`, `default_threshold`, and `default_model`. A name means the same thing everywhere; `/` in a method id is reserved for future `author/method` namespacing of third-party methods (model ids like `openrouter/openai/gpt-4o-mini` keep their slashes in the orthogonal `model=` kwarg).
 
 See [DX_RESOLVER.md](DX_RESOLVER.md) for the before/after of the manual lambda pipeline vs. the declarative `from_schema` + `save`/`load` path.

--- a/docs/TECHNICAL_OVERVIEW.md
+++ b/docs/TECHNICAL_OVERVIEW.md
@@ -176,6 +176,34 @@ resolver = Resolver.load("company_resolver.json")
 
 `from_schema` auto-derives a missing-aware `StringComparator` from the schema's string fields, a `WeightedAverageMatcher` scorer, an `AllPairsBlocker` (or a `VectorBlocker` when `matcher="embedding"`), and a `Clusterer`. `matcher=` accepts `"string"` (default), `"embedding"`, `"zero_shot_llm"`, `"prompt_llm"` (with the same `prompt_template` / `system_prompt` / `response_parser` kwargs as the verbs — a named parser makes the whole prompt-judge artifact `save`/`load` round-trippable), `"random_forest"` (a supervised sklearn `RandomForestMatcher` over the comparator's per-feature similarities — needs the `[trained]` extra and is trainable, so `fit(records, pairs=...)` / `labels=...` it with labeled data before it can score), or a `Matcher` instance. This is the low-level, explicit switch: **no** `"auto"` key-resolution (that magic lives in the verbs). A paid matcher built here **is** spend-capped: `Resolver(..., budget_usd=)` / `from_schema(..., budget_usd=)` defaults to `DEFAULT_BUDGET_USD` ($1.00) and the cap binds for the Resolver's whole lifetime, so two `resolve()` calls share one budget rather than getting one each. `budget_usd=None` means "the default", **not** "uncapped" — pass `langres.core.spend_cap.UNCAPPED_BUDGET_USD` (`float("inf")`) to opt out deliberately. The bound is honest but not magic: spend is capped at `budget_usd` **plus at most one further call**, since an LLM call's cost is only knowable once it has been made. Scope, precisely: the cap meters **every seam that scores through the matcher** — `resolve`, `predict`, `fit`, and `AnchorStore.assign` — because they all route through one internal capped-scorer accessor. The single exception is `distil()` / `fit(method=MIPRO())`: DSPy's compile calls never reach the matcher, so that ledger cannot see them; it caps them via its own `method.budget_usd` monitor, which records $0 until DSPy-compile spend capture lands (issue #100) — so a paid `MIPROv2` compile is **effectively unbounded** today.
 
+### What `save`/`load` records: components *and* class
+
+`resolver.json` is an `ArtifactManifest`: `artifact_version`, `langres_version`,
+the ordered per-slot `components` (each a registry `type_name` + config), any
+sidecar `checksums` — and an optional `model_class`.
+
+`model_class` is the *architecture's* identity: the name a Resolver subclass
+registered with `langres.core.register_model("fuzzy_string")`. `save` stamps it;
+`load` looks it up and reconstructs **that** class, so `Resolver.load(<a
+FuzzyString artifact>)` hands back a `FuzzyString`, not a plain `Resolver`.
+Without it, a save/load would quietly erase which architecture a pipeline was.
+
+It is **optional on purpose**, and the compatibility rules follow from that:
+
+- **Absent ⇒ plain `Resolver`** — which is exactly what every pre-0.4 artifact
+  is, and what an *unregistered* Resolver subclass still saves as (not an error;
+  it degrades to the old behaviour).
+- **`ARTIFACT_VERSION` stays `"1"`.** A bump buys nothing here: the compatible
+  read costs one `if`, whereas `_check_versions` rejects an artifact whose
+  version is older *or* newer, so a bump would break every existing 0.3.0
+  artifact in both directions.
+- Models are their **own registry namespace** (`register_model` / `get_model` /
+  `model_type_name`), separate from components and schemas. A component fills a
+  slot; a model owns the slots — sharing one namespace would let
+  `"type_name": "fuzzy_string"` resolve into a blocker slot.
+- `config_dict()` still emits only `components`, so `model_class` stays **outside**
+  `recipe_id`'s hash domain and no existing recipe hash forks.
+
 All three name-dispatch paths — the verbs, `from_schema`, and the benchmark harness (`langres.methods`) — resolve judge names through the single **method registry** (`langres.core.method_registry`): one `MethodSpec` per name carrying its builder, `score_type`, `default_threshold`, and `default_model`. A name means the same thing everywhere; `/` in a method id is reserved for future `author/method` namespacing of third-party methods (model ids like `openrouter/openai/gpt-4o-mini` keep their slashes in the orthogonal `model=` kwarg).
 
 See [DX_RESOLVER.md](DX_RESOLVER.md) for the before/after of the manual lambda pipeline vs. the declarative `from_schema` + `save`/`load` path.

--- a/src/langres/core/_exports/_resolver.py
+++ b/src/langres/core/_exports/_resolver.py
@@ -6,9 +6,13 @@ See ``langres.core._exports`` for the fragment contract.
 from langres.core.registry import (
     SchemaNotRegistered,
     UnknownComponentType,
+    UnknownModelType,
     get_component,
+    get_model,
     get_schema,
+    model_type_name,
     register,
+    register_model,
     register_schema,
 )
 from langres.core.resolver import Resolver
@@ -24,13 +28,17 @@ __all__ = [
     "ArtifactManifest",
     "ComponentSpec",
     "get_component",
+    "get_model",
     "get_schema",
+    "model_type_name",
     "register",
+    "register_model",
     "register_schema",
     "Resolver",
     "SchemaNotRegistered",
     "SerializableState",
     "UnknownComponentType",
+    "UnknownModelType",
 ]
 
 LAZY_SYMBOLS: dict[str, str] = {}

--- a/src/langres/core/_exports/_training.py
+++ b/src/langres/core/_exports/_training.py
@@ -12,7 +12,7 @@ from typing import TYPE_CHECKING
 from langres.core.fit import SupervisedFitMixin, UnsupervisedFitMixin
 from langres.core.fit_report import FitReport
 from langres.core.harvest import align_pairs
-from langres.core.methods_api import Method
+from langres.core.methods_api import Method, UnsupportedMethodKind
 from langres.core.methods_calibrate import Isotonic, Platt
 from langres.core.methods_prompt import Bootstrap, GEPA, MIPRO
 
@@ -32,6 +32,7 @@ __all__ = [
     "Platt",
     "SupervisedFitMixin",
     "UnsupervisedFitMixin",
+    "UnsupportedMethodKind",
 ]
 
 LAZY_SYMBOLS: dict[str, str] = {

--- a/src/langres/core/methods_api.py
+++ b/src/langres/core/methods_api.py
@@ -27,7 +27,23 @@ from typing import ClassVar
 
 from pydantic import BaseModel
 
-__all__ = ["Method"]
+__all__ = ["Method", "UnsupportedMethodKind"]
+
+
+class UnsupportedMethodKind(TypeError):
+    """Raised when an architecture is asked to fit with a ``Method`` kind it rejects.
+
+    See ``Resolver.accepted_method_kinds`` for the declaration this enforces and
+    why the base :class:`~langres.core.resolver.Resolver` never raises it.
+
+    Subclasses :class:`TypeError` rather than :class:`ValueError` because
+    :attr:`Method.kind` is a ``ClassVar`` -- an identity of the strategy *type*,
+    not a per-instance value (see :class:`Method`) -- so rejecting a kind is
+    rejecting a type of argument. It also matches the sibling ``TypeError`` that
+    ``Resolver._fit_finetune`` already raises for a method-object mismatch
+    ("method kind 'finetune' requires a QLoRA method"), so one ``except
+    TypeError`` catches both shapes of "this method does not belong here".
+    """
 
 
 class Method(BaseModel):

--- a/src/langres/core/registry.py
+++ b/src/langres/core/registry.py
@@ -5,12 +5,23 @@ A serialized Resolver references its components and schemas by string name (so
 ``"schema": "CompanySchema"``). This module provides the registration and
 lookup machinery plus the typed errors that lookups raise.
 
-Two namespaces:
+Three namespaces:
 
 - **Components** (``register`` / ``get_component``): blockers, comparators,
   scorer modules, clusterers — anything the Resolver composes.
 - **Schemas** (``register_schema`` / ``get_schema``): Pydantic entity schemas
   referenced by name in a config.
+- **Models** (``register_model`` / ``get_model``): Resolver *subclasses* — the
+  named architectures — so ``save``/``load`` can round-trip which class a
+  pipeline is, not just which parts it has.
+
+Why models are their own namespace and not just more components: a component
+*fills a slot* in a Resolver; a model *owns* the slots. Sharing one dict would
+make ``"type_name": "fuzzy_string"`` resolvable in a blocker slot — a nonsense
+config the registry would happily construct — and would cross-contaminate the
+did-you-mean suggestions of both. The precedent is already here: schemas got
+their own namespace for exactly this reason (a schema is not a component), so a
+third one is the established pattern rather than a parallel registry.
 
 No abstract base classes live here — only registration, lookup, and errors.
 """
@@ -26,6 +37,7 @@ T = TypeVar("T")
 
 _COMPONENT_REGISTRY: dict[str, type] = {}
 _SCHEMA_REGISTRY: dict[str, type[BaseModel]] = {}
+_MODEL_REGISTRY: dict[str, type] = {}
 
 # Lazy-registration map: ``type_name -> module path``. A component listed here is
 # NOT eager-imported by ``langres.core`` — importing it would pull a heavy or
@@ -101,6 +113,15 @@ class SchemaNotRegistered(KeyError):
     """Raised when a schema name referenced by a config is not registered."""
 
 
+class UnknownModelType(KeyError):
+    """Raised when an artifact's ``model_class`` is not a registered model.
+
+    Carries the available model names and a ``difflib`` did-you-mean suggestion,
+    like :class:`UnknownComponentType`. The usual cause is loading an artifact
+    whose architecture lives in a module the process never imported.
+    """
+
+
 def register(type_name: str) -> Callable[[type[T]], type[T]]:
     """Class decorator: register a component under ``type_name``.
 
@@ -144,6 +165,78 @@ def get_component(type_name: str) -> type:
             f"Available types: {', '.join(available) or '(none registered)'}"
         )
     return _COMPONENT_REGISTRY[type_name]
+
+
+def register_model(type_name: str) -> Callable[[type[T]], type[T]]:
+    """Class decorator: register a Resolver subclass (an architecture) under ``type_name``.
+
+    Registering is what makes a model's identity survive ``save``/``load``:
+    :meth:`Resolver.save` records the registered name in the manifest's
+    ``model_class`` and :meth:`Resolver.load` reconstructs *that* class. An
+    unregistered subclass is not an error — it simply saves without a
+    ``model_class`` and reloads as a plain ``Resolver``, exactly as every
+    Resolver did before this field existed.
+
+    Args:
+        type_name: Unique registry key for the model (e.g. ``"fuzzy_string"``).
+
+    Raises:
+        ValueError: If ``type_name`` is already registered.
+    """
+
+    def decorator(cls: type[T]) -> type[T]:
+        if type_name in _MODEL_REGISTRY:
+            raise ValueError(f"Model type '{type_name}' is already registered")
+        _MODEL_REGISTRY[type_name] = cls
+        return cls
+
+    return decorator
+
+
+def get_model(type_name: str) -> type:
+    """Look up a registered model (Resolver subclass) by name.
+
+    Returns a bare ``type`` rather than ``type[Resolver]`` deliberately: this
+    module sits *beneath* ``core.resolver`` (which imports it), so naming
+    ``Resolver`` here — even under ``TYPE_CHECKING`` — would knot the two into an
+    import cycle. ``tests/test_import_tangle.py`` counts that edge; ``get_component``
+    returns a bare ``type`` for the same reason.
+
+    .. note::
+       There is no lazy ``type_name -> module`` map for models yet (contrast
+       :data:`_LAZY_COMPONENT_MODULES`), because no model is registered anywhere
+       yet — W4 lands the architectures. If W4 puts them off the eager-import
+       path, it needs the same saved-artifact safety net, or a fresh process
+       loading such an artifact will raise :class:`UnknownModelType` here.
+
+    Raises:
+        UnknownModelType: If ``type_name`` is not registered. The message lists
+            the available models and a did-you-mean suggestion.
+    """
+    if type_name not in _MODEL_REGISTRY:
+        available = sorted(_MODEL_REGISTRY)
+        suggestions = difflib.get_close_matches(type_name, available, n=3)
+        hint = f" Did you mean: {', '.join(suggestions)}?" if suggestions else ""
+        raise UnknownModelType(
+            f"Unknown model type '{type_name}'.{hint} It may live in a module this "
+            f"process never imported. Available models: "
+            f"{', '.join(available) or '(none registered)'}"
+        )
+    return _MODEL_REGISTRY[type_name]
+
+
+def model_type_name(cls: type) -> str | None:
+    """Return the registered name for a model class, or ``None`` if unregistered.
+
+    The reverse of :func:`register_model`, used by ``save`` to stamp the
+    manifest. Matches ``cls`` **exactly** rather than walking the MRO: an
+    unregistered subclass of a registered architecture is its own thing, and
+    claiming its parent's name would make ``load`` hand back the wrong class.
+    """
+    for name, registered in _MODEL_REGISTRY.items():
+        if registered is cls:
+            return name
+    return None
 
 
 def register_schema(name: str) -> Callable[[type[T]], type[T]]:

--- a/src/langres/core/resolver.py
+++ b/src/langres/core/resolver.py
@@ -802,10 +802,9 @@ class Resolver:
         allowed = ", ".join(repr(k) for k in sorted(accepted)) or "(no method kinds)"
         raise UnsupportedMethodKind(
             f"{name} does not accept method kind {method.kind!r} ({method.describe()}); "
-            f"{name} accepts: {allowed}. Fitting with {method.kind!r} would change the "
-            f"pipeline's topology, leaving {name} naming a pipeline it no longer is. "
-            f"Use a plain Resolver (which accepts every kind) or an architecture whose "
-            f"identity includes {method.kind!r}."
+            f"it accepts: {allowed}. That fit would change the pipeline's topology, "
+            f"leaving {name} naming a pipeline it no longer is. Use a plain Resolver "
+            f"(which accepts every kind) or an architecture built for it."
         )
 
     # ------------------------------------------------------------------
@@ -1757,15 +1756,26 @@ class Resolver:
         # ``model_class`` (every pre-0.4 artifact, and any unregistered subclass)
         # keeps the old behavior exactly: build ``cls``, whatever load was called on.
         target = cls if manifest.model_class is None else get_model(manifest.model_class)
-        return cast(
-            "Resolver",
-            target(
-                blocker=blocker,
-                comparator=comparator,
-                matcher=module,
-                clusterer=clusterer,
-                calibrator=calibrator,
-            ),
+        # The model registry cannot type-check its own entries: registry.py sits
+        # beneath this module, so it can neither import Resolver nor annotate
+        # ``get_model`` with it. Verify here, where Resolver IS in scope. Without
+        # this, a ``model_class`` registered to a kwargs-swallowing non-Resolver
+        # loads and is cast to Resolver, handing the caller a silently wrong
+        # object instead of an error.
+        if not issubclass(target, Resolver):
+            raise TypeError(
+                f"Artifact model_class {manifest.model_class!r} is registered to "
+                f"{target.__module__}.{target.__qualname__}, which is not a Resolver "
+                f"subclass; register_model is for Resolver subclasses (architectures)."
+            )
+        # No cast needed: the issubclass guard above narrows ``target`` to
+        # ``type[Resolver]`` for the type checker.
+        return target(
+            blocker=blocker,
+            comparator=comparator,
+            matcher=module,
+            clusterer=clusterer,
+            calibrator=calibrator,
         )
 
     @staticmethod

--- a/src/langres/core/resolver.py
+++ b/src/langres/core/resolver.py
@@ -37,7 +37,7 @@ import logging
 import warnings
 from collections.abc import Iterator, Sequence
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, Literal, Self, TypeGuard, cast
+from typing import TYPE_CHECKING, Any, ClassVar, Literal, Self, TypeGuard, cast
 
 from pydantic import BaseModel
 
@@ -55,7 +55,7 @@ from langres.core.fit import (
 )
 from langres.core.fit_report import CalibrationDelta, FitReport
 from langres.core.harvest import Correction, LabeledPair, align_pairs
-from langres.core.methods_api import Method
+from langres.core.methods_api import Method, UnsupportedMethodKind
 from langres.core.matchers.weighted_average import WeightedAverageMatcher
 from langres.core.metrics import (
     PairMetrics,
@@ -358,6 +358,37 @@ class Resolver:
         resolver.save("artifacts/company_v0")
         reloaded = Resolver.load("artifacts/company_v0")
     """
+
+    #: The ``Method.kind``s :meth:`fit` accepts; ``None`` (the default) accepts
+    #: every kind.
+    #:
+    #: This exists for the named architectures of W4 (``FuzzyString``,
+    #: ``VectorLLMCascade``, ...), which make the claim *one architecture = one
+    #: class = one identity*. That claim is falsifiable by ``fit`` itself:
+    #: :meth:`_fit_finetune` deliberately **repoints the matcher slot** at the
+    #: fine-tuned model, so ``FuzzyString().fit(method=QLoRA(...))`` would return
+    #: an LLM-backed pipeline still calling itself ``FuzzyString``. A subclass
+    #: declares the kinds it can absorb without ceasing to be itself; anything
+    #: else is refused at the :meth:`fit` boundary with
+    #: :class:`~langres.core.methods_api.UnsupportedMethodKind`.
+    #:
+    #: The base ``Resolver`` stays ``None`` -- **permissive on purpose**. It makes
+    #: no identity claim ("a resolver" is not a topology), so there is nothing for
+    #: a topology change to falsify, and every fit path it accepts today keeps
+    #: working unchanged.
+    #:
+    #: Alternatives considered and rejected (recorded so this is cheap to flip):
+    #:
+    #: - *A topology-changing ``fit()`` returns a NEW architecture instance*
+    #:   (sklearn ``clone``-like). More principled -- identity would follow the
+    #:   topology instead of constraining it -- but ``fit`` mutates in place and
+    #:   returns ``self``/metrics today, and the flywheel loop depends on that;
+    #:   changing the return contract is far more churn than this gate.
+    #: - *Downgrade the invariant to advisory* (document that ``fit`` may change
+    #:   what the class name means). Zero code, but it guts the whole point of
+    #:   naming architectures: a name that may silently describe something else is
+    #:   not an identity.
+    accepted_method_kinds: ClassVar[frozenset[str] | None] = None
 
     def __init__(
         self,
@@ -666,8 +697,15 @@ class Resolver:
             NotImplementedError: If ``method`` is given but its ``kind``'s fit
                 path is not implemented yet (the seam is wired ahead of the
                 concrete methods; the error names the PR that will land it).
+            UnsupportedMethodKind: If this class declares
+                :attr:`accepted_method_kinds` and ``method.kind`` is not among
+                them. The base ``Resolver`` declares none and never raises it.
         """
         if method is not None:
+            # Architectures that claim an identity refuse the kinds that would
+            # change their topology out from under the class name. The base
+            # Resolver declares no kinds and this is a no-op for it.
+            self._check_method_accepted(method)
             # The ``method=`` object seam: a Method names *how* to train and
             # routes to its own per-kind handler below, so the concrete
             # strategies that fill these in later touch DISJOINT methods instead
@@ -741,6 +779,34 @@ class Resolver:
             )
         self.fit_report_ = FitReport.nothing_trainable(matcher_name)
         return self
+
+    @classmethod
+    def _check_method_accepted(cls, method: Method) -> None:
+        """Refuse a ``Method`` whose kind this architecture does not accept.
+
+        The enforcement half of :attr:`accepted_method_kinds` (see there for the
+        why and the rejected alternatives). A no-op when
+        ``accepted_method_kinds`` is ``None`` -- i.e. always, for the base
+        :class:`Resolver`.
+
+        Raises:
+            UnsupportedMethodKind: If this class declares
+                ``accepted_method_kinds`` and ``method.kind`` is not among them.
+                The message names the class, the offending kind, the method's
+                own ``describe()``, and the kinds that *are* accepted.
+        """
+        accepted = cls.accepted_method_kinds
+        if accepted is None or method.kind in accepted:
+            return
+        name = cls.__name__
+        allowed = ", ".join(repr(k) for k in sorted(accepted)) or "(no method kinds)"
+        raise UnsupportedMethodKind(
+            f"{name} does not accept method kind {method.kind!r} ({method.describe()}); "
+            f"{name} accepts: {allowed}. Fitting with {method.kind!r} would change the "
+            f"pipeline's topology, leaving {name} naming a pipeline it no longer is. "
+            f"Use a plain Resolver (which accepts every kind) or an architecture whose "
+            f"identity includes {method.kind!r}."
+        )
 
     # ------------------------------------------------------------------
     # ``method=`` per-kind fit handlers (the object seam)

--- a/src/langres/core/resolver.py
+++ b/src/langres/core/resolver.py
@@ -1668,6 +1668,18 @@ class Resolver:
         An artifact with no ``model_class`` (every pre-0.4 one, and any
         unregistered subclass) builds ``cls``, exactly as before.
 
+        .. note::
+           **Constraint on registered models:** reconstruction calls the class
+           with this ``__init__``'s component keywords (``blocker=``,
+           ``comparator=``, ``matcher=``, ``clusterer=``, ``calibrator=``). A
+           registered architecture that narrows ``__init__`` to its own
+           ergonomic signature (e.g. ``FuzzyString(threshold=0.8)``) raises
+           ``TypeError: ... unexpected keyword argument 'blocker'`` here. Such an
+           architecture must keep accepting the component keywords — or W4 must
+           add an explicit from-components construction hook. Before
+           ``model_class`` existed this could not bite, because ``load`` always
+           built the base ``Resolver``.
+
         Args:
             path: Directory containing ``resolver.json`` and any sidecars.
 

--- a/src/langres/core/resolver.py
+++ b/src/langres/core/resolver.py
@@ -65,7 +65,7 @@ from langres.core.metrics import (
 )
 from langres.core.models import ERCandidate, PairwiseJudgement
 from langres.core.matcher import Matcher
-from langres.core.registry import get_component
+from langres.core.registry import get_component, get_model, model_type_name
 from langres.core.runs import current_run
 from langres.core.spend import SpendMonitor
 from langres.core.spend_cap import SpendCappedMatcher, effective_budget
@@ -1565,6 +1565,11 @@ class Resolver:
         component into a :class:`ComponentSpec` via :func:`_component_spec`,
         which raises :class:`TypeError` for a component lacking a registry
         ``type_name`` — that error is intentional and not swallowed here.
+
+        Also stamps ``model_class`` with this class's registered model name so a
+        named architecture survives ``save``/``load``. It is ``None`` for the
+        base ``Resolver`` and for any unregistered subclass — see
+        :func:`~langres.core.registry.model_type_name`.
         """
         components = [
             _component_spec(component, slot=slot_name) for slot_name, component in self._slots()
@@ -1572,6 +1577,7 @@ class Resolver:
         return ArtifactManifest(
             artifact_version=ARTIFACT_VERSION,
             langres_version=LANGRES_VERSION,
+            model_class=model_type_name(type(self)),
             components=components,
         )
 
@@ -1620,7 +1626,9 @@ class Resolver:
         :class:`~langres.core.serialization.SerializableState`, a sidecar state
         directory named after the slot. The manifest records, per slot, the
         component ``type_name`` and config (the embedder persists by
-        ``model_name`` only — no model bytes).
+        ``model_name`` only — no model bytes), plus this class's registered
+        ``model_class`` when it has one, so :meth:`load` can rebuild the same
+        architecture rather than a plain ``Resolver``.
 
         Args:
             path: Directory to write the artifact into (created if absent).
@@ -1654,15 +1662,25 @@ class Resolver:
         execution, no pickle). Sidecar state is restored for any
         :class:`~langres.core.serialization.SerializableState` component.
 
+        Reconstructs the **class** the manifest names in ``model_class`` (a
+        registered architecture), not merely the one ``load`` was called on — so
+        ``Resolver.load(<a FuzzyString artifact>)`` hands back a ``FuzzyString``.
+        An artifact with no ``model_class`` (every pre-0.4 one, and any
+        unregistered subclass) builds ``cls``, exactly as before.
+
         Args:
             path: Directory containing ``resolver.json`` and any sidecars.
 
         Returns:
-            A Resolver equivalent to the one that was saved.
+            A Resolver equivalent to the one that was saved — of the saved
+            architecture's class when the manifest names one.
 
         Raises:
             ValueError: If the artifact's ``artifact_version`` is newer than this
                 library understands.
+            UnknownModelType: If the manifest names a ``model_class`` this
+                process has not registered (usually: its module was never
+                imported).
         """
         in_dir = Path(path)
         manifest = ArtifactManifest.model_validate_json((in_dir / _MANIFEST_FILENAME).read_text())
@@ -1722,12 +1740,20 @@ class Resolver:
             else None
         )
 
-        return cls(
-            blocker=blocker,
-            comparator=comparator,
-            matcher=module,
-            clusterer=clusterer,
-            calibrator=calibrator,
+        # Reconstruct the class the artifact says it is, so a named architecture
+        # round-trips as itself instead of decaying into a plain Resolver. Absent
+        # ``model_class`` (every pre-0.4 artifact, and any unregistered subclass)
+        # keeps the old behavior exactly: build ``cls``, whatever load was called on.
+        target = cls if manifest.model_class is None else get_model(manifest.model_class)
+        return cast(
+            "Resolver",
+            target(
+                blocker=blocker,
+                comparator=comparator,
+                matcher=module,
+                clusterer=clusterer,
+                calibrator=calibrator,
+            ),
         )
 
     @staticmethod

--- a/src/langres/core/serialization.py
+++ b/src/langres/core/serialization.py
@@ -76,6 +76,16 @@ class ArtifactManifest(BaseModel):
         artifact_version: Layout version of the artifact (see
             :data:`ARTIFACT_VERSION`).
         langres_version: The ``langres.__version__`` that wrote the artifact.
+        model_class: Registered name of the Resolver *subclass* that wrote the
+            artifact (see ``langres.core.registry.register_model``), so a named
+            architecture survives a round-trip instead of loading back as a
+            plain ``Resolver``. **Optional by design**: ``None``/absent means a
+            plain ``Resolver``, which is what every pre-0.4 artifact — and any
+            unregistered subclass — is. That is why adding it does **not** bump
+            :data:`ARTIFACT_VERSION`: a compatible read costs one ``if``, while a
+            bump would make ``Resolver._check_versions`` reject existing 0.3.0
+            artifacts in *both* directions (it raises on older *and* newer) for
+            no gain.
         components: Ordered component specs composing the Resolver.
         checksums: Optional sidecar checksum map (filename -> checksum) for
             out-of-band state files written by :class:`SerializableState`
@@ -84,5 +94,6 @@ class ArtifactManifest(BaseModel):
 
     artifact_version: str
     langres_version: str
+    model_class: str | None = None
     components: list[ComponentSpec]
     checksums: dict[str, str] = Field(default_factory=dict)

--- a/tests/core/test_registry.py
+++ b/tests/core/test_registry.py
@@ -6,9 +6,13 @@ from pydantic import BaseModel
 from langres.core.registry import (
     SchemaNotRegistered,
     UnknownComponentType,
+    UnknownModelType,
     get_component,
+    get_model,
     get_schema,
+    model_type_name,
     register,
+    register_model,
     register_schema,
 )
 
@@ -83,3 +87,78 @@ class TestRegisterSchema:
         with pytest.raises(SchemaNotRegistered) as exc:
             get_schema("NoSuchSchema123")
         assert "NoSuchSchema123" in str(exc.value)
+
+
+class TestRegisterModel:
+    """The third namespace: Resolver subclasses (architectures), for save/load identity."""
+
+    def test_register_and_lookup(self) -> None:
+        @register_model("test_model_unique_a")
+        class _Arch:
+            pass
+
+        assert get_model("test_model_unique_a") is _Arch
+
+    def test_duplicate_registration_raises(self) -> None:
+        @register_model("test_model_dup")
+        class _ArchA:
+            pass
+
+        with pytest.raises(ValueError, match="already registered"):
+
+            @register_model("test_model_dup")
+            class _ArchB:
+                pass
+
+    def test_unknown_model_raises_actionably(self) -> None:
+        with pytest.raises(UnknownModelType) as exc:
+            get_model("no_such_model_123")
+        message = str(exc.value)
+        assert "no_such_model_123" in message
+        assert "never imported" in message  # the usual cause, named
+
+    def test_unknown_model_suggests_a_near_miss(self) -> None:
+        @register_model("test_model_suggestible")
+        class _Arch:
+            pass
+
+        with pytest.raises(UnknownModelType, match="Did you mean: test_model_suggestible"):
+            get_model("test_model_suggestable")
+
+    def test_model_type_name_reverses_the_lookup(self) -> None:
+        @register_model("test_model_reverse")
+        class _Arch:
+            pass
+
+        assert model_type_name(_Arch) == "test_model_reverse"
+
+    def test_model_type_name_is_none_for_unregistered(self) -> None:
+        class _Unregistered:
+            pass
+
+        assert model_type_name(_Unregistered) is None
+
+    def test_model_type_name_does_not_walk_the_mro(self) -> None:
+        """A subclass of a registered model is its own thing, not its parent.
+
+        Claiming the parent's name would make ``load`` hand back the wrong class.
+        """
+
+        @register_model("test_model_parent")
+        class _Parent:
+            pass
+
+        class _Child(_Parent):
+            pass
+
+        assert model_type_name(_Child) is None
+
+    def test_models_are_a_separate_namespace_from_components(self) -> None:
+        """A model name must not resolve as a component (it cannot fill a slot)."""
+
+        @register_model("test_namespace_isolation")
+        class _Arch:
+            pass
+
+        with pytest.raises(UnknownComponentType):
+            get_component("test_namespace_isolation")

--- a/tests/core/test_resolver_fit_method.py
+++ b/tests/core/test_resolver_fit_method.py
@@ -24,7 +24,7 @@ import pytest
 from langres.core.blockers.all_pairs import AllPairsBlocker
 from langres.core.clusterer import Clusterer
 from langres.core.matcher import Matcher
-from langres.core.methods_api import Method
+from langres.core.methods_api import Method, UnsupportedMethodKind
 from langres.core.models import CompanySchema, ERCandidate, PairwiseJudgement
 from langres.core.reports import ScoreInspectionReport
 from langres.core.resolver import Resolver
@@ -175,3 +175,98 @@ def test_kind_is_classvar_not_a_model_field() -> None:
     """``kind`` is strategy-type identity, so it must not become a serialized field."""
     assert "kind" not in _PromptMethod.model_fields
     assert _PromptMethod.kind == "prompt"
+
+
+# --- accepted_method_kinds: an architecture refuses topology-changing fits ---
+#
+# W4's named architectures claim "one architecture = one class = one identity".
+# ``_fit_finetune`` repoints the matcher slot, so an architecture that let a
+# ``finetune`` through would keep its class name while becoming a different
+# pipeline. A subclass declares what it accepts; the base stays permissive.
+
+
+class _PromptOnlyArchitecture(Resolver):
+    """A stand-in for a W4 architecture that only accepts prompt-optimization."""
+
+    accepted_method_kinds: ClassVar[frozenset[str] | None] = frozenset({"prompt"})
+
+
+class _FrozenArchitecture(Resolver):
+    """An architecture whose topology is fixed: it accepts no ``method=`` at all."""
+
+    accepted_method_kinds: ClassVar[frozenset[str] | None] = frozenset()
+
+
+def _prompt_only() -> _PromptOnlyArchitecture:
+    return _PromptOnlyArchitecture(
+        blocker=AllPairsBlocker(schema=CompanySchema),
+        comparator=None,
+        matcher=_NoHookModule(),
+        clusterer=Clusterer(threshold=0.5),
+    )
+
+
+def test_base_resolver_declares_no_accepted_kinds() -> None:
+    """The base Resolver makes no identity claim, so it constrains no kind."""
+    assert Resolver.accepted_method_kinds is None
+
+
+def test_base_resolver_still_reaches_the_finetune_handler() -> None:
+    """No regression: the permissive base routes ``finetune`` exactly as before.
+
+    The gate must not intercept the base Resolver -- reaching ``_fit_finetune``'s
+    own QLoRA type-guard proves the method got all the way to its handler.
+    """
+    with pytest.raises(TypeError, match=r"method kind 'finetune' requires a QLoRA method"):
+        _resolver().fit(RECORDS, method=_FinetuneMethod())
+
+
+def test_architecture_rejects_kind_outside_its_declaration() -> None:
+    """A restricted architecture refuses a topology-changing kind at the fit boundary."""
+    with pytest.raises(UnsupportedMethodKind) as excinfo:
+        _prompt_only().fit(RECORDS, method=_FinetuneMethod())
+
+    message = str(excinfo.value)
+    assert "_PromptOnlyArchitecture" in message  # names the architecture
+    assert "'finetune'" in message  # names the offending kind
+    assert "fine-tune (QLoRA, ~GPU-seconds)" in message  # carries describe()
+    assert "accepts: 'prompt'" in message  # names what IS accepted
+
+
+def test_unsupported_method_kind_is_a_typeerror() -> None:
+    """The typed error is catchable as TypeError, like its _fit_finetune sibling."""
+    assert issubclass(UnsupportedMethodKind, TypeError)
+    with pytest.raises(TypeError):
+        _prompt_only().fit(RECORDS, method=_FinetuneMethod())
+
+
+def test_architecture_still_accepts_its_declared_kind() -> None:
+    """The gate blocks only undeclared kinds -- a declared one reaches its handler."""
+    with pytest.raises(ValueError, match=r"prompt-optimization needs a DSPyMatcher"):
+        _prompt_only().fit(RECORDS, method=_PromptMethod())
+
+
+def test_gate_runs_before_the_unknown_kind_fallthrough() -> None:
+    """A restricted architecture rejects an unknown kind as unaccepted, not unrecognized."""
+    with pytest.raises(UnsupportedMethodKind, match=r"does not accept method kind 'bogus'"):
+        _prompt_only().fit(RECORDS, method=_UnknownMethod())
+
+
+def test_architecture_accepting_no_kinds_reports_that_readably() -> None:
+    """An empty declaration means "no method= at all" and must not print an empty list."""
+    frozen = _FrozenArchitecture(
+        blocker=AllPairsBlocker(schema=CompanySchema),
+        comparator=None,
+        matcher=_NoHookModule(),
+        clusterer=Clusterer(threshold=0.5),
+    )
+
+    with pytest.raises(UnsupportedMethodKind, match=r"accepts: \(no method kinds\)"):
+        frozen.fit(RECORDS, method=_PromptMethod())
+
+
+def test_gate_does_not_touch_the_method_none_path() -> None:
+    """A restricted architecture still no-ops on ``method=None`` (the default path)."""
+    resolver = _prompt_only()
+
+    assert resolver.fit(RECORDS) is resolver

--- a/tests/core/test_resolver_fit_method.py
+++ b/tests/core/test_resolver_fit_method.py
@@ -230,7 +230,7 @@ def test_architecture_rejects_kind_outside_its_declaration() -> None:
     assert "_PromptOnlyArchitecture" in message  # names the architecture
     assert "'finetune'" in message  # names the offending kind
     assert "fine-tune (QLoRA, ~GPU-seconds)" in message  # carries describe()
-    assert "accepts: 'prompt'" in message  # names what IS accepted
+    assert "it accepts: 'prompt'" in message  # names what IS accepted
 
 
 def test_unsupported_method_kind_is_a_typeerror() -> None:
@@ -261,7 +261,7 @@ def test_architecture_accepting_no_kinds_reports_that_readably() -> None:
         clusterer=Clusterer(threshold=0.5),
     )
 
-    with pytest.raises(UnsupportedMethodKind, match=r"accepts: \(no method kinds\)"):
+    with pytest.raises(UnsupportedMethodKind, match=r"it accepts: \(no method kinds\)"):
         frozen.fit(RECORDS, method=_PromptMethod())
 
 

--- a/tests/fixtures/architectures.py
+++ b/tests/fixtures/architectures.py
@@ -1,0 +1,29 @@
+"""A registered Resolver subclass, standing in for a W4 named architecture.
+
+Lives in ``tests.fixtures`` (not in a test module) so a **fresh subprocess** can
+import it by name and thereby fire its ``@register_model`` — which is exactly
+what the save/load identity round-trip has to prove. W4 lands the real
+architectures (``FuzzyString``, ``VectorLLMCascade``); this is the minimum shape
+needed to test that the seam carries a class identity across a process boundary.
+"""
+
+from typing import ClassVar
+
+from langres.core.registry import register_model
+from langres.core.resolver import Resolver
+
+
+@register_model("fixture_fuzzy_string")
+class FixtureFuzzyString(Resolver):
+    """A registered architecture: string-only, and it accepts no ``method=``.
+
+    Doubles as the B4/B5 crossover check — it carries both an
+    ``accepted_method_kinds`` declaration and a registered model identity, the
+    two things a W4 architecture is made of.
+    """
+
+    accepted_method_kinds: ClassVar[frozenset[str] | None] = frozenset({"calibrate"})
+
+
+class UnregisteredArchitecture(Resolver):
+    """A Resolver subclass nobody registered: must save/load exactly as today."""

--- a/tests/test_resolver_roundtrip.py
+++ b/tests/test_resolver_roundtrip.py
@@ -32,7 +32,14 @@ from pathlib import Path
 import pytest
 
 from langres.core.metrics import calculate_bcubed_metrics
+from langres.core.blockers import AllPairsBlocker
+from langres.core.clusterer import Clusterer
 from langres.core.comparators import StringComparator
+from langres.core.matchers import WeightedAverageMatcher
+from langres.core.models import CompanySchema
+from langres.core.registry import UnknownModelType
+from langres.core.resolver import Resolver
+from tests.fixtures.architectures import FixtureFuzzyString, UnregisteredArchitecture
 from tests.fixtures.companies import COMPANY_RECORDS, EXPECTED_DUPLICATE_GROUPS
 
 # Name-dominant weights mirroring Approach 1 — required for the name-only
@@ -165,6 +172,120 @@ def test_resolver_roundtrip_fresh_process(tmp_path: Path) -> None:
     )
     clusters_subprocess = [set(c) for c in json.loads(proc.stdout)]
     assert _canonical(clusters_before) == _canonical(clusters_subprocess)
+
+
+# --- model_class: save/load carries the architecture's identity (B4) --------
+#
+# Under "one architecture = one class = one identity", a save/load that hands
+# back a plain Resolver has erased the identity. The manifest names the class;
+# an artifact without that name is a plain Resolver, exactly as before.
+
+
+def _architecture_resolver(cls: type) -> object:
+    comparator = StringComparator.from_schema(CompanySchema, weights=NAME_DOMINANT_WEIGHTS)
+    return cls(
+        blocker=AllPairsBlocker(schema=CompanySchema),
+        comparator=comparator,
+        matcher=WeightedAverageMatcher(feature_specs=comparator.feature_specs),
+        clusterer=Clusterer(threshold=0.7),
+    )
+
+
+def test_save_stamps_the_registered_model_class(tmp_path: Path) -> None:
+    """A registered architecture records its identity in the manifest."""
+    _architecture_resolver(FixtureFuzzyString).save(tmp_path)  # type: ignore[attr-defined]
+
+    manifest = json.loads((tmp_path / "resolver.json").read_text())
+    assert manifest["model_class"] == "fixture_fuzzy_string"
+
+
+def test_plain_resolver_writes_no_model_class(tmp_path: Path) -> None:
+    """The base Resolver claims no identity, so it stamps none (today's artifact)."""
+    _architecture_resolver(Resolver).save(tmp_path)  # type: ignore[attr-defined]
+
+    manifest = json.loads((tmp_path / "resolver.json").read_text())
+    assert manifest["model_class"] is None
+
+
+def test_unregistered_subclass_saves_and_loads_as_plain_resolver(tmp_path: Path) -> None:
+    """An unregistered subclass is not an error -- it degrades to today's behavior."""
+    _architecture_resolver(UnregisteredArchitecture).save(tmp_path)  # type: ignore[attr-defined]
+
+    manifest = json.loads((tmp_path / "resolver.json").read_text())
+    assert manifest["model_class"] is None
+    assert type(Resolver.load(tmp_path)) is Resolver
+
+
+def test_load_returns_the_saved_architecture_class(tmp_path: Path) -> None:
+    """``Resolver.load`` on an architecture artifact hands back that architecture."""
+    _architecture_resolver(FixtureFuzzyString).save(tmp_path)  # type: ignore[attr-defined]
+
+    reloaded = Resolver.load(tmp_path)
+
+    assert type(reloaded) is FixtureFuzzyString
+    # The identity is the whole point: its fit contract came back with it.
+    assert reloaded.accepted_method_kinds == frozenset({"calibrate"})
+
+
+def test_manifest_without_model_class_loads_as_plain_resolver(tmp_path: Path) -> None:
+    """A pre-0.4 artifact (no ``model_class`` key at all) still loads, as a Resolver."""
+    _architecture_resolver(Resolver).save(tmp_path)  # type: ignore[attr-defined]
+    manifest_path = tmp_path / "resolver.json"
+    manifest = json.loads(manifest_path.read_text())
+    del manifest["model_class"]  # exactly what a 0.3.0 artifact looks like
+    manifest_path.write_text(json.dumps(manifest))
+
+    reloaded = Resolver.load(tmp_path)
+
+    assert type(reloaded) is Resolver
+    assert reloaded.resolve(COMPANY_RECORDS)
+
+
+def test_load_raises_actionably_on_an_unregistered_model_class(tmp_path: Path) -> None:
+    """An artifact naming a model this process never imported fails with a clear error."""
+    _architecture_resolver(Resolver).save(tmp_path)  # type: ignore[attr-defined]
+    manifest_path = tmp_path / "resolver.json"
+    manifest = json.loads(manifest_path.read_text())
+    manifest["model_class"] = "never_registered"
+    manifest_path.write_text(json.dumps(manifest))
+
+    with pytest.raises(UnknownModelType, match=r"never imported"):
+        Resolver.load(tmp_path)
+
+
+def test_architecture_roundtrip_fresh_process(tmp_path: Path) -> None:
+    """B4: a saved architecture reloads as ITS OWN CLASS in a brand-new process.
+
+    The in-process test cannot prove this on its own -- the class is already
+    imported and registered there. A fresh interpreter that only imports the
+    fixture module is what shows the registry lookup, not ambient state, is
+    carrying the identity across the boundary.
+    """
+    resolver = _architecture_resolver(FixtureFuzzyString)
+    clusters_before = resolver.resolve(COMPANY_RECORDS)  # type: ignore[attr-defined]
+    resolver.save(tmp_path)  # type: ignore[attr-defined]
+
+    script = (
+        "import json, sys\n"
+        "from langres.core import Resolver\n"
+        "import tests.fixtures.architectures  # noqa: F401  -- fires @register_model\n"
+        "from tests.fixtures.companies import COMPANY_RECORDS\n"
+        f"reloaded = Resolver.load({str(tmp_path)!r})\n"
+        "clusters = reloaded.resolve(COMPANY_RECORDS)\n"
+        "sys.stdout.write(json.dumps({\n"
+        "    'cls': type(reloaded).__name__,\n"
+        "    'kinds': sorted(reloaded.accepted_method_kinds),\n"
+        "    'clusters': sorted(sorted(c) for c in clusters),\n"
+        "}))\n"
+    )
+    proc = subprocess.run(
+        [sys.executable, "-c", script], capture_output=True, text=True, check=True
+    )
+
+    out = json.loads(proc.stdout)
+    assert out["cls"] == "FixtureFuzzyString"  # NOT "Resolver"
+    assert out["kinds"] == ["calibrate"]
+    assert _canonical(clusters_before) == _canonical([set(c) for c in out["clusters"]])
 
 
 def test_resolver_from_schema_one_liner() -> None:

--- a/tests/test_resolver_roundtrip.py
+++ b/tests/test_resolver_roundtrip.py
@@ -37,7 +37,7 @@ from langres.core.clusterer import Clusterer
 from langres.core.comparators import StringComparator
 from langres.core.matchers import WeightedAverageMatcher
 from langres.core.models import CompanySchema
-from langres.core.registry import UnknownModelType
+from langres.core.registry import UnknownModelType, register_model
 from langres.core.resolver import Resolver
 from tests.fixtures.architectures import FixtureFuzzyString, UnregisteredArchitecture
 from tests.fixtures.companies import COMPANY_RECORDS, EXPECTED_DUPLICATE_GROUPS
@@ -250,6 +250,28 @@ def test_load_raises_actionably_on_an_unregistered_model_class(tmp_path: Path) -
     manifest_path.write_text(json.dumps(manifest))
 
     with pytest.raises(UnknownModelType, match=r"never imported"):
+        Resolver.load(tmp_path)
+
+
+def test_load_rejects_a_model_class_registered_to_a_non_resolver(tmp_path: Path) -> None:
+    """A registered non-Resolver must fail loudly, not be handed back cast as one.
+
+    ``register_model`` cannot type-check its entries (``registry`` sits beneath
+    ``resolver``), so ``load`` verifies. A kwargs-swallowing class would otherwise
+    construct fine and return a silently wrong object.
+    """
+
+    @register_model("test_roundtrip_not_a_resolver")
+    class _NotAResolver:
+        def __init__(self, **kwargs: object) -> None: ...
+
+    _architecture_resolver(Resolver).save(tmp_path)  # type: ignore[attr-defined]
+    manifest_path = tmp_path / "resolver.json"
+    manifest = json.loads(manifest_path.read_text())
+    manifest["model_class"] = "test_roundtrip_not_a_resolver"
+    manifest_path.write_text(json.dumps(manifest))
+
+    with pytest.raises(TypeError, match=r"is not a Resolver subclass"):
         Resolver.load(tmp_path)
 
 


### PR DESCRIPTION
Clears the last two fork blockers gating **W4** (the `ERModel`/`architectures` wave). Both defend the plan's invariant **I2 — "one architecture = one class = one identity"** — which would otherwise be false on day one. Two sequential commits in one worktree (both touch `resolver.py`).

**No `ERModel` / `architectures/` here — that is W4.** This only removes the blockers.

## B5 — `fit()` mutated topology, falsifying I2

`_fit_finetune` repoints the matcher slot (`self.module = LLMMatcher(...)`), so `FuzzyString().fit(method=QLoRA(...))` would silently become LLM-backed while still being class `FuzzyString`.

A Resolver subclass now declares `accepted_method_kinds`; `fit()` refuses anything else **at the boundary, before dispatch**:

```
UnsupportedMethodKind: FuzzyString does not accept method kind 'finetune'
(fine-tune qwen/Qwen3-0.6B (4-bit QLoRA r=16)); FuzzyString accepts: 'calibrate'.
Fitting with 'finetune' would change the pipeline's topology, leaving FuzzyString
naming a pipeline it no longer is. Use a plain Resolver (which accepts every kind)
or an architecture whose identity includes 'finetune'.
```

- Base `Resolver` stays `None` = **permissive** — it makes no identity claim; no existing fit path changes.
- Real kinds are `prompt` / `finetune` / `calibrate`, **verified at runtime** off `Method.kind` (a `ClassVar`), not guessed.
- `UnsupportedMethodKind` subclasses `TypeError` — `kind` is strategy-*type* identity, and it matches the sibling `TypeError` `_fit_finetune` already raises.
- Rejected alternatives (new-instance-returning `fit()`; advisory I2) are recorded **in-code** with why, so this is cheap to flip.

## B4 — `save`/`load` erased architecture identity

`save` now stamps an **optional** `model_class`; `load` reconstructs that class. Fresh-process proof:

```
--- resolver.json ---            --- FRESH PROCESS: Resolver.load(...) ---
"artifact_version": "1"            loaded class : FixtureFuzzyString
"model_class": "fixture_fuzzy_string"   accepted_method_kinds: ['calibrate']
```

- **Absent ⇒ plain `Resolver`** (every pre-0.4 artifact; an unregistered subclass degrades to today's behaviour, not an error).
- **`ARTIFACT_VERSION` stays `"1"`** — `_check_versions` rejects older *and* newer, so a bump would break existing 0.3.0 artifacts in both directions to buy a read that costs one `if`.
- **Models get their own namespace in the existing `registry.py`** (`register_model`/`get_model`/`model_type_name`), not a parallel registry: a component *fills* a slot, a model *owns* the slots — one dict would make `"type_name": "fuzzy_string"` resolvable in a blocker slot. `registry.py` already keeps schemas separate for exactly this reason.
- `get_model` returns a bare `type` like `get_component`: naming `Resolver` there (even under `TYPE_CHECKING`) would knot `registry <-> resolver` and grow the SCC.
- `config_dict()` still emits only `components`, so `model_class` stays **outside** `recipe_id`'s hash domain — no recipe hash forks.

## Gates (measured, not assumed)

| Gate | Result |
|---|---|
| Import ratchet | runtime cycles **0**, all-edges SCC **[10, 9, 3, 2]** — unchanged |
| `core` coverage (CI cmd) | **98.27%** vs gate 98 — exit 0 |
| Tests | **3681 passed**, 1 skipped (`-m "not slow and not integration"`) |
| `ruff check` / `format --check` | clean / 362 formatted |
| `mypy src/` | Success, 152 files |
| import_budget + public_surface_dod | 45 passed, 1 skipped |

Docs updated in the same PR (`docs/TECHNICAL_OVERVIEW.md`: both contracts) plus `fit`/`save`/`load` docstrings.

## Summary by Sourcery

Introduce architecture identity preservation in resolver save/load and enforce method kind constraints for resolver subclasses to protect pipeline topology.

New Features:
- Add model registry namespace for Resolver subclasses so saved artifacts can reconstruct their architecture class via model_class.
- Expose architecture registration and lookup helpers (register_model, get_model, model_type_name) through the core exports API.
- Allow Resolver subclasses to declare accepted_method_kinds, enabling topology-preserving fit contracts for named architectures.

Enhancements:
- Extend ArtifactManifest and Resolver.save/load so resolver.json includes an optional model_class field without changing artifact_version.
- Add UnsupportedMethodKind error and a pre-dispatch gate in Resolver.fit to reject method kinds outside a subclass’s accepted_method_kinds while keeping the base Resolver permissive.
- Document the save/load model_class semantics and accepted_method_kinds contract in TECHNICAL_OVERVIEW and resolver-related docstrings.

Tests:
- Add resolver save/load round-trip tests that verify architecture identity is preserved, including fresh-process checks and failure modes for unknown model_class values.
- Add tests for the model registry namespace, registration, lookup, suggestions, and separation from component registry.
- Add fit-method tests covering accepted_method_kinds behavior, UnsupportedMethodKind semantics, and ensuring the base Resolver’s existing fit paths remain unchanged.
- Introduce test fixture architectures (registered and unregistered Resolver subclasses) to exercise architecture identity and method kind constraints.