### PR TITLE
test(packaging): gate the wheel/sdist against shipping unlicensed third-party data

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -141,6 +141,15 @@ build-backend = "hatchling.build"
 # (synthetic, BSD-3), fodors_zagat (small), and the peeters_sampled_test.csv
 # pair sets (id/label triples only -- no third-party record text, and the
 # replication seam's sampling stays inspectable from the wheel).
+#
+# !! THESE ARE PATH LITERALS AND THEY FAIL SILENTLY !! Rename a directory below
+# and every pattern quietly matches nothing: the build still succeeds, with zero
+# warnings, and publishes the corpora (measured: 2.16 MB -> 16.07 MB uncompressed
+# wheel, 87.7% third-party CSVs). tests/test_wheel_contents.py is the gate --
+# it builds the real artifacts and compares them against SHIPPED_NON_PY_FILES,
+# an independent allow manifest of what may ship, and separately asserts every
+# pattern here still matches a real file. Moving a dataset means updating BOTH
+# this list and that manifest; the test tells you if you missed one.
 exclude = [
     "src/langres/data/datasets/dblp_acm/*.csv",
     "src/langres/data/datasets/dblp_scholar/*.csv",

--- a/tests/test_wheel_contents.py
+++ b/tests/test_wheel_contents.py
@@ -221,6 +221,17 @@ def test_sdist_ships_exactly_the_declared_data_files(
     with tarfile.open(sdist) as tf:
         names = [m.name for m in tf.getmembers() if m.isfile()]
 
+    # Locating the package by a path marker already fails closed -- if the sdist
+    # layout moved, nothing matches and every manifest entry reports as missing.
+    # But "23 files missing" would misdiagnose a layout change as a deletion, and
+    # a gate whose message points at the wrong cause wastes the incident. Say so.
+    assert any(marker in name for name in names), (
+        f"{sdist.name} contains no member under '{marker}', so this test cannot see "
+        "the package at all. The sdist layout changed (a src-layout move, or a "
+        "different build backend) -- update the marker; do NOT assume the data is "
+        "simply gone."
+    )
+
     shipped = {
         name.split(marker, 1)[1] for name in names if marker in name and not name.endswith(".py")
     }
@@ -228,6 +239,17 @@ def test_sdist_ships_exactly_the_declared_data_files(
 
 
 def _assert_manifest(shipped: set[str], *, artifact: str) -> None:
+    # Both callers filter `.py` out of `shipped`, so a `.py` entry in the manifest
+    # could never match and would surface as a bogus "missing file" -- a real
+    # licence decision is not being made about langres's own source. Name the
+    # actual mistake instead.
+    stray_py = {p for p in SHIPPED_NON_PY_FILES if p.endswith(".py")}
+    assert not stray_py, (
+        f"SHIPPED_NON_PY_FILES lists {len(stray_py)} `.py` path(s): {sorted(stray_py)}. "
+        "The manifest declares the non-`.py` data payload only; `.py` files are "
+        "langres's own source and are not part of this gate."
+    )
+
     unexpected = shipped - SHIPPED_NON_PY_FILES
     missing = SHIPPED_NON_PY_FILES - shipped
     assert not unexpected, (

--- a/tests/test_wheel_contents.py
+++ b/tests/test_wheel_contents.py
@@ -1,0 +1,261 @@
+"""Licence gate: the published artifacts must ship only data we may redistribute.
+
+`[tool.hatch.build].exclude` in `pyproject.toml` keeps the large third-party
+DeepMatcher/Magellan benchmark corpora (vendored for research reproducibility,
+with ATTRIBUTION.md but **no explicit redistribution licence**) out of the
+PyPI artifacts. Those excludes are 14 hand-written path literals, and their
+failure mode is **silent**: rename `src/langres/data/datasets/`, or a dataset
+directory under it, and every literal quietly matches nothing. The build then
+succeeds with zero warnings and ships the corpora anyway. Measured on this
+tree, that is 30 extra CSVs / 13.9 MB -- 87.7% of the resulting wheel.
+
+This has already happened once (a 91%-third-party-data wheel shipped), so this
+file is a regression gate, not a hypothetical.
+
+## Why an explicit manifest, and not a derived rule
+
+The redistribution decision is **not derivable from any property of a file**.
+Measured against this tree, every mechanical rule is wrong:
+
+* "no `.csv` ships" -- false: 13 CSVs ship deliberately.
+* "small CSVs ship" -- false: `wdc_computers/valid.csv` (6,106 B) is excluded
+  while `fodors_zagat/fodors.csv` (44,963 B) ships. No threshold separates them.
+* "a dir with ATTRIBUTION.md ships nothing" -- false: `tiny_fixture` has one and
+  ships all 5 CSVs; `abt_buy`/`amazon_google` have one and ship
+  `peeters_sampled_test.csv`.
+* "only id/label pair files ship" -- false: `fodors.csv` and `person_a.csv` are
+  full record text and ship.
+
+The decision is a per-file human licence judgement, so the expectation has to be
+a per-file human declaration.
+
+Deriving the expectation from the excludes themselves (expected = files on disk
+minus files matching an exclude pattern) is the tempting alternative and it is
+**vacuous**: after a rename the patterns match nothing, so the derived
+expectation becomes "everything ships" and the wheel matching it *passes*. An
+expectation regenerated from the thing that broke cannot detect it breaking.
+
+So: two *independent* descriptions of one decision -- hatchling's deny patterns
+in `pyproject.toml`, and the allow manifest below -- cross-checked against the
+real build output. The direction of rot is what matters. A deny list rots
+**open** (a stale literal silently ships data); this allow list rots **closed**
+(anything the excludes stop catching becomes an unexpected member and fails).
+It is not the 14 literals restated: it is their complement, and it fails on
+drift the literals cannot see -- a rename, a *new* unlicensed dataset, a deleted
+exclude, a build-backend swap.
+
+Keeping the manifest in sync is the intended cost. A new file under
+`src/langres/data/` failing this test is the gate working: adding a dataset is
+exactly when someone must decide, on the record, whether it may be redistributed.
+"""
+
+from __future__ import annotations
+
+import shutil
+import subprocess
+import tarfile
+import tomllib
+import zipfile
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
+# Every non-`.py` file the published artifacts may contain under the `langres`
+# package, as a package-relative path. Scoped to non-`.py` because this gate is
+# about *data*: `.py` is langres's own source, while a redistributed corpus can
+# arrive as .csv today and .parquet/.json/.jsonl tomorrow -- naming the file
+# types we ship rather than the ones we fear keeps those out too.
+#
+# Each entry is a redistribution decision. Do not add one without a reason:
+#
+#   tiny_fixture/*   -- fully synthetic, authored for langres's test suite.
+#                       No third-party data, shares langres's licence.
+#   febrl_person/*   -- FEBRL4 subset: synthetic (no PII), BSD-3 (recordlinkage).
+#   fodors_zagat/*   -- small classic benchmark vendored from QCRI DeepER.
+#   abt_buy/, amazon_google/
+#                    -- third-party corpora, NOT redistributable. Only the
+#                       ATTRIBUTION.md and `peeters_sampled_test.csv` ship: the
+#                       latter is id/label triples with no third-party record
+#                       text, so the replication seam's sampling stays
+#                       inspectable from a pip install.
+#   dblp_acm/, dblp_scholar/, walmart_amazon/, wdc_computers/
+#                    -- third-party corpora, NOT redistributable. ATTRIBUTION.md
+#                       only; every CSV is excluded. Loading one from a pip
+#                       install raises BenchmarkDataNotFoundError pointing at a
+#                       git checkout (langres/data/_benchmark_utils.py).
+SHIPPED_NON_PY_FILES = frozenset(
+    {
+        "py.typed",
+        # -- third-party corpora: attribution only, no records --------------
+        "data/datasets/dblp_acm/ATTRIBUTION.md",
+        "data/datasets/dblp_scholar/ATTRIBUTION.md",
+        "data/datasets/walmart_amazon/ATTRIBUTION.md",
+        "data/datasets/wdc_computers/ATTRIBUTION.md",
+        # -- third-party corpora: attribution + id/label pairs only ---------
+        "data/datasets/abt_buy/ATTRIBUTION.md",
+        "data/datasets/abt_buy/peeters_sampled_test.csv",
+        "data/datasets/amazon_google/ATTRIBUTION.md",
+        "data/datasets/amazon_google/peeters_sampled_test.csv",
+        # -- synthetic, langres-authored ------------------------------------
+        "data/datasets/tiny_fixture/ATTRIBUTION.md",
+        "data/datasets/tiny_fixture/tableA.csv",
+        "data/datasets/tiny_fixture/tableB.csv",
+        "data/datasets/tiny_fixture/train.csv",
+        "data/datasets/tiny_fixture/valid.csv",
+        "data/datasets/tiny_fixture/test.csv",
+        # -- synthetic FEBRL4 subset (BSD-3, no PII) ------------------------
+        "data/datasets/febrl_person/SOURCE.md",
+        "data/datasets/febrl_person/person_a.csv",
+        "data/datasets/febrl_person/person_b.csv",
+        "data/datasets/febrl_person/person_perfectMapping.csv",
+        # -- small classic benchmark (QCRI DeepER) --------------------------
+        "data/datasets/fodors_zagat/SOURCE.md",
+        "data/datasets/fodors_zagat/fodors.csv",
+        "data/datasets/fodors_zagat/zagats.csv",
+        "data/datasets/fodors_zagat/fodors-zagats_perfectMapping.csv",
+    }
+)
+
+# Backstop for bloat the manifest cannot see -- a corpus inlined into a `.py`
+# literal, or vendored outside the `langres` package. A proxy, deliberately
+# secondary to the exact-contents assertion above, and generous so it never
+# bikesheds a legitimate few hundred KB.
+#
+# Uncompressed, matching the vocabulary of the `[tool.hatch.build]` comment in
+# pyproject.toml, and more stable than the compressed size (which moves with
+# zlib's behaviour). Measured at the time of writing: 2.16 MB shipping, 16.07 MB
+# with the excludes dead.
+WHEEL_UNCOMPRESSED_CEILING_BYTES = 4_000_000
+
+
+@pytest.fixture(scope="session")
+def built_artifacts(tmp_path_factory: pytest.TempPathFactory) -> tuple[Path, Path]:
+    """Build the real sdist + wheel with the same command `publish.yml` runs.
+
+    `uv build` (no target flag) builds the sdist and then the wheel *from* that
+    sdist, exactly as the release pipeline does -- so this gate sees what PyPI
+    would get, not a wheel built by a different path. ~1.6s with the build env
+    warm (`uv sync` in CI warms it); the timeout only guards a cold fetch of the
+    build backend.
+    """
+    if shutil.which("uv") is None:  # pragma: no cover - uv is the repo's paved road
+        pytest.fail(
+            "`uv` is not on PATH, so the packaging licence gate cannot build the "
+            "artifacts it exists to check. Run the suite with `uv run pytest`."
+        )
+
+    out_dir = tmp_path_factory.mktemp("dist")
+    subprocess.run(
+        ["uv", "build", "--out-dir", str(out_dir)],
+        cwd=REPO_ROOT,
+        check=True,
+        capture_output=True,
+        timeout=300,
+    )
+    (wheel,) = out_dir.glob("*.whl")
+    (sdist,) = out_dir.glob("*.tar.gz")
+    return wheel, sdist
+
+
+def _hatch_exclude_patterns() -> list[str]:
+    config = tomllib.loads((REPO_ROOT / "pyproject.toml").read_text())
+    excludes = config["tool"]["hatch"]["build"]["exclude"]
+    assert isinstance(excludes, list)
+    return excludes
+
+
+def test_every_exclude_pattern_still_matches_real_files() -> None:
+    """No exclude literal may go dead.
+
+    This is the *upstream* half of the gate and it needs no build, so it runs on
+    every PR (the wheel assertions below are the ground truth, but `test-full`
+    only runs them post-merge). A dead pattern is the exact silent failure this
+    file exists for, and catching it here names the offending literal instead of
+    reporting a mysteriously fat wheel.
+
+    Simple `pathlib` globbing is faithful for the patterns actually in use
+    (a literal path, optionally with `*`). It is not a reimplementation of
+    hatchling's matcher -- the artifact assertions below are what hold the line
+    if a future pattern needs richer semantics.
+    """
+    dead = [p for p in _hatch_exclude_patterns() if not any(REPO_ROOT.glob(p))]
+    assert not dead, (
+        f"{len(dead)} exclude pattern(s) in [tool.hatch.build] match no file on disk:\n"
+        + "\n".join(f"  - {p}" for p in dead)
+        + "\n\nThese patterns keep unlicensed third-party benchmark data out of the "
+        "published wheel/sdist. Matching nothing means they are no longer doing it, "
+        "and the build will NOT warn you. If a dataset moved or was renamed, update "
+        "the pattern to the new path; if it was deleted, drop the pattern."
+    )
+
+
+def test_wheel_ships_exactly_the_declared_data_files(
+    built_artifacts: tuple[Path, Path],
+) -> None:
+    """The wheel's non-`.py` payload must equal the declared manifest."""
+    wheel, _ = built_artifacts
+    with zipfile.ZipFile(wheel) as zf:
+        names = zf.namelist()
+
+    shipped = {
+        name[len("langres/") :]
+        for name in names
+        if name.startswith("langres/") and not name.endswith(".py")
+    }
+    _assert_manifest(shipped, artifact=wheel.name)
+
+
+def test_sdist_ships_exactly_the_declared_data_files(
+    built_artifacts: tuple[Path, Path],
+) -> None:
+    """Same invariant for the sdist.
+
+    `publish.yml` runs `uv build` + `uv publish`, which uploads BOTH artifacts,
+    and `[tool.hatch.build].exclude` is target-agnostic -- so the sdist carries
+    the identical exposure and deserves the identical gate.
+    """
+    _, sdist = built_artifacts
+    marker = "/src/langres/"
+    with tarfile.open(sdist) as tf:
+        names = [m.name for m in tf.getmembers() if m.isfile()]
+
+    shipped = {
+        name.split(marker, 1)[1] for name in names if marker in name and not name.endswith(".py")
+    }
+    _assert_manifest(shipped, artifact=sdist.name)
+
+
+def _assert_manifest(shipped: set[str], *, artifact: str) -> None:
+    unexpected = shipped - SHIPPED_NON_PY_FILES
+    missing = SHIPPED_NON_PY_FILES - shipped
+    assert not unexpected, (
+        f"{artifact} ships {len(unexpected)} data file(s) that are NOT declared "
+        f"redistributable in SHIPPED_NON_PY_FILES:\n"
+        + "\n".join(f"  + {p}" for p in sorted(unexpected))
+        + "\n\nMost likely an exclude pattern in [tool.hatch.build] stopped matching "
+        "(a renamed/moved dataset directory) and third-party benchmark data is now "
+        "in the published artifact -- the build does not warn about this. Either fix "
+        "the exclude, or, if this file really is ours to redistribute, add it to the "
+        "manifest with the licence reason."
+    )
+    assert not missing, (
+        f"{artifact} is MISSING {len(missing)} file(s) the manifest says it ships:\n"
+        + "\n".join(f"  - {p}" for p in sorted(missing))
+        + "\n\nAn over-broad exclude, or a deleted/renamed fixture. If the removal was "
+        "intended, drop the entry from SHIPPED_NON_PY_FILES."
+    )
+
+
+def test_wheel_stays_under_the_size_ceiling(built_artifacts: tuple[Path, Path]) -> None:
+    """Catch-all for payload the manifest cannot see (see the ceiling's comment)."""
+    wheel, _ = built_artifacts
+    with zipfile.ZipFile(wheel) as zf:
+        total = sum(info.file_size for info in zf.infolist())
+
+    assert total <= WHEEL_UNCOMPRESSED_CEILING_BYTES, (
+        f"{wheel.name} is {total:,} B uncompressed, over the "
+        f"{WHEEL_UNCOMPRESSED_CEILING_BYTES:,} B ceiling. Something large is being "
+        "published. If it is legitimate, raise the ceiling deliberately."
+    )


### PR DESCRIPTION
## The exposure (re-measured on this branch, not taken on faith)

`[tool.hatch.build].exclude` keeps the third-party DeepMatcher/Magellan corpora (vendored for research reproducibility; `ATTRIBUTION.md` but **no explicit redistribution licence**) out of the PyPI artifacts. It is **14 hand-written path literals with no test behind them**. Rename `src/langres/data/datasets/` and every literal quietly matches nothing.

**The build then succeeds with zero warnings and ships the corpora.** That silence is the whole problem. This repo has already shipped a 91%-third-party-data wheel once, so this is a regression of a solved problem.

Measured by renaming the directory on disk and rebuilding:

| | wheel (compressed) | wheel (uncompressed) | CSVs | CSV bytes |
|---|---|---|---|---|
| excludes matching (today) | 745,757 B | 2,163,667 B | 13 | 189,707 B (8.8%) |
| excludes dead (post-rename) | 5,902,391 B | 16,072,058 B | 43 | 14,095,044 B (**87.7%**) |

**The sdist carries the identical exposure** (2.26 MB → 7.39 MB; 13 → 43 CSVs). `[tool.hatch.build]` is target-agnostic and `publish.yml` runs `uv build` + `uv publish`, which uploads **both**. Gated both.

## The invariant, and why it is not derived

The redistribution decision is **not derivable from any property of a file**. Every mechanical rule is measurably wrong on this tree:

- *"no `.csv` ships"* — false: 13 CSVs ship deliberately.
- *"small CSVs ship"* — false: `wdc_computers/valid.csv` (6,106 B) is excluded while `fodors_zagat/fodors.csv` (44,963 B) ships. **No threshold separates them.**
- *"a dir with `ATTRIBUTION.md` ships nothing"* — false: `tiny_fixture` has one and ships all 5 CSVs; `abt_buy`/`amazon_google` have one and ship `peeters_sampled_test.csv`.
- *"only id/label pair files ship"* — false: `fodors.csv` and `person_a.csv` are full record text and ship.

It is a per-file human licence judgement, so the expectation must be a per-file human declaration.

**The tempting derivation is vacuous.** Deriving expected-contents from the excludes themselves (*files on disk minus files matching a pattern*) fails open by construction: after a rename the patterns match nothing, so the derived expectation becomes *"everything ships"* — and the fat wheel **passes**. An expectation regenerated from the thing that broke cannot detect it breaking.

So: **two independent descriptions of one decision** — hatchling's deny patterns, and an allow manifest (`SHIPPED_NON_PY_FILES`) — cross-checked against a real `uv build`. Direction of rot is the point: **a deny list rots open; an allow list rots closed.** It is not the 14 literals restated — it is their complement, and it catches drift the literals cannot see (a rename, a *new* unlicensed dataset, a deleted exclude, a backend swap). Scoped to *non-`.py`* rather than `.csv` so a future `.parquet`/`.json` corpus is caught too.

## What is in the gate

1. `test_every_exclude_pattern_still_matches_real_files` — no build; fails naming the **dead literal**. Catches a rename at its source.
2. `test_wheel_ships_exactly_the_declared_data_files` / `..._sdist_...` — ground truth, against the real artifacts.
3. `test_wheel_stays_under_the_size_ceiling` — generous catch-all (4 MB vs 2.16 MB actual) for payload the manifest cannot see (e.g. a corpus inlined into a `.py` literal). Deliberately **secondary**.

## Mutation proof — it bites

**Real directory rename** (`datasets/` → `benchmarks/`, pyproject untouched) — the exact W2/Stream B scenario:
```
AssertionError: 14 exclude pattern(s) in [tool.hatch.build] match no file on disk:
    - src/langres/data/datasets/dblp_acm/*.csv
    ... (all 14)
AssertionError: langres-0.3.0-py3-none-any.whl ships 52 data file(s) that are NOT
declared redistributable in SHIPPED_NON_PY_FILES:
    + data/benchmarks/abt_buy/tableA.csv ...
AssertionError: ... is 16,072,162 B uncompressed, over the 4,000,000 B ceiling.
=== 4 failed in 2.50s ===
```
**Single mangled literal** (`abt_buy/tableA.csv` → `tableA_RENAMED.csv`) — minimal mutation:
```
AssertionError: 1 exclude pattern(s) ... match no file on disk:
    - src/langres/data/datasets/abt_buy/tableA_RENAMED.csv
AssertionError: ... ships 1 data file(s) that are NOT declared redistributable:
    + data/datasets/abt_buy/tableA.csv
=== 3 failed, 1 passed in 1.33s ===
```
The one that passed is the **size check** — a 324 KB CSV does not breach a 4 MB ceiling. That is exactly why size is the secondary signal and contents are the primary one. Unmutated: `4 passed in 2.47s`.

## Which job runs it — verified, not assumed

Collection tested against the **exact marker expressions in `test.yml`**:

| job | marker expr | trigger | collects all 4? |
|---|---|---|---|
| `test` | `not integration and not slow and not finetune` | `pull_request` | ✅ |
| `test-full` | `not integration and not finetune` | `push` → `[main, feat/arch-refactor]` + `workflow_dispatch` | ✅ |

**Not marked `slow`** — deliberately, and this departs from the brief's expectation that a wheel build would be slow. Measured: **the whole file is ~2.5s** (`uv build` is ~1.6s warm; `uv sync` warms the build env in every CI job). This repo's `slow` marker means torch inference / ~10 min. Marking it `slow` would have **removed it from the per-PR job**, so a rename would only be caught *after* merge. Unmarked, it runs in **both** — the rename is caught on the PR that does it.

## Not done, on purpose

No rename, no move of `data/`, no restructure. This is the gate that makes that move safe; the move is a separate, undecided wave.

## Verification

`3661 passed, 1 skipped, 114 deselected` (99% coverage) · `ruff check` clean · `ruff format --check` 423 files clean · `mypy src/` clean (152 files) · `test_import_tangle.py` unaffected (no new `src` imports).

https://claude.ai/code/session_018dBNayZ5NpfnZBxupyJT7U

## Summary by Sourcery

Add a packaging licence gate that ensures built wheels and sdists only include explicitly approved non-Python data files and that Hatch build exclude patterns remain effective.

Documentation:
- Document in `pyproject.toml` how Hatch exclude patterns interact with the new tests and the SHIPPED_NON_PY_FILES manifest, and the requirement to update both when datasets move or change.

Tests:
- Add tests that build real wheel/sdist artifacts with `uv` and assert their non-`.py` contents match a declared allowlist of redistributable data files.
- Add a test ensuring every `[tool.hatch.build].exclude` path pattern still matches files on disk, catching silent failures from dataset renames or moves.
- Add a size-based test that the uncompressed wheel remains under a configurable ceiling as a secondary guard against unexpected payload bloat.