### PR TITLE
fix(rules): durability check must use -uall — `--porcelain` is blind to untracked files

### DIFF
--- a/.claude/rules/expert-knowledge.md
+++ b/.claude/rules/expert-knowledge.md
@@ -122,8 +122,17 @@ lived in `tmp/`. The entire run had to be reconstructed and re-run.
   crash or teardown can't erase what you just wrote.
 - **Never leave a worktree's only copy uncommitted.** Before an agent reports
   done — and before an orchestrator stops, replaces, or moves past a worktree
-  agent — `git -C <worktree> status --porcelain` must be empty of anything you
-  can't afford to lose. Push if the work must outlive the worktree's branch.
+  agent — `git -C <worktree> status --porcelain --untracked-files=all` must be
+  empty of anything you can't afford to lose. Push if the work must outlive the
+  worktree's branch.
+  **`-uall` is mandatory here, not a refinement.** This machine sets
+  `status.showUntrackedFiles = no` globally (`~/.config/git/config`), so a bare
+  `--porcelain` prints *nothing* for a never-`git add`ed file and reports a
+  clean tree. That is exactly the state that lost the run above — a brand-new
+  harness script is untracked — so the check this rule used to mandate was
+  blind to the very accident it was written for. Without `-uall` the check is
+  not weaker, it is **wrong**. (`-uall` over `-unormal` because it names the
+  file at risk instead of collapsing a new directory to `dir/`.)
 - **Treat `tmp/` and other gitignored output as ephemeral.** It dies with the
   worktree and is unrecoverable from git. If a result must survive (a report,
   a dataset, a decision record), commit it to a tracked path or copy it out of
@@ -134,6 +143,16 @@ lived in `tmp/`. The entire run had to be reconstructed and re-run.
 
 The cost of one early `git commit` is nothing. The cost of losing a paid run is
 the run, the time to notice, and the time to redo it.
+
+**The shape of that bug generalizes: a green light decoupled from the thing it
+claims to check.** This repo has hit it four times — a CI step *named* "95%
+coverage gate" while enforcing 90 (`ba90aef`; see the comment on that step in
+`.github/workflows/test.yml`); a cancelled workflow run read as a green run
+(the `concurrency` comment in the same file); a review bot reporting `pass` in
+~5s without ever fetching the diff; and this rule's own `--porcelain` reporting
+a clean tree over unsaved work. When a check says "all clear", confirm it can
+actually observe the failure it exists to catch — a check you have never seen
+fail is a hypothesis, not a safety net.
 
 ## Don't Be Too Assertive Without Context
 


### PR DESCRIPTION
## The bug

`.claude/rules/expert-knowledge.md` § **"Commit Before the Worktree Disappears"** mandated:

> `git -C <worktree> status --porcelain` must be empty of anything you can't afford to lose.

**That command cannot see untracked files in this environment.** The rule exists *because langres already lost a paid benchmark run* — a harness script that was never committed, plus gitignored `tmp/` output. A brand-new, never-`git add`ed script **is untracked**, so `--porcelain` reports a clean tree while the only copy of the work sits unsaved. The safety net had a hole shaped precisely like the accident it was written for.

## Verification (re-run from scratch on this machine, both directions)

Using a path at the repo root that is **not** gitignored — `git check-ignore` exits 1, confirming it is not ignored:

```
$ git config --show-origin --get-all status.showUntrackedFiles
file:/Users/davidgraf/.config/git/config	no

$ git check-ignore -v _untracked_probe_delete_me.txt
check-ignore exit: 1                      # <- NOT ignored

$ git status --porcelain                  # <- the command the rule mandated
                                          #    (empty — untracked file INVISIBLE)

$ git status --porcelain --untracked-files=all
?? _untracked_probe_delete_me.txt         #    shown
```

`git version 2.50.1 (Apple Git-155)`. The default is `no` via the user's **global** `~/.config/git/config`, not any repo-local setting.

`-uall` over `-unormal` — also measured. Both defeat the `no` default, but on a new untracked directory:

```
$ git status --porcelain --untracked-files=normal
?? _probe_dir_delete_me/                  # collapsed — the file is not named
$ git status --porcelain --untracked-files=all
?? _probe_dir_delete_me/harness.py        # names the file actually at risk
```

Probe files were removed; the tree was verified empty afterwards with `-uall`.

## What changed

**`.claude/rules/expert-knowledge.md`** (the only file changed) — the mandated command becomes `git status --porcelain --untracked-files=all`, with one line on *why*, stating plainly that a bare `--porcelain` is **not a weaker check but a wrong one** for this purpose.

It also records the generalizing pattern the task identified — **a green light decoupled from the thing it claims to check** — with four instances. Two are documented in this repo's own CI config and I cite them rather than assert them:

- `.github/workflows/test.yml` — a step *named* "(95% coverage gate)" that actually enforced 90 (`ba90aef` lowered the floor and left the name behind; "the stale name was later read as if it were the configuration").
- `.github/workflows/test.yml` `concurrency:` — "a cancelled run is not a green run".

## `--porcelain` uses deliberately left alone

Not every `--porcelain` is wrong; a blanket replace would have been the wrong change. Left as-is:

| Location | Why left |
|---|---|
| `.claude/dave/workflows/push.md:101` — pre-push "Check Working Tree" | Gates a **push**, which destroys nothing. A missed untracked file yields an incomplete PR, not lost work — the file stays on disk. This is the "is the tree dirty before I do X?" case that is explicitly fine. Borderline; flagging it rather than silently changing a vendored framework workflow. |
| `src/langres/core/runs.py:326` — `git_sha()` dirty flag | Product code (out of scope), and **correct as-is**: it records whether *tracked* code differs from the recorded HEAD sha for run provenance. Adding `-uall` would mark nearly every run "dirty" on any stray scratch file. |
| `docs/plans/20260708_tracking_observability_plan.md:106` | Historical plan doc *describing* the `git_sha()` helper above. Not a prescribed durability check. |
| `src/langres/data/datasets/**/*.csv` | "porcelain" the ceramic (grills, whiteboards). Benchmark data. |

**`.claude/rules/data-safety.md` needed no change** — it cross-references the rule prose but never repeats the command, so there was nothing to drift.

## Scope

- **The user's git config is untouched.** `status.showUntrackedFiles = no` is a deliberate global preference in `~/.config/git/config`, outside this repo and shared with every other tool they run. The rule adapts to the environment, not the reverse. (If David *wants* it flipped, that's his call to make, not this PR's.)
- No `src/` changes, no restructuring, no `.py` touched. One file, one section.

https://claude.ai/code/session_018dBNayZ5NpfnZBxupyJT7U

## Summary by Sourcery

Strengthen the durability rule for worktrees by requiring `git status --porcelain --untracked-files=all` and documenting the underlying class of safety-check failures it aims to prevent.

Documentation:
- Clarify expert-knowledge guidance so durability checks explicitly include untracked files via `-uall` and explain why a bare `--porcelain` can falsely report a clean tree.
- Add a note on the broader pattern of checks that signal success without being able to observe the failures they are meant to catch, with concrete CI examples from this repo.