### PR TITLE
refactor(core): W3 — ModelRef is the one backbone, routed by kind not by the filesystem

### DIFF
--- a/.claude/rules/component-design.md
+++ b/.claude/rules/component-design.md
@@ -181,7 +181,7 @@ Extract when you see:
    method registry (`core/method_registry.py` — the v0.3 unification that
    closed issue #55's three-site wiring debt): a `MethodSpec` carries the
    builder plus identity metadata (`score_type`, `default_threshold`,
-   `default_model`, `accepts_model`, `needs_comparator`, `requires_extra`).
+   `default_model`, `accepted_kinds`, `needs_comparator`, `requires_extra`).
    All three dispatch paths — `core/presets.py:build_judge` (the verbs),
    `core/resolver.py:_build_module_for_judge` (`Resolver.from_schema`), and
    `methods.py:_make_module_builder` (the benchmark harness) — resolve names
@@ -200,6 +200,54 @@ Extract when you see:
 3. **Composition happens in `Resolver`**, not a `Task` class: a resolve is
    blocker → (compare) → judge → clusterer. The verbs (`link` / `dedupe`) are
    the user-facing sugar over it.
+
+## Backbones: `ModelRef` is the ONE model-reference concept
+
+**Architecture = topology** (which components, in what order). **Backbone = what
+fills a model slot.** Swapping a backbone must never mint a new architecture, so
+a component never invents its own model-reference shape: it takes a
+`langres.core.model_ref.ModelRef` (via `normalize_model_ref`, which accepts a
+plain string, a dict, or a ref).
+
+`ModelRef` is a stdlib-only leaf (it imports nothing from `langres`), frozen,
+validated in `__post_init__`, and **weightless** — reference strings only, so it
+round-trips as JSON config via `to_config`. Its fields: `base`, `kind`,
+`adapter`, `api_base`, `revision`.
+
+**`kind` is the discriminator, and routing reads nothing else:**
+
+| `kind` | `base` names | runs |
+|---|---|---|
+| `api` | a litellm id (`openai/gpt-4o`, `gpt-5-mini`) | served (litellm) |
+| `endpoint` | a model served at `api_base` | served (litellm) |
+| `hf` | a Hugging Face Hub id (`org/name`) | in-process |
+| `local` | a local directory path | in-process |
+
+Rules that are load-bearing, each for a measured reason:
+
+- **Never route on the filesystem** (B17). `backend_for(kind)` is the whole rule.
+  The predecessor probed `os.path.isdir(base)`, so the same saved config resolved
+  to a *different backend in a different working directory* (reproduced: a
+  `./gpt-5-mini` directory flipped that API id litellm → transformers). A path is
+  recognized by **syntax** (`./`, `../`, `/`, `~`) — so a bare relative dir name is
+  an API id, not a path.
+- **`revision` pins an `hf` ref** (B16). Without it `org/name` drifts as the Hub
+  moves and an "identical versioned config" is not identical across time.
+- **Don't guess a provider typo.** `org/name` cannot be disambiguated from a
+  typo'd provider by syntax: the real org `mistralai` scores 0.875 against the
+  `mistral` provider while the typo `opeani`→`openai` scores 0.833, so no difflib
+  cutoff exists. A caller who means an API model names `kind="api"`.
+- **DSPy-backed slots are litellm-only** (B10). DSPy routes *every* completion
+  through litellm (`lm.py:forward` → `litellm_completion`); `lm_local` shells out
+  to sglang and points litellm back at localhost. So `require_litellm_routable`
+  rejects local dirs and adapters at construction. It deliberately admits `hf`:
+  litellm knows 146 providers and the prefix table 26, so 120 real provider ids
+  infer as `hf` and rejecting them would break working code.
+
+A method declares which backbones it can run via `MethodSpec.accepted_kinds`, and
+`check_backbone` enforces it on every dispatch path — an empty set means "no model
+slot", so `model=` raises rather than being silently dropped. See
+`docs/ADDING_A_METHOD.md`.
 
 Add docstrings to all public methods, and include a usage example in `examples/`
 for any new user-facing component.

--- a/.claude/rules/component-design.md
+++ b/.claude/rules/component-design.md
@@ -230,7 +230,9 @@ Rules that are load-bearing, each for a measured reason:
   to a *different backend in a different working directory* (reproduced: a
   `./gpt-5-mini` directory flipped that API id litellm → transformers). A path is
   recognized by **syntax** (`./`, `../`, `/`, `~`) — so a bare relative dir name is
-  an API id, not a path.
+  an API id, not a path. Inference is total over non-empty strings: a multi-slash
+  id is never a Hub id (those carry one slash), so it goes to `api` and litellm —
+  which owns the real provider list — reports any error.
 - **`revision` pins an `hf` ref** (B16). Without it `org/name` drifts as the Hub
   moves and an "identical versioned config" is not identical across time.
 - **Don't guess a provider typo.** `org/name` cannot be disambiguated from a

--- a/docs/ADDING_A_METHOD.md
+++ b/docs/ADDING_A_METHOD.md
@@ -133,10 +133,36 @@ register_method(MethodSpec(
     score_type="prob_group_llm",       # the family tag its judgements carry
     default_threshold=0.7,             # E12: per-family threshold scales
     default_model=DEFAULT_OPENROUTER_MODEL,  # what results report as `model`
-    accepts_model=True,                # honors a caller model= override
+    accepted_kinds=LITELLM_ROUTABLE_KINDS,   # WHICH backbones it can actually run
     requires_extra="llm",              # actionable ImportError names the extra
 ))
 ```
+
+### Declaring the backbone slot (`accepted_kinds`)
+
+A **backbone** is what fills a method's model slot — a
+`langres.core.model_ref.ModelRef`: an API id, a served endpoint, an HF Hub id, a
+local directory, or `{base, adapter}` for an unmerged QLoRA. `accepted_kinds`
+names the `kind`s your method can *actually* run, and it is the only thing that
+decides whether a caller's `model=` is honored or refused:
+
+| your method is backed by | `accepted_kinds` | why |
+|---|---|---|
+| nothing (pure string similarity) | `frozenset()` (the default) | no model slot — a caller's `model=` raises `UnsupportedBackboneError` instead of being silently dropped |
+| DSPy (`DSPyMatcher`, `SelectMatcher`) | `LITELLM_ROUTABLE_KINDS` | DSPy routes **every** completion through litellm — it has no in-process route, so a local dir or an adapter is unreachable |
+| `LLMMatcher` | `SERVED_KINDS \| IN_PROCESS_KINDS` | it has litellm **and** a transformers backend |
+| an in-process embedder | `IN_PROCESS_KINDS` | the weights load here |
+
+`MethodSpec.check_backbone(model)` is the one gate every dispatch path calls, so
+all three layers reject the same refs with the same message. **An empty
+`accepted_kinds` is a promise, not an omission**: it says "this method has no
+model", and the registry will enforce it.
+
+> `accepted_kinds` replaced the old `accepts_model: bool` in W3. The bool could
+> only say *whether* a slot took a backbone, never *which kinds* — so the
+> DSPy-backed methods advertised `accepts_model=True` while meaning "a litellm id
+> **string**", and a local path was forwarded into `DSPyMatcher(model=…)` to die
+> deep inside litellm. `accepts_model` is now just `bool(accepted_kinds)`.
 
 Method ids are **bare names**; `/` is reserved for future `author/method`
 namespacing (model ids keep their slashes in the orthogonal `model=` kwarg).

--- a/docs/TECHNICAL_OVERVIEW.md
+++ b/docs/TECHNICAL_OVERVIEW.md
@@ -513,6 +513,88 @@ ReviewQueue("review_queue.jsonl").write(items)
 
 ## 7. Core Data Contracts (Pydantic Models)
 
+### ModelRef (`langres.core.model_ref`) — the ONE backbone contract
+
+An *architecture* is a topology (which components, in what order). A **backbone**
+is what fills one of its model slots. `ModelRef` is how langres names one, and
+**swapping a backbone never mints a new architecture**.
+
+It is a frozen dataclass (not Pydantic — the module is a stdlib-only leaf that
+imports nothing from `langres`, so it stays out of every heavy-dep path),
+validated in `__post_init__`, and **weightless**: reference strings only, never
+weight bytes, so it round-trips as plain JSON config.
+
+```python
+ModelRef(
+    base: str,                 # the id or path
+    kind: BackboneKind,        # "api" | "endpoint" | "hf" | "local"  (REQUIRED)
+    adapter: str | None = None,    # unmerged PEFT adapter; in-process kinds only
+    api_base: str | None = None,   # required by — and exclusive to — kind="endpoint"
+    revision: str | None = None,   # HF Hub git revision; kind="hf" only
+)
+```
+
+**`kind` is the discriminator and the sole input to routing** —
+`backend_for(kind)` is the entire rule, and it never touches the filesystem:
+
+| `kind` | `base` names | routes to |
+|---|---|---|
+| `api` | a litellm id (`openai/gpt-4o`, `gpt-5-mini`) | litellm |
+| `endpoint` | a model served at `api_base` (vLLM/Ollama/OpenAI-compatible) | litellm |
+| `hf` | a Hugging Face Hub id (`org/name`) | transformers (in-process) |
+| `local` | a local directory path | transformers (in-process) |
+
+**Surface forms** — `normalize_model_ref(model, *, api_base=None)` accepts all
+three and infers `kind` by **syntax alone** when it is not named:
+
+```python
+normalize_model_ref("gpt-5-mini")                    # -> kind="api"   (bare id)
+normalize_model_ref("openai/gpt-4o")                 # -> kind="api"   (known provider prefix)
+normalize_model_ref("BAAI/bge-small-en-v1.5")        # -> kind="hf"    (org/name)
+normalize_model_ref("./my-ft")                       # -> kind="local" (path syntax)
+normalize_model_ref("m", api_base="http://x:8000/v1")  # -> kind="endpoint"
+normalize_model_ref({"base": "org/m", "kind": "api"})   # explicit kind wins
+normalize_model_ref({"base": "b", "adapter": "a"})      # -> in-process (QLoRA, unmerged)
+```
+
+Two rules that surprise people, both deliberate:
+
+- **A bare relative directory name is NOT a path.** `"my-model"` is an `api` id
+  even if `./my-model` exists — write `"./my-model"` or pass `kind="local"`.
+  Probing the filesystem is what made routing depend on the working directory:
+  the same saved config resolved to a *different backend* elsewhere.
+- **`org/name` is never second-guessed.** It cannot be distinguished from a
+  typo'd provider by syntax, so a caller who means an API model says
+  `{"base": "...", "kind": "api"}`.
+
+**`revision` is in the v1 schema on purpose.** Without it an `org/name` ref
+drifts as the Hub moves, so two runs of an "identical versioned config" are not
+identical across time.
+
+**Serialization** (`to_config` / `normalize_model_ref` are inverses) emits the
+compact bare-`base` string exactly when that string re-normalizes to an equal
+ref — so the common case stays **byte-identical to pre-`kind` artifacts** — and
+widens to `{"base", "kind", ...}` otherwise. The pinned invariant:
+`normalize_model_ref(to_config(ref)) == ref` for every ref. A stored dict without
+`kind` still loads (it is inferred), so older artifacts keep working.
+
+**Typed errors** (both `ValueError` subclasses):
+
+- `InvalidModelRefError` — the ref is malformed or its form is unrecognizable
+  (an empty base, an unknown `kind`, an adapter on a served kind, `api_base` on a
+  non-endpoint, a `revision` on a non-`hf` ref, a multi-slash id with no known
+  provider).
+- `UnsupportedBackboneError` — the ref is *fine*, but the slot cannot run it:
+  a DSPy-backed matcher handed a local dir/adapter (`require_litellm_routable`),
+  or a method with no model slot handed any `model=` at all
+  (`MethodSpec.check_backbone`).
+
+> **DSPy-backed slots are litellm-only.** `DSPyMatcher` / `SelectMatcher` route
+> every completion through litellm — DSPy has no in-process route — so a `local`
+> directory or an unmerged adapter raises at construction rather than dying deep
+> inside litellm. Use `LLMMatcher` (litellm **and** a transformers backend) to run
+> local weights, or serve the model and pass an `endpoint` ref.
+
 ### ERCandidate[SchemaT]
 
 The internal data wrapper passed into a Flow.

--- a/docs/TECHNICAL_OVERVIEW.md
+++ b/docs/TECHNICAL_OVERVIEW.md
@@ -565,7 +565,13 @@ Two rules that surprise people, both deliberate:
   the same saved config resolved to a *different backend* elsewhere.
 - **`org/name` is never second-guessed.** It cannot be distinguished from a
   typo'd provider by syntax, so a caller who means an API model says
-  `{"base": "...", "kind": "api"}`.
+  `{"base": "...", "kind": "api"}`. Conversely a **multi-slash** id
+  (`nvidia_nim/meta/llama3-8b`) is *never* a Hub id — those carry exactly one
+  slash — so it infers as `api` and litellm, which has the full provider list,
+  produces the error if the provider is wrong.
+
+Inference is **total over non-empty strings**: every one names a kind, so the
+only `InvalidModelRefError` from a bare string is the empty one.
 
 **`revision` is in the v1 schema on purpose.** Without it an `org/name` ref
 drifts as the Hub moves, so two runs of an "identical versioned config" are not
@@ -580,10 +586,9 @@ widens to `{"base", "kind", ...}` otherwise. The pinned invariant:
 
 **Typed errors** (both `ValueError` subclasses):
 
-- `InvalidModelRefError` — the ref is malformed or its form is unrecognizable
-  (an empty base, an unknown `kind`, an adapter on a served kind, `api_base` on a
-  non-endpoint, a `revision` on a non-`hf` ref, a multi-slash id with no known
-  provider).
+- `InvalidModelRefError` — the ref is malformed (an empty base, an unknown
+  `kind`, an adapter on a served kind, `api_base` on a non-endpoint, a `revision`
+  on a non-`hf` ref, a conflicting `api_base`, a non-string `adapter`/`revision`).
 - `UnsupportedBackboneError` — the ref is *fine*, but the slot cannot run it:
   a DSPy-backed matcher handed a local dir/adapter (`require_litellm_routable`),
   or a method with no model slot handed any `model=` at all

--- a/src/langres/core/embeddings.py
+++ b/src/langres/core/embeddings.py
@@ -50,6 +50,7 @@ import numpy as np
 from pydantic import BaseModel
 from sentence_transformers import SentenceTransformer
 
+from langres.core.model_ref import DEFAULT_EMBEDDING_MODEL
 from langres.core.registry import register
 
 logger = logging.getLogger(__name__)
@@ -63,7 +64,7 @@ class SentenceTransformerEmbedderConfig(BaseModel):
     first ``encode()`` call.
     """
 
-    model_name: str = "all-MiniLM-L6-v2"
+    model_name: str = DEFAULT_EMBEDDING_MODEL
     batch_size: int = 32
     show_progress_bar: bool = False
     normalize_embeddings: bool = True
@@ -74,6 +75,18 @@ class FakeEmbedderConfig(BaseModel):
 
     embedding_dim: int = 384
     normalize_embeddings: bool = True
+
+
+class FastEmbedSparseEmbedderConfig(BaseModel):
+    """Light, JSON-serializable construction config for a FastEmbedSparseEmbedder."""
+
+    model_name: str = "Qdrant/bm25"
+
+
+class FastEmbedLateInteractionEmbedderConfig(BaseModel):
+    """Light, JSON-serializable construction config for a FastEmbedLateInteractionEmbedder."""
+
+    model_name: str = "colbert-ir/colbertv2.0"
 
 
 class EmbeddingProvider(Protocol):
@@ -313,7 +326,7 @@ class SentenceTransformerEmbedder:
 
     def __init__(
         self,
-        model_name: str = "all-MiniLM-L6-v2",
+        model_name: str = DEFAULT_EMBEDDING_MODEL,
         batch_size: int = 32,
         show_progress_bar: bool = False,
         normalize_embeddings: bool = True,
@@ -591,6 +604,7 @@ class FakeEmbedder:
 # ============ SPARSE EMBEDDING IMPLEMENTATIONS ============
 
 
+@register("fastembed_sparse_embedder")
 class FastEmbedSparseEmbedder:
     """Sparse embedding provider using FastEmbed library.
 
@@ -617,16 +631,33 @@ class FastEmbedSparseEmbedder:
         Model is loaded lazily on first encode() call.
     """
 
+    # Registry key, mirrored as a class attribute so the Resolver's uniform
+    # serialization helper can discover the type name (see resolver.py).
+    type_name: ClassVar[str] = "fastembed_sparse_embedder"
+
     def __init__(self, model_name: str = "Qdrant/bm25"):
         """Initialize FastEmbed sparse embedder.
 
         Args:
-            model_name: FastEmbed sparse model name.
+            model_name: FastEmbed sparse model name -- the embedder's backbone.
                 Default: "Qdrant/bm25" (classic BM25)
                 Alternative: "prithivida/Splade_PP_en_v1" (neural sparse)
         """
         self.model_name = model_name
         self._model: Any = None  # Lazy-loaded on first encode
+
+    def config(self) -> FastEmbedSparseEmbedderConfig:
+        """Return the light, JSON-serializable construction config.
+
+        The loaded model is intentionally excluded -- it is reloaded lazily from
+        ``model_name`` in :meth:`from_config`.
+        """
+        return FastEmbedSparseEmbedderConfig(model_name=self.model_name)
+
+    @classmethod
+    def from_config(cls, config: FastEmbedSparseEmbedderConfig) -> "FastEmbedSparseEmbedder":
+        """Reconstruct an embedder from its config (model stays unloaded)."""
+        return cls(model_name=config.model_name)
 
     def encode(self, texts: list[str], prompt: str | None = None) -> list[dict[str, Any]]:
         """Generate sparse vectors using FastEmbed.
@@ -713,6 +744,7 @@ class FakeSparseEmbedder:
 # ============ LATE INTERACTION EMBEDDING IMPLEMENTATIONS ============
 
 
+@register("fastembed_late_interaction_embedder")
 class FastEmbedLateInteractionEmbedder:
     """Late-interaction embedding provider using FastEmbed library.
 
@@ -737,6 +769,10 @@ class FastEmbedLateInteractionEmbedder:
         Token count varies per text based on tokenization.
     """
 
+    # Registry key, mirrored as a class attribute so the Resolver's uniform
+    # serialization helper can discover the type name (see resolver.py).
+    type_name: ClassVar[str] = "fastembed_late_interaction_embedder"
+
     def __init__(self, model_name: str = "colbert-ir/colbertv2.0"):
         """Initialize FastEmbed late-interaction embedder.
 
@@ -752,6 +788,21 @@ class FastEmbedLateInteractionEmbedder:
         """
         self.model_name = model_name
         self._model: Any = None  # Lazy-loaded on first encode
+
+    def config(self) -> FastEmbedLateInteractionEmbedderConfig:
+        """Return the light, JSON-serializable construction config.
+
+        The loaded model is intentionally excluded -- it is reloaded lazily from
+        ``model_name`` in :meth:`from_config`.
+        """
+        return FastEmbedLateInteractionEmbedderConfig(model_name=self.model_name)
+
+    @classmethod
+    def from_config(
+        cls, config: FastEmbedLateInteractionEmbedderConfig
+    ) -> "FastEmbedLateInteractionEmbedder":
+        """Reconstruct an embedder from its config (model stays unloaded)."""
+        return cls(model_name=config.model_name)
 
     def _get_model(self) -> Any:
         """Get or load the FastEmbed late-interaction model.

--- a/src/langres/core/finetune.py
+++ b/src/langres/core/finetune.py
@@ -259,10 +259,16 @@ def run_finetune(
     active_trainer = trainer if trainer is not None else QLoRATrainer()
     outcome = active_trainer.train(method.base, conversations, method, output_dir)
 
+    # Both branches normalize so the ``kind`` discriminator is inferred from the
+    # ref's actual shape (an HF base id -> "hf", a local base dir -> "local")
+    # rather than hardcoded here. A merged fine-tune is a self-contained
+    # directory; an unmerged one is base+adapter, which is in-process by
+    # construction (``normalize_model_ref`` forces an in-process kind when an
+    # adapter is present -- litellm cannot assemble one).
     model_ref = (
         normalize_model_ref(outcome.adapter_dir)
         if outcome.merged
-        else ModelRef(base=method.base, adapter=outcome.adapter_dir)
+        else normalize_model_ref({"base": method.base, "adapter": outcome.adapter_dir})
     )
     dollars = outcome.train_seconds / 3600.0 * method.gpu_hourly_usd
     return FinetuneOutcome(

--- a/src/langres/core/matchers/dspy_judge.py
+++ b/src/langres/core/matchers/dspy_judge.py
@@ -34,6 +34,12 @@ from typing import Any, ClassVar, Self
 import dspy
 from dspy.utils.exceptions import AdapterParseError
 
+from langres.core.model_ref import (
+    ModelRef,
+    normalize_model_ref,
+    require_served,
+    to_config,
+)
 from langres.core.models import ERCandidate, PairwiseJudgement
 from langres.core.matcher import Matcher, SchemaT
 from langres.core.registry import register
@@ -173,7 +179,7 @@ class DSPyMatcher(Matcher[SchemaT]):
     def __init__(
         self,
         lm: Any = None,
-        model: str = "openrouter/openai/gpt-4o-mini",
+        model: str | dict[str, str] | ModelRef = "openrouter/openai/gpt-4o-mini",
         temperature: float = 0.0,
         entity_noun: str = "entity",
         program: Any = None,
@@ -185,14 +191,25 @@ class DSPyMatcher(Matcher[SchemaT]):
                 ``None`` a ``dspy.LM(model, cache=False)`` is built lazily on first
                 use — so ``from_config`` / ``load`` never need a key. Inject an LM
                 as an escape hatch (tests inject ``DummyLM`` for zero-spend runs).
-            model: OpenRouter/LiteLLM model id used when ``lm`` is built lazily.
+            model: The backbone that fills this slot — an API model id, or any
+                :class:`~langres.core.model_ref.ModelRef` surface form. **Served
+                kinds only** (``api``/``endpoint``): this slot is DSPy-backed, so
+                an ``hf``/``local``/base+adapter ref raises
+                :class:`~langres.core.model_ref.UnsupportedBackboneError` here —
+                see :func:`~langres.core.model_ref.require_served`.
             temperature: Sampling temperature for the lazily-built LM.
             entity_noun: Domain noun woven into the signature instructions.
             program: Optional pre-built DSPy program (e.g. a compiled one). When
                 ``None`` a fresh ``ChainOfThought`` over the woven signature is
                 built (uncompiled — call :meth:`compile` to tune it).
+
+        Raises:
+            UnsupportedBackboneError: ``model`` names an in-process backbone.
         """
-        self.model = model
+        self.model_ref = require_served(normalize_model_ref(model), slot="DSPyMatcher")
+        # ``self.model`` stays the base id *string* for litellm/provenance/pricing;
+        # the full ref (incl. any endpoint URL) lives on ``self.model_ref``.
+        self.model = self.model_ref.base
         self.temperature = temperature
         self.entity_noun = entity_noun
         self._lm = lm
@@ -218,9 +235,15 @@ class DSPyMatcher(Matcher[SchemaT]):
         self._compile_run_id: str | None = None
 
     def _get_lm(self) -> Any:
-        """Return the DSPy LM, lazily building a ``dspy.LM`` from ``model`` on first use."""
+        """Return the DSPy LM, lazily building a ``dspy.LM`` from ``model`` on first use.
+
+        ``api_base`` is forwarded for the ``endpoint`` kind: ``dspy.LM`` passes
+        unknown kwargs straight to litellm (it lists ``api_base`` among the args it
+        excludes from its cache key), so a served backbone needs no new judge.
+        """
         if self._lm is None:
-            self._lm = dspy.LM(self.model, cache=False, temperature=self.temperature)
+            extra = {"api_base": self.model_ref.api_base} if self.model_ref.api_base else {}
+            self._lm = dspy.LM(self.model, cache=False, temperature=self.temperature, **extra)
         return self._lm
 
     @property
@@ -243,7 +266,9 @@ class DSPyMatcher(Matcher[SchemaT]):
     def config(self) -> dict[str, object]:
         """Pure, serializable construction config (never the LM, program, or secrets)."""
         return {
-            "model": self.model,
+            # A plain API id serializes byte-identically to the pre-``kind`` config;
+            # only an endpoint ref widens to a dict (see ``to_config``).
+            "model": to_config(self.model_ref),
             "temperature": self.temperature,
             "entity_noun": self.entity_noun,
         }
@@ -257,7 +282,9 @@ class DSPyMatcher(Matcher[SchemaT]):
         """
         return cls(
             lm=None,
-            model=str(config["model"]),
+            # Passed through unchanged: a ``str()`` coercion here would stringify an
+            # endpoint ref's dict into ``"{'base': ...}"`` and silently misroute it.
+            model=config["model"],  # type: ignore[arg-type]
             temperature=float(config["temperature"]),  # type: ignore[arg-type]
             entity_noun=str(config["entity_noun"]),
         )

--- a/src/langres/core/matchers/dspy_judge.py
+++ b/src/langres/core/matchers/dspy_judge.py
@@ -37,7 +37,7 @@ from dspy.utils.exceptions import AdapterParseError
 from langres.core.model_ref import (
     ModelRef,
     normalize_model_ref,
-    require_served,
+    require_litellm_routable,
     to_config,
 )
 from langres.core.models import ERCandidate, PairwiseJudgement
@@ -192,11 +192,11 @@ class DSPyMatcher(Matcher[SchemaT]):
                 use — so ``from_config`` / ``load`` never need a key. Inject an LM
                 as an escape hatch (tests inject ``DummyLM`` for zero-spend runs).
             model: The backbone that fills this slot — an API model id, or any
-                :class:`~langres.core.model_ref.ModelRef` surface form. **Served
-                kinds only** (``api``/``endpoint``): this slot is DSPy-backed, so
-                an ``hf``/``local``/base+adapter ref raises
+                :class:`~langres.core.model_ref.ModelRef` surface form. **litellm-routable
+                refs only**: this slot is DSPy-backed, so a ``local`` directory or
+                a base+adapter ref raises
                 :class:`~langres.core.model_ref.UnsupportedBackboneError` here —
-                see :func:`~langres.core.model_ref.require_served`.
+                see :func:`~langres.core.model_ref.require_litellm_routable`.
             temperature: Sampling temperature for the lazily-built LM.
             entity_noun: Domain noun woven into the signature instructions.
             program: Optional pre-built DSPy program (e.g. a compiled one). When
@@ -206,7 +206,7 @@ class DSPyMatcher(Matcher[SchemaT]):
         Raises:
             UnsupportedBackboneError: ``model`` names an in-process backbone.
         """
-        self.model_ref = require_served(normalize_model_ref(model), slot="DSPyMatcher")
+        self.model_ref = require_litellm_routable(normalize_model_ref(model), slot="DSPyMatcher")
         # ``self.model`` stays the base id *string* for litellm/provenance/pricing;
         # the full ref (incl. any endpoint URL) lives on ``self.model_ref``.
         self.model = self.model_ref.base

--- a/src/langres/core/matchers/llm_judge.py
+++ b/src/langres/core/matchers/llm_judge.py
@@ -9,7 +9,6 @@ Supports both direct OpenAI client and LiteLLM for enhanced observability.
 import asyncio
 import logging
 import math
-import os
 import re
 import string
 import time
@@ -26,7 +25,7 @@ except ImportError:
     RateLimitError = Exception
 
 from langres.clients.openrouter import parse_openrouter_billing
-from langres.core.model_ref import ModelRef, normalize_model_ref, to_config
+from langres.core.model_ref import ModelRef, backend_for, normalize_model_ref, to_config
 from langres.core.models import ERCandidate, PairwiseJudgement
 from langres.core.matcher import Matcher, SchemaT
 from langres.core.registry import register
@@ -357,67 +356,6 @@ class _RateLimiter:
             self._token_usage.append((time.time(), token_count))
 
 
-# Known LiteLLM provider-route prefixes. A ``model`` carrying one of these (or no
-# ``/`` at all, i.e. a bare OpenAI-style name like ``gpt-5-mini``) is an API model
-# served over the wire; a bare ``org/name`` that matches NONE of these is treated
-# as an HF Hub id and run in-process. This is a heuristic — ``api_base`` (served
-# endpoint) and a base+adapter ``ModelRef`` (always in-process) are unambiguous and
-# decided first; see :func:`_default_backend_kind`.
-_API_MODEL_PREFIXES = (
-    "openrouter/",
-    "openai/",
-    "azure/",
-    "azure_ai/",
-    "anthropic/",
-    "gemini/",
-    "vertex_ai/",
-    "bedrock/",
-    "together_ai/",
-    "fireworks_ai/",
-    "groq/",
-    "mistral/",
-    "codestral/",
-    "cohere/",
-    "deepseek/",
-    "deepinfra/",
-    "perplexity/",
-    "xai/",
-    "cerebras/",
-    "sambanova/",
-    "huggingface/",
-    "ollama/",
-    "ollama_chat/",
-    "replicate/",
-    "watsonx/",
-)
-
-
-def _default_backend_kind(
-    ref: ModelRef, api_base: str | None
-) -> Literal["litellm", "transformers"]:
-    """Route a :class:`ModelRef` (+ optional ``api_base``) to a completion backend.
-
-    Decision order, unambiguous cases first:
-
-    1. **base+adapter** (``ref.adapter`` set) → ``"transformers"`` — an unmerged
-       PEFT adapter can only be assembled in-process.
-    2. **``api_base`` set** → ``"litellm"`` — a served (vLLM/Ollama/OpenAI-compatible)
-       endpoint is reached through litellm regardless of the model id's shape.
-    3. **existing local directory** → ``"transformers"``.
-    4. **bare name (no ``/``) or a known provider prefix** → ``"litellm"``.
-    5. otherwise (an ``org/name`` HF Hub id) → ``"transformers"``.
-    """
-    if ref.adapter is not None:
-        return "transformers"
-    if api_base is not None:
-        return "litellm"
-    if os.path.isdir(ref.base):
-        return "transformers"
-    if "/" not in ref.base or ref.base.startswith(_API_MODEL_PREFIXES):
-        return "litellm"
-    return "transformers"
-
-
 @register("llm_judge")
 class LLMMatcher(Matcher[SchemaT]):
     """Schema-agnostic LLM-based matching module using LiteLLM.
@@ -474,10 +412,11 @@ class LLMMatcher(Matcher[SchemaT]):
 
     Note:
         The same matcher runs a model over an **API** or **in-process**, decided
-        from ``model`` + ``api_base`` (see :meth:`__init__` and
-        :func:`_default_backend_kind`): an API name goes through litellm; a served
-        endpoint (``api_base=``) through litellm to that URL; an HF id / local dir
-        / base+adapter ref runs locally via a lazily-loaded transformers backend.
+        solely by the :class:`~langres.core.model_ref.ModelRef`'s ``kind``
+        discriminator (see :func:`~langres.core.model_ref.backend_for`): the
+        ``api``/``endpoint`` kinds go through litellm (the latter to
+        ``api_base``); the ``hf``/``local`` kinds — including a base+adapter ref —
+        run locally via a lazily-loaded transformers backend.
         Both backends feed the identical parse + first-token-logprob→score step,
         so ``run your fine-tuned model`` needs no new judge — just a different
         ``model`` / ``api_base``. See ``examples/serve_your_model.py``.
@@ -523,9 +462,13 @@ class LLMMatcher(Matcher[SchemaT]):
                 - a base+adapter dict ``{"base": ..., "adapter": ...}`` (a QLoRA
                   fine-tune served unmerged) — always run in-process.
 
-                The in-process route is chosen automatically for a local dir / HF
-                id / base+adapter ref when no ``api_base`` is given (see
-                :func:`_default_backend_kind`).
+                The in-process route is chosen for the ``hf``/``local`` kinds --
+                inferred from the string's shape by
+                :func:`~langres.core.model_ref.infer_kind`, or named outright via
+                a ``{"base": ..., "kind": ...}`` dict. Note a **bare relative
+                directory name is NOT a path**: write ``"./my-model"`` (or pass
+                ``kind="local"``), since guessing by probing the filesystem is
+                what made routing depend on the working directory (B17).
             api_base: Optional base URL of a served, OpenAI-compatible endpoint
                 (vLLM, Ollama, a hosted gateway). When set, the request is routed
                 there via litellm with ``model`` as the served model id — this is
@@ -608,16 +551,20 @@ class LLMMatcher(Matcher[SchemaT]):
             raise ValueError("confidence must be 'none' or 'logprob'")
 
         self.client = client
-        self.model_ref = normalize_model_ref(model)
+        self.model_ref = normalize_model_ref(model, api_base=api_base)
         # ``self.model`` stays the base id *string* for every existing consumer
         # (litellm ``model=``, provenance, ``LLMUsage``); the full weightless ref
         # (including any PEFT adapter) lives on ``self.model_ref``, and the raw
         # ref serializes in :attr:`config` via :func:`to_config`.
         self.model = self.model_ref.base
-        self.api_base = api_base
-        # Route to a backend once at construction (inputs are fixed): avoids a
-        # per-candidate filesystem stat and keeps sync/async paths consistent.
-        self._backend_kind = _default_backend_kind(self.model_ref, api_base)
+        # ``api_base`` is no longer a second model concept: it is absorbed into the
+        # ref above as the ``endpoint`` form, and read back from it so the two can
+        # never disagree.
+        self.api_base = self.model_ref.api_base
+        # Routing is a pure function of the ref's ``kind`` (B17) -- no filesystem
+        # probe, so a saved config resolves to the SAME backend in any working
+        # directory. Resolved once at construction: the kind is immutable.
+        self._backend_kind = backend_for(self.model_ref.kind)
         self._backend: TransformersBackend | None = None
         self.temperature = temperature
         self.entity_noun = entity_noun

--- a/src/langres/core/matchers/select_judge.py
+++ b/src/langres/core/matchers/select_judge.py
@@ -58,6 +58,12 @@ import dspy
 from dspy.utils.exceptions import AdapterParseError
 
 from langres.core.groups import ERCandidateGroup
+from langres.core.model_ref import (
+    ModelRef,
+    normalize_model_ref,
+    require_served,
+    to_config,
+)
 from langres.core.models import PairwiseJudgement
 from langres.core.matcher import GroupwiseMatcher, SchemaT, stamp_group_cost
 from langres.core.matchers.dspy_judge import _salvage_usage
@@ -115,7 +121,7 @@ class SelectMatcher(GroupwiseMatcher[SchemaT]):
     def __init__(
         self,
         lm: Any = None,
-        model: str = "openrouter/openai/gpt-4o-mini",
+        model: str | dict[str, str] | ModelRef = "openrouter/openai/gpt-4o-mini",
         temperature: float = 0.0,
         entity_noun: str = "entity",
     ) -> None:
@@ -125,11 +131,22 @@ class SelectMatcher(GroupwiseMatcher[SchemaT]):
             lm: Optional pre-built DSPy LM (``dspy.LM`` or ``DummyLM``). When
                 ``None`` a ``dspy.LM(model, cache=False)`` is built lazily on
                 first use, mirroring ``DSPyMatcher``.
-            model: OpenRouter/LiteLLM model id used when ``lm`` is built lazily.
+            model: The backbone that fills this slot — an API model id, or any
+                :class:`~langres.core.model_ref.ModelRef` surface form. **Served
+                kinds only** (``api``/``endpoint``): this slot is DSPy-backed, so
+                an ``hf``/``local``/base+adapter ref raises
+                :class:`~langres.core.model_ref.UnsupportedBackboneError` here —
+                see :func:`~langres.core.model_ref.require_served`.
             temperature: Sampling temperature for the lazily-built LM.
             entity_noun: Domain noun woven into the signature instructions.
+
+        Raises:
+            UnsupportedBackboneError: ``model`` names an in-process backbone.
         """
-        self.model = model
+        self.model_ref = require_served(normalize_model_ref(model), slot="SelectMatcher")
+        # ``self.model`` stays the base id *string* for litellm/provenance/pricing;
+        # the full ref (incl. any endpoint URL) lives on ``self.model_ref``.
+        self.model = self.model_ref.base
         self.temperature = temperature
         self.entity_noun = entity_noun
         self._lm = lm
@@ -143,7 +160,9 @@ class SelectMatcher(GroupwiseMatcher[SchemaT]):
     def config(self) -> dict[str, object]:
         """Pure, serializable construction config (never the LM or secrets)."""
         return {
-            "model": self.model,
+            # A plain API id serializes byte-identically to the pre-``kind`` config;
+            # only an endpoint ref widens to a dict (see ``to_config``).
+            "model": to_config(self.model_ref),
             "temperature": self.temperature,
             "entity_noun": self.entity_noun,
         }
@@ -153,15 +172,23 @@ class SelectMatcher(GroupwiseMatcher[SchemaT]):
         """Rebuild a fresh judge from :attr:`config` (no injected LM; built lazily)."""
         return cls(
             lm=None,
-            model=str(config["model"]),
+            # Passed through unchanged: a ``str()`` coercion here would stringify an
+            # endpoint ref's dict into ``"{'base': ...}"`` and silently misroute it.
+            model=config["model"],  # type: ignore[arg-type]
             temperature=float(config["temperature"]),  # type: ignore[arg-type]
             entity_noun=str(config["entity_noun"]),
         )
 
     def _get_lm(self) -> Any:
-        """Return the DSPy LM, lazily building a ``dspy.LM`` from ``model`` on first use."""
+        """Return the DSPy LM, lazily building a ``dspy.LM`` from ``model`` on first use.
+
+        ``api_base`` is forwarded for the ``endpoint`` kind: ``dspy.LM`` passes
+        unknown kwargs straight to litellm (it lists ``api_base`` among the args it
+        excludes from its cache key), so a served backbone needs no new judge.
+        """
         if self._lm is None:
-            self._lm = dspy.LM(self.model, cache=False, temperature=self.temperature)
+            extra = {"api_base": self.model_ref.api_base} if self.model_ref.api_base else {}
+            self._lm = dspy.LM(self.model, cache=False, temperature=self.temperature, **extra)
         return self._lm
 
     def _cost_usd(self, prompt_tokens: int, completion_tokens: int) -> float:

--- a/src/langres/core/matchers/select_judge.py
+++ b/src/langres/core/matchers/select_judge.py
@@ -61,7 +61,7 @@ from langres.core.groups import ERCandidateGroup
 from langres.core.model_ref import (
     ModelRef,
     normalize_model_ref,
-    require_served,
+    require_litellm_routable,
     to_config,
 )
 from langres.core.models import PairwiseJudgement
@@ -132,18 +132,18 @@ class SelectMatcher(GroupwiseMatcher[SchemaT]):
                 ``None`` a ``dspy.LM(model, cache=False)`` is built lazily on
                 first use, mirroring ``DSPyMatcher``.
             model: The backbone that fills this slot — an API model id, or any
-                :class:`~langres.core.model_ref.ModelRef` surface form. **Served
-                kinds only** (``api``/``endpoint``): this slot is DSPy-backed, so
-                an ``hf``/``local``/base+adapter ref raises
+                :class:`~langres.core.model_ref.ModelRef` surface form. **litellm-routable
+                refs only**: this slot is DSPy-backed, so a ``local`` directory or
+                a base+adapter ref raises
                 :class:`~langres.core.model_ref.UnsupportedBackboneError` here —
-                see :func:`~langres.core.model_ref.require_served`.
+                see :func:`~langres.core.model_ref.require_litellm_routable`.
             temperature: Sampling temperature for the lazily-built LM.
             entity_noun: Domain noun woven into the signature instructions.
 
         Raises:
             UnsupportedBackboneError: ``model`` names an in-process backbone.
         """
-        self.model_ref = require_served(normalize_model_ref(model), slot="SelectMatcher")
+        self.model_ref = require_litellm_routable(normalize_model_ref(model), slot="SelectMatcher")
         # ``self.model`` stays the base id *string* for litellm/provenance/pricing;
         # the full ref (incl. any endpoint URL) lives on ``self.model_ref``.
         self.model = self.model_ref.base

--- a/src/langres/core/method_registry.py
+++ b/src/langres/core/method_registry.py
@@ -46,6 +46,15 @@ from pydantic import BaseModel, ConfigDict
 from langres.core.comparator import Comparator
 from langres.core.comparators import StringComparator
 from langres.core.matcher import Matcher
+from langres.core.model_ref import (
+    DEFAULT_EMBEDDING_MODEL,
+    IN_PROCESS_KINDS,
+    SERVED_KINDS,
+    BackboneKind,
+    ModelRef,
+    UnsupportedBackboneError,
+    normalize_model_ref,
+)
 
 __all__ = [
     "DEFAULT_EMBEDDING_MODEL",
@@ -56,12 +65,14 @@ __all__ = [
     "register_method",
 ]
 
-#: The sentence-transformers model behind ``matcher="embedding"`` and every
-#: preset-built ``VectorBlocker`` (both the verbs' and ``Resolver.from_schema``'s
-#: pipelines pin it). Defined once here so the two construction sites cannot
-#: drift, and so the ``"embedding"`` spec below can report it as the judge's
-#: model identity on results.
-DEFAULT_EMBEDDING_MODEL = "all-MiniLM-L6-v2"
+# ``DEFAULT_EMBEDDING_MODEL`` is re-exported (not defined) here: it now lives in
+# the stdlib-only ``core.model_ref`` leaf beside the rest of the backbone
+# vocabulary, so ``core.embeddings`` can share the ONE literal without importing
+# this registry (which would knot the graph). It stays in ``__all__`` because
+# ``from langres.core.method_registry import DEFAULT_EMBEDDING_MODEL`` is an
+# existing import path. The old comment here claimed it was "defined once so the
+# construction sites cannot drift" -- it was in fact copied twice more into
+# ``core/embeddings.py``, which is exactly the drift it claimed to prevent.
 
 #: Install line for the ``[llm]`` extra, woven into the actionable ImportError
 #: an LLM-family builder raises when its lazy import fails.
@@ -111,9 +122,19 @@ class MethodSpec(BaseModel):
         default_model: The underlying model id when the caller names none --
             the value stamped on results as ``model`` (``None`` for judges
             with no model at all, e.g. pure-string similarity).
-        accepts_model: Whether the builder honors a caller ``model=``
-            override. ``False`` means the caller's ``model`` is ignored and
-            ``default_model`` (if any) names the fixed underlying model.
+        accepted_kinds: The backbone :data:`~langres.core.model_ref.BackboneKind`
+            forms this method can actually run. **Empty means the method has no
+            model slot at all** (pure string similarity), so a caller's
+            ``model=`` is an error rather than a silently-dropped argument.
+
+            This replaces the old ``accepts_model: bool``, which could only say
+            *whether* a slot took a backbone, never *which kinds* — so the
+            DSPy-backed methods advertised ``accepts_model=True`` while
+            meaning "a litellm id **string**", and a local path or
+            ``{base, adapter}`` was forwarded into ``DSPyMatcher(model=...)`` to
+            die deep inside litellm. Declaring the kinds turns that into a typed
+            error at construction, and the bool falls out of it
+            (``accepts_model`` == ``bool(accepted_kinds)``).
         needs_comparator: Whether the pipeline must attach per-feature
             comparison vectors for this judge to score (drives the
             ``Comparator`` slot in the assembled ``Resolver``).
@@ -130,9 +151,52 @@ class MethodSpec(BaseModel):
     score_type: str
     default_threshold: float = 0.5
     default_model: str | None = None
-    accepts_model: bool = False
+    accepted_kinds: frozenset[BackboneKind] = frozenset()
     needs_comparator: bool = False
     requires_extra: str | None = None
+
+    def check_backbone(self, model: str | dict[str, str] | ModelRef | None) -> ModelRef | None:
+        """Validate a caller's ``model=`` against this method's ``accepted_kinds``.
+
+        The ONE place a caller's backbone is checked before construction, so
+        every dispatch path (verbs, ``Resolver.from_schema``, the benchmark
+        harness) rejects the same refs with the same message.
+
+        Returns ``None`` when the caller named no model (the method's
+        ``default_model``, if any, then stands).
+
+        Raises:
+            UnsupportedBackboneError: The method has no model slot, or the ref's
+                kind is not one this method can run.
+            InvalidModelRefError: ``model`` is malformed (from normalization).
+        """
+        if model is None:
+            return None
+        if not self.accepted_kinds:
+            raise UnsupportedBackboneError(
+                f"method {self.name!r} has no model slot, so model={model!r} would be silently "
+                f"ignored. It scores without a model"
+                + (f" (its fixed identity is {self.default_model!r})" if self.default_model else "")
+                + ". Drop the model= argument, or pick a method that takes one: "
+                + ", ".join(sorted(n for n, s in _METHOD_REGISTRY.items() if s.accepted_kinds))
+                + "."
+            )
+        ref = normalize_model_ref(model)
+        if ref.kind not in self.accepted_kinds:
+            raise UnsupportedBackboneError(
+                f"method {self.name!r} cannot run a {ref.kind!r} backbone ({ref.base!r}): it "
+                f"accepts {', '.join(map(repr, sorted(self.accepted_kinds)))}. "
+                + (
+                    "This method is DSPy-backed, and DSPy routes every completion through "
+                    "litellm — it has no in-process route. Serve the model and pass "
+                    '{"base": ..., "kind": "endpoint", "api_base": ...}, or use a method '
+                    "backed by LLMMatcher (e.g. 'prompt_llm'), which runs local weights "
+                    "in-process."
+                    if IN_PROCESS_KINDS & {ref.kind}
+                    else "Name a backbone of an accepted kind."
+                )
+            )
+        return ref
 
 
 _METHOD_REGISTRY: dict[str, MethodSpec] = {}
@@ -470,6 +534,9 @@ def _register_builtins() -> None:
             # The judge scores the preset-built VectorBlocker's cosine sims,
             # so the pipeline's model IS the pinned embedder.
             default_model=DEFAULT_EMBEDDING_MODEL,
+            # The embedder backbone is loaded in-process by the VectorBlocker this
+            # method's pipeline pins; build_resolver threads the caller's model= to it.
+            accepted_kinds=IN_PROCESS_KINDS,
         ),
         MethodSpec(
             name="zero_shot_llm",
@@ -477,7 +544,8 @@ def _register_builtins() -> None:
             score_type="prob_llm",
             default_threshold=0.7,
             default_model=DEFAULT_OPENROUTER_MODEL,
-            accepts_model=True,
+            # DSPy-backed: no in-process route (B10) -- see require_served.
+            accepted_kinds=SERVED_KINDS,
             requires_extra="llm",
         ),
         MethodSpec(
@@ -486,7 +554,8 @@ def _register_builtins() -> None:
             score_type="prob_llm",
             default_threshold=0.7,
             default_model=DEFAULT_OPENROUTER_MODEL,
-            accepts_model=True,
+            # LLMMatcher-backed: litellm AND a transformers backend.
+            accepted_kinds=SERVED_KINDS | IN_PROCESS_KINDS,
             requires_extra="llm",
         ),
         # -- The benchmark-harness method names (methods.py race) ------------
@@ -517,7 +586,8 @@ def _register_builtins() -> None:
             score_type="prob_llm",
             default_threshold=0.7,
             default_model=DEFAULT_OPENROUTER_MODEL,
-            accepts_model=True,
+            # LLMMatcher-backed: litellm AND a transformers backend.
+            accepted_kinds=SERVED_KINDS | IN_PROCESS_KINDS,
             requires_extra="llm",
         ),
         MethodSpec(
@@ -526,7 +596,8 @@ def _register_builtins() -> None:
             score_type="prob_llm",
             default_threshold=0.7,
             default_model=DEFAULT_OPENROUTER_MODEL,
-            accepts_model=True,
+            # DSPy-backed: no in-process route (B10) -- see require_served.
+            accepted_kinds=SERVED_KINDS,
             requires_extra="llm",
         ),
         MethodSpec(
@@ -535,7 +606,8 @@ def _register_builtins() -> None:
             score_type="prob_group_llm",
             default_threshold=0.7,
             default_model=DEFAULT_OPENROUTER_MODEL,
-            accepts_model=True,
+            # DSPy-backed: no in-process route (B10) -- see require_served.
+            accepted_kinds=SERVED_KINDS,
             requires_extra="llm",
         ),
         MethodSpec(
@@ -546,7 +618,8 @@ def _register_builtins() -> None:
             score_type="prob_llm",
             default_threshold=0.7,
             default_model=DEFAULT_OPENROUTER_MODEL,
-            accepts_model=True,
+            # LLMMatcher-backed: litellm AND a transformers backend.
+            accepted_kinds=SERVED_KINDS | IN_PROCESS_KINDS,
             requires_extra="llm",
         ),
         MethodSpec(

--- a/src/langres/core/method_registry.py
+++ b/src/langres/core/method_registry.py
@@ -49,6 +49,7 @@ from langres.core.matcher import Matcher
 from langres.core.model_ref import (
     DEFAULT_EMBEDDING_MODEL,
     IN_PROCESS_KINDS,
+    LITELLM_ROUTABLE_KINDS,
     SERVED_KINDS,
     BackboneKind,
     ModelRef,
@@ -195,6 +196,19 @@ class MethodSpec(BaseModel):
                     if IN_PROCESS_KINDS & {ref.kind}
                     else "Name a backbone of an accepted kind."
                 )
+            )
+        # An unmerged PEFT adapter must be assembled in-process, which only a
+        # method supporting EVERY in-process kind can do. A litellm-only method
+        # nominally accepts `hf` (see LITELLM_ROUTABLE_KINDS) but cannot assemble
+        # anything, so the kind check above would otherwise wave an adapter
+        # through to fail later, deeper, and less legibly.
+        if ref.adapter is not None and not IN_PROCESS_KINDS <= self.accepted_kinds:
+            raise UnsupportedBackboneError(
+                f"method {self.name!r} cannot run an unmerged base+adapter ref "
+                f"(base={ref.base!r}, adapter={ref.adapter!r}): assembling a PEFT adapter "
+                "needs an in-process backend, and this method runs its model over litellm. "
+                "Use a method backed by LLMMatcher (e.g. 'prompt_llm'), or merge the adapter "
+                "into the base weights and reference the merged model."
             )
         return ref
 
@@ -544,8 +558,9 @@ def _register_builtins() -> None:
             score_type="prob_llm",
             default_threshold=0.7,
             default_model=DEFAULT_OPENROUTER_MODEL,
-            # DSPy-backed: no in-process route (B10) -- see require_served.
-            accepted_kinds=SERVED_KINDS,
+            # DSPy-backed: litellm-only, so a local dir/adapter is rejected at
+            # construction (B10). `hf` is admitted -- see LITELLM_ROUTABLE_KINDS.
+            accepted_kinds=LITELLM_ROUTABLE_KINDS,
             requires_extra="llm",
         ),
         MethodSpec(
@@ -596,8 +611,9 @@ def _register_builtins() -> None:
             score_type="prob_llm",
             default_threshold=0.7,
             default_model=DEFAULT_OPENROUTER_MODEL,
-            # DSPy-backed: no in-process route (B10) -- see require_served.
-            accepted_kinds=SERVED_KINDS,
+            # DSPy-backed: litellm-only, so a local dir/adapter is rejected at
+            # construction (B10). `hf` is admitted -- see LITELLM_ROUTABLE_KINDS.
+            accepted_kinds=LITELLM_ROUTABLE_KINDS,
             requires_extra="llm",
         ),
         MethodSpec(
@@ -606,8 +622,9 @@ def _register_builtins() -> None:
             score_type="prob_group_llm",
             default_threshold=0.7,
             default_model=DEFAULT_OPENROUTER_MODEL,
-            # DSPy-backed: no in-process route (B10) -- see require_served.
-            accepted_kinds=SERVED_KINDS,
+            # DSPy-backed: litellm-only, so a local dir/adapter is rejected at
+            # construction (B10). `hf` is admitted -- see LITELLM_ROUTABLE_KINDS.
+            accepted_kinds=LITELLM_ROUTABLE_KINDS,
             requires_extra="llm",
         ),
         MethodSpec(

--- a/src/langres/core/model_ref.py
+++ b/src/langres/core/model_ref.py
@@ -88,6 +88,34 @@ IN_PROCESS_KINDS: frozenset[BackboneKind] = frozenset({"hf", "local"})
 #: Kinds that run **served** (litellm): the weights live behind an API.
 SERVED_KINDS: frozenset[BackboneKind] = frozenset({"api", "endpoint"})
 
+#: Kinds a **litellm-only** slot (i.e. DSPy-backed) may be handed. Note this
+#: includes ``hf``, which reads like a contradiction and is not one — it is the
+#: honest consequence of a *measured* ambiguity.
+#:
+#: :func:`infer_kind` maps a one-slash ``org/name`` to ``hf``, but that same shape
+#: is also how litellm names a provider-routed model. The prefix table below can
+#: only recognize the providers someone remembered to list, and that set is not
+#: closeable: measured against the installed litellm, ``litellm.provider_list``
+#: carries **146** providers while :data:`_API_MODEL_PREFIXES` carries **26** — so
+#: **120** real provider ids (``ai21/...``, ``nvidia_nim/...``, ``voyage/...``)
+#: infer as ``hf``. Rejecting ``hf`` from a litellm-only slot would therefore
+#: reject working code, and the leaf cannot consult ``litellm.provider_list`` to
+#: do better: importing litellm here would put the [llm] extra on every bare
+#: ``import langres`` (``tests/test_import_budget.py`` is the gate).
+#:
+#: So the guard covers only what is **unambiguous**: a ``local`` path and a PEFT
+#: ``adapter`` can never be reached by litellm, whatever the provider list says.
+#: An ``hf``-inferred id is passed through and fails inside litellm exactly as it
+#: did before — no regression, and no false rejection.
+#:
+#: **The stricter alternative, recorded so it is cheap to flip:** drop ``"hf"``
+#: from this set and DSPy-backed slots become API/endpoint-only, forcing every
+#: unlisted-provider id to name ``kind="api"`` explicitly. That is a one-line
+#: change here plus the ``accepted_kinds`` on the three DSPy specs in
+#: ``core/method_registry.py``. It buys stricter typing at the cost of breaking
+#: those 120 provider ids until each caller annotates them.
+LITELLM_ROUTABLE_KINDS: frozenset[BackboneKind] = SERVED_KINDS | frozenset({"hf"})
+
 #: Model-id prefixes that name a litellm provider, used by
 #: :func:`infer_kind` to recognize an ``api`` reference. Not exhaustive and not
 #: meant to be: it disambiguates the *common* provider-prefixed ids from HF Hub
@@ -242,8 +270,8 @@ def backend_for(kind: BackboneKind) -> Literal["litellm", "transformers"]:
     return "litellm" if kind in SERVED_KINDS else "transformers"
 
 
-def require_served(ref: ModelRef, *, slot: str) -> ModelRef:
-    """Assert ``ref`` can run behind an API, or raise :class:`UnsupportedBackboneError`.
+def require_litellm_routable(ref: ModelRef, *, slot: str) -> ModelRef:
+    """Assert litellm could reach ``ref``, or raise :class:`UnsupportedBackboneError`.
 
     The guard for **DSPy-backed slots**, which have no in-process route at all.
     Verified against the installed ``dspy`` (3.2.1), not assumed:
@@ -255,19 +283,23 @@ def require_served(ref: ModelRef, *, slot: str) -> ModelRef:
     litellm at ``http://localhost:{port}/v1`` — i.e. it *serves* the model and
     goes back through litellm.
 
-    So handing such a slot a ``local`` dir or a base+adapter ref cannot work; it
-    dies deep inside litellm with a provider error that names nothing useful.
-    Raising here — at construction — is that failure, hoisted to where the caller
-    can act on it.
+    So handing such a slot a ``local`` directory or a base+adapter ref cannot
+    work: it dies deep inside litellm with a provider error naming nothing
+    useful. Raising here — at construction — is that failure hoisted to where the
+    caller can act on it.
+
+    It deliberately admits the ``hf`` kind: see :data:`LITELLM_ROUTABLE_KINDS`
+    for the measurement (120 of litellm's 146 providers infer as ``hf``), and for
+    the stricter alternative and how to flip to it.
 
     Args:
         ref: The backbone to check.
         slot: The slot's user-facing name, woven into the message.
 
     Raises:
-        UnsupportedBackboneError: ``ref.kind`` is an in-process kind.
+        UnsupportedBackboneError: ``ref`` is a ``local`` dir or carries an adapter.
     """
-    if ref.kind in SERVED_KINDS:
+    if ref.kind in LITELLM_ROUTABLE_KINDS and ref.adapter is None:
         return ref
     detail = (
         f"an unmerged base+adapter ref (base={ref.base!r}, adapter={ref.adapter!r})"

--- a/src/langres/core/model_ref.py
+++ b/src/langres/core/model_ref.py
@@ -328,17 +328,24 @@ def infer_kind(base: str, *, api_base: str | None = None) -> BackboneKind:
     3. a known provider prefix (:data:`_API_MODEL_PREFIXES`) -> ``api``.
     4. no ``/`` -> ``api`` (a bare litellm id like ``"gpt-5-mini"``).
     5. exactly one ``/`` -> ``hf`` (an ``org/name`` Hub id).
-    6. otherwise -> :class:`InvalidModelRefError`.
+    6. two or more ``/`` -> ``api``.
 
-    Rule 6 is the "unknown forms raise" case, and it is deliberately the *only*
-    one: a multi-slash id with no known provider (``"foo/bar/baz"``) is neither a
-    valid Hub id (those carry exactly one slash) nor a provider id we can route,
-    so guessing would only defer the error to a 404. By contrast rule 5's
-    ``org/name`` genuinely *is* a well-formed Hub id even when the caller meant a
-    provider — see the module docstring on why that cannot be second-guessed.
+    **It is total over non-empty strings**: every one names a kind, and only an
+    empty string raises. That is deliberate, and rule 6 is why.
+
+    A Hub id carries *exactly one* slash (``org/name``), so a multi-slash string
+    is definitively **not** a Hub id, and rule 2 already claimed the paths. What
+    is left is a provider-routed litellm id — ``"openrouter/openai/gpt-4o-mini"``
+    when the provider is listed, ``"nvidia_nim/meta/llama3-8b"`` when it is not.
+    Rejecting the unlisted ones would be the :data:`LITELLM_ROUTABLE_KINDS`
+    mistake one level down: the prefix table is 26 of litellm's 146 providers, so
+    an "unknown provider" here means *unknown to this list*, not unknown to
+    litellm. Routing it to ``api`` hands it to the component that actually has
+    the full provider list and can produce a real error — which beats inventing
+    one from a table we know is incomplete.
 
     Raises:
-        InvalidModelRefError: An empty string, or an unrecognizable form.
+        InvalidModelRefError: An empty string (the only unrecognizable form).
     """
     if not isinstance(base, str) or not base:
         raise InvalidModelRefError(f"model string must be non-empty; got {base!r}")
@@ -348,18 +355,7 @@ def infer_kind(base: str, *, api_base: str | None = None) -> BackboneKind:
         return "local"
     if base.startswith(_API_MODEL_PREFIXES):
         return "api"
-    slashes = base.count("/")
-    if slashes == 0:
-        return "api"
-    if slashes == 1:
-        return "hf"
-    raise InvalidModelRefError(
-        f"cannot infer a backbone kind for {base!r}: it has {slashes} '/' separators, so it is "
-        "neither a Hugging Face Hub id ('org/name') nor an id starting with a known provider "
-        f"prefix ({', '.join(_API_MODEL_PREFIXES[:4])}, ...). Name the kind explicitly, e.g. "
-        f'{{"base": {base!r}, "kind": "api"}} to route it to litellm, or "kind": "local" for a '
-        "directory path."
-    )
+    return "hf" if base.count("/") == 1 else "api"
 
 
 def normalize_model_ref(
@@ -450,12 +446,9 @@ def to_config(ref: ModelRef) -> str | dict[str, str]:
     The invariant, pinned by test: ``normalize_model_ref(to_config(ref)) == ref``
     for every ref.
     """
-    try:
-        inferable = infer_kind(ref.base) == ref.kind
-    except InvalidModelRefError:
-        # `base` is a form inference cannot name (e.g. a multi-slash id routed by
-        # an explicit kind). It must carry its kind, or it would not survive load.
-        inferable = False
+    # `infer_kind` cannot raise here: it is total over non-empty strings, and
+    # `__post_init__` already rejected an empty `base`.
+    inferable = infer_kind(ref.base) == ref.kind
     if inferable and ref.adapter is None and ref.api_base is None and ref.revision is None:
         return ref.base
     config: dict[str, str] = {"base": ref.base, "kind": ref.kind}

--- a/src/langres/core/model_ref.py
+++ b/src/langres/core/model_ref.py
@@ -1,82 +1,392 @@
-"""``ModelRef``: normalize a model reference for the serve / finetune paths.
+""":class:`ModelRef`: the ONE backbone concept — what fills a model slot.
 
-A *model reference* names WHICH model an :class:`~langres.core.matchers.llm_judge.LLMMatcher`
-(and, later, ``finetune()``) should run, in one of three forms:
+An *architecture* is a topology (which components, in what order). A **backbone**
+is what fills one of its model slots, and a :class:`ModelRef` is how langres
+names one. Swapping a backbone must never mint a new architecture, so a
+``ModelRef`` is **weightless by construction**: a few reference *strings*, never
+weight bytes, so it round-trips through ``Resolver.save`` / ``load`` as plain
+JSON config (:func:`to_config`). The weights are loaded lazily by the backend on
+first use.
 
-- an **HF Hub id** (``"your-org/your-ft-model"``) or a **local directory path** —
-  a self-contained (base or already-merged) model, and
-- a **base + PEFT adapter** pair (``{"base": ..., "adapter": ...}``) — a QLoRA
-  fine-tune served *without* merging the adapter into the base weights.
+This module is deliberately import-light (stdlib only — no torch / transformers
+/ litellm) so a bare ``import langres`` and the matchers' own imports stay
+heavy-dependency free. It imports nothing from ``langres`` and must stay that
+way: it is the leaf every model-bearing component depends on.
 
-It is **weightless by construction**: a ``ModelRef`` is a small pair of
-*reference strings*, never weight bytes, so it round-trips through
-``Resolver.save`` / ``load`` as plain JSON config (:func:`to_config`). This
-module is deliberately import-light (stdlib only — no torch / transformers) so a
-bare ``import langres`` and the matcher's own import stay heavy-dependency free;
-the actual weights are loaded lazily by the in-process backend on first use.
+The ``kind`` discriminator
+--------------------------
+``kind`` names the *form* of the reference, and it is the **sole input to
+routing**. Four forms:
+
+===========  ==========================================  ==================
+``kind``     what ``base`` names                         runs
+===========  ==========================================  ==================
+``api``      a litellm model id (``"openai/gpt-4o"``,    served (litellm)
+             ``"gpt-5-mini"``)
+``endpoint`` a model served at :attr:`ModelRef.api_base` served (litellm)
+             (vLLM / Ollama / any OpenAI-compatible)
+``hf``       a Hugging Face Hub id (``"org/name"``)      in-process
+``local``    a local directory path                      in-process
+===========  ==========================================  ==================
+
+**Routing is a pure function of ``kind`` — never of the filesystem or the
+current working directory** (B17). The predecessor of this module probed
+``os.path.isdir(ref.base)`` on a *relative* path to decide, which meant a local
+``./openai`` directory silently flipped routing litellm -> transformers: the
+same saved config resolved to a different backend in a different working
+directory. ``kind`` is carried in the config, so a saved artifact resolves
+identically anywhere. :func:`backend_for` is the whole routing rule.
+
+Why there is no "did you mean?" on an ``org/name`` typo
+------------------------------------------------------
+It is tempting to catch ``"opeani/gpt-4o"`` (a typo for the ``openai/``
+provider) at construction by fuzzy-matching the org segment against the known
+provider list. **This is not safely implementable, and the numbers say so.**
+Measured with ``difflib.SequenceMatcher`` against :data:`_API_MODEL_PREFIXES`:
+
+=========================  =========  =======
+org segment                closest    ratio
+=========================  =========  =======
+``opeani``   (a typo)      openai     0.833
+``openia``   (a typo)      openai     0.833
+``mistralai`` (**REAL**)   mistral    **0.875**
+``deepseek-ai`` (**REAL**) deepseek   **0.842**
+=========================  =========  =======
+
+The real HF orgs score *higher* than the typos. Any cutoff that catches
+``opeani`` also rejects ``mistralai/Mistral-7B-v0.1`` — a wrong answer that
+breaks working code, traded for a right answer on a typo that merely 404s. The
+ranges overlap, so no threshold exists. ``org/name`` is genuinely ambiguous
+between "HF Hub id" and "typo'd provider" and cannot be disambiguated by syntax.
+
+So the escape hatch is the discriminator itself, not a guess: a caller who means
+an API model says so (``{"base": "opeani/gpt-4o", "kind": "api"}``) and gets a
+litellm error naming the provider. A did-you-mean belongs where a false positive
+is *free* — in the failure message of a backend that already failed — never in
+the routing decision that precedes it.
 """
 
 from __future__ import annotations
 
 from dataclasses import dataclass
+from typing import Literal, get_args
+
+#: The default embedding backbone. Owned here — beside the other backbone
+#: vocabulary and reachable from both ``core.embeddings`` (which builds the
+#: embedder) and ``core.method_registry`` (which declares the ``embedding``
+#: method's identity) without either importing the other. It previously existed
+#: as three copies of the same literal (``method_registry`` + two in
+#: ``embeddings``), which is exactly how a default drifts.
+DEFAULT_EMBEDDING_MODEL = "all-MiniLM-L6-v2"
+
+#: The form of a backbone reference, and the sole input to routing.
+BackboneKind = Literal["api", "endpoint", "hf", "local"]
+
+#: Kinds that run **in-process** (transformers): the weights are loaded here.
+IN_PROCESS_KINDS: frozenset[BackboneKind] = frozenset({"hf", "local"})
+
+#: Kinds that run **served** (litellm): the weights live behind an API.
+SERVED_KINDS: frozenset[BackboneKind] = frozenset({"api", "endpoint"})
+
+#: Model-id prefixes that name a litellm provider, used by
+#: :func:`infer_kind` to recognize an ``api`` reference. Not exhaustive and not
+#: meant to be: it disambiguates the *common* provider-prefixed ids from HF Hub
+#: ``org/name`` ids. An id whose provider is missing here is still reachable —
+#: name the ``kind`` explicitly rather than growing this list on every release.
+_API_MODEL_PREFIXES: tuple[str, ...] = (
+    "openrouter/",
+    "openai/",
+    "azure/",
+    "azure_ai/",
+    "anthropic/",
+    "gemini/",
+    "vertex_ai/",
+    "bedrock/",
+    "together_ai/",
+    "fireworks_ai/",
+    "groq/",
+    "mistral/",
+    "codestral/",
+    "cohere/",
+    "deepseek/",
+    "deepinfra/",
+    "perplexity/",
+    "xai/",
+    "cerebras/",
+    "sambanova/",
+    "huggingface/",
+    "hosted_vllm/",
+    "ollama/",
+    "ollama_chat/",
+    "replicate/",
+    "watsonx/",
+)
+
+#: Prefixes that make a string *unambiguously* a filesystem path, by **syntax
+#: alone**. Deliberately syntactic: ``os.path.isdir`` would reintroduce the
+#: CWD-dependent routing this module exists to kill. ``"my-model-dir"`` (a bare
+#: relative name) is therefore an ``api`` id, not a path — write ``"./my-model-dir"``
+#: or pass ``kind="local"``.
+_PATH_PREFIXES: tuple[str, ...] = ("./", "../", "/", "~")
+
+
+class InvalidModelRefError(ValueError):
+    """Raised when a model reference is malformed or its form is unrecognizable.
+
+    Carries an actionable message naming the accepted forms. Raised at
+    *construction* — a ``ModelRef`` that exists is always well-formed, so no
+    downstream backend has to re-check it.
+    """
+
+
+class UnsupportedBackboneError(ValueError):
+    """Raised when a slot cannot run a well-formed backbone.
+
+    Distinct from :class:`InvalidModelRefError`: the reference is *fine*, the
+    slot just cannot honor it — e.g. a DSPy-backed matcher handed a ``local``
+    directory (DSPy has no in-process route; see
+    :mod:`langres.core.matchers.dspy_judge`), or a string-similarity method
+    handed any backbone at all.
+    """
 
 
 @dataclass(frozen=True)
 class ModelRef:
-    """A normalized, weightless reference to a served/local model.
+    """A normalized, weightless reference to a model that fills one slot.
 
-    ``base`` is the HF Hub id or local directory of the (base or merged) model;
-    ``adapter`` is an optional PEFT-adapter HF id / local dir applied on top of
-    ``base`` at load time (QLoRA served unmerged). ``adapter is None`` is the
-    self-contained case.
+    Args:
+        base: The model id or path — an HF Hub id, a local directory, or an API
+            model name, per ``kind``.
+        kind: The discriminator (see the module docstring). **Required**: a
+            discriminator you can forget to set is not a discriminator, and
+            routing reads nothing else. Use :func:`normalize_model_ref` to infer
+            it from a user-supplied string.
+        adapter: An optional PEFT-adapter HF id / local dir applied on top of
+            ``base`` at load time (QLoRA served unmerged). In-process kinds only.
+        api_base: The served endpoint's URL. Required by — and exclusive to —
+            ``kind="endpoint"``.
+        revision: The HF Hub git revision (a commit sha, tag, or branch) pinning
+            ``base``. ``hf`` only. **Without it an ``org/name`` reference
+            drifts**: the same config resolves to different weights as the Hub
+            moves, so an "identical versioned config" round-trip is not
+            identical across time (B16).
+
+    Raises:
+        InvalidModelRefError: Any field combination the table above forbids.
     """
 
     base: str
+    kind: BackboneKind
     adapter: str | None = None
+    api_base: str | None = None
+    revision: str | None = None
+
+    def __post_init__(self) -> None:
+        """Validate the ref itself.
+
+        Validation lives *here*, not only in :func:`normalize_model_ref`: this is
+        a public dataclass, so a caller constructing one directly bypasses the
+        normalizer entirely. A frozen dataclass that validates nothing is a
+        contract in name only — every field combination below is one a backend
+        would otherwise discover at load time, or worse, silently ignore.
+        """
+        if not isinstance(self.base, str) or not self.base:
+            raise InvalidModelRefError(
+                f"ModelRef.base must be a non-empty string; got {self.base!r}"
+            )
+        valid_kinds = get_args(BackboneKind)
+        if self.kind not in valid_kinds:
+            raise InvalidModelRefError(
+                f"ModelRef.kind must be one of {', '.join(map(repr, valid_kinds))}; "
+                f"got {self.kind!r}"
+            )
+        if self.adapter is not None:
+            if not isinstance(self.adapter, str) or not self.adapter:
+                raise InvalidModelRefError(
+                    f"ModelRef.adapter must be a non-empty string or None; got {self.adapter!r}"
+                )
+            if self.kind in SERVED_KINDS:
+                raise InvalidModelRefError(
+                    f"ModelRef(kind={self.kind!r}) cannot carry an adapter: an unmerged PEFT "
+                    "adapter can only be assembled in-process, but this kind runs behind an "
+                    "API. Use kind='hf'/'local' to serve base+adapter in-process, or merge the "
+                    "adapter into the base weights and reference the merged model."
+                )
+        if self.kind == "endpoint":
+            if not self.api_base:
+                raise InvalidModelRefError(
+                    "ModelRef(kind='endpoint') requires api_base — the URL the model is served "
+                    "at (e.g. 'http://localhost:8000/v1'). Use kind='api' for a hosted provider "
+                    "model that needs no endpoint."
+                )
+        elif self.api_base is not None:
+            raise InvalidModelRefError(
+                f"ModelRef(kind={self.kind!r}) cannot carry api_base: only kind='endpoint' names "
+                f"a served URL. Did you mean ModelRef(base={self.base!r}, kind='endpoint', "
+                f"api_base={self.api_base!r})?"
+            )
+        if self.revision is not None and self.kind != "hf":
+            raise InvalidModelRefError(
+                f"ModelRef(kind={self.kind!r}) cannot carry a revision: only kind='hf' names a "
+                "Hugging Face Hub git revision. A local directory is pinned by its contents, and "
+                "an API model is versioned by its id."
+            )
 
 
-def normalize_model_ref(model: str | dict[str, str] | ModelRef) -> ModelRef:
-    """Coerce a user-supplied model reference into a :class:`ModelRef`.
+def backend_for(kind: BackboneKind) -> Literal["litellm", "transformers"]:
+    """Route a backbone ``kind`` to a completion backend. **The whole routing rule.**
 
-    Accepts the three surface forms and validates them:
+    A pure function of the discriminator: no filesystem, no environment, no CWD.
+    That is the point — see the module docstring's B17 note.
+    """
+    return "litellm" if kind in SERVED_KINDS else "transformers"
 
-    - ``str`` — an HF Hub id, a local dir, OR an API model name (e.g.
-      ``"gpt-5-mini"``, ``"openrouter/..."``). All become ``ModelRef(base=model)``;
-      the *routing* decision (in-process vs served API) is the matcher's, not
-      this normalizer's — here we only carve out a canonical shape.
-    - ``dict`` — must carry a non-empty ``"base"``; ``"adapter"`` is optional.
-    - :class:`ModelRef` — returned unchanged (idempotent).
+
+def infer_kind(base: str, *, api_base: str | None = None) -> BackboneKind:
+    """Infer a :data:`BackboneKind` from a bare model string, by **syntax alone**.
+
+    The rules, unambiguous cases first:
+
+    1. ``api_base`` given -> ``endpoint``.
+    2. an explicit path prefix (``./``, ``../``, ``/``, ``~``) -> ``local``.
+    3. a known provider prefix (:data:`_API_MODEL_PREFIXES`) -> ``api``.
+    4. no ``/`` -> ``api`` (a bare litellm id like ``"gpt-5-mini"``).
+    5. exactly one ``/`` -> ``hf`` (an ``org/name`` Hub id).
+    6. otherwise -> :class:`InvalidModelRefError`.
+
+    Rule 6 is the "unknown forms raise" case, and it is deliberately the *only*
+    one: a multi-slash id with no known provider (``"foo/bar/baz"``) is neither a
+    valid Hub id (those carry exactly one slash) nor a provider id we can route,
+    so guessing would only defer the error to a 404. By contrast rule 5's
+    ``org/name`` genuinely *is* a well-formed Hub id even when the caller meant a
+    provider — see the module docstring on why that cannot be second-guessed.
 
     Raises:
-        ValueError: An empty string, a dict missing/with an empty ``"base"``, or a
-            non-string ``"adapter"``.
+        InvalidModelRefError: An empty string, or an unrecognizable form.
+    """
+    if not isinstance(base, str) or not base:
+        raise InvalidModelRefError(f"model string must be non-empty; got {base!r}")
+    if api_base is not None:
+        return "endpoint"
+    if base.startswith(_PATH_PREFIXES):
+        return "local"
+    if base.startswith(_API_MODEL_PREFIXES):
+        return "api"
+    slashes = base.count("/")
+    if slashes == 0:
+        return "api"
+    if slashes == 1:
+        return "hf"
+    raise InvalidModelRefError(
+        f"cannot infer a backbone kind for {base!r}: it has {slashes} '/' separators, so it is "
+        "neither a Hugging Face Hub id ('org/name') nor an id starting with a known provider "
+        f"prefix ({', '.join(_API_MODEL_PREFIXES[:4])}, ...). Name the kind explicitly, e.g. "
+        f'{{"base": {base!r}, "kind": "api"}} to route it to litellm, or "kind": "local" for a '
+        "directory path."
+    )
+
+
+def normalize_model_ref(
+    model: str | dict[str, str] | ModelRef, *, api_base: str | None = None
+) -> ModelRef:
+    """Coerce a user-supplied model reference into a validated :class:`ModelRef`.
+
+    Accepts the three surface forms:
+
+    - ``str`` — the kind is inferred by :func:`infer_kind`.
+    - ``dict`` — must carry a non-empty ``"base"``; ``"kind"`` is honored when
+      present and inferred otherwise; ``"adapter"``, ``"api_base"`` and
+      ``"revision"`` are optional.
+    - :class:`ModelRef` — returned unchanged (idempotent), since it is already
+      validated by construction.
+
+    Args:
+        model: The reference in any of the three forms above.
+        api_base: A served endpoint URL supplied *alongside* the model (the
+            legacy parallel kwarg — see :class:`~langres.core.matchers.llm_judge.LLMMatcher`).
+            It is absorbed into the ref as the ``endpoint`` form, which is why
+            ``api_base`` is not a second model concept any more.
+
+    Raises:
+        InvalidModelRefError: A malformed ref, an unrecognizable form, or an
+            ``api_base`` that contradicts the one already on the ref.
         TypeError: Any other type.
     """
     if isinstance(model, ModelRef):
+        if api_base is not None and model.api_base != api_base:
+            raise InvalidModelRefError(
+                f"conflicting api_base: the ModelRef names {model.api_base!r} but api_base="
+                f"{api_base!r} was passed alongside it. Pass one or the other, not both."
+            )
         return model
     if isinstance(model, str):
-        if not model:
-            raise ValueError("model string must be non-empty")
-        return ModelRef(base=model)
+        return ModelRef(base=model, kind=infer_kind(model, api_base=api_base), api_base=api_base)
     if isinstance(model, dict):
         base = model.get("base")
         if not isinstance(base, str) or not base:
-            raise ValueError(f"model dict must carry a non-empty string 'base'; got {model!r}")
+            raise InvalidModelRefError(
+                f"model dict must carry a non-empty string 'base'; got {model!r}"
+            )
         adapter = model.get("adapter")
         if adapter is not None and not isinstance(adapter, str):
-            raise ValueError(f"model dict 'adapter' must be a string or absent; got {adapter!r}")
-        return ModelRef(base=base, adapter=adapter)
+            raise InvalidModelRefError(
+                f"model dict 'adapter' must be a string or absent; got {adapter!r}"
+            )
+        revision = model.get("revision")
+        if revision is not None and not isinstance(revision, str):
+            raise InvalidModelRefError(
+                f"model dict 'revision' must be a string or absent; got {revision!r}"
+            )
+        ref_api_base = model.get("api_base")
+        if ref_api_base is not None and api_base is not None and ref_api_base != api_base:
+            raise InvalidModelRefError(
+                f"conflicting api_base: the model dict names {ref_api_base!r} but api_base="
+                f"{api_base!r} was passed alongside it. Pass one or the other, not both."
+            )
+        resolved_api_base = ref_api_base or api_base
+        kind = model.get("kind")
+        if kind is None:
+            # An unmerged adapter can only be assembled in-process, so a dict
+            # naming one is an in-process ref even when `base` looks like a bare
+            # litellm id. Inference sees only `base`, so it cannot know that.
+            inferred = infer_kind(base, api_base=resolved_api_base)
+            kind = "hf" if adapter is not None and inferred == "api" else inferred
+        return ModelRef(
+            base=base,
+            kind=kind,  # type: ignore[arg-type]  # validated in __post_init__
+            adapter=adapter,
+            api_base=resolved_api_base,
+            revision=revision,
+        )
     raise TypeError(f"model must be a str, dict, or ModelRef; got {type(model).__name__}")
 
 
 def to_config(ref: ModelRef) -> str | dict[str, str]:
     """Serialize a :class:`ModelRef` for ``config`` (the inverse of :func:`normalize_model_ref`).
 
-    A self-contained ref (``adapter is None``) serializes to its bare ``base``
-    string — **byte-identical to the pre-model_ref string config**, so existing
-    saved artifacts and their round-trips are unchanged. Only the base+adapter
-    case widens to a ``{"base": ..., "adapter": ...}`` dict.
+    Emits the **compact string form** (a bare ``base``) exactly when that string
+    round-trips back to an equal ref — i.e. when the kind is what
+    :func:`infer_kind` would have guessed and no other field is set. That keeps
+    the common case **byte-identical to the pre-``kind`` string config**, so
+    existing saved artifacts and their round-trips are unchanged, while any ref
+    that inference could not reproduce widens to an explicit dict.
+
+    The invariant, pinned by test: ``normalize_model_ref(to_config(ref)) == ref``
+    for every ref.
     """
-    if ref.adapter is None:
+    try:
+        inferable = infer_kind(ref.base) == ref.kind
+    except InvalidModelRefError:
+        # `base` is a form inference cannot name (e.g. a multi-slash id routed by
+        # an explicit kind). It must carry its kind, or it would not survive load.
+        inferable = False
+    if inferable and ref.adapter is None and ref.api_base is None and ref.revision is None:
         return ref.base
-    return {"base": ref.base, "adapter": ref.adapter}
+    config: dict[str, str] = {"base": ref.base, "kind": ref.kind}
+    if ref.adapter is not None:
+        config["adapter"] = ref.adapter
+    if ref.api_base is not None:
+        config["api_base"] = ref.api_base
+    if ref.revision is not None:
+        config["revision"] = ref.revision
+    return config

--- a/src/langres/core/model_ref.py
+++ b/src/langres/core/model_ref.py
@@ -242,6 +242,50 @@ def backend_for(kind: BackboneKind) -> Literal["litellm", "transformers"]:
     return "litellm" if kind in SERVED_KINDS else "transformers"
 
 
+def require_served(ref: ModelRef, *, slot: str) -> ModelRef:
+    """Assert ``ref`` can run behind an API, or raise :class:`UnsupportedBackboneError`.
+
+    The guard for **DSPy-backed slots**, which have no in-process route at all.
+    Verified against the installed ``dspy`` (3.2.1), not assumed:
+    ``dspy.clients.lm.LM.forward`` routes *every* completion through
+    ``litellm_completion`` -> ``litellm.completion``, and ``LM.__init__``
+    documents ``model`` as ``"llm_provider/llm_name"``. ``dspy.clients.lm_local``
+    looks like an in-process escape hatch but is not one: ``LocalProvider.launch``
+    requires ``sglang``, shells out with ``subprocess.Popen``, and then points
+    litellm at ``http://localhost:{port}/v1`` — i.e. it *serves* the model and
+    goes back through litellm.
+
+    So handing such a slot a ``local`` dir or a base+adapter ref cannot work; it
+    dies deep inside litellm with a provider error that names nothing useful.
+    Raising here — at construction — is that failure, hoisted to where the caller
+    can act on it.
+
+    Args:
+        ref: The backbone to check.
+        slot: The slot's user-facing name, woven into the message.
+
+    Raises:
+        UnsupportedBackboneError: ``ref.kind`` is an in-process kind.
+    """
+    if ref.kind in SERVED_KINDS:
+        return ref
+    detail = (
+        f"an unmerged base+adapter ref (base={ref.base!r}, adapter={ref.adapter!r})"
+        if ref.adapter is not None
+        else f"a {ref.kind!r} backbone ({ref.base!r})"
+    )
+    raise UnsupportedBackboneError(
+        f"{slot} cannot run {detail}: it is DSPy-backed, and DSPy routes every "
+        "completion through litellm — it has no in-process route, so local weights and "
+        "PEFT adapters are unreachable from this slot.\n"
+        "Fix A: serve the model (e.g. `vllm serve <model>`) and pass the endpoint — "
+        '{"base": "<served-id>", "kind": "endpoint", "api_base": "http://localhost:8000/v1"}.\n'
+        "Fix B: use LLMMatcher instead, which has a transformers backend and runs "
+        "hf/local/base+adapter refs in-process.\n"
+        "Fix C: name an API model (e.g. 'openrouter/openai/gpt-4o-mini')."
+    )
+
+
 def infer_kind(base: str, *, api_base: str | None = None) -> BackboneKind:
     """Infer a :data:`BackboneKind` from a bare model string, by **syntax alone**.
 

--- a/src/langres/core/presets.py
+++ b/src/langres/core/presets.py
@@ -431,18 +431,22 @@ def _resolve_judge_uncapped(
     else:
         judge_used = judge
 
+    # The name is validated by build_judge below, but the backbone must be checked
+    # BEFORE construction: a method that cannot run this ref should say so here,
+    # not fail deep inside litellm (or, worse, drop the argument in silence).
+    spec = get_method(judge_used)
+    spec.check_backbone(resolved_model)
+
     built = build_judge(
         judge_used, schema, model=resolved_model, entity_noun=entity_noun, judge_params=judge_params
     )
-    # build_judge validated the name, so the spec lookup cannot fail here. The
-    # spec is the identity authority: a judge that ignores model= (embedding,
-    # string) reports its fixed default_model -- never the caller's ignored
-    # override -- so the stamped identity is what actually ran.
-    spec = get_method(judge_used)
-    if spec.accepts_model:
-        resolved_model = resolved_model or spec.default_model
-    else:
-        resolved_model = spec.default_model
+    # The spec is the identity authority: a method with no model slot reports its
+    # fixed default_model, and one WITH a slot reports the caller's override.
+    # ``check_backbone`` above already rejected a model= the method cannot honor,
+    # so this can no longer stamp an identity that did not run.
+    resolved_model = (
+        (resolved_model or spec.default_model) if spec.accepted_kinds else spec.default_model
+    )
     return ResolvedModule(built, judge_used, resolved_model)
 
 
@@ -515,8 +519,18 @@ def _text_field_extractor(schema: type[BaseModel]) -> Any:
     return extract
 
 
-def _build_vector_blocker(schema: type[BaseModel]) -> VectorBlocker[Any]:
-    """Build a ``VectorBlocker`` (MiniLM + FAISS cosine) for ``schema``."""
+def _build_vector_blocker(
+    schema: type[BaseModel], *, model: str | None = None
+) -> VectorBlocker[Any]:
+    """Build a ``VectorBlocker`` (FAISS cosine) for ``schema`` over an embedder backbone.
+
+    ``model`` names the sentence-transformers backbone; ``None`` pins
+    :data:`~langres.core.model_ref.DEFAULT_EMBEDDING_MODEL`. This is the seam that
+    makes ``matcher="embedding", model=...`` mean something: the ``embedding``
+    method's model slot is the *blocker's* embedder (its matcher only passes the
+    blocker's cosine similarity through), so the caller's backbone has to land
+    here or nowhere.
+    """
     # Lazy: faiss/sentence-transformers ([semantic] extra) must stay out of
     # sys.modules unless a VectorBlocker is actually built (mirrors the
     # zero_shot_llm branch's lazy dspy import right below).
@@ -524,7 +538,7 @@ def _build_vector_blocker(schema: type[BaseModel]) -> VectorBlocker[Any]:
     from langres.core.embeddings import SentenceTransformerEmbedder
     from langres.core.indexes.vector_index import FAISSIndex
 
-    embedder = SentenceTransformerEmbedder(DEFAULT_EMBEDDING_MODEL)
+    embedder = SentenceTransformerEmbedder(model or DEFAULT_EMBEDDING_MODEL)
     index = FAISSIndex(embedder=embedder, metric="cosine")
     return VectorBlocker(
         vector_index=index,
@@ -663,8 +677,16 @@ def build_resolver(
     )
 
     use_vector = resolved.judge_used == "embedding" or n_records > _ALL_PAIRS_MAX_N
+    # The caller's model= names the EMBEDDER backbone only for the "embedding"
+    # method, whose model slot IS this blocker (see _build_vector_blocker). For any
+    # other judge, model= names that judge's LLM backbone and the blocker -- built
+    # here only as a scaling choice above _ALL_PAIRS_MAX_N -- keeps its own default.
     blocker: Blocker[Any] = (
-        _build_vector_blocker(schema) if use_vector else AllPairsBlocker(schema=schema)
+        _build_vector_blocker(
+            schema, model=resolved.model if resolved.judge_used == "embedding" else None
+        )
+        if use_vector
+        else AllPairsBlocker(schema=schema)
     )
     comparator: Comparator[Any] | None = (
         StringComparator.from_schema(schema) if resolved.judge_used == "string" else None

--- a/src/langres/core/registry.py
+++ b/src/langres/core/registry.py
@@ -91,6 +91,8 @@ _LAZY_COMPONENT_MODULES: dict[str, str] = {
     "dspy_judge": "langres.core.matchers.dspy_judge",
     "faiss_index": "langres.core.indexes.vector_index",
     "fake_embedder": "langres.core.embeddings",
+    "fastembed_late_interaction_embedder": "langres.core.embeddings",
+    "fastembed_sparse_embedder": "langres.core.embeddings",
     "fellegi_sunter_judge": "langres.core.matchers.fellegi_sunter",
     "key_blocker": "langres.core.blockers.key",
     "llm_judge": "langres.core.matchers.llm_judge",

--- a/tests/core/matchers/test_model_ref.py
+++ b/tests/core/matchers/test_model_ref.py
@@ -1,65 +1,172 @@
-"""Unit tests for the weightless ``ModelRef`` normalizer (PR-E serve path).
+"""Unit tests for the weightless ``ModelRef`` — the ONE backbone concept (W3).
 
-Pure, fast, dependency-free: no torch/transformers, no network. Locks the three
-model-reference surface forms (HF id / local dir string, base+adapter dict,
-``ModelRef``), the ``config`` round-trip shape (plain string stays a string; only
-base+adapter widens to a dict), and the validation errors.
+Pure, fast, dependency-free: no torch/transformers, no litellm, no network.
+Locks the surface forms, the ``kind`` discriminator's inference rules, the
+CWD-independence of routing (B17), the ``revision`` field (B16), the validation
+matrix (now enforced in ``__post_init__``, not only in the normalizer), and the
+``config`` round-trip invariant.
 """
 
 from __future__ import annotations
 
 import json
+import os
+from typing import Any
 
 import pytest
 
 from langres.core.matchers.model_ref import ModelRef, normalize_model_ref, to_config
+from langres.core.model_ref import (
+    IN_PROCESS_KINDS,
+    LITELLM_ROUTABLE_KINDS,
+    SERVED_KINDS,
+    InvalidModelRefError,
+    UnsupportedBackboneError,
+    backend_for,
+    infer_kind,
+    require_litellm_routable,
+)
+
+# --------------------------------------------------------------------------- #
+# Kind inference — by syntax alone, never by touching the filesystem.
+# --------------------------------------------------------------------------- #
 
 
-def test_string_normalizes_to_base_only_ref() -> None:
-    assert normalize_model_ref("your-org/your-ft-model") == ModelRef(
-        base="your-org/your-ft-model", adapter=None
-    )
+@pytest.mark.parametrize(
+    ("base", "expected"),
+    [
+        ("gpt-5-mini", "api"),  # bare litellm id
+        ("openai/gpt-4o", "api"),  # known provider prefix
+        ("openrouter/openai/gpt-4o-mini", "api"),  # multi-slash, known prefix
+        ("hosted_vllm/my-model", "api"),
+        ("your-org/your-ft-model", "hf"),  # org/name -> Hub id
+        ("BAAI/bge-small-en-v1.5", "hf"),
+        ("./my-ft", "local"),
+        ("../models/my-ft", "local"),
+        ("/models/my-ft", "local"),
+        ("~/models/my-ft", "local"),
+    ],
+)
+def test_infer_kind(base: str, expected: str) -> None:
+    assert infer_kind(base) == expected
+    assert normalize_model_ref(base).kind == expected
 
 
-def test_local_dir_and_api_names_are_just_base_strings() -> None:
-    # The normalizer does NOT route; it only carves a canonical shape. An API
-    # name and a local path both become base-only refs.
-    assert normalize_model_ref("gpt-5-mini") == ModelRef(base="gpt-5-mini")
-    assert normalize_model_ref("/models/my-ft") == ModelRef(base="/models/my-ft")
+def test_api_base_makes_it_an_endpoint() -> None:
+    ref = normalize_model_ref("my-served-model", api_base="http://localhost:8000/v1")
+    assert ref.kind == "endpoint"
+    assert ref.api_base == "http://localhost:8000/v1"
+    assert backend_for(ref.kind) == "litellm"
+
+
+def test_unknown_multi_slash_form_raises() -> None:
+    """The one 'unknown form' that is unambiguous — so it is the one that raises.
+
+    ``foo/bar/baz`` is neither a Hub id (exactly one slash) nor a known provider
+    id, so guessing would only defer the failure to a 404.
+    """
+    with pytest.raises(InvalidModelRefError, match="cannot infer a backbone kind"):
+        infer_kind("foo/bar/baz")
+    with pytest.raises(InvalidModelRefError, match="Name the kind explicitly"):
+        normalize_model_ref("foo/bar/baz")
+
+
+def test_an_unknown_multi_slash_id_is_reachable_by_naming_its_kind() -> None:
+    ref = normalize_model_ref({"base": "foo/bar/baz", "kind": "api"})
+    assert ref.kind == "api"
+    assert backend_for(ref.kind) == "litellm"
+
+
+def test_inference_never_touches_the_filesystem(tmp_path: Any) -> None:
+    """**B17.** Directories named like model ids must not move the decision.
+
+    The predecessor probed ``os.path.isdir(ref.base)``, so a local ``./openai``
+    directory silently flipped routing litellm -> transformers — the same saved
+    config resolving differently per working directory.
+    """
+    (tmp_path / "openai").mkdir()
+    (tmp_path / "gpt-5-mini").mkdir()
+    cwd = os.getcwd()
+    try:
+        os.chdir(tmp_path)
+        assert infer_kind("openai/gpt-4o") == "api"
+        assert infer_kind("gpt-5-mini") == "api"
+    finally:
+        os.chdir(cwd)
+    assert infer_kind("openai/gpt-4o") == "api"
+    assert infer_kind("gpt-5-mini") == "api"
+
+
+# --------------------------------------------------------------------------- #
+# Routing.
+# --------------------------------------------------------------------------- #
+
+
+def test_backend_for_is_total_over_the_kinds() -> None:
+    assert {backend_for(k) for k in SERVED_KINDS} == {"litellm"}
+    assert {backend_for(k) for k in IN_PROCESS_KINDS} == {"transformers"}
+
+
+# --------------------------------------------------------------------------- #
+# Surface forms.
+# --------------------------------------------------------------------------- #
 
 
 def test_dict_with_base_and_adapter_normalizes() -> None:
     ref = normalize_model_ref({"base": "meta-llama/Llama-3.1-8B", "adapter": "/ad/lora"})
-    assert ref == ModelRef(base="meta-llama/Llama-3.1-8B", adapter="/ad/lora")
+    assert ref == ModelRef(base="meta-llama/Llama-3.1-8B", kind="hf", adapter="/ad/lora")
+
+
+def test_an_adapter_forces_an_in_process_kind() -> None:
+    """A bare-name base + adapter is in-process, though the base alone reads as `api`.
+
+    Inference sees only ``base``, so it cannot know an adapter is coming; the
+    normalizer corrects for it (litellm can never assemble an unmerged adapter).
+    """
+    ref = normalize_model_ref({"base": "some-base", "adapter": "org/lora"})
+    assert ref.kind == "hf"
+    assert backend_for(ref.kind) == "transformers"
 
 
 def test_dict_with_only_base_has_no_adapter() -> None:
-    assert normalize_model_ref({"base": "org/model"}) == ModelRef(base="org/model", adapter=None)
+    assert normalize_model_ref({"base": "org/model"}) == ModelRef(
+        base="org/model", kind="hf", adapter=None
+    )
+
+
+def test_explicit_kind_in_a_dict_overrides_inference() -> None:
+    # `org/name` reads as `hf`, but a caller who means a provider id says so.
+    assert normalize_model_ref({"base": "opeani/gpt-4o", "kind": "api"}).kind == "api"
 
 
 def test_model_ref_passthrough_is_idempotent() -> None:
-    ref = ModelRef(base="org/model", adapter="org/adapter")
+    ref = ModelRef(base="org/model", kind="hf", adapter="org/adapter")
     assert normalize_model_ref(ref) is ref
 
 
+# --------------------------------------------------------------------------- #
+# Validation — enforced in __post_init__, so direct construction cannot bypass it.
+# --------------------------------------------------------------------------- #
+
+
 def test_empty_string_rejected() -> None:
-    with pytest.raises(ValueError, match="non-empty"):
+    with pytest.raises(InvalidModelRefError, match="non-empty"):
         normalize_model_ref("")
 
 
 def test_dict_missing_base_rejected() -> None:
-    with pytest.raises(ValueError, match="'base'"):
+    with pytest.raises(InvalidModelRefError, match="'base'"):
         normalize_model_ref({"adapter": "org/adapter"})
 
 
 def test_dict_empty_base_rejected() -> None:
-    with pytest.raises(ValueError, match="'base'"):
+    with pytest.raises(InvalidModelRefError, match="'base'"):
         normalize_model_ref({"base": ""})
 
 
 def test_dict_non_string_adapter_rejected() -> None:
-    with pytest.raises(ValueError, match="adapter"):
-        normalize_model_ref({"base": "org/model", "adapter": 123})
+    with pytest.raises(InvalidModelRefError, match="adapter"):
+        normalize_model_ref({"base": "org/model", "adapter": 123})  # type: ignore[dict-item]
 
 
 def test_non_ref_type_rejected() -> None:
@@ -67,26 +174,157 @@ def test_non_ref_type_rejected() -> None:
         normalize_model_ref(42)  # type: ignore[arg-type]
 
 
-def test_to_config_of_base_only_is_the_bare_string() -> None:
-    # Byte-identical to the pre-model_ref string config -> old artifacts unchanged.
-    assert to_config(ModelRef(base="gpt-5-mini")) == "gpt-5-mini"
+def test_direct_construction_validates_too() -> None:
+    """The dataclass is public, so ``__post_init__`` is the only guard that cannot
+    be bypassed — a caller need not go through ``normalize_model_ref``."""
+    with pytest.raises(InvalidModelRefError, match="non-empty string"):
+        ModelRef(base="", kind="api")
+    with pytest.raises(InvalidModelRefError, match="kind must be one of"):
+        ModelRef(base="x", kind="bogus")  # type: ignore[arg-type]
 
 
-def test_to_config_of_base_plus_adapter_is_a_dict() -> None:
-    cfg = to_config(ModelRef(base="org/base", adapter="org/adapter"))
-    assert cfg == {"base": "org/base", "adapter": "org/adapter"}
+def test_an_adapter_on_a_served_kind_is_rejected() -> None:
+    with pytest.raises(InvalidModelRefError, match="cannot carry an adapter"):
+        ModelRef(base="org/b", kind="api", adapter="org/a")
+
+
+def test_endpoint_requires_api_base_and_others_forbid_it() -> None:
+    with pytest.raises(InvalidModelRefError, match="requires api_base"):
+        ModelRef(base="m", kind="endpoint")
+    with pytest.raises(InvalidModelRefError, match="cannot carry api_base"):
+        ModelRef(base="m", kind="api", api_base="http://x/v1")
+
+
+def test_conflicting_api_base_is_rejected() -> None:
+    with pytest.raises(InvalidModelRefError, match="conflicting api_base"):
+        normalize_model_ref(
+            {"base": "m", "kind": "endpoint", "api_base": "http://a/v1"},
+            api_base="http://b/v1",
+        )
+    with pytest.raises(InvalidModelRefError, match="conflicting api_base"):
+        normalize_model_ref(
+            ModelRef(base="m", kind="endpoint", api_base="http://a/v1"),
+            api_base="http://b/v1",
+        )
+
+
+# --------------------------------------------------------------------------- #
+# revision (B16) — in the v1 schema NOW, before artifacts depend on it.
+# --------------------------------------------------------------------------- #
+
+
+def test_revision_pins_an_hf_ref_and_survives_the_round_trip() -> None:
+    ref = normalize_model_ref({"base": "org/model", "revision": "abc123"})
+    assert ref.kind == "hf"
+    assert ref.revision == "abc123"
+    assert to_config(ref) == {"base": "org/model", "kind": "hf", "revision": "abc123"}
+    assert normalize_model_ref(to_config(ref)) == ref
+
+
+def test_two_revisions_of_one_base_are_different_refs() -> None:
+    """The point of B16: without ``revision``, ``org/name`` drifts as the Hub moves,
+    so an 'identical versioned config' is not identical across time."""
+    a = normalize_model_ref({"base": "org/model", "revision": "v1"})
+    b = normalize_model_ref({"base": "org/model", "revision": "v2"})
+    assert a != b
+    assert to_config(a) != to_config(b)
+
+
+def test_revision_is_hf_only() -> None:
+    with pytest.raises(InvalidModelRefError, match="cannot carry a revision"):
+        ModelRef(base="gpt-4o", kind="api", revision="abc")
+    with pytest.raises(InvalidModelRefError, match="cannot carry a revision"):
+        ModelRef(base="/models/m", kind="local", revision="abc")
+
+
+def test_non_string_revision_rejected() -> None:
+    with pytest.raises(InvalidModelRefError, match="revision"):
+        normalize_model_ref({"base": "org/model", "revision": 7})  # type: ignore[dict-item]
+
+
+# --------------------------------------------------------------------------- #
+# The litellm-routable guard (B10).
+# --------------------------------------------------------------------------- #
+
+
+def test_require_litellm_routable_admits_served_and_hf() -> None:
+    for base in ("gpt-5-mini", "openai/gpt-4o", "unknown-provider/some-model"):
+        ref = normalize_model_ref(base)
+        assert require_litellm_routable(ref, slot="DSPyMatcher") is ref
+    served = normalize_model_ref("m", api_base="http://x/v1")
+    assert require_litellm_routable(served, slot="DSPyMatcher") is served
+
+
+def test_require_litellm_routable_rejects_local_and_adapters() -> None:
+    with pytest.raises(UnsupportedBackboneError, match="no in-process route"):
+        require_litellm_routable(normalize_model_ref("./my-ft"), slot="DSPyMatcher")
+    with pytest.raises(UnsupportedBackboneError, match="unmerged base\\+adapter"):
+        require_litellm_routable(
+            normalize_model_ref({"base": "org/b", "adapter": "org/a"}), slot="DSPyMatcher"
+        )
+
+
+def test_litellm_routable_includes_hf_deliberately() -> None:
+    """Measured, not stylistic: litellm knows 146 providers, the prefix table 26,
+    so 120 real provider ids infer as ``hf``. Rejecting ``hf`` here would reject
+    working code. See LITELLM_ROUTABLE_KINDS for the alternative."""
+    assert "hf" in LITELLM_ROUTABLE_KINDS
+    assert "local" not in LITELLM_ROUTABLE_KINDS
+    assert SERVED_KINDS <= LITELLM_ROUTABLE_KINDS
+
+
+# --------------------------------------------------------------------------- #
+# config round-trip.
+# --------------------------------------------------------------------------- #
+
+
+def test_to_config_of_an_inferable_ref_is_the_bare_string() -> None:
+    # Byte-identical to the pre-`kind` string config -> old artifacts unchanged.
+    assert to_config(ModelRef(base="gpt-5-mini", kind="api")) == "gpt-5-mini"
+    assert to_config(ModelRef(base="org/model", kind="hf")) == "org/model"
+    assert to_config(ModelRef(base="./m", kind="local")) == "./m"
+
+
+def test_to_config_widens_when_inference_could_not_reproduce_the_ref() -> None:
+    # `org/base` alone would infer as `hf`; the adapter must be carried.
+    assert to_config(ModelRef(base="org/base", kind="hf", adapter="org/adapter")) == {
+        "base": "org/base",
+        "kind": "hf",
+        "adapter": "org/adapter",
+    }
+    # A kind inference would NOT have guessed must be explicit or it misroutes.
+    assert to_config(ModelRef(base="org/model", kind="api")) == {
+        "base": "org/model",
+        "kind": "api",
+    }
+    assert to_config(ModelRef(base="foo/bar/baz", kind="api")) == {
+        "base": "foo/bar/baz",
+        "kind": "api",
+    }
 
 
 @pytest.mark.parametrize(
-    "model",
-    ["gpt-5-mini", "your-org/your-ft-model", {"base": "org/b", "adapter": "org/a"}],
+    "ref",
+    [
+        ModelRef(base="gpt-5-mini", kind="api"),
+        ModelRef(base="org/model", kind="hf"),
+        ModelRef(base="org/model", kind="api"),  # explicit kind beats inference
+        ModelRef(base="org/model", kind="hf", revision="abc123"),
+        ModelRef(base="./m", kind="local"),
+        ModelRef(base="/abs/m", kind="local"),
+        ModelRef(base="org/b", kind="hf", adapter="org/a"),
+        ModelRef(base="foo/bar/baz", kind="api"),
+        ModelRef(base="m", kind="endpoint", api_base="http://localhost:8000/v1"),
+    ],
 )
-def test_config_round_trip_is_weightless_and_stable(model: str | dict[str, str]) -> None:
-    ref = normalize_model_ref(model)
+def test_config_round_trip_is_weightless_and_lossless(ref: ModelRef) -> None:
+    """The invariant: ``normalize_model_ref(to_config(ref)) == ref`` for EVERY ref.
+
+    This is what lets ``to_config`` emit the compact string form as an
+    optimization without it ever being a lossy one.
+    """
     config_value = to_config(ref)
-    # Weightless: the serialized form is a plain JSON string/dict of reference
-    # strings -- no bytes -- and re-normalizes to the identical ref.
-    json.dumps(config_value)
+    json.dumps(config_value)  # weightless: reference strings only, no bytes
     assert normalize_model_ref(config_value) == ref
 
 

--- a/tests/core/matchers/test_model_ref.py
+++ b/tests/core/matchers/test_model_ref.py
@@ -59,22 +59,25 @@ def test_api_base_makes_it_an_endpoint() -> None:
     assert backend_for(ref.kind) == "litellm"
 
 
-def test_unknown_multi_slash_form_raises() -> None:
-    """The one 'unknown form' that is unambiguous — so it is the one that raises.
+def test_a_multi_slash_id_is_an_api_id_even_from_an_unlisted_provider() -> None:
+    """A Hub id has EXACTLY one slash, so a multi-slash string is not one.
 
-    ``foo/bar/baz`` is neither a Hub id (exactly one slash) nor a known provider
-    id, so guessing would only defer the failure to a 404.
+    The prefix table is 26 of litellm's 146 providers, so "unknown provider" here
+    means unknown *to that table*, not to litellm. These are real ids litellm
+    routes today; raising on them would break working code (an earlier revision
+    of this module did, and Sourcery caught it).
     """
-    with pytest.raises(InvalidModelRefError, match="cannot infer a backbone kind"):
-        infer_kind("foo/bar/baz")
-    with pytest.raises(InvalidModelRefError, match="Name the kind explicitly"):
-        normalize_model_ref("foo/bar/baz")
+    for base in ("nvidia_nim/meta/llama3-8b-instruct", "foo/bar/baz"):
+        assert infer_kind(base) == "api"
+        assert backend_for(normalize_model_ref(base).kind) == "litellm"
 
 
-def test_an_unknown_multi_slash_id_is_reachable_by_naming_its_kind() -> None:
-    ref = normalize_model_ref({"base": "foo/bar/baz", "kind": "api"})
-    assert ref.kind == "api"
-    assert backend_for(ref.kind) == "litellm"
+def test_inference_is_total_over_non_empty_strings() -> None:
+    """Only an empty string has no kind -- every other string names one."""
+    with pytest.raises(InvalidModelRefError, match="non-empty"):
+        infer_kind("")
+    for base in ("x", "a/b", "a/b/c", "a/b/c/d", "./x", "/x", "~/x"):
+        assert infer_kind(base) in {"api", "hf", "local", "endpoint"}
 
 
 def test_inference_never_touches_the_filesystem(tmp_path: Any) -> None:
@@ -303,10 +306,6 @@ def test_to_config_widens_when_inference_could_not_reproduce_the_ref() -> None:
     # A kind inference would NOT have guessed must be explicit or it misroutes.
     assert to_config(ModelRef(base="org/model", kind="api")) == {
         "base": "org/model",
-        "kind": "api",
-    }
-    assert to_config(ModelRef(base="foo/bar/baz", kind="api")) == {
-        "base": "foo/bar/baz",
         "kind": "api",
     }
 

--- a/tests/core/matchers/test_model_ref.py
+++ b/tests/core/matchers/test_model_ref.py
@@ -188,6 +188,14 @@ def test_an_adapter_on_a_served_kind_is_rejected() -> None:
         ModelRef(base="org/b", kind="api", adapter="org/a")
 
 
+@pytest.mark.parametrize("adapter", ["", 123])
+def test_a_malformed_adapter_is_rejected_on_direct_construction(adapter: Any) -> None:
+    # `normalize_model_ref` screens dicts, but the dataclass is public: an empty
+    # or non-string adapter must not survive construction either.
+    with pytest.raises(InvalidModelRefError, match="adapter must be a non-empty string"):
+        ModelRef(base="org/b", kind="hf", adapter=adapter)
+
+
 def test_endpoint_requires_api_base_and_others_forbid_it() -> None:
     with pytest.raises(InvalidModelRefError, match="requires api_base"):
         ModelRef(base="m", kind="endpoint")

--- a/tests/core/matchers/test_transformers_backend.py
+++ b/tests/core/matchers/test_transformers_backend.py
@@ -49,7 +49,7 @@ class _FakeModel:
 
 
 def _backend_with(model: _FakeModel) -> TransformersBackend:
-    backend = TransformersBackend(ModelRef(base="fake/model"))
+    backend = TransformersBackend(ModelRef(base="fake/model", kind="hf"))
     # Pre-seed so _ensure_loaded() early-returns (no transformers download).
     backend._tokenizer = _FakeTokenizer()
     backend._model = model
@@ -130,7 +130,7 @@ def test_response_feeds_the_matchers_shared_pyes_step() -> None:
     sequences = torch.tensor([[7, 8, 1]])
     # P(Yes) logit high, P(No) lower; other ids negligible.
     scores = (torch.tensor([[-10.0, 2.0, 0.5, -10.0]]),)
-    backend = TransformersBackend(ModelRef(base="fake/model"))
+    backend = TransformersBackend(ModelRef(base="fake/model", kind="hf"))
     backend._tokenizer = _YesNoTokenizer()
     backend._model = _FakeModel(sequences, scores)
 

--- a/tests/core/modules/test_llm_judge_serve.py
+++ b/tests/core/modules/test_llm_judge_serve.py
@@ -12,6 +12,7 @@ from __future__ import annotations
 import asyncio
 import json
 import math
+import os
 from types import SimpleNamespace
 from typing import Any
 from unittest.mock import AsyncMock
@@ -20,10 +21,14 @@ import pytest
 
 from langres.core.matchers.llm_judge import (
     LLMMatcher,
-    _default_backend_kind,
     parse_binary_yes_no,
 )
-from langres.core.matchers.model_ref import ModelRef, normalize_model_ref
+from langres.core.model_ref import (
+    InvalidModelRefError,
+    ModelRef,
+    backend_for,
+    normalize_model_ref,
+)
 from langres.core.models import CompanySchema, ERCandidate
 
 
@@ -182,10 +187,14 @@ def test_base_adapter_model_ref_round_trips_weightlessly() -> None:
     )
     # self.model stays the base id string for every existing consumer.
     assert original.model == "meta-llama/Llama-3.1-8B"
-    assert original.model_ref == ModelRef(base="meta-llama/Llama-3.1-8B", adapter="your-org/lora")
-    # config["model"] widens to a dict of reference strings (no weights).
+    assert original.model_ref == ModelRef(
+        base="meta-llama/Llama-3.1-8B", kind="hf", adapter="your-org/lora"
+    )
+    # config["model"] widens to a dict of reference strings (no weights), and
+    # carries the explicit `kind` so the saved ref routes without re-inferring.
     assert original.config["model"] == {
         "base": "meta-llama/Llama-3.1-8B",
+        "kind": "hf",
         "adapter": "your-org/lora",
     }
     json.dumps(original.config)
@@ -193,6 +202,25 @@ def test_base_adapter_model_ref_round_trips_weightlessly() -> None:
     rebuilt = LLMMatcher.from_config(original.config)
     assert rebuilt.model_ref == original.model_ref
     assert rebuilt.config == original.config
+
+
+def test_pre_kind_artifacts_still_load() -> None:
+    """A base+adapter config written BEFORE `kind` existed must still resolve.
+
+    Back-compat: the discriminator is inferred when a stored dict omits it, so
+    artifacts saved by earlier versions keep loading (and gain the explicit kind
+    the next time they are saved).
+    """
+    rebuilt = LLMMatcher.from_config(
+        {
+            "model": {"base": "meta-llama/Llama-3.1-8B", "adapter": "your-org/lora"},
+            "temperature": 0.0,
+            "prompt_template": "x {left} {right}",
+            "entity_noun": "entity",
+        }
+    )
+    assert rebuilt.model_ref.kind == "hf"
+    assert rebuilt._backend_kind == "transformers"
 
 
 # --------------------------------------------------------------------------- #
@@ -207,24 +235,94 @@ def test_base_adapter_model_ref_round_trips_weightlessly() -> None:
         ("openrouter/openai/gpt-4o-mini", None, "litellm"),  # provider prefix
         ("azure/gpt-4", None, "litellm"),
         ("huggingface/org/model", None, "litellm"),  # litellm HF *inference* route
+        ("hosted_vllm/my-model", None, "litellm"),  # prefix added in W3
         ("your-org/your-ft-model", None, "transformers"),  # HF Hub id -> in-process
+        ("./my-ft-model", None, "transformers"),  # explicit path syntax -> local
+        ("/abs/path/to/model", None, "transformers"),
         ("my-ft-model", "http://localhost:8000/v1", "litellm"),  # served endpoint
         ("your-org/your-ft-model", "http://localhost:8000/v1", "litellm"),  # api_base wins
     ],
 )
-def test_default_backend_kind(model: str, api_base: str | None, expected: str) -> None:
-    assert _default_backend_kind(normalize_model_ref(model), api_base) == expected
+def test_backend_routing(model: str, api_base: str | None, expected: str) -> None:
+    """Routing is a pure function of the ref's ``kind`` -- nothing else."""
+    ref = normalize_model_ref(model, api_base=api_base)
+    assert backend_for(ref.kind) == expected
+
+
+def test_routing_is_independent_of_the_working_directory(tmp_path: Any) -> None:
+    """**B17, the whole point.** The same config must route the same way anywhere.
+
+    The predecessor probed ``os.path.isdir(ref.base)`` on a *relative* path, so a
+    directory merely NAMED like a provider silently flipped routing
+    litellm -> transformers. Here we create exactly that trap -- a real ``./openai``
+    directory -- chdir into it, and assert the decision does not move.
+    """
+    (tmp_path / "openai").mkdir()
+    (tmp_path / "your-org").mkdir()
+    ref_api = normalize_model_ref("openai/gpt-4o")
+    ref_hf = normalize_model_ref("your-org/your-ft-model")
+
+    cwd = os.getcwd()
+    try:
+        os.chdir(tmp_path)  # a CWD where BOTH ids exist as real directories
+        assert backend_for(normalize_model_ref("openai/gpt-4o").kind) == "litellm"
+        assert backend_for(normalize_model_ref("your-org/your-ft-model").kind) == "transformers"
+        # ...and the refs themselves are identical to the ones built elsewhere.
+        assert normalize_model_ref("openai/gpt-4o") == ref_api
+        assert normalize_model_ref("your-org/your-ft-model") == ref_hf
+        assert LLMMatcher(client=object(), model="openai/gpt-4o")._backend_kind == "litellm"
+    finally:
+        os.chdir(cwd)
+
+    assert backend_for(ref_api.kind) == "litellm"
+    assert backend_for(ref_hf.kind) == "transformers"
+
+
+def test_a_bare_relative_dir_name_is_not_a_path(tmp_path: Any) -> None:
+    """A slashless name is an API id even if a same-named dir exists (B17).
+
+    This is the deliberate trade for CWD-independence: ``"my-model"`` cannot be
+    disambiguated from a bare litellm id by syntax, so a local directory must be
+    named as one -- ``"./my-model"`` -- or carry an explicit ``kind``.
+    """
+    (tmp_path / "my-model").mkdir()
+    cwd = os.getcwd()
+    try:
+        os.chdir(tmp_path)
+        assert normalize_model_ref("my-model").kind == "api"
+        assert normalize_model_ref("./my-model").kind == "local"
+        assert normalize_model_ref({"base": "my-model", "kind": "local"}).kind == "local"
+    finally:
+        os.chdir(cwd)
 
 
 def test_local_directory_routes_in_process(tmp_path: Any) -> None:
-    ref = normalize_model_ref(str(tmp_path))  # an existing dir
-    assert _default_backend_kind(ref, None) == "transformers"
+    ref = normalize_model_ref(str(tmp_path))  # an absolute path -> `local` by syntax
+    assert ref.kind == "local"
+    assert backend_for(ref.kind) == "transformers"
 
 
-def test_base_adapter_always_routes_in_process_even_with_api_base() -> None:
-    # An unmerged adapter can only be assembled locally -> in-process wins.
-    ref = ModelRef(base="org/base", adapter="org/adapter")
-    assert _default_backend_kind(ref, "http://localhost:8000/v1") == "transformers"
+def test_base_adapter_routes_in_process() -> None:
+    # An unmerged adapter can only be assembled locally -> an in-process kind.
+    ref = normalize_model_ref({"base": "org/base", "adapter": "org/adapter"})
+    assert ref.kind == "hf"
+    assert backend_for(ref.kind) == "transformers"
+
+
+def test_base_adapter_with_api_base_is_rejected() -> None:
+    """Contradictory by construction, so it raises instead of silently picking one.
+
+    The predecessor let the adapter win and ignored ``api_base`` without a word.
+    (Serving a LoRA adapter behind vLLM needs no ``adapter`` field: the served
+    adapter has its own model id, so it is a plain ``endpoint`` ref.)
+    """
+    with pytest.raises(InvalidModelRefError, match="cannot carry an adapter"):
+        normalize_model_ref(
+            {"base": "org/base", "adapter": "org/adapter"},
+            api_base="http://localhost:8000/v1",
+        )
+    with pytest.raises(InvalidModelRefError, match="cannot carry an adapter"):
+        ModelRef(base="org/base", kind="endpoint", adapter="a", api_base="http://x/v1")
 
 
 def test_matcher_resolves_backend_kind_at_construction() -> None:

--- a/tests/core/test_embedder_serialization.py
+++ b/tests/core/test_embedder_serialization.py
@@ -11,7 +11,12 @@ the slow lane.
 import numpy as np
 import pytest
 
-from langres.core.embeddings import FakeEmbedder, SentenceTransformerEmbedder
+from langres.core.embeddings import (
+    FakeEmbedder,
+    FastEmbedLateInteractionEmbedder,
+    FastEmbedSparseEmbedder,
+    SentenceTransformerEmbedder,
+)
 from langres.core.registry import get_component
 
 
@@ -86,3 +91,56 @@ class TestSentenceTransformerEmbedderRoundtripSlow:
 
         assert rebuilt._model is not None
         assert embeddings.shape == (2, rebuilt.embedding_dim)
+
+
+class TestFastEmbedBackbonesRoundTrip:
+    """W3: the FastEmbed embedders were unregistered and unserializable.
+
+    A backbone that cannot round-trip is a backbone a saved pipeline silently
+    loses. These two carry a ``model_name`` exactly like the dense embedder did,
+    but had no ``@register``, no ``type_name``, and no ``config``/``from_config``
+    -- so a Resolver holding one could not ``save`` at all (``_component_spec``
+    raises on a missing ``type_name``). All fast: FastEmbed models are lazy, so
+    nothing is downloaded here.
+    """
+
+    @pytest.mark.parametrize(
+        ("cls", "type_name", "model_name"),
+        [
+            (FastEmbedSparseEmbedder, "fastembed_sparse_embedder", "Qdrant/bm25"),
+            (
+                FastEmbedLateInteractionEmbedder,
+                "fastembed_late_interaction_embedder",
+                "colbert-ir/colbertv2.0",
+            ),
+        ],
+    )
+    def test_registered_under_its_type_name(
+        self, cls: type, type_name: str, model_name: str
+    ) -> None:
+        assert get_component(type_name) is cls
+        assert cls.type_name == type_name
+
+    @pytest.mark.parametrize(
+        ("cls", "model_name"),
+        [
+            (FastEmbedSparseEmbedder, "prithivida/Splade_PP_en_v1"),
+            (FastEmbedLateInteractionEmbedder, "answerdotai/answerai-colbert-small-v1"),
+        ],
+    )
+    def test_config_roundtrip_preserves_the_backbone(self, cls: type, model_name: str) -> None:
+        original = cls(model_name=model_name)
+        cfg = original.config()
+        # Through JSON, as a saved artifact would go.
+        rebuilt = cls.from_config(type(cfg).model_validate_json(cfg.model_dump_json()))
+        assert rebuilt.model_name == model_name
+        assert rebuilt._model is None  # still lazy: a config carries no weights
+
+    def test_a_fresh_process_can_resolve_the_type_name(self) -> None:
+        """The lazy-registration entry: ``langres.core.embeddings`` is not on the
+        eager-import path, so without a ``_LAZY_COMPONENT_MODULES`` entry a fresh
+        process loading such an artifact would raise UnknownComponentType."""
+        from langres.core.registry import _LAZY_COMPONENT_MODULES
+
+        for type_name in ("fastembed_sparse_embedder", "fastembed_late_interaction_embedder"):
+            assert _LAZY_COMPONENT_MODULES[type_name] == "langres.core.embeddings"

--- a/tests/core/test_finetune.py
+++ b/tests/core/test_finetune.py
@@ -183,7 +183,7 @@ def test_run_finetune_unmerged_returns_base_plus_adapter_ref() -> None:
     outcome = run_finetune(pairs, QLoRA(base="tiny/model"), trainer=trainer, output_dir="/tmp/x")
 
     assert isinstance(outcome, FinetuneOutcome)
-    assert outcome.model_ref == ModelRef(base="tiny/model", adapter="/tmp/x")
+    assert outcome.model_ref == ModelRef(base="tiny/model", kind="hf", adapter="/tmp/x")
     assert outcome.base == "tiny/model"
     assert outcome.merged is False
     assert outcome.device == "cpu"
@@ -200,7 +200,7 @@ def test_run_finetune_merged_returns_self_contained_ref() -> None:
         pairs, QLoRA(base="tiny/model", merge_adapter=True), trainer=trainer, output_dir="/tmp/m"
     )
 
-    assert outcome.model_ref == ModelRef(base="/tmp/m", adapter=None)
+    assert outcome.model_ref == ModelRef(base="/tmp/m", kind="local", adapter=None)
     assert outcome.merged is True
 
 
@@ -269,7 +269,7 @@ def test_finetune_returns_the_model_ref() -> None:
 
     ref = finetune(pairs, QLoRA(base="tiny/model"), trainer=trainer, output_dir="/tmp/f")
 
-    assert ref == ModelRef(base="tiny/model", adapter="/tmp/f")
+    assert ref == ModelRef(base="tiny/model", kind="hf", adapter="/tmp/f")
 
 
 # --- The real peft/trl path: CPU dry-run (test-finetune job / --all-extras) ---

--- a/tests/core/test_method_registry.py
+++ b/tests/core/test_method_registry.py
@@ -2,7 +2,7 @@
 
 Covers the registry contract itself (lookup, did-you-mean, the reserved ``/``
 id grammar, collision), the identity metadata each built-in spec carries
-(``default_model`` / ``accepts_model`` / ``default_threshold`` /
+(``default_model`` / ``accepted_kinds`` / ``default_threshold`` /
 ``score_type``), and that the three former dispatch sites -- the verbs'
 ``presets.build_judge``, ``Resolver.from_schema``, and the benchmark
 harness's ``methods._make_module_builder`` -- now build the SAME class for
@@ -125,9 +125,41 @@ class TestBuiltinSpecs:
         for name in ("zero_shot_llm", "prompt_llm", "llm_judge", "dspy_judge"):
             spec = get_method(name)
             assert spec.default_model == DEFAULT_OPENROUTER_MODEL, name
-            assert spec.accepts_model is True, name
+            assert spec.accepted_kinds, name  # every LLM method HAS a model slot
             assert spec.default_threshold == 0.7, name
             assert spec.requires_extra == "llm", name
+
+    def test_dspy_backed_methods_declare_no_local_slot(self) -> None:
+        """B10 as data: DSPy routes everything through litellm, so its methods
+        cannot accept a local directory -- and the registry says so, rather than
+        forwarding the path into DSPyMatcher to die inside litellm."""
+        from langres.core.model_ref import LITELLM_ROUTABLE_KINDS
+
+        for name in ("zero_shot_llm", "dspy_judge", "select_judge"):
+            assert get_method(name).accepted_kinds == LITELLM_ROUTABLE_KINDS, name
+            assert "local" not in get_method(name).accepted_kinds, name
+
+    def test_llm_matcher_backed_methods_accept_every_kind(self) -> None:
+        """LLMMatcher has BOTH litellm and a transformers backend, so unlike the
+        DSPy family it really can run local weights."""
+        for name in ("prompt_llm", "llm_judge", "cascade"):
+            assert get_method(name).accepted_kinds == {"api", "endpoint", "hf", "local"}, name
+
+    def test_check_backbone_rejects_what_a_method_cannot_run(self) -> None:
+        from langres.core.model_ref import UnsupportedBackboneError
+
+        with pytest.raises(UnsupportedBackboneError, match="cannot run a 'local' backbone"):
+            get_method("dspy_judge").check_backbone("./my-ft")
+        with pytest.raises(UnsupportedBackboneError, match=r"unmerged base\+adapter"):
+            get_method("dspy_judge").check_backbone({"base": "org/b", "adapter": "org/a"})
+        with pytest.raises(UnsupportedBackboneError, match="has no model slot"):
+            get_method("string").check_backbone("gpt-4o")
+
+    def test_check_backbone_admits_what_a_method_can_run(self) -> None:
+        assert get_method("string").check_backbone(None) is None
+        assert get_method("dspy_judge").check_backbone("gpt-4o").kind == "api"
+        # An LLMMatcher-backed method really can take the local dir DSPy cannot.
+        assert get_method("prompt_llm").check_backbone("./my-ft").kind == "local"
 
     def test_random_forest_declares_the_trained_extra(self) -> None:
         """The supervised forest needs scikit-learn, so its spec names the extra."""
@@ -151,13 +183,13 @@ class TestBuiltinSpecs:
     def test_embedding_reports_the_pinned_embedder_as_its_model(self) -> None:
         spec = get_method("embedding")
         assert spec.default_model == DEFAULT_EMBEDDING_MODEL == "all-MiniLM-L6-v2"
-        # model= is ignored by the builder, so the spec must not honor it either.
-        assert spec.accepts_model is False
+        # Its model slot is the blocker's embedder: in-process kinds, no API.
+        assert spec.accepted_kinds == {"hf", "local"}
 
     def test_string_has_no_model_identity(self) -> None:
         spec = get_method("string")
         assert spec.default_model is None
-        assert spec.accepts_model is False
+        assert spec.accepted_kinds == frozenset()  # no model slot at all
         assert spec.score_type == "heuristic"
         assert spec.default_threshold == 0.5
 

--- a/tests/core/test_presets.py
+++ b/tests/core/test_presets.py
@@ -27,6 +27,7 @@ from langres.core.matchers.weighted_average import WeightedAverageMatcher
 from langres.core.models import ERCandidate, PairwiseJudgement
 from langres.core.matcher import Matcher, stamp_group_cost
 from langres.core.matchers.dspy_judge import DSPyMatcher
+from langres.core.model_ref import DEFAULT_EMBEDDING_MODEL
 from langres.core.presets import (
     DEFAULT_AUTO_MODEL,
     DEFAULT_BUDGET_USD,
@@ -621,6 +622,48 @@ class TestNoticeAndEstimate:
 
 
 class TestBuildResolver:
+    @pytest.mark.slow  # constructs a SentenceTransformerEmbedder (no download: lazy load)
+    def test_build_resolver_threads_the_embedder_backbone_to_the_blocker(self) -> None:
+        """W3: the caller's ``model=`` reaches the component that actually embeds.
+
+        The behavioral half of the silent-drop fix. ``_build_embedding`` legitimately
+        has no model of its own -- ``EmbeddingScoreMatcher`` just passes the blocker's
+        cosine similarity through -- so the ``embedding`` method's model slot IS the
+        VectorBlocker's embedder. If the backbone did not land here it would land
+        nowhere, and the report would be a claim about a model that never ran.
+        """
+        resolved = build_resolver(
+            PresetCompany,
+            judge="embedding",
+            model="BAAI/bge-small-en-v1.5",
+            entity_noun="entity",
+            threshold=None,
+            n_records=5,
+        )
+        blocker = resolved.resolver.blocker
+        assert isinstance(blocker, VectorBlocker)
+        # The embedder is lazy: `model_name` is the reference, no weights loaded.
+        assert blocker.vector_index.embedder.model_name == "BAAI/bge-small-en-v1.5"
+        # ...and the reported identity is that same model -- not a pinned default.
+        assert resolved.model == "BAAI/bge-small-en-v1.5"
+
+    @pytest.mark.slow  # constructs a SentenceTransformerEmbedder (no download: lazy load)
+    def test_a_non_embedding_judge_leaves_the_blockers_embedder_at_the_default(self) -> None:
+        """``model=`` names the JUDGE's backbone for every other method, so a
+        VectorBlocker built merely for scale must not adopt an LLM id as its
+        embedder."""
+        resolved = build_resolver(
+            PresetCompany,
+            judge="string",
+            model=None,
+            entity_noun="entity",
+            threshold=None,
+            n_records=_ALL_PAIRS_MAX_N + 1,  # forces a VectorBlocker for scale
+        )
+        blocker = resolved.resolver.blocker
+        assert isinstance(blocker, VectorBlocker)
+        assert blocker.vector_index.embedder.model_name == DEFAULT_EMBEDDING_MODEL
+
     def test_string_judge_small_n_uses_all_pairs_blocker(self) -> None:
         resolved = build_resolver(
             PresetCompany,
@@ -829,13 +872,32 @@ class TestResolveJudgeModelIdentity:
         resolved = resolve_judge("embedding", PresetCompany)
         assert resolved.model == DEFAULT_EMBEDDING_MODEL
 
-    def test_embedding_ignored_model_override_is_not_reported(self) -> None:
-        """model= is ignored by the embedding judge, so reporting it back
-        would lie about what ran -- the pinned embedder is the truth."""
+    def test_embedding_honors_a_model_override_instead_of_dropping_it(self) -> None:
+        """W3: model= names the EMBEDDER backbone and is honored, not swallowed.
+
+        Previously ``_build_embedding`` accepted ``model=`` and silently dropped
+        it, and the spec reported the pinned default. The report was honest (the
+        pinned embedder really did run) but the caller's explicit override
+        vanished without a word. Now the ``embedding`` method declares an
+        in-process model slot, ``build_resolver`` threads the backbone to the
+        VectorBlocker that actually embeds, and the report names it -- see
+        ``test_build_resolver_threads_the_embedder_backbone_to_the_blocker``.
+        """
+        resolved = resolve_judge("embedding", PresetCompany, model="BAAI/bge-small-en-v1.5")
+        assert resolved.model == "BAAI/bge-small-en-v1.5"
+
+    def test_embedding_without_an_override_reports_the_pinned_embedder(self) -> None:
         from langres.core.method_registry import DEFAULT_EMBEDDING_MODEL
 
-        resolved = resolve_judge("embedding", PresetCompany, model="some/other-model")
+        resolved = resolve_judge("embedding", PresetCompany)
         assert resolved.model == DEFAULT_EMBEDDING_MODEL
+
+    def test_string_rejects_a_model_it_could_only_ignore(self) -> None:
+        """A method with no model slot must say so, not accept-and-drop."""
+        from langres.core.model_ref import UnsupportedBackboneError
+
+        with pytest.raises(UnsupportedBackboneError, match="has no model slot"):
+            resolve_judge("string", PresetCompany, model="gpt-4o")
 
     def test_zero_shot_llm_defaults_to_the_pinned_auto_model(self) -> None:
         resolved = resolve_judge("zero_shot_llm", PresetCompany)


### PR DESCRIPTION
**W3 (backbones)** of the architecture refactor. Base: `feat/arch-refactor` (`a6f46a8`). **Not for main.**

W4 (`ERModel` + `architectures/`) takes `embedder=` / `llm=` backbones, so backbone handling had to be sane and round-trippable first.

## The concept

**Architecture = topology. Backbone = what fills a slot.** Swapping a backbone must never mint a new architecture. There were **six ad-hoc model-reference concepts**; there is now one, `ModelRef`, with an explicit `kind` discriminator.

| `kind` | `base` names | routes to |
|---|---|---|
| `api` | a litellm id (`openai/gpt-4o`, `gpt-5-mini`) | litellm |
| `endpoint` | a model served at `api_base` | litellm |
| `hf` | a Hugging Face Hub id (`org/name`) | transformers |
| `local` | a local directory path | transformers |

## What changed

1. **`ModelRef` is the one backbone concept.** Gains `kind` (required — a discriminator you can forget to set is not one), absorbs the parallel `api_base` kwarg as the **endpoint** form, and gains **`revision`** in the v1 schema now (B16) — without it `org/name` drifts as the Hub moves. Validation moved into **`__post_init__`**: the dataclass is public, so `normalize_model_ref` could be bypassed. `to_config` emits the compact bare string exactly when it re-normalizes to an equal ref, so common artifacts stay **byte-identical**; the invariant `normalize_model_ref(to_config(ref)) == ref` is pinned over all 9 ref shapes. Pre-`kind` artifacts still load (the kind is inferred).
2. **B17 — routing is a pure function of config.** `backend_for(kind)` is the whole rule; the `os.path.isdir` probe is gone (and with it `import os`). Pinned by tests that mutate the CWD.
3. **B10 — DSPy-backed slots are litellm-only.** Re-verified in the venv (dspy 3.2.1): `LM.forward` routes **every** completion through `litellm_completion` → `litellm.completion`; `lm_local.LocalProvider.launch` requires sglang, `subprocess.Popen`s, and points litellm at `localhost`. `DSPyMatcher`/`SelectMatcher` now take a `ModelRef`, forward `api_base` to `dspy.LM`, and reject local dirs/adapters at construction. Their `from_config`'s `str(config["model"])` is fixed — it would have stringified an endpoint dict into `"{'base': ...}"`.
4. **`accepts_model` retired → `accepted_kinds: frozenset[BackboneKind]`.** The bool could only say *whether* a slot took a backbone, never *which kinds* — so the DSPy trio advertised `True` while meaning "a litellm id **string**". `MethodSpec.check_backbone` is the one gate all three dispatch paths call. Empty set = no model slot ⇒ `model=` **raises** instead of being dropped.
5. **`_build_embedding` no longer silently drops `model=`.** The `embedding` method's model slot *is* the VectorBlocker's embedder, so `build_resolver` threads the caller's backbone to it — verified end-to-end (report and the embedder that actually runs now agree).
6. **FastEmbed embedders registered.** Sparse + late-interaction were unregistered and unserializable; now `@register`ed with `config`/`from_config` + lazy-registration entries.
7. **`DEFAULT_EMBEDDING_MODEL` de-triplicated** onto the `model_ref` leaf.

## Findings that outrank the brief (measured, not argued)

- **A strict served-only DSPy guard is not safely implementable.** `litellm.provider_list` carries **146** providers; the prefix table carries **26** — so **120** real provider ids (`ai21/`, `nvidia_nim/`, `voyage/`) infer as `hf` and a strict guard would **reject working code**, including this repo's own `unknown/model-not-in-table` fixtures. The guard covers only the unambiguous in-process forms (local dirs, adapters) — which is the brief's own *"raise … for local/adapter refs"* clause. The strict alternative is recorded in `LITELLM_ROUTABLE_KINDS`; flipping it is one line + 3 spec fields.
- **Provider-typo did-you-mean is impossible at any cutoff.** Real HF org `mistralai` scores **0.875** vs provider `mistral`, `deepseek-ai` **0.842** — both *above* the typo `opeani`→`openai` at **0.833**. The ranges overlap, so catching the typo means rejecting `mistralai/Mistral-7B`. Did-you-mean belongs in failure messages, not routing.
- **The brief's "report lies about which model ran" is not accurate.** The report was *honest* (the pinned embedder really did run — `presets.py:526`); the defect was the **silent ignore** of the caller's override. Fixed by honoring it, not by changing the report.
- **Sourcery caught a real regression I introduced** (its review was a genuine 1m9s one, not the ~5s no-op). `infer_kind` raised on a multi-slash id with no *listed* provider — but the table is 26 of 146, so `nvidia_nim/meta/llama3-8b-instruct` raised where litellm routes it today. Fixed: a Hub id has exactly one slash, so a multi-slash string is never one ⇒ `api`, and litellm (which owns the real provider list) reports any error. Inference is now **total over non-empty strings**, which made a `try/except` in `to_config` provably unreachable — removed rather than left as dead code. Its other two findings were skipped with reasons (long messages are deliberately actionable and match the repo's did-you-mean style; the `_METHOD_REGISTRY` traversal happens only while building a message it is about to `raise` with — a raise is not a hot path).
- **The CWD trap needs the full model id.** The probe is `isdir(base)` on the whole string, so a bare `./openai` does *not* flip `openai/gpt-4o`; it takes `./openai/gpt-4o` or `./gpt-5-mini`. The bug is real (reproduced: one config, two backends) but harder to trigger than stated.

## Out of scope — found, not touched

- **B18**: `serialization.py:99` `checksums` is never populated or verified; `trust_remote_code` is never passed anywhere.
- **`QdrantHybridIndex` is not `@register`ed** (`indexes/hybrid_vector_index.py:39`) — so a hybrid index cannot serialize at all. Plausibly *why* the sparse embedders were never registered: they had no serializable host.
- Stale `Resolver.distil` references remain (`resolver.py`, `docs/TECHNICAL_OVERVIEW.md`); `distil` does not exist.

## Gates

- `tests/test_import_tangle.py`: runtime **0**, all-edges **[10, 9, 3, 2]** — **unchanged** (measured; the new leaf has fan-out 0).
- `test_import_budget.py` + `test_public_surface_dod.py`: pass.
- Fast suite: **3734 passed, 1 skipped**. Full suite incl. slow (locally, since `test-full` skips on PRs): **3835 passed, 1 skipped**.
- **`core` coverage gate** (the exact CI command, `--include="src/langres/core/*" --fail-under=98`): **98.89%** — passes. `model_ref.py` is **100%**. (The brief said 98.27%; that number had moved up.)
- `mypy src/`: clean (152 files). `ruff check` + `format --check`: clean. **CI: all green.**

## Docs (same PR)

`TECHNICAL_OVERVIEW.md` gains the ModelRef contract section; `ADDING_A_METHOD.md` gains the `accepted_kinds` table; `.claude/rules/component-design.md` gains the backbone rules with their measured reasons.

https://claude.ai/code/session_018dBNayZ5NpfnZBxupyJT7U
