### PR TITLE
refactor(w5): close out the arch refactor — the sweep was done; the advice wasn't

### DIFF
--- a/.claude/rules/component-design.md
+++ b/.claude/rules/component-design.md
@@ -37,8 +37,8 @@ a model is the user's job, not a heuristic's. The real layering is:)
      record *sets* — a reserved M5 stub, see below).
 
 2. **`langres.Resolver`** (a plain alias of `ERModel`; `Resolver is ERModel`) — the declarative mid-layer.
-   - `Resolver.from_schema(schema, judge=...)` builds a default dedup pipeline
-     (blocker + comparator + judge + clusterer); `.resolve(records)` runs it;
+   - `Resolver.from_schema(schema, matcher=...)` builds a default dedup pipeline
+     (blocker + comparator + matcher + clusterer); `.resolve(records)` runs it;
      `.save`/`.load` serialize it via the config-registry (no pickle).
    - **Spend-capped too** (B1), not just the named architectures above (they
      share the same `ERModel` machinery): `budget_usd=` on the

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -16,6 +16,7 @@ on:
       - "src/**" # API reference is generated from docstrings
       - "mkdocs.yml"
       - "pyproject.toml"
+      - "CHANGELOG.md" # docs/CHANGELOG.md inlines it via pymdownx.snippets
       - ".github/workflows/docs.yml"
   pull_request:
     paths:
@@ -23,6 +24,7 @@ on:
       - "src/**"
       - "mkdocs.yml"
       - "pyproject.toml"
+      - "CHANGELOG.md"
       - ".github/workflows/docs.yml"
   workflow_dispatch:
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,8 +52,13 @@ heuristic guessed well or a cap held.
   `default_threshold_for`, `PAID_JUDGE_NAMES`, `MatcherName`). Deleted, not
   relocated. `Resolver.from_schema(matcher="auto")` now raises and names a
   concrete architecture instead.
-- `LANGRES_OFFLINE` no longer affects the front door — it only ever gated the
-  deleted `auto` path. (`Settings` still reads it; nothing acts on it.)
+- **`LANGRES_OFFLINE` / `Settings.langres_offline`** — deleted outright, not just
+  disconnected. It only ever gated the `auto` path, so once that went it was a
+  *documented spend guard that did nothing* — the worst failure mode a safety
+  switch has. There is no auto-decision left to disarm: naming a paid
+  architecture is now the only way to spend. `Settings` uses `extra="ignore"`,
+  so a leftover `LANGRES_OFFLINE=1` in an existing `.env` is ignored rather than
+  a `ValidationError`.
 - `default_threshold_for` has no replacement, deliberately: a bound model carries
   its own cut in its `Clusterer`, so `compare()` reads `self.clusterer.threshold`.
   The name→threshold table existed only because the verbs had no model to ask.
@@ -71,6 +76,45 @@ heuristic guessed well or a cap held.
   production path regardless: an inferred schema is an ephemeral class a fresh
   process cannot import, so it could never round-trip through `save()`/`load()`.
 - `examples/quickstart_verbs.py` → `examples/quickstart_models.py`.
+
+#### Known limitation — `VectorLLMCascade` cannot `save()`
+
+`VectorLLMCascade(...).save(path)` raises `NotImplementedError`, by design,
+naming the real gap. `FuzzyString` saves and loads today.
+
+Its `VectorBlocker` is built with a `text_field_extractor` **closure** (blocking
+text = every comparable field concatenated), and a callable cannot round-trip
+through a JSON config. This is **inherited, not new**: the deleted `presets`
+path built the same closure — it simply never called `save()`, so nothing ever
+raised. Naming the architecture is what made the gap *visible*, because a class
+that looks persistable is expected to persist.
+
+To persist an embedding pipeline today, build the `ERModel` directly with a
+serializable single named field instead of the closure:
+
+```python
+ERModel.from_components(
+    blocker=VectorBlocker(
+        vector_index=FAISSIndex(embedder=SentenceTransformerEmbedder("BAAI/bge-small-en-v1.5")),
+        schema=MySchema,
+        text_field="name",   # a named field serializes; a closure does not
+    ),
+    comparator=StringComparator(feature_specs=[FeatureSpec(name="name", kind="string")]),
+    matcher=EmbeddingScoreMatcher(threshold=0.7),
+    clusterer=Clusterer(threshold=0.7),
+)
+```
+
+**Open design decision (not made here):** the fix is a named-extractor seam
+mirroring `LLMMatcher(response_parser=...)` — a registry of named extractors so
+the *name* serializes instead of the closure. That changes what `VectorBlocker`
+accepts on the paid path, so it is an architecture call, deliberately left to
+its owner rather than settled at the end of a wave.
+
+**Scope note for the HF-readiness gate:** the weightless-round-trip proof is
+green only for architectures **without a closure-bearing blocker**. It
+round-trips `FuzzyString`. It does not — and currently cannot — cover
+`VectorLLMCascade`.
 
 ### `Resolver` is spend-capped (B1) — **behavior change**
 

--- a/examples/research/phase1_llm_placement.py
+++ b/examples/research/phase1_llm_placement.py
@@ -133,12 +133,12 @@ class _MeteredJudge(Matcher[Any]):
     """Wrap a judge, metering each judgement's real cost through a shared monitor.
 
     Reuses the exact spend-cap pattern of
-    :class:`~langres.core.presets._SpendCappedMatcher` and
+    :class:`~langres.core.spend_cap.SpendCappedMatcher` and
     ``examples/research/w3_paid_smoke.py``'s ``_charge`` -- add each judgement's
     honest ``provenance["cost_usd"]`` to a :class:`SpendMonitor`, ``check()`` it,
     and re-raise :class:`BudgetExceeded` with every already-paid-for judgement on
     ``.partial_judgements``. The one difference (and the reason this is not just
-    ``_SpendCappedMatcher``): the monitor is **injected**, so ONE cumulative
+    ``SpendCappedMatcher``): the monitor is **injected**, so ONE cumulative
     ledger spans the valid-derivation pass, the test pass, and every dataset in
     the run -- a genuinely run-wide hard cap.
 

--- a/src/langres/architectures/vector_llm_cascade.py
+++ b/src/langres/architectures/vector_llm_cascade.py
@@ -213,9 +213,10 @@ class VectorLLMCascade(ERModel):
             "concatenated) and a callable cannot round-trip through JSON config. "
             "This is a known gap inherited from the pre-W4 embedding path, not a "
             "property of your model. FuzzyString saves and loads today. To persist "
-            "an embedding pipeline now, build a Resolver/ERModel directly with a "
-            "VectorBlocker constructed as VectorBlocker(schema=..., text_field=...) "
-            "-- a single named field, which is serializable."
+            "an embedding pipeline now, build a Resolver/ERModel directly via "
+            "ERModel.from_components(...) with a VectorBlocker constructed as "
+            "VectorBlocker(vector_index=..., schema=..., text_field='<field>') -- a "
+            "single named field, which is serializable, unlike a closure."
         )
 
     def _topology(self, schema: type[BaseModel]) -> dict[str, Any]:

--- a/src/langres/architectures/vector_llm_cascade.py
+++ b/src/langres/architectures/vector_llm_cascade.py
@@ -215,8 +215,9 @@ class VectorLLMCascade(ERModel):
             "property of your model. FuzzyString saves and loads today. To persist "
             "an embedding pipeline now, build a Resolver/ERModel directly via "
             "ERModel.from_components(...) with a VectorBlocker constructed as "
-            "VectorBlocker(vector_index=..., schema=..., text_field='<field>') -- a "
-            "single named field, which is serializable, unlike a closure."
+            "VectorBlocker(vector_index=..., schema=..., text_field='your_text_field') "
+            "-- text_field takes the NAME of one text field on your schema (e.g. "
+            "'name'), and a named field is serializable, unlike a closure."
         )
 
     def _topology(self, schema: type[BaseModel]) -> dict[str, Any]:

--- a/tests/architectures/test_w4_proofs.py
+++ b/tests/architectures/test_w4_proofs.py
@@ -618,3 +618,39 @@ class TestReviewFoundRegressions:
         model = VectorLLMCascade(llm="openrouter/openai/gpt-4o-mini", schema=Company)
         with pytest.raises(NotImplementedError, match="cannot be saved yet"):
             model.save("unreachable")
+
+    def test_save_error_names_every_required_arg_of_the_escape_hatch(self) -> None:
+        """The advice must RUN. It told users to do something that TypeErrors.
+
+        The message's escape hatch is a hand-built `VectorBlocker` with a named
+        `text_field=` instead of the closure. As shipped it read
+        ``VectorBlocker(schema=..., text_field=...)`` -- which raises
+        ``TypeError: missing 1 required positional argument: 'vector_index'``.
+        Advice a user cannot copy is worse than none: it costs them the round-trip
+        to discover our error message is wrong.
+
+        This asserts the message names every REQUIRED parameter, derived from the
+        live signature rather than hard-coded, so adding a required arg to
+        `VectorBlocker` fails here instead of silently rotting the message again.
+        """
+        import inspect
+
+        from langres.core.blockers.vector import VectorBlocker
+
+        model = VectorLLMCascade(llm="openrouter/openai/gpt-4o-mini", schema=Company)
+        try:
+            model.save("unreachable")
+        except NotImplementedError as exc:
+            message = str(exc)
+
+        required = [
+            name
+            for name, p in inspect.signature(VectorBlocker.__init__).parameters.items()
+            if name != "self" and p.default is inspect.Parameter.empty
+        ]
+        assert required, "VectorBlocker grew no required args -- rewrite this proof"
+        for name in required:
+            assert f"{name}=" in message, (
+                f"save()'s advice omits required VectorBlocker arg {name!r}; a user "
+                f"copying it hits a TypeError. Message: {message}"
+            )


### PR DESCRIPTION
**W5 — close out the architecture refactor.** Last wave. Merges into
`feat/arch-refactor`, **not** `main`.

Everything below was measured at a stated commit, not recalled. Where the wave
brief and the repo disagreed, the repo won and I say so.

---

## The headline: the docs sweep this wave was scoped around was already done

W5 was planned as "the bulk of this wave = a docs/examples sweep; the repo still
describes a deleted API." **It doesn't.** W4 (#183) already swept 16 files in its
final commits. Measured at `47fd82f`, before I changed anything:

| Brief said | Measured | Verdict |
|---|---|---|
| `README.md:126` is `## Quickstart: dedupe() and link()` | `README.md:128` is `## Quickstart: named architectures, `.dedupe()` and `.compare()``, already leading with `FuzzyString` | **false at this commit** |
| "4 of 18 examples" reference the deleted API | **0 of 60** examples have a broken `langres` import (AST-resolved, `tmp/example_imports.py`) | **false** |
| `examples/quickstart_verbs.py` is executed by CI and dies with the verbs | already renamed to `quickstart_models.py`; CI already repointed | **already fixed by W4** |
| `mkdocs.yml` autodocs `::: langres.core.presets`; `mkdocs build --strict` hard-fails | `uv run --no-dev --group docs mkdocs build --strict` → **exit 0** | **already fixed by W4** |
| "no local gate covers it" / find out if CI builds docs | `.github/workflows/docs.yml` runs the exact strict build on PRs. It **caught this for real** on #183: `failure` 03:40 → `success` 03:43 | gate exists **and works** |

Remaining stale prose in `CLAUDE.md`, `AGENTS.md`, `component-design.md`,
`TECHNICAL_OVERVIEW.md`, `USE_CASES.md`: **none**. Every surviving mention of
`langres.link` / `matcher="auto"` / `core.presets` is prose *stating the API is
gone* — deliberate, not stale. `DX_RESOLVER.md` and `BENCHMARKS.md` never used
the verbs at all.

**So this PR is small on docs and spends its weight on what the sweep was hiding.**

## What actually needed fixing (4 things, each verified by execution)

1. **`component-design.md:40` documented a call that raises.**
   `Resolver.from_schema(schema, judge=...)` → `TypeError: unexpected keyword
   argument 'judge'`. The kwarg has been `matcher=` since the judge→Matcher
   rename (#140) — that rename's leftover, not W4's. Fixed.
2. **`phase1_llm_placement.py` xref'd `core.presets._SpendCappedMatcher`** — a
   module W4 deleted. Repointed to `core.spend_cap.SpendCappedMatcher`, verified
   by importing the target. Refactor-caused broken xrefs: **1 → 0**
   (`tmp/xref_check.py` resolves every xref by import + attribute walk).
3. **`VectorLLMCascade.save()`'s advice told users to run something that
   TypeErrors** — see below. The wave's one real defect.
4. **`docs.yml` never built the docs when root `CHANGELOG.md` changed**, though
   the site inlines it. See below.

## The defect worth the wave: honest error, unrunnable advice

W4 shipped an honest `NotImplementedError` for `VectorLLMCascade.save()`. Its
remedy did not run:

```
VectorBlocker(schema=..., text_field=...)
→ TypeError: missing 1 required positional argument: 'vector_index'
```

Every gate sailed past it because the only test matched `"cannot be saved yet"`
and never tried the remedy. The *substance* was right — I built the recommended
model and it `save()`s **and** `load()`s — it just omitted a required arg. Advice
a user cannot copy is worse than none: it spends their round-trip to discover our
error is wrong, exactly when they're already blocked.

Fixed, plus a proof that **derives the required args from `VectorBlocker.__init__`'s
live signature** rather than hard-coding them, so a new required arg fails the
proof instead of silently rotting the message again. **Mutation-tested** per this
repo's rule that a proof which cannot fail proves nothing: restored the old
message → proof fails with `save()'s advice omits required VectorBlocker arg
'vector_index'` → restored the fix.

## ⚠️ The one decision for the owner — NOT made here

**`VectorLLMCascade` cannot `save()`.** Its `VectorBlocker` holds a
`text_field_extractor` **closure**; a callable cannot round-trip through JSON.

- **Inherited, not a W4 regression** — the deleted `presets` path built the same
  closure and never called `save()`, so it never raised. Naming the architecture
  is what made the gap *visible*.
- **The fix is an architecture call**: a named-extractor seam mirroring
  `LLMMatcher(response_parser=...)` (register extractors so the *name*
  serializes). It changes what `VectorBlocker` accepts on the paid path.
  Deliberately left to its owner.
- **Proof #4 (HF-readiness / weightless round-trip) is green ONLY for
  architectures without a closure-bearing blocker.** It round-trips
  `FuzzyString`. It does not — and currently cannot — cover `VectorLLMCascade`.
  Recorded in `CHANGELOG.md` under **Known limitation**, with a migration
  snippet I executed end-to-end.

## Proof table — measured at `073581b`, honest

| # | Proof | Status | Evidence |
|---|---|---|---|
| 1 | Thin contract (`Matcher.__abstractmethods__ == ['forward']`) | ✅ pass | pre-verified upstream; not redone |
| 2a | Spend gate is honest | ✅ pass | pre-verified upstream (mutation-tested) |
| 2b / 3 / 4 | tripwire / backbone swap / weightless round-trip | ✅ pass | `tests/architectures/test_w4_proofs.py` — **25 passed** (23 + my 2). **#4 scope-limited — see above** |
| 5 | Import budget: bare `import langres` pulls no torch/litellm/faiss | ✅ **pass** | `test_import_budget.py` + `test_public_surface_dod.py` → 43 passed, 1 skipped |
| 6 | "import-linter passes with zero waivers" | ⛔ **N/A — never adopted; not silently dropped** | see below |
| 7 | Real numbers reproduce | ✅ **pass, reproduces exactly** | `recipe_lift_proof.py` → baseline **0.2043** → recipe **0.5833**, `$0`, exit 0 (brief: 0.204→0.583) |
| 8 | In-process training, no vLLM/service | 🟡 **half proven by execution, half by reading** | see below |

### #6 — there are no waivers, because import-linter was never adopted

Stated plainly rather than quietly dropped. **Verified:** `importlinter` is not
installed and is not a dependency; there is no `.importlinter`/config; therefore
**there are no waivers to remove**. Only `grimp` (its engine) is a dep — as
*ground truth*, not a gate.

W0 deferred import-linter with evidence, recorded in
`docs/research/20260716_import_graph_baseline.md`: grimp counts function-local +
`TYPE_CHECKING` imports as real edges (**102 of 493 edges — 21% — don't run at
import time**), and no option excludes function-local, so it structurally cannot
see the *runtime* view; `type = layers` also hard-crashes on absent packages.

**What replaced it:** `tests/test_import_tangle.py` — an exact-equality SCC
ratchet — cross-validated by
`tests/test_import_graph.py::test_edges_match_grimp_exactly`, so the hand-rolled
graph can't drift from grimp's authoritative resolution. **49 passed.**

### #8 — what is and isn't proven

- **Training in-process: PROVEN by execution.** `test_qlora_trainer_cpu_dry_run`
  (the *only* non-slow `finetune` test — the entire `test-finetune` job) does a
  real peft+trl LoRA on a tiny model pinned to CPU. I ran it: **1 passed, 21.63s.**
- **Serving in-process: verified by READING, not running.** `backend_for(kind)`
  returns `"litellm"` only for `SERVED_KINDS = {"api","endpoint"}`; everything
  else → `"transformers"`, which loads `AutoModelForCausalLM` + optional
  `PeftModel` adapter in-process (`model.eval()`, a lock around `generate`). No
  HTTP, no service. **vLLM is reachable only via an explicit `api_base`.**
- **The test that would prove "trains AND serves" end-to-end
  (`test_finetune_overfit_train_serve_evaluate`) is `@pytest.mark.slow` and
  therefore NOT run by CI** — `test-finetune` runs `-m "finetune and not slow"`.
  Per the brief I did not run a GPU fine-tune.
- **`test-finetune` runs on this PR but is `continue-on-error: true`** — it
  cannot fail the build. So proof #8 is gated by nothing on this branch.

## Gates — measured at `073581b` / `4c3ec57`

- **Full suite:** `uv run pytest -m "not slow and not integration"` → **3645
  passed, 1 skipped, 107 deselected, 0 failures** (base `47fd82f`: 3644 — the +1
  is the new proof). Repo-wide coverage **98.30%** ≥ 90 gate.
- **CI-equivalent run** (`-m "not integration and not finetune"`, i.e. slow
  **included**, exactly what `test-full` runs) → **3737 passed, 1 skipped, 15
  deselected, exit 0** (15m55s).
- **`core` contract gate**, CI's exact command
  (`coverage report --include="src/langres/core/*" --precision=2 --fail-under=98`)
  → **98.43%**, exit **0**.
  *Worth recording:* run against the **fast** suite this reads **97.91% and
  fails**. That is a slow-test-exclusion artifact, not a regression — the gate is
  only meaningful on `test-full`'s marker set. I nearly reported a false red here.
- **Import tangle ratchet:** all-edges SCC **[9, 9, 3, 2]**, runtime **0** —
  exactly the baseline. Docs didn't move it. **Measured, not hand-edited.**
- `ruff check` → All checks passed. `ruff format --check` → formatted.
  `mypy src/` → **Success: no issues found in 155 source files**.
- `mkdocs build --strict` → **exit 0**.
- The 3 `$0` examples CI gates (`quickstart_models`, `quickstart_eval`,
  `flywheel_min`) → all **exit 0** at this HEAD.

## Deliberately NOT done

- **The W0 CI widening is NOT reverted here, and I agree with that call.**
  `test.yml:18` keeps `push: branches: [main, feat/arch-refactor]`. Verified why:
  `test-full` is `if: github.event_name != 'pull_request'` — **push-only**.
  Reverting it in this PR would mean this PR's own merge to the integration
  branch never runs `test-full`. Empirically it's load-bearing: the base's push
  to `feat/arch-refactor` ran `test-full` for 30m36s and passed.
  **→ Revert it in the final `feat/arch-refactor` → `main` PR**, where the branch
  stops existing anyway. That PR must also drop the parenthetical in
  `.claude/rules/testing.md` that documents the widening.
- **Not adopting import-linter** (see #6).
- **Not fixing the `save()` closure** (owner's architecture call).

## Mentioned, not touched (pre-existing, out of a close-out's scope)

- **8 broken doc xrefs**, none refactor-caused: 4× `core.comparator.StringComparator`
  (now `core.comparators.string`), 2× `core.runs.RunRecord.artifacts`, 2×
  `core.methods_api.Method.kind`.
- **`evaluate()`'s first param is still named `module`** while docs call it
  `judge` and the codebase renamed judge→Matcher — three names for one thing.
  The doc snippets pass it **positionally**, so they run; only the prose
  *signature* misnames it. Renaming the param is an API change, not a close-out's.
- **`pymdownx.snippets` `base_path: [".", "docs"]` self-shadowing** — the reason
  the CHANGELOG gap failed silently (below).
- 5 dangling `examples/*.py` paths in docs: 1 is legitimate rename history
  (CHANGELOG), 3 are historical benchmark docs predating the `examples/research/`
  move, 1 is a stale agent doc.
- B18 (`checksums` never populated/verified; `trust_remote_code` never passed);
  stale `Resolver.distil` refs; `QdrantHybridIndex` unregistered;
  `TUTORIAL_YOUR_OWN_CSV.md`'s ">100 rows auto-switches blockers" claim (true of
  the deleted `build_resolver`; `FuzzyString` is honestly O(N²) always).

## The CI gap I found and fixed

`docs/CHANGELOG.md` is a 5-line stub whose body is `--8<-- "CHANGELOG.md"` — the
root changelog, inlined. Root `CHANGELOG.md` was a docs-site **input in neither
path filter**, so a CHANGELOG-only push to main never rebuilt or redeployed the
site: the published Changelog page silently lagged the repo. This wave writes
that file.

**My first hypothesis was wrong and running it said so** — I predicted a missing
root `CHANGELOG.md` would hard-fail `--strict` like the presets blocker did:

```
root CHANGELOG.md present : exit 0, site/CHANGELOG/index.html has 5x "Unreleased"
root CHANGELOG.md absent  : exit 0, site/CHANGELOG/index.html has 0x "Unreleased"
```

It fails **silently**, publishing an empty page — which is why no gate caught it.
`check_paths: true` doesn't help: `base_path: [".", "docs"]` lets
`--8<-- "CHANGELOG.md"` resolve to `docs/CHANGELOG.md` — the including file
itself — so the path always "exists" and the recursion guard drops it without a
word. Added `CHANGELOG.md` to both filters.

## Review

**Sourcery read this diff** — verified, not assumed. Its Reviewer's Guide names
the actual changes (the `save()` advice fix, the resolver docs TypeError, the
xref repoint, the docs CI filter). Contrast #183, where it green-checked in
35–45s with a body saying it had hit its weekly rate limit. Duration doesn't
distinguish the two; the body does.

- **Applied:** the `text_field='<field>'` placeholder invited copying the angle
  brackets literally — the same copyability defect this PR exists to fix
  (`4c3ec57`).
- **Skipped with reasoning** (see [review reply](https://github.com/fxd24/langres/pull/184#issuecomment-4999355178)):
  building the advice from structured data would make the proof tautological and
  reopen the exact bug; the CHANGELOG/error-message "duplication" is two
  artifacts with different lifecycles (frozen history vs. live 2am error).

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018dBNayZ5NpfnZBxupyJT7U
