### PR TITLE
chore: bring main into the integration branch + retire the W0 CI widening

### DIFF
--- a/.claude/rules/expert-knowledge.md
+++ b/.claude/rules/expert-knowledge.md
@@ -122,8 +122,17 @@ lived in `tmp/`. The entire run had to be reconstructed and re-run.
   crash or teardown can't erase what you just wrote.
 - **Never leave a worktree's only copy uncommitted.** Before an agent reports
   done — and before an orchestrator stops, replaces, or moves past a worktree
-  agent — `git -C <worktree> status --porcelain` must be empty of anything you
-  can't afford to lose. Push if the work must outlive the worktree's branch.
+  agent — `git -C <worktree> status --porcelain --untracked-files=all` must be
+  empty of anything you can't afford to lose. Push if the work must outlive the
+  worktree's branch.
+  **`-uall` is mandatory here, not a refinement.** This machine sets
+  `status.showUntrackedFiles = no` globally (`~/.config/git/config`), so a bare
+  `--porcelain` prints *nothing* for a never-`git add`ed file and reports a
+  clean tree. That is exactly the state that lost the run above — a brand-new
+  harness script is untracked — so the check this rule used to mandate was
+  blind to the very accident it was written for. Without `-uall` the check is
+  not weaker, it is **wrong**. (`-uall` over `-unormal` because it names the
+  file at risk instead of collapsing a new directory to `dir/`.)
 - **Treat `tmp/` and other gitignored output as ephemeral.** It dies with the
   worktree and is unrecoverable from git. If a result must survive (a report,
   a dataset, a decision record), commit it to a tracked path or copy it out of
@@ -134,6 +143,16 @@ lived in `tmp/`. The entire run had to be reconstructed and re-run.
 
 The cost of one early `git commit` is nothing. The cost of losing a paid run is
 the run, the time to notice, and the time to redo it.
+
+**The shape of that bug generalizes: a green light decoupled from the thing it
+claims to check.** This repo has hit it four times — a CI step *named* "95%
+coverage gate" while enforcing 90 (`ba90aef`; see the comment on that step in
+`.github/workflows/test.yml`); a cancelled workflow run read as a green run
+(the `concurrency` comment in the same file); a review bot reporting `pass` in
+~5s without ever fetching the diff; and this rule's own `--porcelain` reporting
+a clean tree over unsaved work. When a check says "all clear", confirm it can
+actually observe the failure it exists to catch — a check you have never seen
+fail is a hypothesis, not a safety net.
 
 ## Don't Be Too Assertive Without Context
 

--- a/.claude/rules/testing.md
+++ b/.claude/rules/testing.md
@@ -39,8 +39,6 @@ code. Verify as you go.** Read before writing tests or running the suite.
     heavy test as fast slows every PR, and the coverage floors are verified on
     each merge to main, not per-PR. Run the full suite locally
     (`uv run pytest`) before merging a change to ML/embedding code.
-    (While the architecture refactor is in flight, `test-full` also runs on
-    every merge to the `feat/arch-refactor` integration branch.)
 - Run tests: `uv run pytest` (pre-push hook runs non-slow, non-integration tests automatically)
 - Check coverage: `uv run pytest --cov`; keep `core/**` in the 95–100% tier
   (the repo-wide gate is a relaxed 90% floor — see `pyproject.toml`)

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -2,16 +2,14 @@ name: Lint
 
 on:
   # NOTE: `pull_request.branches` filters by TARGET branch -- a PR into a branch
-  # not listed here runs NO lint at all (no ruff, no mypy). Each integration
-  # branch has had to be added below; `feat/arch-refactor` is the architecture
-  # refactor's. mypy is the gate that catches exactly what a package split
-  # breaks (moved symbols, stale re-exports, circular imports), so a sub-PR
-  # landing there unlinted is the failure this list exists to prevent.
-  # TEMPORARY: drop `feat/arch-refactor` from both lists once the refactor lands.
+  # not listed here runs NO lint at all (no ruff, no mypy). Every integration
+  # branch that sub-PRs land on has to be added below, or those sub-PRs merge
+  # unlinted: mypy is the gate that catches exactly what a package split breaks
+  # (moved symbols, stale re-exports, circular imports).
   push:
-    branches: [main, feat/arch-refactor]
+    branches: [main]
   pull_request:
-    branches: [main, feat/m4-foundation, feat/m5-foundation, feat/tracking-observability, feat/autoresearch, feat/arch-refactor]
+    branches: [main, feat/m4-foundation, feat/m5-foundation, feat/tracking-observability, feat/autoresearch]
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,13 +9,7 @@ name: Test
 on:
   pull_request:
   push:
-    # TEMPORARY (architecture refactor): `feat/arch-refactor` is the integration
-    # branch the refactor's sub-PRs merge into. Without it here, `test-full` --
-    # the ONLY job that runs the slow tests and enforces the coverage gates --
-    # would not run for the entire refactor, and a regression would surface only
-    # at the final merge to main. REVERT THIS LIST TO `[main]` once the refactor
-    # has landed and the integration branch is deleted.
-    branches: [main, feat/arch-refactor]
+    branches: [main]
   workflow_dispatch:
 
 concurrency:
@@ -33,8 +27,7 @@ concurrency:
   # from "cancelled while running" to "cancelled while pending". Keying the
   # group on the SHA gives every merge commit its own group, so each one is
   # gated on its own merits. This has already bitten `main` (6 of the last 30
-  # push runs were cancelled), and matters more once sub-PRs land on the
-  # integration branch above.
+  # push runs were cancelled).
   group: ${{ github.workflow }}-${{ github.ref }}-${{ github.event_name == 'pull_request' && 'pr' || github.sha }}
   cancel-in-progress: true
 


### PR DESCRIPTION
Prep for the final `feat/arch-refactor` → `main` PR. Two things, no code changes.

### 1. Merge `origin/main` into the integration branch
`main` was 1 commit ahead: **e927554** (#181, the durability rule → `.claude/rules/expert-knowledge.md`). Docs-only — one file, +21/−2. Merged clean, no conflicts.

### 2. Retire the W0 CI widening
W0 widened the `push` triggers to `[main, feat/arch-refactor]` so every sub-PR merged into the integration branch ran `test-full` (the only job running the slow tests + both coverage gates) and lint (mypy being the gate that catches what a package split breaks). It did its job. **The branch stops existing when the refactor merges, so the widening goes with it** — per its own "REVERT once the refactor has landed" instruction.

- **`test.yml`** — `push.branches` → `[main]`; drop the TEMPORARY comment block, and the now-dangling *"the integration branch above"* clause in the `concurrency` comment that referred to it.
- **`lint.yml`** — drop `feat/arch-refactor` from **both** lists, as its own TEMPORARY note explicitly instructs. The durable NOTE (a PR into an unlisted target branch runs **no lint at all**) stays — that trap outlives this refactor. The other stale integration branches already in `pull_request.branches` are pre-existing and deliberately left alone.
- **`.claude/rules/testing.md`** — drop the parenthetical documenting the widening.

### Expected CI on this PR
`test-full` is push-only → shows *skipping* (by design). Lint will **not** run on this PR: this very change removes `feat/arch-refactor` from `lint.yml`'s `pull_request.branches`, and that filter reads the head branch's own workflow file. Verified locally at `d0f5ef1` instead — `ruff check`: all passed; `ruff format --check`: 427 files already formatted; `mypy src/`: no issues in 155 source files; `mkdocs build --strict`: clean. The final PR into `main` runs the full gate set on this identical tree.

Claude-Session: https://claude.ai/code/session_018dBNayZ5NpfnZBxupyJT7U

## Summary by Sourcery

Retire the temporary CI widening used for the architecture refactor and incorporate the latest expert knowledge and testing rules updates from main.

Enhancements:
- Clarify durability guidance by requiring `git status --porcelain --untracked-files=all` and documenting the broader pattern of checks that can silently miss failures.
- Update testing rules to reflect that `test-full` now only runs on merges to `main`, removing the special-case mention of the integration branch.

CI:
- Restore `test.yml` push triggers to run only on `main` and tidy related concurrency comments now that the integration branch is gone.
- Limit `lint.yml` push and pull_request branches back to `main` and the long-lived integration branches, removing the temporary architecture refactor branch.

Documentation:
- Expand the expert-knowledge documentation on durability checks and CI gate reliability, including examples of past failures and guidance on validating that checks can observe their intended failures.