### PR TITLE
refactor(core): move CostTrack to the core.usage leaf — one edge held a 9-module knot

### DIFF
--- a/examples/research/m3_race.py
+++ b/examples/research/m3_race.py
@@ -65,7 +65,6 @@ from dotenv import load_dotenv  # noqa: E402
 
 from langres.core.benchmark import (  # noqa: E402
     BudgetedModuleRunner,
-    CostTrack,
     JudgePairEval,
     _cost_track,
     _pipeline_track,
@@ -75,6 +74,7 @@ from langres.core.benchmark import (  # noqa: E402
 )
 from langres.core.embeddings import SentenceTransformerEmbedder  # noqa: E402
 from langres.core.models import ERCandidate, PairwiseJudgement  # noqa: E402
+from langres.core.usage import CostTrack  # noqa: E402
 from langres.data.amazon_google import (  # noqa: E402
     AmazonGoogleBenchmark,
     ProductSchema,

--- a/examples/research/w3_paid_smoke.py
+++ b/examples/research/w3_paid_smoke.py
@@ -95,9 +95,9 @@ from langres.clients.openrouter import (  # noqa: E402
 )
 from langres.core.benchmark import (  # noqa: E402
     BudgetedModuleRunner,
-    CostTrack,
     evaluate_judge_on_candidates,
 )
+from langres.core.usage import CostTrack  # noqa: E402
 from langres.core.groups import ERCandidateGroup, derive_groups_from_pairs  # noqa: E402
 from langres.core.judgement_log import JudgementLog  # noqa: E402
 from langres.core.metrics import pair_pr_curve  # noqa: E402

--- a/src/langres/clients/openrouter.py
+++ b/src/langres/clients/openrouter.py
@@ -27,8 +27,8 @@ from collections.abc import Callable, Mapping
 from typing import TYPE_CHECKING, Any
 
 if TYPE_CHECKING:
-    from langres.core.benchmark import CostTrack
     from langres.core.models import PairwiseJudgement
+    from langres.core.usage import CostTrack
 
     # Type-checker view of the back-compat re-exports; the runtime path is the
     # PEP 562 module __getattr__ at the bottom of this file.
@@ -274,8 +274,7 @@ def make_token_cost_track(
     Returns:
         A ``track(judgements) -> CostTrack`` closure priced against ``model``.
     """
-    from langres.core.benchmark import CostTrack
-    from langres.core.usage import LLMUsage
+    from langres.core.usage import CostTrack, LLMUsage
 
     in_per_1m, out_per_1m = _price_for(model, prices)
     in_per_tok, out_per_tok = in_per_1m / 1_000_000.0, out_per_1m / 1_000_000.0

--- a/src/langres/core/benchmark.py
+++ b/src/langres/core/benchmark.py
@@ -54,7 +54,16 @@ from langres.core.matcher import Matcher
 # below everything.
 from langres.core.spend_cap import effective_budget
 from langres.core.resolver import Resolver
-from langres.core.usage import LLMUsage
+
+# ``CostTrack``/``CostBasis`` live in the `core.usage` leaf, next to the
+# ``LLMUsage`` that ``CostTrack.usage`` holds: tokens are the fact, dollars are
+# derived, and both models on that sentence belong together. They lived here
+# until `clients/openrouter.py` -- the HTTP client, i.e. the floor -- had to
+# import this 1.7k-line harness to build one, which is what held a 9-module SCC
+# together (see `core/usage.py`'s docstring and `tests/test_import_tangle.py`).
+# The aggregator `_cost_track` below stays: it reads this harness's provenance
+# conventions, so moving it would cost `core.usage` its leaf property.
+from langres.core.usage import CostBasis, CostTrack, LLMUsage
 
 logger = logging.getLogger(__name__)
 
@@ -175,56 +184,6 @@ class PipelineTrack(BaseModel):
     cluster_pairwise_f1: float
     delta_above_floor: float
     sanity_floor_f1: float
-
-
-#: How a run's cost was determined. A single ``cost_is_real: bool`` cannot express
-#: a run that mixes real OpenRouter-billed cost, a litellm/pinned-price estimate,
-#: a zero-cost local judge (no cost concept at all), and DSPy's billed-but-
-#: unparseable calls (``cost_untracked``) -- so :func:`_judgement_cost_basis`
-#: classifies each judgement into one of the four leaves, and
-#: :func:`_combined_cost_basis` collapses a run to ``"mixed"`` the moment two
-#: judgements disagree.
-CostBasis = Literal["real", "estimated", "mixed", "untracked", "none"]
-
-
-class CostTrack(BaseModel):
-    """Spend accounting for a method run. Zero-spend methods leave the optionals empty.
-
-    Attributes:
-        usd_total: Total measured spend across all judged test pairs.
-        usd_per_1k_pairs: Spend normalized per 1k candidate pairs.
-        est_usd_per_100k: Linear extrapolation to 100k pairs.
-        escalation_rate: Fraction of pairs escalated to the expensive stage
-            (cascade methods only); ``None`` for single-stage methods.
-        llm_calls_per_candidate: Mean LLM calls per candidate (cascade methods
-            only); ``None`` for zero-LLM methods.
-        usage: Token-usage vector summed across every judgement (tokens are the
-            fact; ``usd_total`` is derived from them where a real price is
-            known). All-zero for judges that report no usage (string/embedding,
-            or a judge that never populated ``provenance["usage"]``).
-        cost_basis: How ``usd_total`` was determined -- see :data:`CostBasis`.
-            ``"none"`` for an empty judgement list.
-    """
-
-    usd_total: float = 0.0
-    usd_per_1k_pairs: float = 0.0
-    est_usd_per_100k: float = 0.0
-    escalation_rate: float | None = None
-    llm_calls_per_candidate: float | None = None
-    usage: LLMUsage = Field(default_factory=LLMUsage)
-    cost_basis: CostBasis = "none"
-
-    @property
-    def cost_is_real(self) -> bool:
-        """Whether ``usd_total`` is entirely real, billed spend (``cost_basis == "real"``).
-
-        Kept for continuity with the pre-Task-3 boolean signal; prefer
-        :attr:`cost_basis` for the full picture (a run can be ``"estimated"``,
-        ``"mixed"``, ``"untracked"``, or ``"none"`` — all of which this reports
-        as ``False``, exactly as the old bool-only signal would have wanted for
-        anything short of "fully real").
-        """
-        return self.cost_basis == "real"
 
 
 class LatencyTrack(BaseModel):

--- a/src/langres/core/usage.py
+++ b/src/langres/core/usage.py
@@ -1,4 +1,28 @@
-"""``LLMUsage``: the typed token-usage vector for one LLM call (the fact layer).
+"""The cost fact layer: ``LLMUsage`` (one call's tokens) and ``CostTrack`` (a run's spend).
+
+Tokens are the fact; dollars are derived from them. Both models on that sentence
+live here, in a module that imports **nothing from langres** -- which is the
+whole point (see "Import-safety" below).
+
+``CostTrack`` moved here from ``core/benchmark.py``, the 1.7k-line benchmark
+harness, and the reason is an import cycle rather than tidiness.
+``clients/openrouter.py`` -- a low-level HTTP client -- builds a ``CostTrack`` in
+``make_token_cost_track``, so it had to import the harness: the floor importing
+the ceiling. Both statements were lazy (one ``TYPE_CHECKING``, one
+function-local), so the *runtime* graph never saw it, but grimp/import-linter
+did, and that single edge held a **9-module** all-edges SCC together
+(``openrouter`` <-> ``benchmark`` <-> ``methods`` <-> the matchers). Deleting it
+dropped the tangle 23 -> 18 modules; see ``tests/test_import_tangle.py``.
+
+The destination is not arbitrary. ``CostTrack.usage`` is an :class:`LLMUsage`,
+so the model now sits next to its own field's type, and the pair depends only on
+pydantic. **What did NOT move: ``benchmark._cost_track``**, the aggregator that
+builds a ``CostTrack`` from a judgement list. It reads
+``PairwiseJudgement.provenance`` (``_COST_KEYS``, ``cost_is_real``,
+``cost_untracked``), so bringing it here would force a
+``usage -> core.models`` import and cost this module the leaf property that
+makes it a safe home in the first place. The data model is the contract; the
+aggregation over the harness's provenance conventions is the harness's.
 
 Judges (``LLMMatcher``, ``DSPyMatcher``, ``SelectMatcher``) previously recorded only
 ``prompt_tokens`` / ``completion_tokens`` into ``PairwiseJudgement.provenance``
@@ -31,9 +55,9 @@ to price a call without pulling any of core's heavy optional dependencies.
 
 from __future__ import annotations
 
-from typing import Any
+from typing import Any, Literal
 
-from pydantic import BaseModel, ConfigDict
+from pydantic import BaseModel, ConfigDict, Field
 
 
 def _read(obj: Any, key: str) -> Any:
@@ -151,3 +175,56 @@ class LLMUsage(BaseModel):
             provider=provider,
             model=model,
         )
+
+
+#: How a run's cost was determined. A single ``cost_is_real: bool`` cannot express
+#: a run that mixes real OpenRouter-billed cost, a litellm/pinned-price estimate,
+#: a zero-cost local judge (no cost concept at all), and DSPy's billed-but-
+#: unparseable calls (``cost_untracked``) -- so
+#: :func:`~langres.core.benchmark._judgement_cost_basis` classifies each judgement
+#: into one of the four leaves, and
+#: :func:`~langres.core.benchmark._combined_cost_basis` collapses a run to
+#: ``"mixed"`` the moment two judgements disagree. (Both classifiers read the
+#: harness's provenance conventions, so they stay in ``core/benchmark.py`` and
+#: import this alias back -- see the module docstring.)
+CostBasis = Literal["real", "estimated", "mixed", "untracked", "none"]
+
+
+class CostTrack(BaseModel):
+    """Spend accounting for a method run. Zero-spend methods leave the optionals empty.
+
+    Attributes:
+        usd_total: Total measured spend across all judged test pairs.
+        usd_per_1k_pairs: Spend normalized per 1k candidate pairs.
+        est_usd_per_100k: Linear extrapolation to 100k pairs.
+        escalation_rate: Fraction of pairs escalated to the expensive stage
+            (cascade methods only); ``None`` for single-stage methods.
+        llm_calls_per_candidate: Mean LLM calls per candidate (cascade methods
+            only); ``None`` for zero-LLM methods.
+        usage: Token-usage vector summed across every judgement (tokens are the
+            fact; ``usd_total`` is derived from them where a real price is
+            known). All-zero for judges that report no usage (string/embedding,
+            or a judge that never populated ``provenance["usage"]``).
+        cost_basis: How ``usd_total`` was determined -- see :data:`CostBasis`.
+            ``"none"`` for an empty judgement list.
+    """
+
+    usd_total: float = 0.0
+    usd_per_1k_pairs: float = 0.0
+    est_usd_per_100k: float = 0.0
+    escalation_rate: float | None = None
+    llm_calls_per_candidate: float | None = None
+    usage: LLMUsage = Field(default_factory=LLMUsage)
+    cost_basis: CostBasis = "none"
+
+    @property
+    def cost_is_real(self) -> bool:
+        """Whether ``usd_total`` is entirely real, billed spend (``cost_basis == "real"``).
+
+        Kept for continuity with the pre-Task-3 boolean signal; prefer
+        :attr:`cost_basis` for the full picture (a run can be ``"estimated"``,
+        ``"mixed"``, ``"untracked"``, or ``"none"`` — all of which this reports
+        as ``False``, exactly as the old bool-only signal would have wanted for
+        anything short of "fully real").
+        """
+        return self.cost_basis == "real"

--- a/src/langres/methods.py
+++ b/src/langres/methods.py
@@ -61,13 +61,14 @@ from collections.abc import Callable
 from typing import Any, Protocol
 
 from langres.clients.openrouter import DEFAULT_OPENROUTER_MODEL
-from langres.core.benchmark import CostTrack, _cost_track
+from langres.core.benchmark import _cost_track
 from langres.core.blockers.vector import VectorBlocker
 from langres.core.clusterer import Clusterer
 from langres.core.comparator import Comparator
 from langres.core.comparators import StringComparator
 from langres.core.method_registry import get_method
 from langres.core.models import PairwiseJudgement
+from langres.core.usage import CostTrack
 from langres.core.matcher import Matcher
 from langres.core.matchers.cascade import CASCADE_LLM_DECISION_STEP
 from langres.core.resolver import Resolver

--- a/src/langres/methods.py
+++ b/src/langres/methods.py
@@ -228,7 +228,7 @@ def cascade_cost_track(judgements: list[PairwiseJudgement]) -> CostTrack:
         judgements: The cascade module's per-pair judgements.
 
     Returns:
-        A :class:`~langres.core.benchmark.CostTrack` with spend totals plus the
+        A :class:`~langres.core.usage.CostTrack` with spend totals plus the
         escalation rate and mean LLM-calls-per-candidate populated.
     """
     base = _cost_track(judgements)

--- a/tests/core/test_benchmark.py
+++ b/tests/core/test_benchmark.py
@@ -23,7 +23,6 @@ from langres.core.benchmark import (
     BenchmarkTable,
     BlindCostError,
     BudgetedModuleRunner,
-    CostTrack,
     LatencyTrack,
     MethodResult,
     PairTrack,
@@ -35,6 +34,7 @@ from langres.core.benchmark import (
     run_methods,
     tune_threshold_on_train,
 )
+from langres.core.usage import CostTrack
 from langres.core.blockers.all_pairs import AllPairsBlocker
 from langres.core.blockers.vector import VectorBlocker
 from langres.core.clusterer import Clusterer

--- a/tests/examples/test_w3_paid_smoke.py
+++ b/tests/examples/test_w3_paid_smoke.py
@@ -28,8 +28,8 @@ from dspy.utils.dummies import DummyLM
 
 from examples.research.w3_paid_smoke import SmokeConfig, run_smoke
 from langres.clients.openrouter import BudgetExceeded
-from langres.core.benchmark import CostTrack
 from langres.core.models import PairwiseJudgement
+from langres.core.usage import CostTrack
 
 # Small AG subset keeps the DummyLM answer pools + import cost modest.
 _AG_GROUPS = 3

--- a/tests/test_import_tangle.py
+++ b/tests/test_import_tangle.py
@@ -216,19 +216,18 @@ RUNTIME = TangleBaseline(
     tangled=frozenset(),
 )
 
-# All-edges view: 23 modules across four cycles, the largest being 9. Killing the
+# All-edges view: 18 modules across five cycles, the largest being 9. Killing the
 # runtime cycle collapsed this view (39 -> 10, tangled 44 -> 24): the root, both
 # `_exports` trees, `verbs` and `optimize` were only ever tangled here *via* that
-# same `resolver -> langres` edge, so they left with it. What remains are four
+# same `resolver -> langres` edge, so they left with it. What remains are five
 # genuinely lazy knots, none of them touching the root:
-#    9  the matcher/resolver + methods/benchmark knot (litellm seam)
 #    9  the `data.data_profile.*` section graph
 #    3  {core.analysis, core.reports, plotting.blockers}
+#    2  {core.anchor_store, core.resolver}
+#    2  {core.benchmark, langres.methods}
 #    2  {core.runs, core.trackers}
-# `tangled` covers all four; `largest_scc` pins the biggest so they cannot
-# silently merge into one. NOTE the two 9s are different components that happen
-# to be the same size -- `largest_scc` alone cannot tell them apart, which is
-# exactly why `tangled` is pinned alongside it.
+# `tangled` covers all five; `largest_scc` pins the biggest so they cannot
+# silently merge into one.
 #
 # W4 (the ERModel/architectures wave) ratcheted this DOWN: 10 -> 9, tangled
 # 24 -> 23. `langres.core.presets` left, because W4 deleted it outright. It was
@@ -237,6 +236,36 @@ RUNTIME = TangleBaseline(
 # `core/benchmark.py` reaching for `_effective_budget`, an alias it now imports
 # from the `core.spend_cap` leaf that always owned it. Nothing was moved to buy
 # this: the module is gone.
+#
+# The `CostTrack` wave ratcheted it down again: tangled 23 -> 18, and the OTHER
+# 9 -- "the matcher/resolver + methods/benchmark knot (litellm seam)" this
+# comment used to list first -- did not shrink, it **disintegrated**, into
+# {anchor_store, resolver} and {benchmark, methods}. Five modules left in one
+# move: `clients.openrouter`, `core.finetune`, `core.matchers.cascade`,
+# `core.matchers.llm_judge`, `core.method_registry`.
+#
+# ONE edge held all nine together: `clients/openrouter.py` -- an HTTP client --
+# imported `CostTrack` from `core/benchmark.py`, a 1.7k-line benchmark harness,
+# to build one in `make_token_cost_track`. The floor importing the ceiling, and
+# the same shape as PR #176's `resolver -> langres.__version__`. Both statements
+# were lazy (one TYPE_CHECKING, one function-local), which is exactly why the
+# runtime view was already 0 while this view carried a 9: the edge was invisible
+# to `import langres` and fully visible to grimp. `CostTrack` (and its
+# `CostBasis` alias) now live in the `core.usage` leaf beside the `LLMUsage`
+# that `CostTrack.usage` holds -- tokens are the fact, dollars are derived, so
+# the two models belong together and `core.usage` still imports nothing from
+# langres. The aggregator `benchmark._cost_track` deliberately did NOT move: it
+# reads the harness's `PairwiseJudgement.provenance` conventions, so it would
+# have dragged `core.models` in and cost `core.usage` the leaf property that
+# made it a safe home. Verified by dropping the edge and recomputing Tarjan
+# BEFORE writing the move: predicted [9, 3, 2, 2, 2] / 18, measured the same.
+#
+# `largest_scc` stays 9 and that is a measurement, not an oversight: the two 9s
+# were always different components that happened to be the same size (the note
+# this comment used to carry about `largest_scc` being unable to tell them
+# apart). The litellm-seam 9 is gone; the `data.data_profile.*` 9 -- a
+# self-contained knot in a package this wave never touched -- is what the number
+# now pins. Whoever unpicks that one gets to lower it.
 #
 # Measured fact for whoever plans the next wave: the NEW `langres.architectures`
 # package did **not** join the tangle, in either view. Its modules import
@@ -250,14 +279,9 @@ ALL_EDGES = TangleBaseline(
     largest_scc=9,
     tangled=frozenset(
         {
-            "langres.clients.openrouter",
             "langres.core.analysis",
             "langres.core.anchor_store",
             "langres.core.benchmark",
-            "langres.core.finetune",
-            "langres.core.matchers.cascade",
-            "langres.core.matchers.llm_judge",
-            "langres.core.method_registry",
             "langres.core.reports",
             "langres.core.resolver",
             "langres.core.runs",


### PR DESCRIPTION
## One edge held a 9-module knot together

`clients/openrouter.py` — a low-level HTTP client — imported `CostTrack` from
`core/benchmark.py`, a 1,769-line benchmark harness, to build one in
`make_token_cost_track`. **The floor importing the ceiling.** Both statements
were lazy (one `TYPE_CHECKING`, one function-local), which is exactly why the
*runtime* SCC was already 0 while the *all-edges* SCC carried a 9: the edge was
invisible to `import langres` and fully visible to grimp/import-linter.

Same shape as PR #176, where the entire 12-module runtime cycle existed so
`resolver.py` could read `langres.__version__`.

## The move

`CostTrack` + its `CostBasis` alias → `src/langres/core/usage.py`, beside the
`LLMUsage` that `CostTrack.usage` holds. Tokens are the fact, dollars are
derived — both models on that sentence now live together, and `core.usage`
still imports **nothing** from langres.

**Pure move: no signature, field, or behaviour changed** (7 fields, same
`cost_is_real` property). `CostTrack` is not public (absent from both
`__all__`), so no public API cost — and `from langres.core.benchmark import
CostTrack` still resolves to the *same object*, so the harness's callers are
unaffected.

### What did NOT move, and why

`benchmark._cost_track` stays put. It reads the harness's
`PairwiseJudgement.provenance` conventions (`_COST_KEYS`, `cost_is_real`,
`cost_untracked`) via `_judgement_cost` / `_judgement_cost_basis` /
`_combined_cost_basis`. Moving it would force `usage → core.models` and cost
`core.usage` the **leaf property that makes it a safe home in the first place**.
The data model is the contract; aggregation over the harness's provenance
conventions is the harness's. So `methods.py`'s import splits in two, as
predicted.

## Measured — `uv run python tools/import_graph.py kinds`

| | all-edges SCCs | tangled | runtime SCCs |
|---|---|---|---|
| before (`4679489`) | `[9, 9, 3, 2]` | **23** | `[]` |
| after | `[9, 3, 2, 2, 2]` | **18** | `[]` |

The brief predicted 23 → 18. **Confirmed exactly**, and the counterfactual
Tarjan prediction was verified *before* the move was written.

**The litellm-seam 9 did not shrink — it disintegrated**, into
`{anchor_store, resolver}` and `{benchmark, methods}`. Five modules left, zero
entered:

- `langres.clients.openrouter`
- `langres.core.finetune`
- `langres.core.matchers.cascade`
- `langres.core.matchers.llm_judge`
- `langres.core.method_registry`

`largest_scc` stays **9** — a measurement, not an oversight. The two 9s were
always *different components of the same size*; the one remaining is the
self-contained `data.data_profile.*` knot, in a package this PR never touches.

## The ratchet

`tests/test_import_tangle.py` failed on exact equality until lowered — the
ratchet working as designed. `tangled` 23 → 18; `largest_scc` unchanged at 9.
**Nothing was raised.** Header comment records this wave in the existing house
style (why each number moved, not just what it is). No relay/shim module was
interposed — SCC membership counted, never mutual pairs.

## Verification

- `3642 passed, 1 skipped` — `uv sync --all-extras --no-extra finetune` +
  `pytest -m "not integration and not slow and not finetune"` (CI-equivalent), 98% coverage
- `tests/test_import_budget.py` green under **bare** `uv sync` (the real CI condition)
- `len(langres.__all__) == 36`, `len(langres.core.__all__) == 76` — unchanged
- `uv run mypy src/` — clean, 155 files
- `ruff format` + `ruff check` — clean
- Docs: no doc names `CostTrack`'s module; the ones naming `_cost_track` in
  `langres.core.benchmark` stay true since it did not move.

### Money safety

No paid path invoked. `tests/examples/test_w3_paid_smoke.py` was **not run** —
verified `--collect-only` (2 tests collected) to prove the changed import
resolves, with no test body executed. `LANGRES_RUN_PAID_TESTS` and
`OPENROUTER_API_KEY` both unset, and no `.env` exists in this worktree, so the
gate structurally cannot fire.

### Pre-existing, not from this PR (verified at base `4679489`)

A bare `uv sync` venv fails `test_public_surface_dod.py::test_every_exported_exception_is_actually_raised_somewhere`
(`No module named 'litellm'`) and yields 9 mypy import-not-found errors.
Reproduced identically at the base commit; **mypy diff base vs. this branch is
empty**. Both vanish once extras are installed, which is what CI does.

https://claude.ai/code/session_018dBNayZ5NpfnZBxupyJT7U
