### PR TITLE
docs: render THEORY.md math on the site (stranded #194 follow-up) + erratum 14

### DIFF
--- a/docs/THEORY.md
+++ b/docs/THEORY.md
@@ -632,6 +632,15 @@ Recorded because the corrections are more instructive than the claims.
 13. **"The literature is siloed."** True *until recently*, and documented **by**
     the paper that broke it: Leone et al. (PVLDB 15(8), 2022) *"draw a parallel
     between EA and record linkage"* and benchmark Ditto on EA.
+14. **§6.2 — "Zamani's Eq. 4 *is* the precision formula."** Over-credited. Their
+    Eq. 4 is derived under *"for illustration, let us assume k = 1"*; the general-$k$
+    case is simulation-only (their Fig. 3), and at $k=1$ the objective is pure
+    precision, whose $\arg\min_N \rho$ is **$\varepsilon$-invariant** — the optimum
+    does **not** shift with reranker quality. This is exactly where the transplant
+    is *stronger* than the source, not weaker: ER's $F_1$ trades the recall gain
+    against a $\varphi \cdot n k$ term, so $k^\*$ shifts **continuously** with
+    $\varphi$ (§6.3). State the source result as $k=1$, and claim the continuous
+    dependence as ours.
 
 ---
 

--- a/docs/javascripts/mathjax.js
+++ b/docs/javascripts/mathjax.js
@@ -1,0 +1,22 @@
+// MathJax config for pymdownx.arithmatex (generic mode). Re-typesets on
+// mkdocs-material's instant-navigation page swaps so math survives client-side
+// nav. See https://squidfunk.github.io/mkdocs-material/reference/math/
+window.MathJax = {
+  tex: {
+    inlineMath: [["\\(", "\\)"]],
+    displayMath: [["\\[", "\\]"]],
+    processEscapes: true,
+    processEnvironments: true,
+  },
+  options: {
+    ignoreHtmlClass: ".*|",
+    processHtmlClass: "arithmatex",
+  },
+};
+
+document$.subscribe(() => {
+  MathJax.startup.output.clearCache();
+  MathJax.typesetClear();
+  MathJax.texReset();
+  MathJax.typesetPromise();
+});

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -46,6 +46,14 @@ markdown_extensions:
       base_path: [".", "docs"]
       check_paths: true
   - pymdownx.superfences
+  # Renders the $…$ / $$…$$ math in docs/THEORY.md (generic mode → MathJax,
+  # loaded via extra_javascript below).
+  - pymdownx.arithmatex:
+      generic: true
+
+extra_javascript:
+  - javascripts/mathjax.js
+  - https://unpkg.com/mathjax@3/es5/tex-mml-chtml.js
 
 plugins:
   - search
@@ -81,6 +89,7 @@ not_in_nav: |
   /POC.md
   /RESOURCES.md
   /TESTING_AT_ZERO_COST.md
+  /THEORY.md
   /plans/
   /research/
 


### PR DESCRIPTION
Follow-up to #194. THEORY.md merged with 151 `$…$` / `$$…$$` that the docs site could not render — `mkdocs.yml` carried no math extension, so on the built site they show as literal dollar signs. This adds the rendering. It was meant to be part of #194 but got stranded: the commit landed on the branch after GitHub had already cached the PR head one commit back, so #194 merged without it.

## Changes (3 files, 40 lines)

- **`mkdocs.yml`** — `pymdownx.arithmatex` (generic mode) + a MathJax loader in `extra_javascript`. arithmatex ships inside `pymdown-extensions`, already required by the existing config (superfences, highlight, snippets), so **no new dependency**.
- **`docs/javascripts/mathjax.js`** — re-typesets on mkdocs-material's instant-navigation page swaps, so math survives client-side nav.
- **`docs/THEORY.md`** — registers nothing here; adds **Errata 14**: §6.2 over-credited Zamani's Eq. 4, which is derived at *k=1 only*. The continuous `k*(φ)` dependence is the transplant's contribution, not the source's.
- **`mkdocs.yml`** — also lists `THEORY.md` under `not_in_nav` (built + searchable, out of the curated nav, like `POC.md`/`FUTURE.md` — it's a design record). Hygiene, not a build fix: the site builds `--strict` either way.

## Verified

`uv run --no-dev --group docs mkdocs build --strict` (the exact CI command) is clean on top of current main. The built `THEORY/index.html` has **240 arithmatex spans and zero literal `$`** leaking into rendered math.

Docs-only. Depends on nothing; #194 is already merged.
