### PR TITLE
W1-T2: thread Pairs through the spine (behind bridges) — #193

### DIFF
--- a/src/langres/core/_model_run.py
+++ b/src/langres/core/_model_run.py
@@ -34,6 +34,7 @@ from langres.core.models import (
     PairwiseJudgement,
     predicted_match,
 )
+from langres.core.pairs import Pairs
 from langres.core.results import DedupeResult, LinkVerdict
 from langres.core.spend_cap import SpendCappedMatcher
 
@@ -88,13 +89,25 @@ def _coerce_log(log: "JudgementLog | str | Path | None") -> JudgementLog | None:
 class ModelRun(ModelState):
     """The run path of an ``ERModel``: candidates, scoring, clustering, front door."""
 
-    def _candidates(self, records: list[Any]) -> Iterator[ERCandidate[Any]]:
-        """Block records into candidates, attaching comparisons if configured.
+    def _candidates(self, records: list[Any]) -> Pairs[Any]:
+        """Block records into a :class:`~langres.core.pairs.Pairs`, comparing if configured.
 
         Builds an index-backed blocker's index transparently before streaming,
         so callers never call ``create_index`` themselves. Records are fed in
         the caller's stable list order. Shared by ``_judgements`` (scoring)
-        and ``fit`` (training) -- both need the same candidate stream.
+        and ``fit`` (training) -- both bridge back to ``ERCandidate`` at the
+        matcher boundary via :meth:`~langres.core.pairs.Pairs.to_candidates`
+        (matchers still consume the legacy stream; migrating them is W2).
+
+        The blocker's per-pair ``similarity_score`` lands on each row as an
+        *unscored* ``score`` (``score_type is None`` -- a blocker similarity,
+        never a judge score, ``F-W1a``); the comparator's ``ComparisonVector``,
+        when configured, is attached to each row's ``comparison`` before the
+        carrier is built, so ``.left``/``.right`` stay bound to the shared
+        store. Materializing the post-blocking set here (rather than streaming
+        it lazily as this method used to) is the W1 carrier trade-off: rows are
+        lightweight id-refs over one shared entity store, and behavior --
+        clusters, scores -- is byte-identical.
         """
         self._ensure_index_built(records)
         candidates = self.blocker.stream(records)
@@ -104,15 +117,18 @@ class ModelRun(ModelState):
                 c.model_copy(update={"comparison": comparator.compare(c.left, c.right)})
                 for c in candidates
             )
-        return candidates
+        return Pairs.from_candidates(list(candidates))
 
     def candidates(self, records: list[Any]) -> list[ERCandidate[Any]]:
         """Block records into a materialized list of judge-ready candidates.
 
         The public counterpart to :meth:`_candidates`: same blocking (building
         any index-backed blocker's index transparently) and the same
-        comparison-attachment behavior, but returns a **list** rather than a
-        generator. Comparison vectors ARE attached whenever this Resolver has a
+        comparison-attachment behavior, but returns the legacy
+        **``list[ERCandidate]``** (bridged off the ``Pairs`` carrier
+        ``_candidates`` now returns) rather than the carrier itself -- external
+        callers depend on this exact shape. Comparison vectors ARE attached
+        whenever this Resolver has a
         comparator configured (the default for ``Resolver.from_schema``) --
         a caller that instead reaches into e.g. ``bench.build_blocker().stream(records)``
         directly gets candidates WITHOUT comparison vectors, which silently
@@ -134,7 +150,7 @@ class ModelRun(ModelState):
         Returns:
             The blocked candidates, materialized as a list (never a generator).
         """
-        return list(self._candidates(records))
+        return self._candidates(records).to_candidates()
 
     def _scorer(self, *, log: JudgementLog | None = None) -> SpendCappedMatcher:
         """This model's matcher, metered by its ONE spend ledger.
@@ -200,8 +216,13 @@ class ModelRun(ModelState):
         every ranking judgement's raw ``score`` is mapped to a calibrated
         probability before it reaches :meth:`predict`/:meth:`resolve` -- so the
         clusterer thresholds on a real probability. Pure pass-through otherwise.
+
+        The :meth:`_candidates` :class:`~langres.core.pairs.Pairs` is bridged
+        back to the legacy ``ERCandidate`` stream at the matcher boundary (W1):
+        the matcher, its spend cap and its logging wrapper still consume
+        ``Iterator[ERCandidate]`` unchanged -- migrating them is W2.
         """
-        judgements = self._scorer(log=log).forward(self._candidates(records))
+        judgements = self._scorer(log=log).forward(iter(self._candidates(records).to_candidates()))
         if self.calibrator is None:
             return judgements
         return self._apply_calibrator(judgements, self.calibrator)
@@ -375,8 +396,8 @@ class ModelRun(ModelState):
             BudgetExceeded: If scoring this pair would cross the spend cap.
         """
         normalized = self._prepare([left, right])
-        candidate = self._pair_candidate(normalized)
-        judgements = list(self._scorer(log=_coerce_log(log)).forward(iter([candidate])))
+        pair = self._pair_candidate(normalized)
+        judgements = list(self._scorer(log=_coerce_log(log)).forward(iter(pair.to_candidates())))
         if not judgements:
             raise RuntimeError(
                 f"the {type(self.module).__name__} matcher produced no judgement for this pair; "
@@ -408,17 +429,24 @@ class ModelRun(ModelState):
             judgement=judgement,
         )
 
-    def _pair_candidate(self, records: list[dict[str, Any]]) -> ERCandidate[Any]:
-        """The ONE candidate for :meth:`compare` -- blocker-attached, never blocker-vetoed.
+    def _pair_candidate(self, records: list[dict[str, Any]]) -> Pairs[Any]:
+        """The ONE pair for :meth:`compare` -- blocker-attached, never blocker-vetoed.
 
         Runs the real pipeline first, so anything the blocker attaches (a
         ``VectorBlocker``'s ``similarity_score``; the comparator's
-        ``ComparisonVector``) is present exactly as it would be in a batch. Falls
-        back to a directly-built candidate when the blocker yields nothing --
-        see :meth:`compare` on why a veto must not decide the verdict.
+        ``ComparisonVector``) is present exactly as it would be in a batch, and
+        keeps only the *first* blocked pair (mirroring the pre-carrier
+        "return the first candidate" behavior). Falls back to a directly-built
+        pair when the blocker yields nothing -- see :meth:`compare` on why a
+        veto must not decide the verdict.
+
+        Returns a single-row :class:`~langres.core.pairs.Pairs`;
+        :meth:`compare` bridges it back to an ``ERCandidate`` at the matcher
+        boundary via :meth:`~langres.core.pairs.Pairs.to_candidates`.
         """
-        for candidate in self._candidates(records):
-            return candidate
+        pairs = self._candidates(records)
+        if pairs.rows:
+            return Pairs(store=pairs.store, rows=pairs.rows[:1])
 
         from langres.core.blockers.all_pairs import schema_to_factory
 
@@ -436,7 +464,7 @@ class ModelRun(ModelState):
             candidate = candidate.model_copy(
                 update={"comparison": self.comparator.compare(left_entity, right_entity)}
             )
-        return candidate
+        return Pairs.from_candidates([candidate])
 
     def _ensure_index_built(self, records: list[Any]) -> None:
         """Build/populate every reachable ``VectorBlocker``'s index from ``records``.

--- a/src/langres/core/resolver.py
+++ b/src/langres/core/resolver.py
@@ -571,7 +571,7 @@ class ERModel(ModelRun, ModelPersistence):
                     "labels=<Sequence[bool] aligned with the blocked candidates> "
                     "(or pairs=<id-keyed labels>) to fit()."
                 )
-            self.module.fit(self._candidates(data), labels)
+            self.module.fit(iter(self._candidates(data).to_candidates()), labels)
             self.fit_report_ = FitReport.build(
                 trainable=f"{matcher_name} (SupervisedFitMixin)",
                 trained=True,

--- a/tests/core/test_spine_pairs_w1_t2.py
+++ b/tests/core/test_spine_pairs_w1_t2.py
@@ -1,0 +1,151 @@
+"""W1-T2: the ERModel spine carries a :class:`Pairs` internally.
+
+The spine (``_candidates`` -> score -> cluster) now threads a
+:class:`~langres.core.pairs.Pairs` carrier and bridges back to the legacy
+``ERCandidate`` at the matcher boundary (matchers are unmigrated -- that is W2).
+These tests pin the bridge: ``_candidates(records)`` is a ``Pairs`` whose
+``.to_candidates()`` is field-for-field the ``ERCandidate`` stream the old
+generator produced, and ``compare`` (incl. its "blocking cannot veto" fallback)
+still returns the same verdicts through the carrier.
+"""
+
+import pytest
+
+from langres.core.models import CompanySchema, ERCandidate
+from langres.core.pairs import Pairs
+from langres.core.resolver import Resolver
+
+_RECORDS = [
+    {"id": "1", "name": "Acme Corporation", "address": "1 Main St"},
+    {"id": "2", "name": "Acme Corp", "address": "1 Main Street"},
+    {"id": "3", "name": "Totally Unrelated Restaurant"},
+]
+
+
+def _resolver() -> Resolver:
+    """A cheap, offline default Resolver (AllPairsBlocker + comparator + string matcher)."""
+    return Resolver.from_schema(CompanySchema)
+
+
+def _pre_refactor_candidates(resolver: Resolver, records: list[dict]) -> list[ERCandidate]:
+    """Reconstruct exactly what the pre-carrier ``_candidates`` returned.
+
+    The old generator was ``blocker.stream(records)`` with, when a comparator is
+    configured, a per-candidate ``comparison`` attached by ``model_copy`` -- the
+    ground truth the new ``Pairs`` bridge must reproduce field-for-field.
+    """
+    candidates = list(resolver.blocker.stream(records))
+    if resolver.comparator is not None:
+        comparator = resolver.comparator
+        candidates = [
+            c.model_copy(update={"comparison": comparator.compare(c.left, c.right)})
+            for c in candidates
+        ]
+    return candidates
+
+
+def test_private_candidates_returns_a_pairs_carrier() -> None:
+    """``_candidates`` now yields a ``Pairs`` of unscored, store-bound rows."""
+    resolver = _resolver()
+    pairs = resolver._candidates(_RECORDS)
+
+    assert isinstance(pairs, Pairs)
+    assert len(pairs) == 3  # AllPairs over 3 records -> C(3,2) = 3
+    for row in pairs:
+        # A freshly-blocked row is "blocked, not yet scored": no judge output.
+        assert row.score_type is None
+        assert row.decision is None
+        # The comparator (wired by from_schema) attached its vector before build.
+        assert row.comparison is not None
+        # Store-bound: the typed entities materialize on access.
+        assert row.left.id in {"1", "2", "3"}
+        assert row.right.id in {"1", "2", "3"}
+
+
+def test_candidates_bridge_equals_the_pre_refactor_stream_with_comparator() -> None:
+    """candidates() (Pairs -> to_candidates) == the legacy compared ERCandidate list."""
+    resolver = _resolver()
+    assert resolver.comparator is not None  # from_schema wires one by default
+
+    expected = _pre_refactor_candidates(resolver, _RECORDS)
+    via_bridge = resolver.candidates(_RECORDS)
+
+    # Full Pydantic value equality: ids, blocker_name, similarity_score, comparison.
+    assert via_bridge == expected
+    assert all(c.comparison is not None for c in via_bridge)
+
+
+def test_candidates_bridge_equals_the_pre_refactor_stream_without_comparator() -> None:
+    """The AllPairs+String pipeline with NO comparator round-trips losslessly too."""
+    resolver = _resolver()
+    resolver.comparator = None
+
+    expected = _pre_refactor_candidates(resolver, _RECORDS)
+    via_bridge = resolver.candidates(_RECORDS)
+
+    assert via_bridge == expected
+    assert all(c.comparison is None for c in via_bridge)
+
+
+def test_public_candidates_is_the_bridge_of_private_candidates() -> None:
+    """``candidates()`` is exactly ``_candidates().to_candidates()`` -- one list, same ids."""
+    resolver = _resolver()
+
+    via_public = resolver.candidates(_RECORDS)
+    via_bridge = resolver._candidates(_RECORDS).to_candidates()
+
+    assert isinstance(via_public, list)
+    assert all(isinstance(c, ERCandidate) for c in via_public)
+    assert via_public == via_bridge
+
+
+def test_compare_returns_correct_verdicts_through_the_carrier() -> None:
+    """compare() over the single-row Pairs still matches / rejects the right pairs."""
+    resolver = _resolver()
+
+    match = resolver.compare(_RECORDS[0], _RECORDS[1])  # Acme Corporation ~ Acme Corp
+    non_match = resolver.compare(_RECORDS[0], _RECORDS[2])  # Acme ~ a restaurant
+
+    assert match.match is True
+    assert non_match.match is False
+
+
+def test_pair_candidate_is_a_single_row_pairs() -> None:
+    """``_pair_candidate`` returns a one-row ``Pairs`` for the named pair."""
+    resolver = _resolver()
+    normalized = resolver._prepare([_RECORDS[0], _RECORDS[1]])
+
+    pair = resolver._pair_candidate(normalized)
+
+    assert isinstance(pair, Pairs)
+    assert len(pair) == 1
+    candidates = pair.to_candidates()
+    assert len(candidates) == 1
+    assert {candidates[0].left.id, candidates[0].right.id} == {"1", "2"}
+
+
+def test_blocking_cannot_veto_the_pair_fallback_still_builds_it(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """When the blocker yields nothing, ``_pair_candidate`` builds the pair directly.
+
+    Blocking is a recall optimization for batches; a caller naming exactly two
+    records has decided the pair is worth judging. So a blocker that filters it
+    out must NOT silently veto compare() to a no-match -- the carrier routes the
+    fallback exactly as before.
+    """
+    resolver = _resolver()
+    # Force the blocker to emit no candidates for any input.
+    monkeypatch.setattr(resolver.blocker, "stream", lambda records: iter([]))
+
+    normalized = resolver._prepare([_RECORDS[0], _RECORDS[1]])
+    pair = resolver._pair_candidate(normalized)
+
+    assert isinstance(pair, Pairs)
+    assert len(pair) == 1  # built directly, not vetoed to empty
+    assert pair.rows[0].blocker_name == "compare"
+    assert {pair.rows[0].left.id, pair.rows[0].right.id} == {"1", "2"}
+
+    # And compare() end-to-end still returns a verdict rather than a silent no-match.
+    verdict = resolver.compare(_RECORDS[0], _RECORDS[1])
+    assert verdict.match is True


### PR DESCRIPTION
## W1-T2 — spine on `Pairs` (epic #193, wave 1, sub-task 2)

Threads the unified `Pairs` carrier (added in W1-T1, #203) through the `ERModel`
spine's **input path**, behind the existing bridges. **Pure refactor — zero
observable behavior change.** Matchers, blockers, comparators, the clusterer,
the `SpendCappedMatcher`/`LoggingMatcher` wrappers, `JudgementLog` bytes, and
every public method signature are untouched. Only the spine's *internal* carrier
changes from `ERCandidate` streams to `Pairs`, bridged back to `ERCandidate` at
the matcher boundary (matchers migrate to native `Pairs` in **W2**, alongside
the `Op` rename — not here, to avoid touching every body twice).

### What changed
- **`_candidates(records)`** → returns `Pairs[Any]` (was `Iterator[ERCandidate]`).
  Blocking (`_ensure_index_built` + `blocker.stream`) and the comparator attach
  are unchanged; the compared candidates are wrapped via `Pairs.from_candidates`,
  so comparison lands on each `PairRow.comparison` and `.left`/`.right` stay
  store-bound.
- **`candidates(records)`** — public API, **still `list[ERCandidate]`**
  (external callers depend on it); now `self._candidates(records).to_candidates()`.
- **`_judgements`** / **`compare`** — bridge at the matcher boundary via
  `.to_candidates()`; `_scorer` and the matcher `forward` still consume
  `Iterator[ERCandidate]`.
- **`_pair_candidate`** → single-row `Pairs`; the "blocking cannot veto the pair"
  fallback is preserved exactly.
- **`resolver.fit`** — bridges `_candidates(...).to_candidates()`; label order
  preserved.

### Gates (all green, run in the worktree)
- **`tests/parity`: 7 passed, 1 skipped** — byte-identical `FuzzyString`/cascade
  goldens (the point of the wave).
- Import gates (`test_import_budget`/`test_import_tangle`/`test_import_graph`): 82 passed.
- `test_resolver_spend_cap`: 24 passed (scoring still routes only through `_scorer`).
- Full fast suite (CI shape): **3696 passed, 2 skipped**.
- `mypy src/`: clean. `ruff format --check` + `ruff check`: clean.
- New `tests/core/test_spine_pairs_w1_t2.py`: 7 tests; `pairs.py` 100%.

### Accepted trade-off
`_candidates` now materializes the post-blocking set into a `Pairs` (lightweight
id-ref rows over one shared store) instead of a lazy generator — aligned with the
theory's "concrete after the first select" and with `candidates()` already
returning a list. Clusters/scores unchanged; only the memory profile shifts.

### Note for W2
`tests/core/test_resolver_candidates.py::test_candidates_matches_private_candidates_generator_content`
still passes but its name is now slightly stale (`_candidates` returns a `Pairs`,
not a generator). Left untouched (surgical); tidy in W2 if desired.

https://claude.ai/code/session_011XYuhyiigi1Bw2YnWCxMr9