### PR TITLE
W2 de-risk: expressiveness proof — a reranker is a forward() sequence (#193)

### DIFF
--- a/examples/op_reranker_expressiveness.py
+++ b/examples/op_reranker_expressiveness.py
@@ -1,0 +1,279 @@
+"""Expressiveness proof for the Op algebra (epic #193, W2 de-risk).
+
+**The claim.** The old ``langres.core`` had exactly ONE legal in-pipeline shape:
+``blocker -> comparator -> matcher -> clusterer`` — four fixed slots, the matcher
+pinned to a single position before the clusterer. The new algebra
+(:mod:`langres.core.op`) says *position is not a type*: every in-pipeline stage is
+one :class:`~langres.core.op.Op` (``Pairs -> Pairs``) in one of two roles —
+:class:`~langres.core.op.Score` ("same rows, new scores") or
+:class:`~langres.core.op.Select` ("same scores, fewer rows"). Because both ends of
+an ``Op`` are the same :class:`~langres.core.pairs.Pairs` carrier, ``Op``\\ s
+*compose freely*: you can put a ``Score`` **after** a ``Select``.
+
+That single freedom is a **reranker**, and it is inexpressible in four fixed
+slots. This script builds two pipelines out of the additive Op adapters
+(:mod:`langres.core.op_adapters`) and runs both **end-to-end at $0** (rapidfuzz
+string similarity only — no LLM, no embeddings):
+
+1. ``baseline`` — the classic four-slot shape, expressed as Ops:
+   ``BlockerSource -> MatcherScore -> Select(THRESHOLD) -> ClustererStage``.
+
+2. ``reranker`` — a topology the four-slot core could NOT express, a ``Score``
+   AFTER a ``Select``:
+   ``BlockerSource -> Score(cheap name sim) -> Select(TOPK) ->
+   Score(sharper name+address sim) -> Select(THRESHOLD) -> ClustererStage``.
+   The second ``Score`` rescores the survivors of the first selection
+   (retrieve-then-rerank).
+
+Both pipelines use the **same** threshold and the **same** clusterer, so the only
+difference is the inserted TOPK-prune + rescoring ``Score``. On the fixed dataset
+below the reranker recovers the true duplicate structure, while the name-only
+baseline over-merges same-name / different-address branches.
+
+**A gap this script surfaces (see the NOTE on the Select classes).** The adapters
+in ``op_adapters.py`` bridge Source / Score / ClusterStage / Finalize, but there
+is **no concrete ``Select`` adapter** on the branch — the old core folded
+thresholding into the ``Clusterer``, so a first-class selection ``Op`` has no
+shipped implementation yet. The two ``Select`` subclasses here realize the real
+selection semantics (THRESHOLD, TOPK); they are the example's own, not stubs
+hiding a gap. W3 will need a concrete ``Select`` to make selection a real pipeline
+stage rather than a knob on the clusterer.
+
+Run it:  ``uv run python examples/op_reranker_expressiveness.py``
+"""
+
+from __future__ import annotations
+
+from collections import defaultdict
+from typing import Generic, TypeVar
+
+from pydantic import BaseModel
+
+from langres.core.blockers.all_pairs import AllPairsBlocker
+from langres.core.clusterer import Clusterer
+from langres.core.matchers.rapidfuzz import RapidfuzzMatcher
+from langres.core.models import CompanySchema
+from langres.core.op import Feasible, Records, Select, Sequential
+from langres.core.op_adapters import BlockerSource, ClustererStage, MatcherScore
+from langres.core.pairs import PairRow, Pairs
+
+SchemaT = TypeVar("SchemaT", bound=BaseModel)
+
+
+# --------------------------------------------------------------------------------------
+# Concrete Select ops.
+#
+# NOTE (de-risk finding): op.py defines Select as an ABSTRACT role — it validates
+# the Feasible class in __init__ but never implements forward(), and
+# op_adapters.py ships NO concrete Select (the legacy 4-slot core folded
+# thresholding into the Clusterer's own threshold). So expressing selection as a
+# first-class Op requires implementing forward() here. These are the real
+# selection semantics for two Feasible classes, not stubs:
+#   * THRESHOLD -> keep every row whose score clears the price (no shape rule).
+#   * TOPK      -> keep at most k rows per left record (the retrieval shape).
+# --------------------------------------------------------------------------------------
+
+
+class ThresholdSelect(Select[SchemaT], Generic[SchemaT]):
+    """``Select`` at :attr:`~langres.core.op.Feasible.THRESHOLD`: keep rows that clear ``threshold``.
+
+    Uses the canonical match rule (:meth:`~langres.core.pairs.PairRow.predicted_match`
+    — decision wins over score, an abstention is dropped) rather than testing
+    ``score >= threshold`` by hand.
+    """
+
+    def __init__(self, threshold: float) -> None:
+        super().__init__(feasible=Feasible.THRESHOLD)
+        self.threshold = threshold
+
+    def forward(self, pairs: Pairs[SchemaT]) -> Pairs[SchemaT]:
+        """Keep the rows whose score clears ``threshold`` (order preserved)."""
+        kept = [row for row in pairs.rows if row.predicted_match(self.threshold) is True]
+        return Pairs(store=pairs.store, rows=kept)
+
+
+class TopKSelect(Select[SchemaT], Generic[SchemaT]):
+    """``Select`` at :attr:`~langres.core.op.Feasible.TOPK`: keep the ``k`` best rows per left id.
+
+    The retrieval / blocking shape — each anchor keeps its ``k`` highest-scoring
+    partners. Grouping by ``left_id`` is exactly "at most k per left record" over
+    the blocker's ``i < j`` pair set; ties keep input order.
+    """
+
+    def __init__(self, k: int) -> None:
+        super().__init__(feasible=Feasible.TOPK)
+        self.k = k
+
+    def forward(self, pairs: Pairs[SchemaT]) -> Pairs[SchemaT]:
+        """Keep at most ``k`` highest-scoring rows per ``left_id`` (input order preserved)."""
+        by_left: dict[str, list[PairRow[SchemaT]]] = defaultdict(list)
+        for row in pairs.rows:
+            by_left[row.left_id].append(row)
+
+        keep: set[tuple[str, str]] = set()
+        for group in by_left.values():
+            ranked = sorted(
+                group,
+                key=lambda row: row.score if row.score is not None else -1.0,
+                reverse=True,
+            )
+            for row in ranked[: self.k]:
+                keep.add((row.left_id, row.right_id))
+
+        kept = [row for row in pairs.rows if (row.left_id, row.right_id) in keep]
+        return Pairs(store=pairs.store, rows=kept)
+
+
+# --------------------------------------------------------------------------------------
+# Fixed in-memory dataset (a dozen records; no benchmark download).
+#
+# True duplicate structure:
+#   * {a1, a2}  Acme       -- same name AND same address (true dup)
+#   * {g1, g2}  Globex     -- same name AND same address (true dup)
+#   * i1, i2    Initech    -- SAME name, DIFFERENT address (two branches, NOT a dup)
+#   * u1, u2    Umbrella    -- SAME name, DIFFERENT address (two branches, NOT a dup)
+#   * s1, h1, w1, p1        -- singletons
+# The Initech/Umbrella branches are the trap: a name-only matcher (sim = 1.0)
+# fuses them; only a matcher that also weighs the address keeps them apart.
+# --------------------------------------------------------------------------------------
+
+RECORDS: Records = [
+    {"id": "a1", "name": "Acme Inc", "address": "1 Main St"},
+    {"id": "a2", "name": "Acme Inc", "address": "1 Main Street"},
+    {"id": "g1", "name": "Globex Corporation", "address": "500 Oak Ave"},
+    {"id": "g2", "name": "Globex Corporation", "address": "500 Oak Avenue"},
+    {"id": "i1", "name": "Initech", "address": "5 North Ave"},
+    {"id": "i2", "name": "Initech", "address": "820 South Blvd"},
+    {"id": "u1", "name": "Umbrella LLC", "address": "3 River Rd"},
+    {"id": "u2", "name": "Umbrella LLC", "address": "77 Hill St"},
+    {"id": "s1", "name": "Soylent Foods", "address": "7 Green Way"},
+    {"id": "h1", "name": "Hooli", "address": "1 Infinite Loop"},
+    {"id": "w1", "name": "Wayne Enterprises", "address": "1007 Mountain Dr"},
+    {"id": "p1", "name": "Stark Industries", "address": "10880 Malibu Point"},
+]
+
+# The single knobs shared by BOTH pipelines, so the only variable is the topology.
+THRESHOLD = 0.85
+TOPK = 3
+
+
+def _cheap_scorer() -> MatcherScore[CompanySchema]:
+    """A cheap, coarse ``Score``: name-only rapidfuzz similarity ($0)."""
+    matcher = RapidfuzzMatcher[CompanySchema](field_extractors={"name": (lambda e: e.name, 1.0)})
+    return MatcherScore(matcher, out_space="heuristic")
+
+
+def _sharp_scorer() -> MatcherScore[CompanySchema]:
+    """A sharper rescoring ``Score`` σ: name AND address, so branches separate ($0)."""
+    matcher = RapidfuzzMatcher[CompanySchema](
+        field_extractors={
+            "name": (lambda e: e.name, 0.5),
+            "address": (lambda e: e.address or "", 0.5),
+        }
+    )
+    return MatcherScore(matcher, out_space="heuristic")
+
+
+def _source() -> BlockerSource[CompanySchema]:
+    """The pipeline entry: all-pairs blocking over the fixed dataset ($0)."""
+    return BlockerSource(AllPairsBlocker(schema=CompanySchema))
+
+
+def _clusterer_stage() -> ClustererStage[CompanySchema]:
+    """Pure transitive closure over whatever the final ``Select`` kept.
+
+    Threshold 0.0 makes the clusterer treat every surviving (already-selected) row
+    as an edge, so the explicit ``Select`` — not the clusterer — is the match gate.
+    """
+    return ClustererStage(Clusterer(threshold=0.0))
+
+
+def _merge_groups(clusters: list[set[str]]) -> list[list[str]]:
+    """Order-independent view of the non-singleton clusters (the actual merges)."""
+    return sorted(sorted(cluster) for cluster in clusters if len(cluster) > 1)
+
+
+def run_baseline() -> list[set[str]]:
+    """The classic four-slot shape, expressed as Ops and run by manual ``forward`` chaining.
+
+    ``BlockerSource -> MatcherScore(name only) -> Select(THRESHOLD) -> ClustererStage``.
+    A ``Sequential`` validates the wiring at construction (it has no ``forward`` —
+    topology is code); execution is the manual ``.forward()`` chain below.
+    """
+    source, score, select, cluster = (
+        _source(),
+        _cheap_scorer(),
+        ThresholdSelect[CompanySchema](THRESHOLD),
+        _clusterer_stage(),
+    )
+    Sequential([source, score, select, cluster])  # wiring check runs here
+
+    pairs = source.forward(RECORDS)
+    pairs = score.forward(pairs)
+    pairs = select.forward(pairs)
+    return cluster.forward(pairs)
+
+
+def run_reranker() -> list[set[str]]:
+    """A ``Score`` AFTER a ``Select`` — the topology four fixed slots cannot express.
+
+    ``BlockerSource -> Score(cheap name sim) -> Select(TOPK) ->
+    Score(sharper name+address sim) -> Select(THRESHOLD) -> ClustererStage``.
+
+    The first ``Select(TOPK)`` keeps each record's ``k`` best candidates by the
+    cheap score; the second ``Score`` rescores *only those survivors* with a
+    sharper matcher; the final ``Select(THRESHOLD)`` gates on the sharper score.
+    Same threshold and clusterer as the baseline — the rescoring is the only added
+    freedom.
+    """
+    source = _source()
+    cheap = _cheap_scorer()
+    topk = TopKSelect[CompanySchema](TOPK)
+    sharp = _sharp_scorer()
+    threshold = ThresholdSelect[CompanySchema](THRESHOLD)
+    cluster = _clusterer_stage()
+
+    # A Score (sharp) sits AFTER a Select (topk): the wiring guard accepts it,
+    # because every Op is Pairs -> Pairs and composes freely.
+    Sequential([source, cheap, topk, sharp, threshold, cluster])  # wiring check runs here
+
+    pairs = source.forward(RECORDS)
+    pairs = cheap.forward(pairs)
+    pairs = topk.forward(pairs)  # keep each record's TOPK candidates
+    pairs = sharp.forward(pairs)  # rescore ONLY the survivors (rerank)
+    pairs = threshold.forward(pairs)
+    return cluster.forward(pairs)
+
+
+def main() -> None:
+    """Run both pipelines at $0 and print the contrast."""
+    truth = [["a1", "a2"], ["g1", "g2"]]  # the only true duplicate pairs
+    baseline = _merge_groups(run_baseline())
+    reranker = _merge_groups(run_reranker())
+
+    print("langres Op algebra — expressiveness proof (#193), all $0 (rapidfuzz only)\n")
+    print(f"records: {len(RECORDS)}   shared threshold: {THRESHOLD}   topk: {TOPK}\n")
+
+    print("True duplicate merges:")
+    print(f"  {truth}\n")
+
+    print("BASELINE   Source -> Score(name) -> Select(THRESHOLD) -> ClustererStage")
+    print("           (the classic four-slot shape, as Ops)")
+    print(f"  merges:  {baseline}")
+    print("  -> over-merges the same-name / different-address branches (Initech, Umbrella)\n")
+
+    print("RERANKER   Source -> Score(name) -> Select(TOPK) -> Score(name+address)")
+    print("                  -> Select(THRESHOLD) -> ClustererStage")
+    print("           (a Score AFTER a Select — INEXPRESSIBLE in four fixed slots)")
+    print(f"  merges:  {reranker}")
+    print("  -> the sharper rescore of the survivors separates the branches\n")
+
+    assert reranker == truth, f"reranker should recover the true merges, got {reranker}"
+    assert baseline != reranker, "the reranker topology should change the outcome"
+    tightened = [group for group in baseline if group not in reranker]
+    print(f"Result: the reranker is tighter — it dropped {len(tightened)} wrong merge(s): {tightened}")
+    print("The four-slot core could not place that second Score; the Op algebra composes it.")
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/op_reranker_expressiveness.py
+++ b/examples/op_reranker_expressiveness.py
@@ -271,7 +271,9 @@ def main() -> None:
     assert reranker == truth, f"reranker should recover the true merges, got {reranker}"
     assert baseline != reranker, "the reranker topology should change the outcome"
     tightened = [group for group in baseline if group not in reranker]
-    print(f"Result: the reranker is tighter — it dropped {len(tightened)} wrong merge(s): {tightened}")
+    print(
+        f"Result: the reranker is tighter — it dropped {len(tightened)} wrong merge(s): {tightened}"
+    )
     print("The four-slot core could not place that second Score; the Op algebra composes it.")
 
 

--- a/tests/examples/test_op_reranker_expressiveness.py
+++ b/tests/examples/test_op_reranker_expressiveness.py
@@ -1,0 +1,111 @@
+"""Proof that the Op-algebra expressiveness example runs and shows the reranker win.
+
+Drives the importable core of ``examples/op_reranker_expressiveness.py``: two $0
+rapidfuzz pipelines built from the additive Op adapters. The crux is the
+**reranker** — a ``Score`` AFTER a ``Select``, a topology the old four-slot core
+(blocker -> comparator -> matcher -> clusterer) could not place. This test pins
+that the algebra both *accepts* that topology (``Sequential.check()``) and *runs*
+it end-to-end to a tighter clustering than the four-slot baseline.
+
+Guards the W3 spine flip: if the additive adapters ever stop composing without an
+``ERModel``, or a ``Select`` refuses a carrier a prior ``Score`` emits, these fail.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from examples.op_reranker_expressiveness import (
+    RECORDS,
+    THRESHOLD,
+    TOPK,
+    ThresholdSelect,
+    TopKSelect,
+    _merge_groups,
+    _cheap_scorer,
+    _clusterer_stage,
+    _sharp_scorer,
+    _source,
+    run_baseline,
+    run_reranker,
+)
+from langres.core.models import CompanySchema
+from langres.core.op import Op, Score, Select, Sequential
+
+_TRUE_MERGES = [["a1", "a2"], ["g1", "g2"]]
+
+
+def test_baseline_runs_and_over_merges_same_name_branches() -> None:
+    """The four-slot shape (as Ops) fuses the same-name / different-address branches."""
+    merges = _merge_groups(run_baseline())
+    assert merges == [["a1", "a2"], ["g1", "g2"], ["i1", "i2"], ["u1", "u2"]]
+
+
+def test_reranker_recovers_the_true_duplicate_structure() -> None:
+    """A Score-after-Select rescores the survivors and separates the branches."""
+    assert _merge_groups(run_reranker()) == _TRUE_MERGES
+
+
+def test_reranker_is_strictly_tighter_than_the_baseline() -> None:
+    """Same threshold + clusterer; the only variable is the inserted rescoring Score."""
+    baseline = _merge_groups(run_baseline())
+    reranker = _merge_groups(run_reranker())
+    assert reranker != baseline
+    # Every reranker merge is also a baseline merge -> the reranker only DROPPED
+    # (wrong) merges, never invented one.
+    assert all(group in baseline for group in reranker)
+    assert len(reranker) < len(baseline)
+
+
+def test_selects_are_ops_in_the_select_role() -> None:
+    """The concrete THRESHOLD / TOPK selects are Ops (Pairs -> Pairs) in the Select role."""
+    for select in (ThresholdSelect[CompanySchema](THRESHOLD), TopKSelect[CompanySchema](TOPK)):
+        assert isinstance(select, Op)
+        assert isinstance(select, Select)
+
+
+def test_topk_select_actually_prunes_and_threshold_gates() -> None:
+    """TOPK removes low-score candidates; THRESHOLD keeps only rows clearing the price."""
+    scored = _cheap_scorer().forward(_source().forward(RECORDS))
+    pruned = TopKSelect[CompanySchema](TOPK).forward(scored)
+    assert 0 < len(pruned.rows) < len(scored.rows)  # genuinely pruned, not empty
+
+    gated = ThresholdSelect[CompanySchema](THRESHOLD).forward(scored)
+    assert all(row.predicted_match(THRESHOLD) is True for row in gated.rows)
+    assert len(gated.rows) < len(scored.rows)
+
+
+def test_wiring_guard_accepts_a_score_after_a_select() -> None:
+    """The expressiveness crux: Sequential.check() admits Score-after-Select.
+
+    ``BlockerSource -> Score -> Select(TOPK) -> Score -> Select(THRESHOLD) ->
+    ClustererStage`` — the second Score sits AFTER the first Select. The four-slot
+    core has one matcher position before the clusterer, so this is structurally new.
+    """
+    source, cheap, topk, sharp, thr, cluster = (
+        _source(),
+        _cheap_scorer(),
+        TopKSelect[CompanySchema](TOPK),
+        _sharp_scorer(),
+        ThresholdSelect[CompanySchema](THRESHOLD),
+        _clusterer_stage(),
+    )
+    seq: Sequential[CompanySchema] = Sequential(
+        [source, cheap, topk, sharp, thr, cluster]
+    )  # no raise == accepted
+    # The Score-after-Select really is present in the validated topology.
+    roles = [type(stage).__name__ for stage in seq.stages]
+    assert roles.index("MatcherScore", roles.index("TopKSelect")) > roles.index("TopKSelect")
+    assert isinstance(sharp, Score)
+
+
+def test_wiring_guard_rejects_a_score_after_the_cluster_stage() -> None:
+    """The guard is real: an Op after the ClusterStage (pairs gone) is refused."""
+    source, cheap, cluster, sharp = (
+        _source(),
+        _cheap_scorer(),
+        _clusterer_stage(),
+        _sharp_scorer(),
+    )
+    with pytest.raises(ValueError, match="carrier"):
+        Sequential([source, cheap, cluster, sharp])


### PR DESCRIPTION
## What

An **additive** de-risk artifact for epic #193: a runnable, $0 example proving the new `Op` algebra expresses a topology the old four-slot core (`blocker → comparator → matcher → clusterer`) could not — a **`Score` after a `Select`** (a reranker).

- `examples/op_reranker_expressiveness.py` — two rapidfuzz-only ($0) pipelines composed by **manually chaining `.forward()`** over the additive `op_adapters`, on a fixed 12-record in-memory dataset (no benchmark download).
- `tests/examples/test_op_reranker_expressiveness.py` — smoke test guarding the proof for the W3 spine flip.

Touches **no** existing source or test (`op.py` / `op_adapters.py` / `pairs.py` untouched).

## The two topologies

```
baseline  BlockerSource → MatcherScore(name)          → Select(THRESHOLD) → ClustererStage
reranker  BlockerSource → Score(name) → Select(TOPK)  → Score(name+addr)  → Select(THRESHOLD) → ClustererStage
                                          ^^^^^^^^^^^^^^^^ a Score AFTER a Select
```

Same threshold, same clusterer — the only variable is the inserted TOPK-prune + rescoring `Score`. The four-slot core has one matcher position before the clusterer, so it cannot place that second `Score`.

## It runs (verified `uv run python examples/op_reranker_expressiveness.py`)

```
True duplicate merges:  [['a1', 'a2'], ['g1', 'g2']]
BASELINE  merges:       [['a1','a2'], ['g1','g2'], ['i1','i2'], ['u1','u2']]   # over-merges branches
RERANKER  merges:       [['a1','a2'], ['g1','g2']]                              # recovers the truth
Result: the reranker is tighter — it dropped 2 wrong merge(s): [['i1','i2'], ['u1','u2']]
```

The name-only baseline fuses same-name / different-address branches (Initech, Umbrella); the reranker's sharper (name+address) rescore of the TOPK survivors separates them. `Sequential.check()` **accepts** the Score-after-Select topology at construction and rejects a genuinely mis-wired one.

## Gap surfaced for W3 (honest reporting)

The algebra **composes and runs end-to-end on the additive adapters without `ERModel`** — yes. One friction to resolve in W3:

- **No concrete `Select` ships.** `op.py` defines `Select` as an abstract role (validates the `Feasible` class in `__init__`, never implements `forward`), and `op_adapters.py` bridges Source/Score/ClusterStage/Finalize but **no `Select`** — the legacy core folded thresholding into the `Clusterer`'s `threshold`. So this example supplies its own `ThresholdSelect` / `TopKSelect` (real selection semantics, not stubs). W3 needs a concrete `Select` op to make selection a first-class pipeline stage rather than a knob on the clusterer.

No blocker found for the atomic W3 spine flip; the carrier hands cleanly between every adapter.

https://claude.ai/code/session_011XYuhyiigi1Bw2YnWCxMr9