### PR TITLE
W3-a: route the spine through Op adapters (widen, byte-parity) — #193

### DIFF
--- a/src/langres/core/_model_run.py
+++ b/src/langres/core/_model_run.py
@@ -13,9 +13,25 @@ Two audiences, one pipeline:
   :meth:`ModelRun.compare` (one pair -> a verdict), the replacements for the
   deleted ``langres.dedupe`` / ``langres.link`` verbs.
 
+**The block -> (compare) -> score -> cluster pipeline runs through the Op
+adapters** (:mod:`langres.core.op_adapters`), derived from the four slots
+(W3-a, epic #193): :class:`~langres.core.op_adapters.BlockerSource` +
+:class:`~langres.core.op_adapters.ComparatorScore` are the block/compare half
+(:meth:`ModelRun._candidates`); :class:`~langres.core.op_adapters.MatcherScore`
+wraps the spend-capped, optionally-logged matcher (:meth:`ModelRun._matcher_score`
+over :meth:`ModelRun._scorer`) into the scoring half (:meth:`ModelRun._scored_pairs`);
+:class:`~langres.core.op_adapters.ClustererStage` is the exit
+(:meth:`ModelRun.resolve` / :meth:`ModelRun.dedupe`). The slots stay the source
+of truth -- the ops are assembled from them per call, never cached, so the
+topology is an explicit chain of ``forward`` calls over the one ``Pairs``
+carrier and behavior is byte-identical to the legacy direct-call spine.
+
 Everything that scores goes through :meth:`ModelRun._scorer`, so the spend cap
 cannot be bypassed; ``tests/core/test_resolver_spend_cap.py`` AST-bans
-``<any>.module.forward(...)`` in ``src/`` to keep it that way.
+``<any>.module.forward(...)`` in ``src/`` to keep it that way. The
+:class:`~langres.core.op_adapters.MatcherScore` adapter wraps the *capped*
+matcher (not the raw one), so draining its rescored rows still trips the cap
+mid-pull.
 """
 
 import logging
@@ -33,6 +49,12 @@ from langres.core.models import (
     MatcherAbstainedError,
     PairwiseJudgement,
     predicted_match,
+)
+from langres.core.op_adapters import (
+    BlockerSource,
+    ClustererStage,
+    ComparatorScore,
+    MatcherScore,
 )
 from langres.core.pairs import Pairs
 from langres.core.results import DedupeResult, LinkVerdict
@@ -108,16 +130,20 @@ class ModelRun(ModelState):
         it lazily as this method used to) is the W1 carrier trade-off: rows are
         lightweight id-refs over one shared entity store, and behavior --
         clusters, scores -- is byte-identical.
+
+        The block/compare half runs through the Op adapters (W3-a, epic #193):
+        :class:`~langres.core.op_adapters.BlockerSource` bridges
+        ``blocker.stream(records)`` into the ``Pairs``, and (when a comparator is
+        configured) :class:`~langres.core.op_adapters.ComparatorScore` attaches
+        each row's ``ComparisonVector``. The index side-effect is deliberately
+        NOT absorbed by the source adapter -- :meth:`_ensure_index_built` still
+        runs here first, before the source streams.
         """
         self._ensure_index_built(records)
-        candidates = self.blocker.stream(records)
+        pairs = BlockerSource(self.blocker).forward(records)
         if self.comparator is not None:
-            comparator = self.comparator
-            candidates = (
-                c.model_copy(update={"comparison": comparator.compare(c.left, c.right)})
-                for c in candidates
-            )
-        return Pairs.from_candidates(list(candidates))
+            pairs = ComparatorScore(self.comparator).forward(pairs)
+        return pairs
 
     def candidates(self, records: list[Any]) -> list[ERCandidate[Any]]:
         """Block records into a materialized list of judge-ready candidates.
@@ -202,59 +228,109 @@ class ModelRun(ModelState):
             )
         return SpendCappedMatcher(module, monitor=self._spend_monitor)
 
+    def _matcher_score(self, *, log: JudgementLog | None = None) -> MatcherScore[Any]:
+        """This model's scoring :class:`~langres.core.op_adapters.MatcherScore` Op.
+
+        Wraps :meth:`_scorer` -- the SAME ``SpendCappedMatcher(LoggingMatcher)``
+        the legacy spine scored through -- so the cap stays lazy: the adapter
+        drains the capped generator to rescore rows, and the cap trips mid-pull
+        (budget + at most one call) exactly as before. Deliberately wraps the
+        *capped* matcher, never the raw ``self.module``.
+
+        ``out_space`` is the Score's advertised score-family metadata and is
+        **inert in the spine**: :func:`~langres.core.op_adapters._rescore` stamps
+        each row with its judgement's OWN ``score_type`` (never this declared
+        family), and nothing in the run path reads a ``Score.out_space``. So the
+        declared value cannot change behavior; it is a neutral placeholder, while
+        the authoritative per-row family is the matcher's own (also what
+        :meth:`dedupe`'s ``DedupeResult.score_type`` reports). If a later wave
+        makes ``out_space`` load-bearing (e.g. a wiring check in the spine),
+        derive it from the matcher's real family here.
+        """
+        return MatcherScore(self._scorer(log=log), out_space="heuristic")
+
+    def _scored_pairs(self, records: list[Any], *, log: JudgementLog | None = None) -> Pairs[Any]:
+        """Block -> (compare) -> score as an Op chain, then calibrate: the scoring spine.
+
+        The block/compare half is :meth:`_candidates`
+        (:class:`~langres.core.op_adapters.BlockerSource` +
+        :class:`~langres.core.op_adapters.ComparatorScore`); this adds the
+        :class:`~langres.core.op_adapters.MatcherScore` scoring Op
+        (:meth:`_matcher_score`) and runs the whole thing as an explicit chain of
+        ``forward`` calls over the one ``Pairs`` carrier. Scoring runs through
+        :meth:`_scorer`, so this model's spend cap (``budget_usd=``) and its
+        ledger are shared across every :meth:`resolve`/:meth:`predict`/:meth:`dedupe`
+        call on this instance -- two successive resolves cannot each spend a full
+        budget, and a matcher that overruns the cap raises ``BudgetExceeded`` from
+        the ``MatcherScore`` drain here.
+
+        When :attr:`calibrator` is set (by ``fit(method=Platt()/Isotonic())``),
+        every scored ranking row's raw ``score`` is mapped to a calibrated
+        probability (:meth:`_apply_calibrator_to_pairs`) before clustering, so the
+        clusterer thresholds on a real probability. Pure pass-through otherwise.
+        Calibration is a per-score transform applied in the spine, NOT an Op
+        adapter (W3-a keeps it here).
+        """
+        pairs = self._matcher_score(log=log).forward(self._candidates(records))
+        if self.calibrator is not None:
+            pairs = self._apply_calibrator_to_pairs(pairs, self.calibrator)
+        return pairs
+
     def _judgements(
         self, records: list[Any], *, log: JudgementLog | None = None
     ) -> Iterator[PairwiseJudgement]:
         """Block records into candidates, score them, and calibrate if fitted.
 
-        Scoring runs through :meth:`_scorer`, so this model's spend cap
-        (``budget_usd=``) and its ledger are shared across every
-        :meth:`resolve`/:meth:`predict` call on this instance -- two successive
-        resolves cannot each spend a full budget.
-
-        When :attr:`calibrator` is set (by ``fit(method=Platt()/Isotonic())``),
-        every ranking judgement's raw ``score`` is mapped to a calibrated
-        probability before it reaches :meth:`predict`/:meth:`resolve` -- so the
-        clusterer thresholds on a real probability. Pure pass-through otherwise.
-
-        The :meth:`_candidates` :class:`~langres.core.pairs.Pairs` is bridged
-        back to the legacy ``ERCandidate`` stream at the matcher boundary (W1):
-        the matcher, its spend cap and its logging wrapper still consume
-        ``Iterator[ERCandidate]`` unchanged -- migrating them is W2.
+        Projects the scored :class:`~langres.core.pairs.Pairs`
+        (:meth:`_scored_pairs`) back to the legacy judgement stream: a matcher
+        yields exactly one judgement per candidate, so every scored row
+        (``score_type is not None``) becomes one ``PairwiseJudgement`` in the
+        carrier's row order (the blocker's stream order). A generator body keeps
+        the projection lazy -- ``_scored_pairs`` runs (and any ``BudgetExceeded``
+        raises) only when the stream is first drained, exactly as the legacy
+        ``_scorer(...).forward`` stream did.
         """
-        judgements = self._scorer(log=log).forward(iter(self._candidates(records).to_candidates()))
-        if self.calibrator is None:
-            return judgements
-        return self._apply_calibrator(judgements, self.calibrator)
+        for row in self._scored_pairs(records, log=log).rows:
+            if row.score_type is not None:
+                yield row.to_judgement()
 
-    def _apply_calibrator(
-        self, judgements: Iterator[PairwiseJudgement], calibrator: CalibratorFitMixin
-    ) -> Iterator[PairwiseJudgement]:
-        """Map each ranking judgement's ``score`` through the fitted calibrator.
+    def _apply_calibrator_to_pairs(
+        self, pairs: Pairs[Any], calibrator: CalibratorFitMixin
+    ) -> Pairs[Any]:
+        """Map each scored ranking row's ``score`` through the fitted calibrator.
 
-        Deciders (``score is None``) pass through untouched -- there is no score to
-        calibrate. A mapped judgement keeps its ids/decision, retags
-        ``score_type="calibrated_prob"``, and records the raw score under
-        ``provenance["calibration"]`` for auditability.
+        The carrier counterpart to the legacy judgement-stream calibration.
+        Deciders (a scored row with ``score is None``) pass through untouched --
+        there is no score to calibrate -- as do unscored rows (``score_type is
+        None``), whose ``score`` is a *blocker* similarity, never a judge score
+        (``F-W1a``), and so must not be run through a score calibrator. A mapped
+        row keeps its ids/decision, retags ``score_type="calibrated_prob"``, and
+        records the raw score under ``provenance["calibration"]`` for
+        auditability -- byte-identical to what the old ``_apply_calibrator``
+        produced on the judgement stream (which only ever saw scored rows).
         """
-        for judgement in judgements:
-            if judgement.score is None:
-                yield judgement
+        rows = []
+        for row in pairs.rows:
+            if row.score_type is None or row.score is None:
+                rows.append(row)
                 continue
-            calibrated = calibrator.transform([judgement.score])[0]
-            yield judgement.model_copy(
-                update={
-                    "score": calibrated,
-                    "score_type": "calibrated_prob",
-                    "provenance": {
-                        **judgement.provenance,
-                        "calibration": {
-                            "method": getattr(calibrator, "method", None),
-                            "raw_score": judgement.score,
+            calibrated = calibrator.transform([row.score])[0]
+            rows.append(
+                row.model_copy(
+                    update={
+                        "score": calibrated,
+                        "score_type": "calibrated_prob",
+                        "provenance": {
+                            **row.provenance,
+                            "calibration": {
+                                "method": getattr(calibrator, "method", None),
+                                "raw_score": row.score,
+                            },
                         },
-                    },
-                }
+                    }
+                )
             )
+        return Pairs(store=pairs.store, rows=rows)
 
     def predict(self, records: list[Any]) -> list[PairwiseJudgement]:
         """Return the scored pairwise judgements before clustering.
@@ -267,8 +343,11 @@ class ModelRun(ModelState):
     def resolve(self, records: list[Any]) -> list[set[str]]:
         """Resolve records into entity clusters (sets of IDs).
 
-        Orchestrates blocking -> (compare) -> score -> cluster. Singletons are
-        dropped by the Clusterer (it returns only connected components with an
+        Orchestrates blocking -> (compare) -> score -> cluster through the Op
+        adapters (:meth:`_scored_pairs` +
+        :class:`~langres.core.op_adapters.ClustererStage`, the pipeline exit that
+        keeps the match cut folded in the ``Clusterer``'s threshold). Singletons
+        are dropped by the Clusterer (it returns only connected components with an
         edge), so the result contains only multi-record clusters.
 
         Args:
@@ -277,7 +356,7 @@ class ModelRun(ModelState):
         Returns:
             A list of clusters, each a set of entity IDs.
         """
-        return self.clusterer.cluster(self._judgements(records))
+        return ClustererStage(self.clusterer).forward(self._scored_pairs(records))
 
     # ------------------------------------------------------------------
     # The front door: dedupe a batch / compare one pair
@@ -342,16 +421,22 @@ class ModelRun(ModelState):
             )
         normalized = self._prepare(records)
         check_no_duplicate_ids([record["id"] for record in normalized])
-        judgements = list(self._judgements(normalized, log=_coerce_log(log)))
-        clusters = self.clusterer.cluster(iter(judgements))
+        pairs = self._scored_pairs(normalized, log=_coerce_log(log))
+        clusters = ClustererStage(self.clusterer).forward(pairs)
+        # The scored rows' OWN score_type, not a per-name lookup table: the
+        # matcher that ran is the only honest authority on what its scores mean.
+        # The first scored row is the first candidate's judgement (one judgement
+        # per candidate, in blocker order -- so this equals the legacy
+        # ``judgements[0].score_type``). None only when the blocker yielded no
+        # pair at all, which reports "unknown".
+        score_type = next(
+            (row.score_type for row in pairs.rows if row.score_type is not None), None
+        )
         return DedupeResult(
             clusters,
             architecture=type(self).__name__,
             backbone=self.backbone,
-            # The judgements' OWN score_type, not a per-name lookup table: the
-            # matcher that ran is the only honest authority on what its scores
-            # mean. "unknown" only when the blocker yielded no pair at all.
-            score_type=judgements[0].score_type if judgements else "unknown",
+            score_type=score_type if score_type is not None else "unknown",
             threshold=self.clusterer.threshold,
         )
 
@@ -397,16 +482,17 @@ class ModelRun(ModelState):
         """
         normalized = self._prepare([left, right])
         pair = self._pair_candidate(normalized)
-        judgements = list(self._scorer(log=_coerce_log(log)).forward(iter(pair.to_candidates())))
-        if not judgements:
+        scored = self._matcher_score(log=_coerce_log(log)).forward(pair)
+        if self.calibrator is not None:
+            scored = self._apply_calibrator_to_pairs(scored, self.calibrator)
+        scored_rows = [row for row in scored.rows if row.score_type is not None]
+        if not scored_rows:
             raise RuntimeError(
                 f"the {type(self.module).__name__} matcher produced no judgement for this pair; "
                 "every candidate must yield exactly one PairwiseJudgement. This indicates a bug "
                 "in the matcher."
             )
-        judgement = judgements[0]
-        if self.calibrator is not None:
-            judgement = next(self._apply_calibrator(iter([judgement]), self.calibrator))
+        judgement = scored_rows[0].to_judgement()
 
         threshold = self.clusterer.threshold
         predicted = predicted_match(judgement, threshold)

--- a/src/langres/core/_model_run.py
+++ b/src/langres/core/_model_run.py
@@ -24,7 +24,22 @@ over :meth:`ModelRun._scorer`) into the scoring half (:meth:`ModelRun._scored_pa
 (:meth:`ModelRun.resolve` / :meth:`ModelRun.dedupe`). The slots stay the source
 of truth -- the ops are assembled from them per call, never cached, so the
 topology is an explicit chain of ``forward`` calls over the one ``Pairs``
-carrier and behavior is byte-identical to the legacy direct-call spine.
+carrier.
+
+**What "same behavior" means, precisely.** The *resolution* outputs are
+byte-identical to the legacy direct-call spine -- clusters, ``DedupeResult``
+metadata (``score_type``/``threshold``), metrics, and the judgement log all
+match the frozen goldens (``tests/parity/test_behavior_parity_w0.py``). The one
+deliberate change is the *order* of :meth:`ModelRun.predict` /
+:meth:`ModelRun._judgements`: they now emit in deterministic carrier (blocker)
+order, because :class:`~langres.core.op_adapters.MatcherScore` maps each
+judgement back onto its row by ``(left_id, right_id)`` identity. For a pairwise
+matcher that equals the legacy matcher-emission order (one judgement per
+candidate, in candidate order), so it is invisible. For a *reordering* matcher --
+a :class:`~langres.core.matcher.GroupwiseMatcher`, whose ``forward`` regroups the
+stream by anchor -- the legacy spine returned that anchor-group emission order;
+the new spine returns the blocker's carrier order. That intentional, more
+deterministic contract is pinned by ``tests/parity/test_groupwise_spine_w3a.py``.
 
 Everything that scores goes through :meth:`ModelRun._scorer`, so the spend cap
 cannot be bypassed; ``tests/core/test_resolver_spend_cap.py`` AST-bans
@@ -56,7 +71,7 @@ from langres.core.op_adapters import (
     ComparatorScore,
     MatcherScore,
 )
-from langres.core.pairs import Pairs
+from langres.core.pairs import PairRow, Pairs
 from langres.core.results import DedupeResult, LinkVerdict
 from langres.core.spend_cap import SpendCappedMatcher
 
@@ -309,7 +324,7 @@ class ModelRun(ModelState):
         auditability -- byte-identical to what the old ``_apply_calibrator``
         produced on the judgement stream (which only ever saw scored rows).
         """
-        rows = []
+        rows: list[PairRow[Any]] = []
         for row in pairs.rows:
             if row.score_type is None or row.score is None:
                 rows.append(row)

--- a/tests/parity/test_groupwise_spine_w3a.py
+++ b/tests/parity/test_groupwise_spine_w3a.py
@@ -1,0 +1,131 @@
+"""W3-a spine parity for a GROUPWISE matcher (epic #193).
+
+The W0 goldens (``tests/parity/test_behavior_parity_w0.py``) pin byte-identical
+RESOLUTION for PAIRWISE matchers (``FuzzyString``, ``Resolver`` string), where a
+matcher emits one judgement per candidate in candidate order -- so routing the
+spine through the Op adapters
+(:class:`~langres.core.op_adapters.MatcherScore`, whose ``_rescore`` re-emits in
+the incoming carrier's row order) is order-preserving and invisible.
+
+A GROUPWISE matcher is the one place the new spine's judgement *order* differs
+from the legacy one. :class:`~langres.core.matcher.GroupwiseMatcher`'s
+``forward`` regroups the pairwise stream via
+:func:`~langres.core.groups.derive_groups_from_pairs` and emits in anchor-group
+order, which need not equal the blocker's carrier order. The legacy spine
+returned :meth:`~langres.core.resolver.Resolver.predict`'s judgements in that
+emission order; the new spine returns them in deterministic carrier (blocker)
+order (``MatcherScore`` maps each judgement back onto its row by ``(left_id,
+right_id)`` identity). This is an intentional, better contract -- deterministic
+and independent of a matcher's internal emission order -- but it is a real
+behavior change that no golden covers. This test pins BOTH halves: the groupwise
+RESOLUTION results stay correct, and ``predict`` returns carrier order.
+
+``$0``: a scripted :class:`~langres.core.matcher.GroupwiseMatcher` (no LLM, no
+network) that deliberately emits each group's judgements in REVERSED member
+order, so its emission order differs from the carrier order. That reversal is a
+faithful stand-in for any real set-wise matcher whose ``forward`` emission order
+!= carrier order -- with ``AllPairsBlocker``'s already-anchor-grouped ``i < j``
+stream a real ``SelectMatcher``'s emission happens to equal the carrier order, so
+it could not exhibit (and therefore could not pin) the divergence this test
+exists to lock down.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterator
+
+from langres.core.blockers.all_pairs import AllPairsBlocker
+from langres.core.clusterer import Clusterer
+from langres.core.groups import ERCandidateGroup
+from langres.core.matcher import GroupwiseMatcher
+from langres.core.models import CompanySchema, PairwiseJudgement
+from langres.core.resolver import Resolver
+
+_THRESHOLD = 0.5
+
+#: Duplicate structure keyed by name: {a1, a2} Acme and {b1, b2} Beta are true
+#: duplicates; c1 Gamma is a singleton (dropped by the clusterer).
+RECORDS = [
+    {"id": "a1", "name": "Acme"},
+    {"id": "a2", "name": "Acme"},
+    {"id": "b1", "name": "Beta"},
+    {"id": "b2", "name": "Beta"},
+    {"id": "c1", "name": "Gamma"},
+]
+
+
+class _ReversingGroupwiseMatcher(GroupwiseMatcher[CompanySchema]):
+    """A ``$0`` set-wise matcher: score a member ``1.0`` iff its name equals the
+    anchor's, else ``0.0``, tagging ``score_type="prob_group_llm"`` like a real
+    ComEM-style select judge. It emits each group's judgements in REVERSED member
+    order on purpose, so the matcher's emission order differs from the blocker's
+    carrier order. No LLM, no network, no cost."""
+
+    def forward_groups(
+        self, groups: Iterator[ERCandidateGroup[CompanySchema]]
+    ) -> Iterator[PairwiseJudgement]:
+        for group in groups:
+            for member in reversed(group.members):
+                yield PairwiseJudgement(
+                    left_id=group.anchor.id,
+                    right_id=member.id,
+                    score=1.0 if member.name == group.anchor.name else 0.0,
+                    score_type="prob_group_llm",
+                    decision_step="reversing_groupwise",
+                    provenance={"group_id": group.group_id},
+                )
+
+
+def _resolver() -> Resolver:
+    """A Resolver with the reversing GROUPWISE matcher in the module slot."""
+    return Resolver(
+        blocker=AllPairsBlocker(schema=CompanySchema),
+        comparator=None,
+        matcher=_ReversingGroupwiseMatcher(),
+        clusterer=Clusterer(threshold=_THRESHOLD),
+    )
+
+
+def _canonical(clusters: list[set[str]]) -> list[list[str]]:
+    return sorted(sorted(cluster) for cluster in clusters)
+
+
+def _emission_order() -> list[tuple[str, str]]:
+    """The matcher's OWN (reversed-per-group) emission order via the real
+    groupwise path -- what the legacy direct-call spine would have returned."""
+    candidates = _resolver().candidates(RECORDS)
+    matcher = _ReversingGroupwiseMatcher()
+    return [(j.left_id, j.right_id) for j in matcher.forward(iter(candidates))]
+
+
+def test_groupwise_resolve_and_dedupe_results_are_correct() -> None:
+    """(a) A GROUPWISE matcher through the new Op-adapter spine still produces the
+    correct clusters and the honest ``DedupeResult`` metadata."""
+    resolver = _resolver()
+
+    assert _canonical(resolver.resolve(RECORDS)) == [["a1", "a2"], ["b1", "b2"]]
+
+    result = resolver.dedupe(RECORDS)
+    assert _canonical(list(result)) == [["a1", "a2"], ["b1", "b2"]]
+    assert result.score_type == "prob_group_llm"
+    assert result.threshold == _THRESHOLD
+
+
+def test_predict_returns_judgements_in_deterministic_carrier_order() -> None:
+    """(b) ``predict`` returns judgements in deterministic blocker/carrier order --
+    NOT the matcher's (reversed) emission order. Pins the intentional W3-a change:
+    ``MatcherScore`` re-maps judgements onto their rows by identity, so the stream
+    order is the blocker's, independent of how the matcher emitted."""
+    resolver = _resolver()
+    carrier_order = [
+        (candidate.left.id, candidate.right.id) for candidate in resolver.candidates(RECORDS)
+    ]
+    predict_order = [
+        (judgement.left_id, judgement.right_id) for judgement in resolver.predict(RECORDS)
+    ]
+
+    assert predict_order == carrier_order
+    # Non-triviality: the matcher emits each group REVERSED, so its emission order
+    # differs from the carrier order -- this assertion would fail if the new spine
+    # passed the matcher's emission order through instead of re-sorting to carrier.
+    assert predict_order != _emission_order()


### PR DESCRIPTION
## What

**W3-a** — the foundational, non-breaking, byte-parity-guarded first step of epic #193's forward-spine flip. This is a **WIDEN** step: nothing is deleted.

The ERModel spine's internal `block -> (compare) -> score -> cluster` pipeline now RUNS THROUGH the merged Op adapters (`op_adapters.py`), derived from the four existing slots, instead of calling `self.blocker`/`self.comparator`/`self.module`/`self.clusterer` directly. The topology is now an explicit chain of `.forward()` calls over the one `Pairs` carrier.

## How the ops are assembled from the slots

All in `src/langres/core/_model_run.py`; the four slots (`_blocker`/`_comparator`/`_module`/`_clusterer`) stay the source of truth, ops are derived per call (never cached):

- **`_candidates`** (block + compare) → `BlockerSource(self.blocker).forward(records)` then, if a comparator is set, `ComparatorScore(self.comparator).forward(pairs)`. `_ensure_index_built` still runs first (the source adapter does NOT absorb the index lifecycle).
- **`_matcher_score(log)`** → `MatcherScore(self._scorer(log=log), out_space=...)` — wraps the **SAME** `SpendCappedMatcher(LoggingMatcher(...))` `_scorer` builds, not the raw module.
- **`_scored_pairs`** → `MatcherScore(...).forward(self._candidates(records))`, then spine-level calibration.
- **`resolve`/`dedupe`** → `ClustererStage(self.clusterer).forward(pairs)` (the match cut stays folded in the clusterer's threshold — no explicit `Select`).
- **`predict`** projects the scored `Pairs` back to the legacy `PairwiseJudgement` stream (lossless round-trip); **`compare`** scores its one pair through `MatcherScore`.

## Byte-parity

- **W0 parity harness green, byte-identical** (`tests/parity/`): FuzzyString `.dedupe`/`.compare` and `Resolver.from_schema(matcher="string")` pair-level judgements — clusters, `score_type`, thresholds, BCubed/pairwise metrics all match the goldens. Legacy save/load parity green too.
- **Full fast suite: 3761 passed, 2 skipped** (`-m "not integration and not slow and not finetune"`, `--all-extras --no-extra finetune`), coverage 98%.

## Spend cap preserved exactly

`MatcherScore` wraps the **capped+logged** matcher and drains it inside `_rescore`, so the cap's laziness survives: it trips mid-pull, budget + at most one call, and an already-tripped cap costs \$0. `tests/core/test_resolver_spend_cap.py` green (24 tests), including the AST-ban of `<any>.module.forward(...)` in `src/`.

## Out of scope (later W3 steps — untouched)

persistence/save-load, the `SpendCappedOp` redesign, fit migration, the concrete `Select`, deleting slots, porting architectures.

## Behavior that stays a spine step (not routed through an adapter — for the next W3 step)

- **Calibration** — a per-score `Pairs`-row transform (`_apply_calibrator_to_pairs`), not an Op adapter.
- **The index side-effect** — `_ensure_index_built` still runs in the spine before `BlockerSource`.
- **`compare`'s abstain handling** and **`dedupe`'s `score_type`/`"unknown"`** — read off the scored rows in the spine.
- **`MatcherScore.out_space`** is inert here (`_rescore` stamps each row with its judgement's own `score_type`); declared as a documented neutral placeholder.

https://claude.ai/code/session_011XYuhyiigi1Bw2YnWCxMr9