### PR TITLE
test(parity): mixed-family cascade byte-parity golden (gates W3-d) — #193

### DIFF
--- a/tests/parity/_cascade_fixture.py
+++ b/tests/parity/_cascade_fixture.py
@@ -51,7 +51,6 @@ golden -- a change here is a deliberate re-baseline, never an accident.
 from __future__ import annotations
 
 from collections.abc import Iterator
-from typing import Any
 
 from pydantic import BaseModel
 
@@ -207,8 +206,3 @@ def build_cascade_model() -> tuple[Resolver, ScriptedDecider[CascadeBusinessW3D]
         clusterer=Clusterer(threshold=CASCADE_THRESHOLD),
     )
     return model, escalation
-
-
-def record(record_id: str) -> dict[str, Any]:
-    """The one fixture record with ``id == record_id`` (fixture ids are unique)."""
-    return next(r for r in RECORDS if r["id"] == record_id)

--- a/tests/parity/_cascade_fixture.py
+++ b/tests/parity/_cascade_fixture.py
@@ -1,0 +1,214 @@
+"""Frozen fixture for the mixed-family cascade byte-parity net (epic #193, W3-d).
+
+A ``$0``, offline, deterministic scripted cascade whose sole purpose is to
+exercise the **mixed-family, decision-vs-score** path that the W3-d match-cut
+rewire is most likely to break. W3-d moves the match cut out of the
+:class:`~langres.core.clusterer.Clusterer` into a ``Select(THRESHOLD)`` and runs
+the clusterer as pure transitive closure, on the claim::
+
+    ThresholdSelect(t) -> Clusterer(0.0)  ==  Clusterer(t)
+
+That equivalence hinges entirely on :func:`~langres.core.models.predicted_match`
+being applied identically before and after the move -- and ``predicted_match``
+gives a judge's boolean ``decision`` **precedence over its numeric ``score``**
+(a decider already decided; the threshold never overrides it). A rewrite that
+naively re-implements the cut as ``score >= t`` -- dropping that precedence --
+would silently break exactly the rows where ``decision`` and ``score`` disagree.
+
+This fixture builds a real :class:`~langres.core.matchers.cascade_judge.CascadeMatcher`
+(the production mixed-family matcher) over a scripted, no-network student and
+escalation, wired into a plain :class:`~langres.core.resolver.ERModel` over an
+:class:`~langres.core.blockers.AllPairsBlocker`. The student emits a ``sim_cos``
+numeric score for every pair; pairs whose student score lands inside the band
+escalate to a scripted decider that emits a ``prob_llm`` **decision**. The result
+is a genuinely mixed ``sim_cos``/``prob_llm`` stream flowing through
+``resolve()`` / ``dedupe()`` / ``predict()`` -- the exact shape W3-d rewires.
+
+Seven disjoint pairs pin the seven cases that matter (``r{2k-1}``, ``r{2k}``):
+
+======  ============================  =================================================
+ pair    what the cascade emits        why it is here (the W3-d guard)
+======  ============================  =================================================
+r01/r02  student ``sim_cos`` 0.95      score-decided MATCH (score > band, score >= thr)
+r03/r04  student ``sim_cos`` 0.10      score-decided NON-match (score < band, score < thr)
+r05/r06  escalated ``decision=True``   decider MATCH (score=None -> decision drives)
+r07/r08  escalated ``decision=False``  decider NON-match (score=None -> decision drives)
+r09/r10  escalated **abstain**         no decision, no score -> EXCLUDED (not a "no")
+r11/r12  ``decision=True``, score 0.20 **decision wins over a LOW score** -> MATCH
+r13/r14  ``decision=False``, score 0.90 **decision suppresses a HIGH score** -> NON-match
+======  ============================  =================================================
+
+``r11/r12`` and ``r13/r14`` are the crux: a ``score >= t`` cut would *drop*
+``r11/r12`` (0.20 < 0.5) and *wrongly add* ``r13/r14`` (0.90 >= 0.5). Only a
+faithful ``predicted_match`` produces the clustering this fixture freezes. Every
+other pair the ``AllPairsBlocker`` generates is a background ``sim_cos`` 0.05
+student non-match (below band and threshold -> never escalated, never merged).
+
+Do not edit the records, scripts, band, or threshold without regenerating the
+golden -- a change here is a deliberate re-baseline, never an accident.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterator
+from typing import Any
+
+from pydantic import BaseModel
+
+from langres.core.blockers import AllPairsBlocker
+from langres.core.clusterer import Clusterer
+from langres.core.matcher import Matcher, SchemaT
+from langres.core.matchers.cascade_judge import CascadeMatcher
+from langres.core.models import ERCandidate, PairwiseJudgement
+from langres.core.reports import ScoreInspectionReport, _inspect_scores_impl
+from langres.core.resolver import Resolver
+from langres.testing import ScriptedJudge
+
+#: Clusterer / match-cut threshold. 0.20 falls below it and 0.90 above it, so the
+#: two decision-vs-score conflict pairs genuinely straddle the cut.
+CASCADE_THRESHOLD = 0.5
+
+#: The student's uncertainty band (over its ``sim_cos`` scores). A 0.50 student
+#: score lands inside it and escalates; 0.95 / 0.10 / 0.05 fall outside.
+CASCADE_BAND: tuple[float, float] = (0.3, 0.7)
+
+#: Background score for any pair not deliberately scripted below: a ``sim_cos``
+#: non-match, out of band (never escalated) and under threshold (never merged).
+_BACKGROUND_SCORE = 0.05
+
+
+class CascadeBusinessW3D(BaseModel):
+    """A tiny entity: ``id`` + ``name``. The scripts key on ``id`` only."""
+
+    id: str
+    name: str
+
+
+class ScriptedDecider(Matcher[SchemaT]):
+    """A ``$0`` escalation double that emits a scripted ``(decision, score)`` per pair.
+
+    :class:`~langres.testing.ScriptedJudge` can only *score* or abstain -- it has
+    no way to emit a boolean ``decision``, which is precisely the signal the
+    decision-vs-score path turns on. This minimal decider fills that gap: it maps
+    each unordered pair (``frozenset({left_id, right_id})``) to a
+    ``(decision, score)`` verdict and stamps it ``score_type="prob_llm"`` (a
+    probability family, so the cascade's shared-scale contract stays quiet for
+    the escalation tier). A pair absent from the map defaults to a confident
+    ``decision=False`` -- but with this fixture the escalation is only ever
+    reached by the five deliberately in-band pairs, so the default is never hit.
+    """
+
+    def __init__(self, verdicts: dict[frozenset[str], tuple[bool | None, float | None]]) -> None:
+        self.verdicts = verdicts
+        self.seen: list[frozenset[str]] = []
+
+    def forward(self, candidates: Iterator[ERCandidate[SchemaT]]) -> Iterator[PairwiseJudgement]:
+        for candidate in candidates:
+            key = frozenset(
+                {candidate.left.id, candidate.right.id}  # type: ignore[attr-defined]
+            )
+            self.seen.append(key)
+            decision, score = self.verdicts.get(key, (False, None))
+            yield PairwiseJudgement(
+                left_id=candidate.left.id,  # type: ignore[attr-defined]
+                right_id=candidate.right.id,  # type: ignore[attr-defined]
+                decision=decision,
+                score=score,
+                score_type="prob_llm",
+                decision_step="scripted_frontier",
+                provenance={},
+            )
+
+    def inspect_scores(
+        self, judgements: list[PairwiseJudgement], sample_size: int = 10
+    ) -> ScoreInspectionReport:
+        return _inspect_scores_impl(judgements, sample_size)
+
+
+#: 14 records = 7 disjoint pairs (see the module docstring's table).
+RECORDS: list[dict[str, object]] = [
+    {"id": f"r{i:02d}", "name": f"Entity {i}"} for i in range(1, 15)
+]
+
+
+def _pair(left_id: str, right_id: str) -> frozenset[str]:
+    return frozenset({left_id, right_id})
+
+
+#: Student ``sim_cos`` scores. Only these seven pairs are scripted; every other
+#: pair the AllPairsBlocker generates falls to ``_BACKGROUND_SCORE`` (0.05).
+_STUDENT_SCORES: dict[frozenset[str], float] = {
+    _pair("r01", "r02"): 0.95,  # > band high, > threshold -> student MATCH
+    _pair("r03", "r04"): 0.10,  # < band low,  < threshold -> student NON-match
+    _pair("r05", "r06"): 0.50,  # in band -> escalate
+    _pair("r07", "r08"): 0.50,  # in band -> escalate
+    _pair("r09", "r10"): 0.50,  # in band -> escalate
+    _pair("r11", "r12"): 0.50,  # in band -> escalate
+    _pair("r13", "r14"): 0.50,  # in band -> escalate
+}
+
+#: Escalation verdicts for the five in-band pairs (decision drives the outcome).
+_ESCALATION_VERDICTS: dict[frozenset[str], tuple[bool | None, float | None]] = {
+    _pair("r05", "r06"): (True, None),  # decider MATCH
+    _pair("r07", "r08"): (False, None),  # decider NON-match
+    _pair("r09", "r10"): (None, None),  # ABSTAIN -> excluded (not a "no")
+    _pair("r11", "r12"): (True, 0.20),  # decision wins over a LOW score -> MATCH
+    _pair("r13", "r14"): (False, 0.90),  # decision suppresses a HIGH score -> NON-match
+}
+
+#: The pairs whose behavior the golden is really about (for focused assertions).
+INTERESTING_PAIRS: dict[str, tuple[str, str]] = {
+    "student_match": ("r01", "r02"),
+    "student_nonmatch": ("r03", "r04"),
+    "escalated_decision_match": ("r05", "r06"),
+    "escalated_decision_nonmatch": ("r07", "r08"),
+    "escalated_abstain": ("r09", "r10"),
+    "decision_over_low_score": ("r11", "r12"),
+    "decision_over_high_score": ("r13", "r14"),
+}
+
+#: The three multi-record clusters the fixture must produce (everything else is a
+#: singleton the Clusterer drops). Pinned as a semantic backstop so a blind
+#: ``LANGRES_PARITY_UPDATE=1`` re-baseline still has to reproduce these.
+EXPECTED_CLUSTERS: list[set[str]] = [
+    {"r01", "r02"},  # student sim_cos match
+    {"r05", "r06"},  # escalated decision=True
+    {"r11", "r12"},  # decision=True beats a below-threshold score
+]
+
+#: Ids that must NOT be in any cluster (the decision/score conflict + abstain
+#: NON-matches). ``r13``/``r14`` are the load-bearing ones: a ``score >= t`` cut
+#: would merge them (0.90 >= 0.5); a faithful ``predicted_match`` does not.
+EXPECTED_UNMERGED_IDS: set[str] = {"r03", "r04", "r07", "r08", "r09", "r10", "r13", "r14"}
+
+
+def build_cascade_model() -> tuple[Resolver, ScriptedDecider[CascadeBusinessW3D]]:
+    """Build the scripted mixed-family cascade pipeline.
+
+    Returns the wired :class:`~langres.core.resolver.ERModel` and the escalation
+    decider (so a test can assert on its ``seen`` escalation-laziness spy). A
+    fresh instance per call keeps the ``seen`` spy and the cascade's one-time
+    ``score_type`` warning flag un-shared across tests.
+    """
+    student: ScriptedJudge[CascadeBusinessW3D] = ScriptedJudge(
+        _STUDENT_SCORES,
+        score_type="sim_cos",
+        decision_step="scripted_student",
+        default_score=_BACKGROUND_SCORE,
+    )
+    escalation: ScriptedDecider[CascadeBusinessW3D] = ScriptedDecider(_ESCALATION_VERDICTS)
+    cascade: CascadeMatcher[CascadeBusinessW3D] = CascadeMatcher(
+        student=student, escalation=escalation, band=CASCADE_BAND
+    )
+    model = Resolver(
+        blocker=AllPairsBlocker(schema=CascadeBusinessW3D),
+        comparator=None,
+        matcher=cascade,
+        clusterer=Clusterer(threshold=CASCADE_THRESHOLD),
+    )
+    return model, escalation
+
+
+def record(record_id: str) -> dict[str, Any]:
+    """The one fixture record with ``id == record_id`` (fixture ids are unique)."""
+    return next(r for r in RECORDS if r["id"] == record_id)

--- a/tests/parity/goldens/mixed_family_cascade_w3d.json
+++ b/tests/parity/goldens/mixed_family_cascade_w3d.json
@@ -1,0 +1,772 @@
+{
+  "band": [
+    0.3,
+    0.7
+  ],
+  "dedupe": {
+    "architecture": "ERModel",
+    "backbone": null,
+    "clusters": [
+      [
+        "r01",
+        "r02"
+      ],
+      [
+        "r05",
+        "r06"
+      ],
+      [
+        "r11",
+        "r12"
+      ]
+    ],
+    "score_type": "sim_cos",
+    "threshold": 0.5
+  },
+  "n_pairs": 91,
+  "pairs": [
+    {
+      "decision": null,
+      "decision_step": "cascade_student",
+      "left_id": "r01",
+      "right_id": "r02",
+      "score": 0.95,
+      "score_type": "sim_cos"
+    },
+    {
+      "decision": null,
+      "decision_step": "cascade_student",
+      "left_id": "r01",
+      "right_id": "r03",
+      "score": 0.05,
+      "score_type": "sim_cos"
+    },
+    {
+      "decision": null,
+      "decision_step": "cascade_student",
+      "left_id": "r01",
+      "right_id": "r04",
+      "score": 0.05,
+      "score_type": "sim_cos"
+    },
+    {
+      "decision": null,
+      "decision_step": "cascade_student",
+      "left_id": "r01",
+      "right_id": "r05",
+      "score": 0.05,
+      "score_type": "sim_cos"
+    },
+    {
+      "decision": null,
+      "decision_step": "cascade_student",
+      "left_id": "r01",
+      "right_id": "r06",
+      "score": 0.05,
+      "score_type": "sim_cos"
+    },
+    {
+      "decision": null,
+      "decision_step": "cascade_student",
+      "left_id": "r01",
+      "right_id": "r07",
+      "score": 0.05,
+      "score_type": "sim_cos"
+    },
+    {
+      "decision": null,
+      "decision_step": "cascade_student",
+      "left_id": "r01",
+      "right_id": "r08",
+      "score": 0.05,
+      "score_type": "sim_cos"
+    },
+    {
+      "decision": null,
+      "decision_step": "cascade_student",
+      "left_id": "r01",
+      "right_id": "r09",
+      "score": 0.05,
+      "score_type": "sim_cos"
+    },
+    {
+      "decision": null,
+      "decision_step": "cascade_student",
+      "left_id": "r01",
+      "right_id": "r10",
+      "score": 0.05,
+      "score_type": "sim_cos"
+    },
+    {
+      "decision": null,
+      "decision_step": "cascade_student",
+      "left_id": "r01",
+      "right_id": "r11",
+      "score": 0.05,
+      "score_type": "sim_cos"
+    },
+    {
+      "decision": null,
+      "decision_step": "cascade_student",
+      "left_id": "r01",
+      "right_id": "r12",
+      "score": 0.05,
+      "score_type": "sim_cos"
+    },
+    {
+      "decision": null,
+      "decision_step": "cascade_student",
+      "left_id": "r01",
+      "right_id": "r13",
+      "score": 0.05,
+      "score_type": "sim_cos"
+    },
+    {
+      "decision": null,
+      "decision_step": "cascade_student",
+      "left_id": "r01",
+      "right_id": "r14",
+      "score": 0.05,
+      "score_type": "sim_cos"
+    },
+    {
+      "decision": null,
+      "decision_step": "cascade_student",
+      "left_id": "r02",
+      "right_id": "r03",
+      "score": 0.05,
+      "score_type": "sim_cos"
+    },
+    {
+      "decision": null,
+      "decision_step": "cascade_student",
+      "left_id": "r02",
+      "right_id": "r04",
+      "score": 0.05,
+      "score_type": "sim_cos"
+    },
+    {
+      "decision": null,
+      "decision_step": "cascade_student",
+      "left_id": "r02",
+      "right_id": "r05",
+      "score": 0.05,
+      "score_type": "sim_cos"
+    },
+    {
+      "decision": null,
+      "decision_step": "cascade_student",
+      "left_id": "r02",
+      "right_id": "r06",
+      "score": 0.05,
+      "score_type": "sim_cos"
+    },
+    {
+      "decision": null,
+      "decision_step": "cascade_student",
+      "left_id": "r02",
+      "right_id": "r07",
+      "score": 0.05,
+      "score_type": "sim_cos"
+    },
+    {
+      "decision": null,
+      "decision_step": "cascade_student",
+      "left_id": "r02",
+      "right_id": "r08",
+      "score": 0.05,
+      "score_type": "sim_cos"
+    },
+    {
+      "decision": null,
+      "decision_step": "cascade_student",
+      "left_id": "r02",
+      "right_id": "r09",
+      "score": 0.05,
+      "score_type": "sim_cos"
+    },
+    {
+      "decision": null,
+      "decision_step": "cascade_student",
+      "left_id": "r02",
+      "right_id": "r10",
+      "score": 0.05,
+      "score_type": "sim_cos"
+    },
+    {
+      "decision": null,
+      "decision_step": "cascade_student",
+      "left_id": "r02",
+      "right_id": "r11",
+      "score": 0.05,
+      "score_type": "sim_cos"
+    },
+    {
+      "decision": null,
+      "decision_step": "cascade_student",
+      "left_id": "r02",
+      "right_id": "r12",
+      "score": 0.05,
+      "score_type": "sim_cos"
+    },
+    {
+      "decision": null,
+      "decision_step": "cascade_student",
+      "left_id": "r02",
+      "right_id": "r13",
+      "score": 0.05,
+      "score_type": "sim_cos"
+    },
+    {
+      "decision": null,
+      "decision_step": "cascade_student",
+      "left_id": "r02",
+      "right_id": "r14",
+      "score": 0.05,
+      "score_type": "sim_cos"
+    },
+    {
+      "decision": null,
+      "decision_step": "cascade_student",
+      "left_id": "r03",
+      "right_id": "r04",
+      "score": 0.1,
+      "score_type": "sim_cos"
+    },
+    {
+      "decision": null,
+      "decision_step": "cascade_student",
+      "left_id": "r03",
+      "right_id": "r05",
+      "score": 0.05,
+      "score_type": "sim_cos"
+    },
+    {
+      "decision": null,
+      "decision_step": "cascade_student",
+      "left_id": "r03",
+      "right_id": "r06",
+      "score": 0.05,
+      "score_type": "sim_cos"
+    },
+    {
+      "decision": null,
+      "decision_step": "cascade_student",
+      "left_id": "r03",
+      "right_id": "r07",
+      "score": 0.05,
+      "score_type": "sim_cos"
+    },
+    {
+      "decision": null,
+      "decision_step": "cascade_student",
+      "left_id": "r03",
+      "right_id": "r08",
+      "score": 0.05,
+      "score_type": "sim_cos"
+    },
+    {
+      "decision": null,
+      "decision_step": "cascade_student",
+      "left_id": "r03",
+      "right_id": "r09",
+      "score": 0.05,
+      "score_type": "sim_cos"
+    },
+    {
+      "decision": null,
+      "decision_step": "cascade_student",
+      "left_id": "r03",
+      "right_id": "r10",
+      "score": 0.05,
+      "score_type": "sim_cos"
+    },
+    {
+      "decision": null,
+      "decision_step": "cascade_student",
+      "left_id": "r03",
+      "right_id": "r11",
+      "score": 0.05,
+      "score_type": "sim_cos"
+    },
+    {
+      "decision": null,
+      "decision_step": "cascade_student",
+      "left_id": "r03",
+      "right_id": "r12",
+      "score": 0.05,
+      "score_type": "sim_cos"
+    },
+    {
+      "decision": null,
+      "decision_step": "cascade_student",
+      "left_id": "r03",
+      "right_id": "r13",
+      "score": 0.05,
+      "score_type": "sim_cos"
+    },
+    {
+      "decision": null,
+      "decision_step": "cascade_student",
+      "left_id": "r03",
+      "right_id": "r14",
+      "score": 0.05,
+      "score_type": "sim_cos"
+    },
+    {
+      "decision": null,
+      "decision_step": "cascade_student",
+      "left_id": "r04",
+      "right_id": "r05",
+      "score": 0.05,
+      "score_type": "sim_cos"
+    },
+    {
+      "decision": null,
+      "decision_step": "cascade_student",
+      "left_id": "r04",
+      "right_id": "r06",
+      "score": 0.05,
+      "score_type": "sim_cos"
+    },
+    {
+      "decision": null,
+      "decision_step": "cascade_student",
+      "left_id": "r04",
+      "right_id": "r07",
+      "score": 0.05,
+      "score_type": "sim_cos"
+    },
+    {
+      "decision": null,
+      "decision_step": "cascade_student",
+      "left_id": "r04",
+      "right_id": "r08",
+      "score": 0.05,
+      "score_type": "sim_cos"
+    },
+    {
+      "decision": null,
+      "decision_step": "cascade_student",
+      "left_id": "r04",
+      "right_id": "r09",
+      "score": 0.05,
+      "score_type": "sim_cos"
+    },
+    {
+      "decision": null,
+      "decision_step": "cascade_student",
+      "left_id": "r04",
+      "right_id": "r10",
+      "score": 0.05,
+      "score_type": "sim_cos"
+    },
+    {
+      "decision": null,
+      "decision_step": "cascade_student",
+      "left_id": "r04",
+      "right_id": "r11",
+      "score": 0.05,
+      "score_type": "sim_cos"
+    },
+    {
+      "decision": null,
+      "decision_step": "cascade_student",
+      "left_id": "r04",
+      "right_id": "r12",
+      "score": 0.05,
+      "score_type": "sim_cos"
+    },
+    {
+      "decision": null,
+      "decision_step": "cascade_student",
+      "left_id": "r04",
+      "right_id": "r13",
+      "score": 0.05,
+      "score_type": "sim_cos"
+    },
+    {
+      "decision": null,
+      "decision_step": "cascade_student",
+      "left_id": "r04",
+      "right_id": "r14",
+      "score": 0.05,
+      "score_type": "sim_cos"
+    },
+    {
+      "decision": true,
+      "decision_step": "cascade_escalated",
+      "left_id": "r05",
+      "right_id": "r06",
+      "score": null,
+      "score_type": "prob_llm"
+    },
+    {
+      "decision": null,
+      "decision_step": "cascade_student",
+      "left_id": "r05",
+      "right_id": "r07",
+      "score": 0.05,
+      "score_type": "sim_cos"
+    },
+    {
+      "decision": null,
+      "decision_step": "cascade_student",
+      "left_id": "r05",
+      "right_id": "r08",
+      "score": 0.05,
+      "score_type": "sim_cos"
+    },
+    {
+      "decision": null,
+      "decision_step": "cascade_student",
+      "left_id": "r05",
+      "right_id": "r09",
+      "score": 0.05,
+      "score_type": "sim_cos"
+    },
+    {
+      "decision": null,
+      "decision_step": "cascade_student",
+      "left_id": "r05",
+      "right_id": "r10",
+      "score": 0.05,
+      "score_type": "sim_cos"
+    },
+    {
+      "decision": null,
+      "decision_step": "cascade_student",
+      "left_id": "r05",
+      "right_id": "r11",
+      "score": 0.05,
+      "score_type": "sim_cos"
+    },
+    {
+      "decision": null,
+      "decision_step": "cascade_student",
+      "left_id": "r05",
+      "right_id": "r12",
+      "score": 0.05,
+      "score_type": "sim_cos"
+    },
+    {
+      "decision": null,
+      "decision_step": "cascade_student",
+      "left_id": "r05",
+      "right_id": "r13",
+      "score": 0.05,
+      "score_type": "sim_cos"
+    },
+    {
+      "decision": null,
+      "decision_step": "cascade_student",
+      "left_id": "r05",
+      "right_id": "r14",
+      "score": 0.05,
+      "score_type": "sim_cos"
+    },
+    {
+      "decision": null,
+      "decision_step": "cascade_student",
+      "left_id": "r06",
+      "right_id": "r07",
+      "score": 0.05,
+      "score_type": "sim_cos"
+    },
+    {
+      "decision": null,
+      "decision_step": "cascade_student",
+      "left_id": "r06",
+      "right_id": "r08",
+      "score": 0.05,
+      "score_type": "sim_cos"
+    },
+    {
+      "decision": null,
+      "decision_step": "cascade_student",
+      "left_id": "r06",
+      "right_id": "r09",
+      "score": 0.05,
+      "score_type": "sim_cos"
+    },
+    {
+      "decision": null,
+      "decision_step": "cascade_student",
+      "left_id": "r06",
+      "right_id": "r10",
+      "score": 0.05,
+      "score_type": "sim_cos"
+    },
+    {
+      "decision": null,
+      "decision_step": "cascade_student",
+      "left_id": "r06",
+      "right_id": "r11",
+      "score": 0.05,
+      "score_type": "sim_cos"
+    },
+    {
+      "decision": null,
+      "decision_step": "cascade_student",
+      "left_id": "r06",
+      "right_id": "r12",
+      "score": 0.05,
+      "score_type": "sim_cos"
+    },
+    {
+      "decision": null,
+      "decision_step": "cascade_student",
+      "left_id": "r06",
+      "right_id": "r13",
+      "score": 0.05,
+      "score_type": "sim_cos"
+    },
+    {
+      "decision": null,
+      "decision_step": "cascade_student",
+      "left_id": "r06",
+      "right_id": "r14",
+      "score": 0.05,
+      "score_type": "sim_cos"
+    },
+    {
+      "decision": false,
+      "decision_step": "cascade_escalated",
+      "left_id": "r07",
+      "right_id": "r08",
+      "score": null,
+      "score_type": "prob_llm"
+    },
+    {
+      "decision": null,
+      "decision_step": "cascade_student",
+      "left_id": "r07",
+      "right_id": "r09",
+      "score": 0.05,
+      "score_type": "sim_cos"
+    },
+    {
+      "decision": null,
+      "decision_step": "cascade_student",
+      "left_id": "r07",
+      "right_id": "r10",
+      "score": 0.05,
+      "score_type": "sim_cos"
+    },
+    {
+      "decision": null,
+      "decision_step": "cascade_student",
+      "left_id": "r07",
+      "right_id": "r11",
+      "score": 0.05,
+      "score_type": "sim_cos"
+    },
+    {
+      "decision": null,
+      "decision_step": "cascade_student",
+      "left_id": "r07",
+      "right_id": "r12",
+      "score": 0.05,
+      "score_type": "sim_cos"
+    },
+    {
+      "decision": null,
+      "decision_step": "cascade_student",
+      "left_id": "r07",
+      "right_id": "r13",
+      "score": 0.05,
+      "score_type": "sim_cos"
+    },
+    {
+      "decision": null,
+      "decision_step": "cascade_student",
+      "left_id": "r07",
+      "right_id": "r14",
+      "score": 0.05,
+      "score_type": "sim_cos"
+    },
+    {
+      "decision": null,
+      "decision_step": "cascade_student",
+      "left_id": "r08",
+      "right_id": "r09",
+      "score": 0.05,
+      "score_type": "sim_cos"
+    },
+    {
+      "decision": null,
+      "decision_step": "cascade_student",
+      "left_id": "r08",
+      "right_id": "r10",
+      "score": 0.05,
+      "score_type": "sim_cos"
+    },
+    {
+      "decision": null,
+      "decision_step": "cascade_student",
+      "left_id": "r08",
+      "right_id": "r11",
+      "score": 0.05,
+      "score_type": "sim_cos"
+    },
+    {
+      "decision": null,
+      "decision_step": "cascade_student",
+      "left_id": "r08",
+      "right_id": "r12",
+      "score": 0.05,
+      "score_type": "sim_cos"
+    },
+    {
+      "decision": null,
+      "decision_step": "cascade_student",
+      "left_id": "r08",
+      "right_id": "r13",
+      "score": 0.05,
+      "score_type": "sim_cos"
+    },
+    {
+      "decision": null,
+      "decision_step": "cascade_student",
+      "left_id": "r08",
+      "right_id": "r14",
+      "score": 0.05,
+      "score_type": "sim_cos"
+    },
+    {
+      "decision": null,
+      "decision_step": "cascade_escalated",
+      "left_id": "r09",
+      "right_id": "r10",
+      "score": null,
+      "score_type": "prob_llm"
+    },
+    {
+      "decision": null,
+      "decision_step": "cascade_student",
+      "left_id": "r09",
+      "right_id": "r11",
+      "score": 0.05,
+      "score_type": "sim_cos"
+    },
+    {
+      "decision": null,
+      "decision_step": "cascade_student",
+      "left_id": "r09",
+      "right_id": "r12",
+      "score": 0.05,
+      "score_type": "sim_cos"
+    },
+    {
+      "decision": null,
+      "decision_step": "cascade_student",
+      "left_id": "r09",
+      "right_id": "r13",
+      "score": 0.05,
+      "score_type": "sim_cos"
+    },
+    {
+      "decision": null,
+      "decision_step": "cascade_student",
+      "left_id": "r09",
+      "right_id": "r14",
+      "score": 0.05,
+      "score_type": "sim_cos"
+    },
+    {
+      "decision": null,
+      "decision_step": "cascade_student",
+      "left_id": "r10",
+      "right_id": "r11",
+      "score": 0.05,
+      "score_type": "sim_cos"
+    },
+    {
+      "decision": null,
+      "decision_step": "cascade_student",
+      "left_id": "r10",
+      "right_id": "r12",
+      "score": 0.05,
+      "score_type": "sim_cos"
+    },
+    {
+      "decision": null,
+      "decision_step": "cascade_student",
+      "left_id": "r10",
+      "right_id": "r13",
+      "score": 0.05,
+      "score_type": "sim_cos"
+    },
+    {
+      "decision": null,
+      "decision_step": "cascade_student",
+      "left_id": "r10",
+      "right_id": "r14",
+      "score": 0.05,
+      "score_type": "sim_cos"
+    },
+    {
+      "decision": true,
+      "decision_step": "cascade_escalated",
+      "left_id": "r11",
+      "right_id": "r12",
+      "score": 0.2,
+      "score_type": "prob_llm"
+    },
+    {
+      "decision": null,
+      "decision_step": "cascade_student",
+      "left_id": "r11",
+      "right_id": "r13",
+      "score": 0.05,
+      "score_type": "sim_cos"
+    },
+    {
+      "decision": null,
+      "decision_step": "cascade_student",
+      "left_id": "r11",
+      "right_id": "r14",
+      "score": 0.05,
+      "score_type": "sim_cos"
+    },
+    {
+      "decision": null,
+      "decision_step": "cascade_student",
+      "left_id": "r12",
+      "right_id": "r13",
+      "score": 0.05,
+      "score_type": "sim_cos"
+    },
+    {
+      "decision": null,
+      "decision_step": "cascade_student",
+      "left_id": "r12",
+      "right_id": "r14",
+      "score": 0.05,
+      "score_type": "sim_cos"
+    },
+    {
+      "decision": false,
+      "decision_step": "cascade_escalated",
+      "left_id": "r13",
+      "right_id": "r14",
+      "score": 0.9,
+      "score_type": "prob_llm"
+    }
+  ],
+  "resolve_clusters": [
+    [
+      "r01",
+      "r02"
+    ],
+    [
+      "r05",
+      "r06"
+    ],
+    [
+      "r11",
+      "r12"
+    ]
+  ],
+  "threshold": 0.5
+}

--- a/tests/parity/test_behavior_parity_cascade_w3d.py
+++ b/tests/parity/test_behavior_parity_cascade_w3d.py
@@ -1,0 +1,182 @@
+"""Mixed-family cascade byte-parity net for epic #193 -- the W3-d match-cut guard.
+
+The companion to :mod:`tests.parity.test_behavior_parity_w0` for the *cascade*
+path W0 deferred. Where the W0 net covers the ``$0`` string architecture, this
+one covers the fragile bit W3-d actually rewires: a **mixed-family** cascade that
+emits some rows with a numeric ``sim_cos`` *score* and escalates others to a
+``prob_llm`` *decision*, run end-to-end through ``resolve()`` / ``dedupe()`` /
+``predict()`` and frozen to a byte-identical golden.
+
+Why this and not a full ``VectorLLMCascade``: the risk W3-d must not regress is
+narrow. It moves the match cut out of the :class:`~langres.core.clusterer.Clusterer`
+into a ``Select(THRESHOLD)`` and runs the clusterer as pure transitive closure,
+on the claim ``ThresholdSelect(t) -> Clusterer(0.0) == Clusterer(t)``. That
+equivalence turns entirely on :func:`~langres.core.models.predicted_match` -- and
+``predicted_match`` gives a judge's boolean ``decision`` precedence over its
+numeric ``score``. The path most likely to break is a mixed stream where the two
+disagree, which needs no real embedder or LLM to reproduce -- only a scripted
+``sim_cos`` student and a scripted ``prob_llm`` decider (see
+:mod:`tests.parity._cascade_fixture`). A faithful offline embedder was the reason
+W0 deferred cascade parity; this reframing sidesteps it while guarding the same
+seam.
+
+What the golden pins (all offline, deterministic, ``$0`` -- no network, no key):
+
+- **``resolve()`` clusters** -- the connected components the match cut produces.
+- **``dedupe()`` ``DedupeResult`` metadata** -- ``score_type`` (the FIRST scored
+  row's own family: ``sim_cos``, honestly reporting a mixed stream) + effective
+  ``threshold`` + ``architecture`` + ``backbone``.
+- **every blocked pair's ``predict()`` judgement** -- ``(score, score_type,
+  decision, decision_step)`` sorted canonically, so a change to how *any* pair is
+  scored (a lost decision, a mislabelled family, a dropped escalation) is caught
+  at the pair level, not only if it survives to alter the final clusters.
+
+Regenerate deliberately (a re-baseline, never the default -- CI always asserts)::
+
+    LANGRES_PARITY_UPDATE=1 uv run pytest tests/parity --no-cov
+"""
+
+from __future__ import annotations
+
+import warnings
+
+from tests.parity._cascade_fixture import (
+    CASCADE_BAND,
+    CASCADE_THRESHOLD,
+    EXPECTED_CLUSTERS,
+    EXPECTED_UNMERGED_IDS,
+    INTERESTING_PAIRS,
+    RECORDS,
+    build_cascade_model,
+)
+from tests.parity._golden import canonical_clusters, check_golden
+
+
+def _run_all() -> tuple[list[dict[str, object]], object, object, object]:
+    """Run predict/resolve/dedupe once on one model; return (pairs, judgements, clusters, result).
+
+    The cascade emits a one-time ``UserWarning`` for its ``sim_cos`` student
+    (outside the shared probability scale) -- that contract is already covered in
+    ``tests/core/modules/test_cascade_judge.py``; here it is expected noise, so we
+    silence it rather than let it fail a ``-W error`` run.
+    """
+    model, _escalation = build_cascade_model()
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore", UserWarning)
+        judgements = model.predict(RECORDS)
+        clusters = model.resolve(RECORDS)
+        result = model.dedupe(RECORDS)
+    pairs = [
+        {
+            "left_id": judgement.left_id,
+            "right_id": judgement.right_id,
+            "score": judgement.score,
+            "score_type": judgement.score_type,
+            "decision": judgement.decision,
+            "decision_step": judgement.decision_step,
+        }
+        for judgement in sorted(judgements, key=lambda j: (j.left_id, j.right_id))
+    ]
+    return pairs, judgements, clusters, result
+
+
+def test_mixed_family_cascade_parity() -> None:
+    """Byte-parity snapshot of the whole mixed-family cascade run.
+
+    One frozen golden over ``predict()`` + ``resolve()`` + ``dedupe()`` on the
+    scripted ``sim_cos``/``prob_llm`` cascade -- the tightest net for the W3-d
+    match-cut rewire.
+    """
+    pairs, _judgements, clusters, result = _run_all()
+    payload = {
+        "threshold": CASCADE_THRESHOLD,
+        "band": list(CASCADE_BAND),
+        "n_pairs": len(pairs),
+        "pairs": pairs,
+        "resolve_clusters": canonical_clusters(clusters),
+        "dedupe": {
+            "architecture": result.architecture,  # type: ignore[attr-defined]
+            "backbone": result.backbone,  # type: ignore[attr-defined]
+            "score_type": result.score_type,  # type: ignore[attr-defined]
+            "threshold": result.threshold,  # type: ignore[attr-defined]
+            "clusters": canonical_clusters(result),
+        },
+    }
+    check_golden("mixed_family_cascade_w3d", payload)
+
+
+def test_decision_precedence_semantics_are_pinned() -> None:
+    """Semantic backstop: the decision-vs-score outcomes hold, byte-parity aside.
+
+    A byte golden re-baselines silently under ``LANGRES_PARITY_UPDATE=1``; these
+    assertions do not. They pin the exact behavior the W3-d equivalence rests on,
+    so a rewrite that swaps ``predicted_match`` for a bare ``score >= t`` cut
+    fails here even if someone regenerates the golden.
+    """
+    _pairs, judgements, clusters, _result = _run_all()
+    cluster_sets = {frozenset(c) for c in clusters}
+
+    # The three multi-record clusters, and nothing merged that must not be.
+    assert cluster_sets == {frozenset(c) for c in EXPECTED_CLUSTERS}
+    merged_ids = {rid for cluster in clusters for rid in cluster}
+    assert merged_ids.isdisjoint(EXPECTED_UNMERGED_IDS)
+
+    by_pair = {frozenset({j.left_id, j.right_id}): j for j in judgements}
+
+    # decision wins over a LOW score: score 0.20 < 0.5 threshold, decision=True
+    # -> MATCH. A ``score >= t`` cut would DROP this cluster.
+    low = by_pair[frozenset(INTERESTING_PAIRS["decision_over_low_score"])]
+    assert low.decision is True and low.score is not None and low.score < CASCADE_THRESHOLD
+    assert set(INTERESTING_PAIRS["decision_over_low_score"]) in [set(c) for c in clusters]
+
+    # decision suppresses a HIGH score: score 0.90 >= 0.5 threshold, decision=False
+    # -> NON-match. A ``score >= t`` cut would WRONGLY merge this pair.
+    high = by_pair[frozenset(INTERESTING_PAIRS["decision_over_high_score"])]
+    assert high.decision is False and high.score is not None and high.score >= CASCADE_THRESHOLD
+    assert not (set(INTERESTING_PAIRS["decision_over_high_score"]) <= merged_ids)
+
+    # abstain (no decision, no score) is EXCLUDED -- never graded a confident "no".
+    abstain = by_pair[frozenset(INTERESTING_PAIRS["escalated_abstain"])]
+    assert abstain.decision is None and abstain.score is None
+    assert abstain.is_abstain
+
+
+def test_stream_is_genuinely_mixed_family() -> None:
+    """The stream really carries both families (not a degenerate single-type run).
+
+    If the whole stream collapsed to one ``score_type`` the golden would still
+    pass but stop testing the *mixed*-family path this net exists for -- so pin
+    that both ``sim_cos`` (student) and ``prob_llm`` (escalated) rows are present.
+    """
+    _pairs, judgements, _clusters, result = _run_all()
+    score_types = {j.score_type for j in judgements}
+    assert {"sim_cos", "prob_llm"} <= score_types
+    # dedupe reports the FIRST scored row's own family, honestly (the r01/r02
+    # student pair leads the AllPairsBlocker order): a mixed stream is not
+    # mislabelled as a single global type.
+    assert result.score_type == "sim_cos"  # type: ignore[attr-defined]
+
+
+def test_escalation_is_lazy_only_in_band_pairs_escalate() -> None:
+    """Only the five in-band pairs reach the (expensive) escalation tier.
+
+    Proves the mixed stream is produced the real way -- student everywhere,
+    escalation at the margin -- rather than by every pair hitting the decider,
+    which would erase the ``sim_cos`` half of the stream.
+    """
+    model, escalation = build_cascade_model()
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore", UserWarning)
+        model.predict(RECORDS)
+    in_band = {
+        frozenset(INTERESTING_PAIRS[name])
+        for name in (
+            "escalated_decision_match",
+            "escalated_decision_nonmatch",
+            "escalated_abstain",
+            "decision_over_low_score",
+            "decision_over_high_score",
+        )
+    }
+    assert set(escalation.seen) == in_band
+    assert len(escalation.seen) == 5

--- a/tests/parity/test_behavior_parity_cascade_w3d.py
+++ b/tests/parity/test_behavior_parity_cascade_w3d.py
@@ -40,6 +40,9 @@ from __future__ import annotations
 
 import warnings
 
+from langres.core.models import PairwiseJudgement
+from langres.core.results import DedupeResult
+
 from tests.parity._cascade_fixture import (
     CASCADE_BAND,
     CASCADE_THRESHOLD,
@@ -52,7 +55,9 @@ from tests.parity._cascade_fixture import (
 from tests.parity._golden import canonical_clusters, check_golden
 
 
-def _run_all() -> tuple[list[dict[str, object]], object, object, object]:
+def _run_all() -> tuple[
+    list[dict[str, object]], list[PairwiseJudgement], list[set[str]], DedupeResult
+]:
     """Run predict/resolve/dedupe once on one model; return (pairs, judgements, clusters, result).
 
     The cascade emits a one-time ``UserWarning`` for its ``sim_cos`` student
@@ -66,7 +71,7 @@ def _run_all() -> tuple[list[dict[str, object]], object, object, object]:
         judgements = model.predict(RECORDS)
         clusters = model.resolve(RECORDS)
         result = model.dedupe(RECORDS)
-    pairs = [
+    pairs: list[dict[str, object]] = [
         {
             "left_id": judgement.left_id,
             "right_id": judgement.right_id,
@@ -95,10 +100,10 @@ def test_mixed_family_cascade_parity() -> None:
         "pairs": pairs,
         "resolve_clusters": canonical_clusters(clusters),
         "dedupe": {
-            "architecture": result.architecture,  # type: ignore[attr-defined]
-            "backbone": result.backbone,  # type: ignore[attr-defined]
-            "score_type": result.score_type,  # type: ignore[attr-defined]
-            "threshold": result.threshold,  # type: ignore[attr-defined]
+            "architecture": result.architecture,
+            "backbone": result.backbone,
+            "score_type": result.score_type,
+            "threshold": result.threshold,
             "clusters": canonical_clusters(result),
         },
     }
@@ -154,7 +159,7 @@ def test_stream_is_genuinely_mixed_family() -> None:
     # dedupe reports the FIRST scored row's own family, honestly (the r01/r02
     # student pair leads the AllPairsBlocker order): a mixed stream is not
     # mislabelled as a single global type.
-    assert result.score_type == "sim_cos"  # type: ignore[attr-defined]
+    assert result.score_type == "sim_cos"
 
 
 def test_escalation_is_lazy_only_in_band_pairs_escalate() -> None:


### PR DESCRIPTION
## What

Adds a **mixed-family cascade byte-parity golden** to `tests/parity/` — the cascade net W0 deferred, reframed around the risk W3-d actually carries. **Additive, test-only: touches no `src/` file, no `_model_run.py`/`op.py`/`op_adapters.py`.** Based on the epic tip `ef82bb9` (post-W3-a).

## Why (this is the guard, not a green check)

W3-d moves the match cut out of the `Clusterer` into a `Select(THRESHOLD)` and runs the clusterer as pure transitive closure, on the claim:

```
ThresholdSelect(t) → Clusterer(0.0)  ≡  Clusterer(t)
```

That equivalence turns entirely on `predicted_match`, which gives a judge's boolean **`decision` precedence over its numeric `score`**. The fragile path is a **mixed-family** stream where the two disagree. A real `VectorLLMCascade` (embedder + LLM) is not needed to reproduce it — a scripted `sim_cos` student + `prob_llm` decider is sufficient and $0/offline.

## Approach: real `CascadeMatcher`, scripted $0 children

A production `CascadeMatcher` (student = `langres.testing.ScriptedJudge` emitting `sim_cos`; escalation = a tiny per-pair `ScriptedDecider` emitting `prob_llm` decisions — `ScriptedJudge` can't emit a boolean `decision`) wired into a plain `ERModel` over `AllPairsBlocker`, run through `resolve()`/`dedupe()`/`predict()`. 14 records / 7 disjoint pairs pin:

| pair | emits | guards |
|---|---|---|
| r01/r02 | student `sim_cos` 0.95 | score-decided MATCH |
| r03/r04 | student `sim_cos` 0.10 | score-decided NON-match |
| r05/r06 | escalated `decision=True`, score=None | decider MATCH |
| r07/r08 | escalated `decision=False`, score=None | decider NON-match |
| r09/r10 | escalated **abstain** | EXCLUDED (not a "no") |
| **r11/r12** | `decision=True`, **score 0.20** (< thr 0.5) | **decision wins over a LOW score → MATCH** |
| **r13/r14** | `decision=False`, **score 0.90** (≥ thr 0.5) | **decision suppresses a HIGH score → NON-match** |

The golden freezes `resolve()` clusters `{r01,r02},{r05,r06},{r11,r12}`, `dedupe()` metadata (`score_type=sim_cos` — the first scored row's own family, honestly reporting a mixed stream), and all 91 `predict()` judgements' `(score, score_type, decision, decision_step)`.

## It discriminates

Re-clustering the same judgements with a decision-blind `score >= t` cut yields `{r01,r02},{r13,r14}` — it drops the decision-driven matches (r05/r06, r11/r12) and wrongly merges r13/r14. So the golden diff (and the added semantic assertions, which survive a blind `LANGRES_PARITY_UPDATE=1` re-baseline) fire on exactly the W3-d regression.

## Gates
- `uv run pytest tests/parity` → 13 passed, 1 skipped (pre-existing deferred VectorLLMCascade placeholder)
- ruff format + lint clean, `mypy` clean on both new files

https://claude.ai/code/session_011XYuhyiigi1Bw2YnWCxMr9