### PR TITLE
W3-b: concrete Select (Threshold/TopK) + honest OutSpace sentinel — #193

### DIFF
--- a/examples/op_reranker_expressiveness.py
+++ b/examples/op_reranker_expressiveness.py
@@ -30,98 +30,25 @@ difference is the inserted TOPK-prune + rescoring ``Score``. On the fixed datase
 below the reranker recovers the true duplicate structure, while the name-only
 baseline over-merges same-name / different-address branches.
 
-**A gap this script surfaces (see the NOTE on the Select classes).** The adapters
-in ``op_adapters.py`` bridge Source / Score / ClusterStage / Finalize, but there
-is **no concrete ``Select`` adapter** on the branch — the old core folded
-thresholding into the ``Clusterer``, so a first-class selection ``Op`` has no
-shipped implementation yet. The two ``Select`` subclasses here realize the real
-selection semantics (THRESHOLD, TOPK); they are the example's own, not stubs
-hiding a gap. W3 will need a concrete ``Select`` to make selection a real pipeline
-stage rather than a knob on the clusterer.
+**Selection is now first-class (W3-b).** The adapters in ``op_adapters.py`` bridge
+Source / Score / ClusterStage / Finalize, and W3-b added the two concrete
+``Select`` ops — :class:`~langres.core.op.ThresholdSelect` (keep the rows that
+clear the price) and :class:`~langres.core.op.TopKSelect` (keep each anchor's k
+best) — to :mod:`langres.core.op`. So selection is a real pipeline stage now, not
+a knob folded into the clusterer's own threshold; this script imports both from
+src rather than defining its own.
 
 Run it:  ``uv run python examples/op_reranker_expressiveness.py``
 """
 
 from __future__ import annotations
 
-from collections import defaultdict
-from typing import Generic, TypeVar
-
-from pydantic import BaseModel
-
 from langres.core.blockers.all_pairs import AllPairsBlocker
 from langres.core.clusterer import Clusterer
 from langres.core.matchers.rapidfuzz import RapidfuzzMatcher
 from langres.core.models import CompanySchema
-from langres.core.op import Feasible, Records, Select, Sequential
+from langres.core.op import Records, Sequential, ThresholdSelect, TopKSelect
 from langres.core.op_adapters import BlockerSource, ClustererStage, MatcherScore
-from langres.core.pairs import PairRow, Pairs
-
-SchemaT = TypeVar("SchemaT", bound=BaseModel)
-
-
-# --------------------------------------------------------------------------------------
-# Concrete Select ops.
-#
-# NOTE (de-risk finding): op.py defines Select as an ABSTRACT role — it validates
-# the Feasible class in __init__ but never implements forward(), and
-# op_adapters.py ships NO concrete Select (the legacy 4-slot core folded
-# thresholding into the Clusterer's own threshold). So expressing selection as a
-# first-class Op requires implementing forward() here. These are the real
-# selection semantics for two Feasible classes, not stubs:
-#   * THRESHOLD -> keep every row whose score clears the price (no shape rule).
-#   * TOPK      -> keep at most k rows per left record (the retrieval shape).
-# --------------------------------------------------------------------------------------
-
-
-class ThresholdSelect(Select[SchemaT], Generic[SchemaT]):
-    """``Select`` at :attr:`~langres.core.op.Feasible.THRESHOLD`: keep rows that clear ``threshold``.
-
-    Uses the canonical match rule (:meth:`~langres.core.pairs.PairRow.predicted_match`
-    — decision wins over score, an abstention is dropped) rather than testing
-    ``score >= threshold`` by hand.
-    """
-
-    def __init__(self, threshold: float) -> None:
-        super().__init__(feasible=Feasible.THRESHOLD)
-        self.threshold = threshold
-
-    def forward(self, pairs: Pairs[SchemaT]) -> Pairs[SchemaT]:
-        """Keep the rows whose score clears ``threshold`` (order preserved)."""
-        kept = [row for row in pairs.rows if row.predicted_match(self.threshold) is True]
-        return Pairs(store=pairs.store, rows=kept)
-
-
-class TopKSelect(Select[SchemaT], Generic[SchemaT]):
-    """``Select`` at :attr:`~langres.core.op.Feasible.TOPK`: keep the ``k`` best rows per left id.
-
-    The retrieval / blocking shape — each anchor keeps its ``k`` highest-scoring
-    partners. Grouping by ``left_id`` is exactly "at most k per left record" over
-    the blocker's ``i < j`` pair set; ties keep input order.
-    """
-
-    def __init__(self, k: int) -> None:
-        super().__init__(feasible=Feasible.TOPK)
-        self.k = k
-
-    def forward(self, pairs: Pairs[SchemaT]) -> Pairs[SchemaT]:
-        """Keep at most ``k`` highest-scoring rows per ``left_id`` (input order preserved)."""
-        by_left: dict[str, list[PairRow[SchemaT]]] = defaultdict(list)
-        for row in pairs.rows:
-            by_left[row.left_id].append(row)
-
-        keep: set[tuple[str, str]] = set()
-        for group in by_left.values():
-            ranked = sorted(
-                group,
-                key=lambda row: row.score if row.score is not None else -1.0,
-                reverse=True,
-            )
-            for row in ranked[: self.k]:
-                keep.add((row.left_id, row.right_id))
-
-        kept = [row for row in pairs.rows if (row.left_id, row.right_id) in keep]
-        return Pairs(store=pairs.store, rows=kept)
 
 
 # --------------------------------------------------------------------------------------

--- a/src/langres/core/op.py
+++ b/src/langres/core/op.py
@@ -36,6 +36,7 @@ later wave, so the edge runs one way, into this module.
 from __future__ import annotations
 
 from abc import ABC, abstractmethod
+from collections import defaultdict
 from collections.abc import Sequence
 from dataclasses import dataclass
 from enum import Enum
@@ -43,7 +44,7 @@ from typing import Any, Generic, Literal, TypeAlias, TypeVar, get_args
 
 from pydantic import BaseModel
 
-from langres.core.pairs import Pairs
+from langres.core.pairs import PairRow, Pairs
 from langres.core.score_type import ScoreType
 
 SchemaT = TypeVar("SchemaT", bound=BaseModel)
@@ -71,14 +72,22 @@ GoldenRecord: TypeAlias = BaseModel
 Scope: TypeAlias = Literal["pair", "group", "global"]
 
 #: The score family a :class:`Score` produces: one of the frozen
-#: :data:`~langres.core.score_type.ScoreType` families, or ``"vector"`` when it
+#: :data:`~langres.core.score_type.ScoreType` families, ``"vector"`` when it
 #: emits a :class:`~langres.core.feature.ComparisonVector` (the old Comparator
-#: role — a vector score, ``S = R^d``, which is not orderable).
-OutSpace: TypeAlias = ScoreType | Literal["vector"]
+#: role — a vector score, ``S = R^d``, which is not orderable), or ``"unknown"``
+#: — a scalar-family placeholder for a Score that produces an *orderable* scalar
+#: whose exact family is not (yet) pinned. Unlike ``"vector"``, ``"unknown"`` is
+#: a scalar, so a :class:`Select` may follow it (selection is defined on any
+#: scalar order); it is the honest sentinel for "some scalar score" — never a
+#: real :data:`ScoreType` value borrowed as a stand-in.
+OutSpace: TypeAlias = ScoreType | Literal["vector", "unknown"]
 
 _VALID_SCOPES: frozenset[str] = frozenset(get_args(Scope))
 _SCORE_FAMILIES: frozenset[str] = frozenset(get_args(ScoreType))
-_VALID_OUT_SPACES: frozenset[str] = _SCORE_FAMILIES | {"vector"}
+#: The scalar-family sentinel: an orderable score whose family is not (yet)
+#: pinned. NOT a vector, so it is admissible upstream of a :class:`Select`.
+_UNKNOWN_OUT_SPACE: str = "unknown"
+_VALID_OUT_SPACES: frozenset[str] = _SCORE_FAMILIES | {"vector", _UNKNOWN_OUT_SPACE}
 
 #: The heuristics a raw ``Select(CLUSTERING)`` or a :class:`ClusterStage` may
 #: name. Correlation clustering with real weights is not approximable, so there
@@ -344,6 +353,78 @@ class Select(Op[SchemaT]):
 
 
 # --------------------------------------------------------------------------------------
+# Concrete Selects — the two exact-feasible selections that need no named heuristic.
+# A blocker's top-k prune and a matcher's threshold gate are the SAME select role at
+# two feasibles; both keep a subset of the incoming rows and touch no score.
+# --------------------------------------------------------------------------------------
+
+
+class ThresholdSelect(Select[SchemaT], Generic[SchemaT]):
+    """:class:`Select` at :attr:`Feasible.THRESHOLD`: keep every row that clears ``threshold``.
+
+    The matcher's match gate, as a first-class selection ``Op`` — no shape rule on
+    the kept answer, just "keep the rows that pay the price". It asks the canonical
+    match rule (:meth:`~langres.core.pairs.PairRow.predicted_match` — a ``decision``
+    wins over the score, an abstention is dropped) rather than testing
+    ``score >= threshold`` by hand, so a decider row and an abstaining row are
+    handled exactly as everywhere else in the library.
+
+    Args:
+        threshold: The price a row's score must clear to be kept.
+    """
+
+    def __init__(self, threshold: float) -> None:
+        super().__init__(feasible=Feasible.THRESHOLD)
+        self.threshold = threshold
+
+    def forward(self, pairs: Pairs[SchemaT]) -> Pairs[SchemaT]:
+        """Keep the rows whose ``predicted_match(threshold)`` is ``True`` (order preserved).
+
+        An abstaining row (``predicted_match`` returns ``None``) is dropped — it is
+        never graded a confident "no" — and a decider's explicit ``decision`` wins
+        over its score, exactly as :func:`~langres.core.models.predicted_match`.
+        """
+        kept = [row for row in pairs.rows if row.predicted_match(self.threshold) is True]
+        return Pairs(store=pairs.store, rows=kept)
+
+
+class TopKSelect(Select[SchemaT], Generic[SchemaT]):
+    """:class:`Select` at :attr:`Feasible.TOPK`: keep the ``k`` best rows per left id.
+
+    The retrieval / blocking shape, as a first-class selection ``Op`` — each anchor
+    keeps its ``k`` highest-scoring partners. Grouping by ``left_id`` is exactly
+    "at most k per left record" over a blocker's ``i < j`` pair set; ties keep input
+    order, and a row missing a score sorts last (``score`` read as ``-1.0``).
+
+    Args:
+        k: The maximum number of rows to keep per ``left_id``.
+    """
+
+    def __init__(self, k: int) -> None:
+        super().__init__(feasible=Feasible.TOPK)
+        self.k = k
+
+    def forward(self, pairs: Pairs[SchemaT]) -> Pairs[SchemaT]:
+        """Keep at most ``k`` highest-scoring rows per ``left_id`` (input order preserved)."""
+        by_left: dict[str, list[PairRow[SchemaT]]] = defaultdict(list)
+        for row in pairs.rows:
+            by_left[row.left_id].append(row)
+
+        keep: set[tuple[str, str]] = set()
+        for group in by_left.values():
+            ranked = sorted(
+                group,
+                key=lambda row: row.score if row.score is not None else -1.0,
+                reverse=True,
+            )
+            for row in ranked[: self.k]:
+                keep.add((row.left_id, row.right_id))
+
+        kept = [row for row in pairs.rows if (row.left_id, row.right_id) in keep]
+        return Pairs(store=pairs.store, rows=kept)
+
+
+# --------------------------------------------------------------------------------------
 # Boundary stages — the honest source/sink codomains (NOT Op subclasses: their
 # carriers differ from Pairs -> Pairs).
 # --------------------------------------------------------------------------------------
@@ -480,7 +561,9 @@ class Sequential(Generic[SchemaT]):
         2. **Select on a vector space.** A Select positioned to consume rows a
            Score produced with ``out_space == "vector"``. A ``ComparisonVector``
            (``S = R^d``) is not orderable, so selecting on it is a type error; the
-           fix is a scalarizer Score (vector -> scalar) in between.
+           fix is a scalarizer Score (vector -> scalar) in between. Only ``"vector"``
+           is rejected — a Select after any *scalar* family, including the
+           ``"unknown"`` sentinel, is legal (an orderable scalar admits selection).
 
         Raises:
             ValueError: On any wiring fault, with a problem + cause + fix message.
@@ -507,6 +590,10 @@ class Sequential(Generic[SchemaT]):
             if isinstance(stage, Score):
                 current_space = stage.out_space
             elif isinstance(stage, Select):
+                # Only a vector space is rejected: selection is undefined on a
+                # non-orderable ComparisonVector. Every scalar family is fine, and
+                # so is the ``"unknown"`` sentinel — an orderable scalar whose family
+                # is not yet pinned is still orderable, so a Select may follow it.
                 if current_space == "vector":
                     raise ValueError(_select_on_vector_message(index))
 

--- a/src/langres/core/op.py
+++ b/src/langres/core/op.py
@@ -84,10 +84,9 @@ OutSpace: TypeAlias = ScoreType | Literal["vector", "unknown"]
 
 _VALID_SCOPES: frozenset[str] = frozenset(get_args(Scope))
 _SCORE_FAMILIES: frozenset[str] = frozenset(get_args(ScoreType))
-#: The scalar-family sentinel: an orderable score whose family is not (yet)
-#: pinned. NOT a vector, so it is admissible upstream of a :class:`Select`.
-_UNKNOWN_OUT_SPACE: str = "unknown"
-_VALID_OUT_SPACES: frozenset[str] = _SCORE_FAMILIES | {"vector", _UNKNOWN_OUT_SPACE}
+# "unknown" is the scalar-family sentinel: an orderable score whose family is not
+# (yet) pinned. NOT a vector, so it is admissible upstream of a Select.
+_VALID_OUT_SPACES: frozenset[str] = _SCORE_FAMILIES | {"vector", "unknown"}
 
 #: The heuristics a raw ``Select(CLUSTERING)`` or a :class:`ClusterStage` may
 #: name. Correlation clustering with real weights is not approximable, so there

--- a/tests/core/test_op.py
+++ b/tests/core/test_op.py
@@ -9,12 +9,19 @@ Covers the keystone contract at the core tier (behavior + edges + errors):
   ``is_heuristic``) and the exact-feasible path (no algorithm needed);
 - :class:`ClusterStage` defaulting its algorithm, marking heuristic, and
   rejecting an unknown one (the same validator ``Select(CLUSTERING)`` uses);
+- the concrete W3-b Selects — :class:`ThresholdSelect` (keep the
+  ``predicted_match`` rows: decision-wins, abstain dropped) and
+  :class:`TopKSelect` (keep the k best per ``left_id``);
+- the ``"unknown"`` OutSpace sentinel — a scalar-family placeholder a
+  :class:`Score` may declare, so a :class:`Select` legally follows it while a
+  ``"vector"`` Score still raises;
 - :meth:`Sequential.check` running at construction — a valid pipeline builds; a
   Select-after-vector-Score, a carrier mismatch and a missing Source all raise a
   problem + fix message.
 
-The stages are trivial test doubles (identity ``forward``\\ s), since this wave
-ships the wiring CONTRACT, not the concrete impls or an executor.
+The boundary/``Score`` stages are trivial test doubles (identity ``forward``\\ s),
+since this contract ships no executor; the two concrete Selects are real and
+their ``forward`` selection semantics are exercised on built ``Pairs``.
 """
 
 import pytest
@@ -32,8 +39,10 @@ from langres.core.op import (
     Select,
     Sequential,
     Source,
+    ThresholdSelect,
+    TopKSelect,
 )
-from langres.core.pairs import Pairs
+from langres.core.pairs import PairRow, Pairs
 
 # --------------------------------------------------------------------------------------
 # Test doubles — trivial forwards, one per role/boundary.
@@ -316,3 +325,126 @@ def test_an_unknown_stage_type_raises_typeerror():
 
     with pytest.raises(TypeError, match="not a Source, Op"):
         Sequential([_NotAStage()])  # type: ignore[list-item]
+
+
+# --------------------------------------------------------------------------------------
+# Concrete Selects — ThresholdSelect / TopKSelect (W3-b).
+# --------------------------------------------------------------------------------------
+
+
+def _scored(
+    left: str, right: str, score: float | None, *, decision: bool | None = None
+) -> PairRow[CompanySchema]:
+    """A SCORED heuristic-family row — the input a Select consumes (score_type set)."""
+    return PairRow(
+        left_id=left,
+        right_id=right,
+        blocker_name="test",
+        score=score,
+        score_type="heuristic",
+        decision=decision,
+    )
+
+
+def _pairs(rows: list[PairRow[CompanySchema]]) -> Pairs[CompanySchema]:
+    """A Pairs over a minimal store (a Select reads ids/score/decision, not entities)."""
+    ids = {rid for row in rows for rid in (row.left_id, row.right_id)}
+    return Pairs(store={i: CompanySchema(id=i, name=i) for i in ids}, rows=rows)
+
+
+def test_threshold_and_topk_construct_at_their_feasible():
+    thr = ThresholdSelect[CompanySchema](0.7)
+    assert isinstance(thr, Select) and isinstance(thr, Op)
+    assert thr.feasible is Feasible.THRESHOLD
+    assert thr.threshold == 0.7
+    assert thr.algorithm is None and thr.is_heuristic is False  # exact feasible
+
+    topk = TopKSelect[CompanySchema](3)
+    assert isinstance(topk, Select) and isinstance(topk, Op)
+    assert topk.feasible is Feasible.TOPK
+    assert topk.k == 3
+    assert topk.algorithm is None and topk.is_heuristic is False
+
+
+def test_threshold_select_keeps_exactly_the_predicted_matches():
+    """Keep the ``predicted_match(t) is True`` rows: abstain -> None dropped, decision wins."""
+    pairs = _pairs(
+        [
+            _scored("a", "b", 0.9),  # clears the price -> kept
+            _scored("a", "c", 0.3),  # below the price -> dropped
+            _scored("d", "e", None),  # abstain (no score, no decision) -> dropped, not a "no"
+            _scored("f", "g", 0.1, decision=True),  # decision wins over a low score -> kept
+            _scored("h", "i", 0.99, decision=False),  # decision wins over a high score -> dropped
+        ]
+    )
+    kept = ThresholdSelect[CompanySchema](0.5).forward(pairs)
+
+    # Exactly the predicted matches, in input order.
+    assert [(r.left_id, r.right_id) for r in kept.rows] == [("a", "b"), ("f", "g")]
+    assert all(r.predicted_match(0.5) is True for r in kept.rows)
+    # Entities are carried by reference (never deep-copied).
+    assert all(kept.store[k] is pairs.store[k] for k in pairs.store)
+
+
+def test_topk_select_keeps_the_k_best_rows_per_left_id():
+    """Keep at most k highest-scoring rows per left_id; a smaller group keeps all of it."""
+    pairs = _pairs(
+        [
+            _scored("x", "a", 0.9),  # x: top-2 by score are a(0.9) and c(0.7)
+            _scored("x", "b", 0.5),  # dropped (3rd best for x)
+            _scored("x", "c", 0.7),
+            _scored("x", "d", 0.2),  # dropped (4th best for x)
+            _scored("y", "e", 0.4),  # y has one row < k -> kept
+        ]
+    )
+    kept = TopKSelect[CompanySchema](2).forward(pairs)
+
+    # k best per left_id, and input order preserved among the survivors.
+    assert [(r.left_id, r.right_id) for r in kept.rows] == [("x", "a"), ("x", "c"), ("y", "e")]
+
+
+def test_topk_select_ties_keep_input_order():
+    """On a score tie the earlier (input-order) row wins the last kept slot."""
+    pairs = _pairs(
+        [
+            _scored("x", "a", 0.5),  # tie with b; a appears first -> kept
+            _scored("x", "b", 0.5),  # tie with a; dropped (k=1, a came first)
+        ]
+    )
+    kept = TopKSelect[CompanySchema](1).forward(pairs)
+    assert [(r.left_id, r.right_id) for r in kept.rows] == [("x", "a")]
+
+
+# --------------------------------------------------------------------------------------
+# The "unknown" OutSpace sentinel — a scalar family, so a Select may follow it.
+# --------------------------------------------------------------------------------------
+
+
+def test_score_out_space_may_be_the_unknown_sentinel():
+    score = _Score(scope="pair", out_space="unknown")
+    assert score.out_space == "unknown"
+
+
+def test_select_after_an_unknown_score_is_legal_but_after_a_vector_still_raises():
+    """The sentinel is a scalar: selection is defined on it (unlike a vector)."""
+    # Legal: a Select after a scalar "unknown" Score (a concrete TopKSelect composes too).
+    ok = Sequential(
+        [
+            _Source(),
+            _Score(scope="pair", out_space="unknown"),
+            TopKSelect[CompanySchema](2),
+            _ClusterStage(),
+        ]
+    )
+    assert any(isinstance(stage, TopKSelect) for stage in ok.stages)
+
+    # Still illegal: a Select after a "vector" Score (a ComparisonVector is not orderable).
+    with pytest.raises(ValueError, match="not orderable"):
+        Sequential(
+            [
+                _Source(),
+                _Score(scope="pair", out_space="vector"),
+                ThresholdSelect[CompanySchema](0.5),
+                _ClusterStage(),
+            ]
+        )


### PR DESCRIPTION
## W3-b: concrete `Select` (Threshold/TopK) + honest `OutSpace` sentinel

Additive `op.py` leaf change — no spine edits, nothing breaking. Base is
`epic/193-core-algebra` (NOT main).

### What changed

**1. Concrete `Select` subclasses in `op.py`.** `Select` was an abstract role
(it validated the `Feasible` in `__init__` but never implemented `forward`, so
`Select(...)` raised `TypeError`). Lifted the two real selection ops from the
working `examples/op_reranker_expressiveness.py` into src:

- `ThresholdSelect(threshold)` — `Feasible.THRESHOLD`; keeps rows where
  `row.predicted_match(threshold) is True` (decision wins over score, an
  abstention returns `None` and is dropped — never graded a confident "no").
- `TopKSelect(k)` — `Feasible.TOPK`; keeps each `left_id`'s `k` highest-scoring
  rows (ties keep input order; a missing score sorts last).

`op.py` stays a **strict leaf**: the only new imports are `PairRow` (sibling
`pairs` leaf, already the source of `Pairs`) and stdlib `defaultdict`. Nothing
from matcher/blocker/comparator/clusterer/resolver.

**2. Honest `"unknown"` `OutSpace` sentinel.** Added a non-vector scalar-family
placeholder to `OutSpace` / `_VALID_OUT_SPACES`. `Sequential.check` already
discriminated on `== "vector"`, so a `Select` after an `"unknown"` `Score` is
legal (an orderable scalar admits selection) while a `Select` after `"vector"`
still raises (π on ℝ^d is a type error). Documented the intent at the guard and
in the `check` docstring. This is the honest replacement for using the real
`"heuristic"` family as a stand-in; W3-c will use it.

**3. Example imports from src.** Deleted the local `ThresholdSelect`/`TopKSelect`
defs in `examples/op_reranker_expressiveness.py`; it now imports both from
`langres.core.op`. Docstring updated ("selection is now first-class"). The
matcher's `out_space="heuristic"` is left as-is — `RapidfuzzMatcher` genuinely
emits the `heuristic` family (verified in `test_op_adapters`), so it is honest
there, not a placeholder.

**4. Tests** (`tests/core/test_op.py`): `ThresholdSelect.forward` keeps exactly
the `predicted_match(t) is True` rows (abstain→None dropped, decision-wins both
ways); `TopKSelect.forward` keeps `k` best per `left_id` + tie order;
construction validates the `Feasible`; the `"unknown"` sentinel makes a `Select`
legal after a scalar `Score` while `"vector"` still raises.

### Gates (local, extras installed to match the CI fast job)

- Full fast suite: **3769 passed, 2 skipped, 0 failed** (`uv sync --all-extras
  --no-extra finetune`, `-m "not integration and not slow and not finetune"`).
- `tests/core/test_op.py` + `tests/examples/test_op_reranker_expressiveness.py`: green.
- `mypy src`: clean. `ruff format`/`check`: clean.
- Import gates (`test_import_budget` / `test_import_tangle` / `test_import_graph`):
  green — `op.py` stays a leaf, no new module (no `refactor_target_packages.json`
  change needed).
- Example runs end-to-end at $0; reranker still recovers the true merges.

https://claude.ai/code/session_011XYuhyiigi1Bw2YnWCxMr9
