### PR TITLE
W3-d: explicit match cut (ThresholdSelect) + pure-equivalence clustering — #193

### DIFF
--- a/src/langres/core/_model_run.py
+++ b/src/langres/core/_model_run.py
@@ -509,9 +509,13 @@ class ModelRun(ModelState):
         threshold, followed by pure-equivalence
         :class:`~langres.core.op_adapters.ClustererStage` clustering over the
         survivors, per ``docs/THEORY.md``'s Select-π vs equivalence-π split).
-        Singletons are dropped by the Clusterer (it returns only connected
-        components with an edge), so the result contains only multi-record
-        clusters.
+        The output is whatever the (zeroed) equivalence clusterer returns over
+        the selected edges: the base connected-components
+        :class:`~langres.core.clusterer.Clusterer` emits only multi-record
+        clusters (an isolated record never enters the graph), whereas a pivot
+        :class:`~langres.core.clusterers.correlation.CorrelationClusterer` can
+        leave a singleton behind -- a record with a qualifying edge whose only
+        neighbours an earlier pivot already claimed.
 
         Args:
             records: Raw records (dicts) in a stable list order.

--- a/src/langres/core/_model_run.py
+++ b/src/langres/core/_model_run.py
@@ -497,7 +497,7 @@ class ModelRun(ModelState):
         :meth:`_scored_pairs`'s output), so the cut thresholds the CALIBRATED
         score, exactly as the clusterer did.
         """
-        selected = ThresholdSelect(self.clusterer.threshold).forward(scored_pairs)
+        selected: Pairs[Any] = ThresholdSelect(self.clusterer.threshold).forward(scored_pairs)
         return ClustererStage(self._closure_clusterer()).forward(selected)
 
     def resolve(self, records: list[Any]) -> list[set[str]]:

--- a/src/langres/core/_model_run.py
+++ b/src/langres/core/_model_run.py
@@ -20,8 +20,13 @@ adapters** (:mod:`langres.core.op_adapters`), derived from the four slots
 (:meth:`ModelRun._candidates`); :class:`~langres.core.op_adapters.MatcherScore`
 wraps the spend-capped, optionally-logged matcher (:meth:`ModelRun._matcher_score`
 over :meth:`ModelRun._scorer`) into the scoring half (:meth:`ModelRun._scored_pairs`);
-:class:`~langres.core.op_adapters.ClustererStage` is the exit
-(:meth:`ModelRun.resolve` / :meth:`ModelRun.dedupe`). The one per-call factory
+and the exit (:meth:`ModelRun._cluster`, shared by :meth:`ModelRun.resolve` /
+:meth:`ModelRun.dedupe`) is the two selections ``docs/THEORY.md`` separates -- an
+explicit match cut (:class:`~langres.core.op.ThresholdSelect`, the selection π at
+feasible-class THRESHOLD) THEN
+:class:`~langres.core.op_adapters.ClustererStage` over a threshold-zeroed clone of
+the clusterer (the equivalence π: pure transitive closure / pivot, no internal
+cut). The one per-call factory
 :meth:`ModelRun._stages` assembles the block -> (compare) -> score stages from the
 slots (W3-c), and the generic driver :func:`_run_stages` folds ``forward`` across
 them. The slots stay the source of truth -- the stages are assembled from them
@@ -58,6 +63,7 @@ from typing import TYPE_CHECKING, Any, cast
 
 from langres.core._model_state import ModelState
 from langres.core.blockers.composite import CompositeBlocker
+from langres.core.clusterer import Clusterer
 from langres.core.fit import CalibratorFitMixin
 from langres.core.inputs import check_no_duplicate_ids
 from langres.tracking.judgement_log import JudgementLog, LoggingMatcher
@@ -67,7 +73,7 @@ from langres.core.models import (
     PairwiseJudgement,
     predicted_match,
 )
-from langres.core.op import Score, Source
+from langres.core.op import Score, Source, ThresholdSelect
 from langres.core.op_adapters import (
     BlockerSource,
     ClustererStage,
@@ -451,15 +457,61 @@ class ModelRun(ModelState):
         """
         return list(self._judgements(records))
 
+    def _closure_clusterer(self) -> Clusterer:
+        """A pure-equivalence clone of this model's clusterer, its threshold zeroed.
+
+        Clones the clusterer's OWN class through ``config``/``from_config`` -- NOT
+        the base :class:`~langres.core.clusterer.Clusterer` -- so a
+        :class:`~langres.core.clusterers.correlation.CorrelationClusterer` stays a
+        *pivot* clusterer rather than being silently downgraded to transitive
+        closure (which would merge pivot-split chains that must stay separate).
+        The threshold is zeroed because the match cut already ran in
+        :meth:`_cluster` (a :class:`~langres.core.op.ThresholdSelect`); this clone
+        does pure equivalence over the survivors and must not re-threshold.
+
+        It is a FRESH instance -- ``self.clusterer`` keeps its real threshold: the
+        ThresholdSelect reads it, and ``dedupe``'s ``DedupeResult`` reports it.
+        """
+        return type(self.clusterer).from_config({**self.clusterer.config, "threshold": 0.0})
+
+    def _cluster(self, scored_pairs: Pairs[Any]) -> list[set[str]]:
+        """The pipeline exit: match cut (Select at THRESHOLD) THEN pure clustering.
+
+        The two selections ``docs/THEORY.md`` separates, made explicit (epic #193,
+        W3-d), shared by :meth:`resolve` and :meth:`dedupe`. The **match cut** is a
+        :class:`~langres.core.op.ThresholdSelect` -- a ``Select`` at feasible-class
+        THRESHOLD (the theory's selection π) keeping exactly the rows whose score
+        clears ``self.clusterer.threshold`` (via
+        :func:`~langres.core.models.predicted_match`: a decider's decision wins, an
+        abstention is dropped). The **clustering** is then a separate equivalence π
+        -- transitive closure, or pivot for a ``CorrelationClusterer`` -- run by a
+        clusterer with NO threshold of its own (:meth:`_closure_clusterer`).
+
+        Byte-identical to the legacy ``ClustererStage(self.clusterer)`` that kept
+        the cut folded inside the clusterer's threshold: ``predicted_match(j, t) is
+        True`` implies ``predicted_match(j, 0.0) is True`` (a decision is
+        threshold-independent; else ``score >= t`` implies ``score >= 0``), so the
+        zeroed clone's own filter is redundant given the ThresholdSelect and the
+        surviving edge set is unchanged -- for transitive closure AND for pivot.
+        ``scored_pairs`` must already be calibrated (callers pass
+        :meth:`_scored_pairs`'s output), so the cut thresholds the CALIBRATED
+        score, exactly as the clusterer did.
+        """
+        selected = ThresholdSelect(self.clusterer.threshold).forward(scored_pairs)
+        return ClustererStage(self._closure_clusterer()).forward(selected)
+
     def resolve(self, records: list[Any]) -> list[set[str]]:
         """Resolve records into entity clusters (sets of IDs).
 
         Orchestrates blocking -> (compare) -> score -> cluster through the Op
-        adapters (:meth:`_scored_pairs` +
-        :class:`~langres.core.op_adapters.ClustererStage`, the pipeline exit that
-        keeps the match cut folded in the ``Clusterer``'s threshold). Singletons
-        are dropped by the Clusterer (it returns only connected components with an
-        edge), so the result contains only multi-record clusters.
+        adapters (:meth:`_scored_pairs`, then :meth:`_cluster` -- the explicit
+        match cut, a :class:`~langres.core.op.ThresholdSelect` at the clusterer's
+        threshold, followed by pure-equivalence
+        :class:`~langres.core.op_adapters.ClustererStage` clustering over the
+        survivors, per ``docs/THEORY.md``'s Select-π vs equivalence-π split).
+        Singletons are dropped by the Clusterer (it returns only connected
+        components with an edge), so the result contains only multi-record
+        clusters.
 
         Args:
             records: Raw records (dicts) in a stable list order.
@@ -467,7 +519,7 @@ class ModelRun(ModelState):
         Returns:
             A list of clusters, each a set of entity IDs.
         """
-        return ClustererStage(self.clusterer).forward(self._scored_pairs(records))
+        return self._cluster(self._scored_pairs(records))
 
     # ------------------------------------------------------------------
     # The front door: dedupe a batch / compare one pair
@@ -533,7 +585,11 @@ class ModelRun(ModelState):
         normalized = self._prepare(records)
         check_no_duplicate_ids([record["id"] for record in normalized])
         pairs = self._scored_pairs(normalized, log=_coerce_log(log))
-        clusters = ClustererStage(self.clusterer).forward(pairs)
+        # The pipeline exit: an explicit match cut (ThresholdSelect at the
+        # clusterer's threshold) THEN pure-equivalence clustering over the
+        # survivors (THEORY.md's Select π vs equivalence π); byte-identical to the
+        # legacy clusterer-owned cut -- see _cluster.
+        clusters = self._cluster(pairs)
         # The scored rows' OWN score_type, not a per-name lookup table: the
         # matcher that ran is the only honest authority on what its scores mean.
         # The first scored row is the first candidate's judgement (one judgement

--- a/tests/parity/test_match_cut_correlation_w3d.py
+++ b/tests/parity/test_match_cut_correlation_w3d.py
@@ -1,0 +1,129 @@
+"""CorrelationClusterer match-cut parity net for epic #193 -- the W3-d trap guard.
+
+W3-d splits the fused match-cut-and-cluster in the ``resolve()`` / ``dedupe()``
+spine into the two selections ``docs/THEORY.md`` separates: an explicit
+:class:`~langres.core.op.ThresholdSelect` (the selection π at feasible-class
+THRESHOLD) THEN pure-equivalence clustering over the survivors by a clusterer
+with NO threshold of its own (:meth:`~langres.core._model_run.ModelRun._cluster`
+over :meth:`~langres.core._model_run.ModelRun._closure_clusterer`).
+
+The two W0/cascade goldens (``test_behavior_parity_w0`` /
+``test_behavior_parity_cascade_w3d``) exercise only the DEFAULT transitive-closure
+:class:`~langres.core.clusterer.Clusterer`, so they cannot catch the one thing the
+rewire is most likely to get wrong: the closure clusterer must be a clone of the
+clusterer's OWN class, not a hardcoded base ``Clusterer``. A
+:class:`~langres.core.clusterers.correlation.CorrelationClusterer` does PIVOT
+clustering, not transitive closure; downgrading it to the base class would merge
+pivot-split chains that must stay separate -- and it would still pass both goldens
+(they use the default clusterer), failing only a test that actually runs a
+``CorrelationClusterer`` through the spine. This is that test.
+
+The fixture is the classic over-merge chain: ``a-b`` and ``b-c`` both clear the
+threshold, but there is NO direct ``a-c`` edge. Pivot clustering keeps ``{a, b}``
+and ``{c}`` apart; transitive closure (the trap) would merge all three into
+``{a, b, c}``. The test asserts the real spine helper reproduces the pivot split
+and NOT the transitive-closure merge, so a revert of ``_closure_clusterer`` to a
+hardcoded ``Clusterer`` turns it red.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from langres.core.clusterer import Clusterer
+from langres.core.clusterers.correlation import CorrelationClusterer
+from langres.core.models import CompanySchema
+from langres.core.op import ThresholdSelect
+from langres.core.op_adapters import ClustererStage
+from langres.core.pairs import PairRow, Pairs
+from langres.core.resolver import Resolver
+
+_THRESHOLD = 0.8
+
+
+def _sorted(clusters: list[set[str]]) -> list[list[str]]:
+    """Order-independent view of a clustering, for equality assertions."""
+    return sorted(sorted(cluster) for cluster in clusters)
+
+
+def _chain_pairs() -> Pairs[CompanySchema]:
+    """A scored ``Pairs`` for the over-merge chain a-b, b-c (NO direct a-c edge).
+
+    Both edges score 0.9 (>= the 0.8 threshold). Pivot clustering splits this into
+    ``{a, b}`` / ``{c}``; transitive closure merges it into ``{a, b, c}`` -- the
+    exact input that distinguishes the two clustering algorithms.
+    """
+    store = {rid: CompanySchema(id=rid, name=rid) for rid in ("a", "b", "c")}
+    rows = [
+        PairRow(left_id="a", right_id="b", blocker_name="test", score=0.9, score_type="heuristic"),
+        PairRow(left_id="b", right_id="c", blocker_name="test", score=0.9, score_type="heuristic"),
+    ]
+    return Pairs(store=store, rows=rows)
+
+
+@pytest.fixture
+def correlation_model() -> Resolver:
+    """A real spine (blocker+comparator+matcher wired) with a CorrelationClusterer slot.
+
+    Built through the ordinary ``from_schema`` door, then its clusterer slot is
+    swapped for a ``CorrelationClusterer`` -- so ``_cluster`` / ``_closure_clusterer``
+    run exactly as they do in production, over a pivot clusterer.
+    """
+    model = Resolver.from_schema(CompanySchema, matcher="string", threshold=_THRESHOLD)
+    model.clusterer = CorrelationClusterer(threshold=_THRESHOLD)
+    return model
+
+
+def test_closure_clusterer_clones_the_clusterers_own_class(correlation_model: Resolver) -> None:
+    """``_closure_clusterer`` returns a threshold-zeroed clone of the OWN class.
+
+    The core of the trap guard: for a ``CorrelationClusterer`` slot the closure
+    clusterer must itself be a ``CorrelationClusterer`` (a pivot clusterer), not a
+    base ``Clusterer`` -- and its threshold is zeroed because the match cut already
+    ran. ``self.clusterer`` is untouched (still holds its real threshold).
+    """
+    closure = correlation_model._closure_clusterer()
+
+    assert type(closure) is CorrelationClusterer  # the OWN class, not base Clusterer
+    assert closure.threshold == 0.0
+    # self.clusterer is not mutated -- it keeps its real threshold.
+    assert correlation_model.clusterer.threshold == _THRESHOLD
+    assert type(correlation_model.clusterer) is CorrelationClusterer
+
+
+def test_cluster_matches_legacy_clusterer_owned_cut(correlation_model: Resolver) -> None:
+    """The W3-d ``_cluster`` path == the legacy ``ClustererStage(CorrelationClusterer(t))``.
+
+    Legacy folded the match cut inside the clusterer's threshold; W3-d makes it an
+    explicit ThresholdSelect then runs a zeroed pivot clone. The clusters must be
+    byte-identical -- and specifically the pivot split ``{a, b}`` / ``{c}``.
+    """
+    pairs = _chain_pairs()
+
+    # Legacy oracle: the clusterer owned the cut (threshold=_THRESHOLD), no Select.
+    legacy = ClustererStage(CorrelationClusterer(threshold=_THRESHOLD)).forward(pairs)
+    # W3-d: the real spine helper (ThresholdSelect -> zeroed pivot clone).
+    got = correlation_model._cluster(pairs)
+
+    assert _sorted(got) == _sorted(legacy)
+    assert _sorted(got) == [["a", "b"], ["c"]]  # pivot split, NOT the merged chain
+
+
+def test_the_trap_would_produce_the_wrong_merged_chain(correlation_model: Resolver) -> None:
+    """Documents the trap: a hardcoded base ``Clusterer(0.0)`` merges the whole chain.
+
+    The teeth of the test made explicit -- if ``_closure_clusterer`` were reverted
+    to a hardcoded ``Clusterer``, the closure step would be transitive closure and
+    merge ``{a, b, c}``. The real path must differ from that wrong answer.
+    """
+    pairs = _chain_pairs()
+    selected = ThresholdSelect(_THRESHOLD).forward(pairs)
+
+    # What the hardcoded-Clusterer trap would yield: transitive closure over-merges.
+    trap = ClustererStage(Clusterer(threshold=0.0)).forward(selected)
+    assert _sorted(trap) == [["a", "b", "c"]]
+
+    # The real W3-d path avoids it (stays a pivot clusterer).
+    got = correlation_model._cluster(pairs)
+    assert _sorted(got) != _sorted(trap)
+    assert _sorted(got) == [["a", "b"], ["c"]]


### PR DESCRIPTION
## W3-d: explicit match cut (`ThresholdSelect`) + pure-equivalence clustering — #193

Splits the fused match-cut-and-cluster in the `resolve()`/`dedupe()` spine into the two selections `docs/THEORY.md` separates: an explicit **match cut** (`ThresholdSelect` at the clusterer's threshold — the selection π at feasible-class THRESHOLD) THEN **pure-equivalence clustering** over the survivors by a clusterer with no threshold of its own (the equivalence π: transitive closure / pivot).

### The rewire
One helper both `resolve()` and `dedupe()` now use, replacing the inline `ClustererStage(self.clusterer).forward(<scored pairs>)`:

```python
def _closure_clusterer(self) -> Clusterer:
    return type(self.clusterer).from_config({**self.clusterer.config, "threshold": 0.0})

def _cluster(self, scored_pairs):
    selected = ThresholdSelect(self.clusterer.threshold).forward(scored_pairs)
    return ClustererStage(self._closure_clusterer()).forward(selected)
```

**The trap avoided:** the closure clusterer is a clone of the clusterer's **OWN class** (`type(self.clusterer).from_config`), NOT a hardcoded base `Clusterer`. Hardcoding the base would silently downgrade a `CorrelationClusterer` (pivot) to transitive closure — merging pivot-split chains — and would still pass both existing goldens (they use the default `Clusterer`).

### Byte-parity argument
`predicted_match(j, t) is True ⟹ predicted_match(j, 0.0) is True` (a decision is threshold-independent; else `score >= t ⟹ score >= 0`). `self.threshold` is used in exactly one place per clusterer — the `predicted_match(t) is True` pre-filter — so the zeroed clone's own filter is redundant given the `ThresholdSelect`, and the surviving edge set is identical for **both** `Clusterer` and `CorrelationClusterer`. The `ThresholdSelect` is inserted AFTER calibration (operates on `_scored_pairs`' calibrated output). `self.clusterer` is never mutated (keeps its real threshold for `ThresholdSelect` and `DedupeResult`). `compare()` is untouched — it terminates at scoring and uses `predicted_match` directly, never routing through the clusterer.

### Tests
- **New:** `tests/parity/test_match_cut_correlation_w3d.py` — runs a `CorrelationClusterer` (pivot) through the real spine `_cluster` on the classic a-b-c chain (no direct a-c edge) and asserts the pivot split `{a,b}/{c}`, not the transitive-closure merge `{a,b,c}` the trap would produce. **Confirmed it has teeth:** all 3 cases go red when `_closure_clusterer` is reverted to a hardcoded `Clusterer`.
- Parity gates green: `test_behavior_parity_w0`, `test_behavior_parity_cascade_w3d`, `test_groupwise_spine_w3a`.
- Targeted: `test_op_adapters`, `test_op`, `test_clusterer`, `test_correlation_clusterer`, `test_resolver_spend_cap` (133 passed).
- Full fast suite: **3776 passed, 2 skipped**; import gates green; `mypy --strict` + `ruff` clean.

### Behavior proof (before == after)
`before` = the exact `ClustererStage(self.clusterer).forward(...)` line W3-d replaced; `after` = `_cluster`; both computed on the same scored pairs plus `resolve()` end-to-end:
- Real `$0` `FuzzyString().dedupe` (parity records, default `Clusterer`): `[['b01','b02'],['b03','b04'],['b05','b06'],['b07','b08']]` — identical.
- Real `CorrelationClusterer` pipeline on a chain (a-b=0.9, b-c=0.9, a-c=0.1): `[['a','b'],['c']]` — identical; closure clone is a `CorrelationClusterer` @ threshold 0.0, `self.clusterer` unchanged @ 0.5; base transitive-closure `Clusterer` merges the same chain to `[['a','b','c']]`.

Base branch: `epic/193-core-algebra`. Diff: 2 files, +195/-10.

https://claude.ai/code/session_011XYuhyiigi1Bw2YnWCxMr9
