### PR TITLE
W3-f: VectorLLMCascade.save() round-trips via a named blocking extractor (#193)

### DIFF
--- a/src/langres/architectures/vector_llm_cascade.py
+++ b/src/langres/architectures/vector_llm_cascade.py
@@ -7,7 +7,6 @@ other code also knows how to build.
 
 from __future__ import annotations
 
-from pathlib import Path
 from typing import Any, ClassVar
 
 from pydantic import BaseModel
@@ -67,23 +66,15 @@ class VectorLLMCascade(ERModel):
     Both are :class:`~langres.core.model_ref.ModelRef`\\ s, so both are
     **weightless**: neither carries weight bytes, only a reference string.
 
-    .. warning::
-       **This architecture cannot** ``save()`` **yet** -- it raises
-       :class:`NotImplementedError` with the reason. Its ``VectorBlocker`` is
-       built with a ``text_field_extractor`` closure (blocking text = every
-       comparable field concatenated), and a callable cannot round-trip through
-       JSON config. This is a **pre-existing limitation inherited from the
-       deleted ``presets``/``_build_embedding_blocker`` path, not a W4
-       regression** -- that path never called ``save()``, so it never surfaced.
-       What W4 changed is that this is now a named class that *looks* like it
-       persists, so the gap is stated rather than discovered at runtime.
-
-       The fix is a named-extractor seam mirroring the one
-       :class:`~langres.core.matchers.llm_judge.LLMMatcher` already has for
-       ``response_parser`` (accept ``Callable | str``, resolve a registered name,
-       serialize the name). Deliberately deferred: it changes what
-       ``VectorBlocker`` accepts, in the paid path. ``FuzzyString`` round-trips
-       today and proves the mechanism.
+    **It persists.** ``save()``/``load()`` round-trip like any other
+    architecture (inherited from :meth:`~langres.core.resolver.ERModel.save`).
+    The ``VectorBlocker``'s multi-field blocking text is a **named**, registered
+    extractor (``core.blockers.vector.concat_comparable_fields``) rather than a
+    closure, so it serializes as a name and reloads intact -- mirroring the
+    named-callable seam :class:`~langres.core.matchers.llm_judge.LLMMatcher` uses
+    for ``response_parser``. Pass ``schema=`` (not an inferred one) for anything
+    you intend to ``save`` -- an inferred schema is an ephemeral class a fresh
+    process cannot import back.
 
     **Where the money goes.** The student scores every blocked pair for free; only
     pairs in ``escalation_band`` reach the LLM. Cost therefore tracks the *band
@@ -194,32 +185,6 @@ class VectorLLMCascade(ERModel):
         llm: ModelRef | None = getattr(self, "llm", None)
         return None if llm is None else llm.base
 
-    def save(self, path: str | Path) -> None:
-        """Not supported yet -- fails with the reason instead of a confusing one.
-
-        Without this override the user gets ``VectorBlocker``'s own error, which
-        tells them to "construct with schema= and text_field= to persist" -- an
-        instruction they cannot act on, because they never constructed the
-        ``VectorBlocker``; :meth:`_topology` did. Raising here names the real
-        situation at the layer the user is actually holding.
-
-        Raises:
-            NotImplementedError: Always. See the class docstring's warning for
-                why, and for the named-extractor seam that would fix it.
-        """
-        raise NotImplementedError(
-            "VectorLLMCascade cannot be saved yet: its VectorBlocker uses a "
-            "text_field_extractor closure (blocking text = every comparable field "
-            "concatenated) and a callable cannot round-trip through JSON config. "
-            "This is a known gap inherited from the pre-W4 embedding path, not a "
-            "property of your model. FuzzyString saves and loads today. To persist "
-            "an embedding pipeline now, build a Resolver/ERModel directly via "
-            "ERModel.from_components(...) with a VectorBlocker constructed as "
-            "VectorBlocker(vector_index=..., schema=..., text_field='your_text_field') "
-            "-- text_field takes the NAME of one text field on your schema (e.g. "
-            "'name'), and a named field is serializable, unlike a closure."
-        )
-
     def _topology(self, schema: type[BaseModel]) -> dict[str, Any]:
         """Build the four slots for ``schema``. Called once, on binding.
 
@@ -236,22 +201,18 @@ class VectorLLMCascade(ERModel):
         from langres.core.matchers.llm_judge import LLMMatcher
 
         comparator: StringComparator[Any] = StringComparator.from_schema(schema)
-        field_names = [spec.name for spec in comparator.feature_specs]
-
-        def extract(entity: Any) -> str:
-            """Concatenate every comparable string field into one blocking text."""
-            parts = [
-                str(getattr(entity, name)) for name in field_names if getattr(entity, name, None)
-            ]
-            return " ".join(parts)
 
         index = FAISSIndex(
             embedder=SentenceTransformerEmbedder(self.embedder.base), metric="cosine"
         )
+        # The blocking text is every comparable string field concatenated. Passed
+        # by REGISTERED NAME, not a closure, so the blocker (and therefore this
+        # whole model) round-trips through ``save``/``load`` -- see
+        # ``core.blockers.vector.concat_comparable_fields``.
         blocker = VectorBlocker(
             vector_index=index,
             schema=schema,
-            text_field_extractor=extract,
+            text_field_extractor="concat_comparable_fields",
             k_neighbors=self.k_neighbors,
         )
         student: EmbeddingScoreMatcher[Any] = EmbeddingScoreMatcher(threshold=self.threshold)

--- a/src/langres/core/blockers/vector.py
+++ b/src/langres/core/blockers/vector.py
@@ -24,6 +24,7 @@ from langres.core.blockers.all_pairs import (
 from langres.core.groups import ERCandidateGroup
 from langres.core.indexes.vector_index import VectorIndex
 from langres.core.models import ERCandidate
+from langres.core.named_callable import resolve_named
 from langres.core.registry import (
     UnknownComponentType,
     get_component,
@@ -82,6 +83,43 @@ def _index_config_dict(index: object) -> dict[str, object]:
     if isinstance(raw, BaseModel):
         return raw.model_dump()
     return dict(raw)
+
+
+def concat_comparable_fields(entity: Any) -> str:
+    """Blocking text = every comparable string field, space-joined.
+
+    The serializable, *named* replacement for the multi-field extractor closure
+    the embedding architectures (e.g.
+    :class:`~langres.architectures.vector_llm_cascade.VectorLLMCascade`) used to
+    build inline. A closure cannot round-trip through JSON config -- this can,
+    because it is referenced by name (see :data:`TEXT_FIELD_EXTRACTORS`).
+
+    It reproduces that closure **byte-for-byte**: the field set is
+    ``StringComparator.from_schema(...).feature_specs`` (the ``str | None`` fields
+    except ``id``, in schema-declaration order), each present (truthy) field's
+    value is ``str()``-cast, falsy values are skipped, and the parts are joined
+    with a single space. Because a named module-level function cannot close over a
+    per-schema field list, it derives the field set from ``type(entity)`` at call
+    time -- identical to the closure whenever the blocker's ``schema_factory``
+    builds ``schema`` instances, which it does (see
+    :func:`~langres.core.blockers.all_pairs.schema_to_factory`).
+    """
+    from langres.core.comparators import StringComparator
+
+    field_names = [spec.name for spec in StringComparator.from_schema(type(entity)).feature_specs]
+    parts = [str(getattr(entity, name)) for name in field_names if getattr(entity, name, None)]
+    return " ".join(parts)
+
+
+#: Named ``text_field_extractor`` registry -- the same serialization contract as
+#: ``llm_judge.RESPONSE_PARSERS`` / ``RECORD_SERIALIZERS`` (both resolved by the
+#: shared :func:`~langres.core.named_callable.resolve_named`): a name here is
+#: accepted as ``VectorBlocker(text_field_extractor="concat_comparable_fields")``
+#: and, unlike a bare closure, round-trips in :attr:`VectorBlocker.config`. Add an
+#: entry to make a multi-field extractor name-selectable and serializable.
+TEXT_FIELD_EXTRACTORS: dict[str, Callable[[Any], str]] = {
+    "concat_comparable_fields": concat_comparable_fields,
+}
 
 
 @register("vector_blocker")
@@ -212,7 +250,7 @@ class VectorBlocker(Blocker[SchemaT]):
         vector_index: VectorIndex,
         schema_factory: Callable[[dict[str, Any]], SchemaT] | None = None,
         schema: type[SchemaT] | None = None,
-        text_field_extractor: Callable[[SchemaT], str] | None = None,
+        text_field_extractor: Callable[[SchemaT], str] | str | None = None,
         text_field: str | None = None,
         k_neighbors: int = 10,
         query_prompt: str | None = None,
@@ -225,11 +263,17 @@ class VectorBlocker(Blocker[SchemaT]):
         - ``schema=`` + ``text_field=`` (declarative): entities are rebuilt as
           ``schema(**{f: record.get(f) for f in schema.model_fields})`` and text
           is ``getattr(entity, text_field)``. This form is **config-serializable**.
-        - ``schema_factory=`` + ``text_field_extractor=`` (callables): full
-          control, but **not serializable** (callables can't round-trip).
+        - ``schema=`` + ``text_field_extractor="<name>"`` (a registered name, see
+          :data:`TEXT_FIELD_EXTRACTORS` -- e.g. ``"concat_comparable_fields"``):
+          full multi-field extraction that is **still config-serializable**,
+          because the name (not the callable) is what round-trips.
+        - ``schema_factory=`` + ``text_field_extractor=<callable>`` (an
+          unregistered callable): full control, but **not serializable**
+          (a bare callable can't round-trip).
 
         The two styles can be mixed per-axis, but a blocker only serializes if
-        **both** axes are declarative.
+        **both** axes are declarative (a schema type + a ``text_field`` name or a
+        registered ``text_field_extractor`` name).
 
         Args:
             vector_index: Index for ANN search on embeddings. The index owns the
@@ -239,9 +283,13 @@ class VectorBlocker(Blocker[SchemaT]):
                 exclusive with ``schema``.
             schema: Pydantic schema class for declarative reconstruction.
                 Mutually exclusive with ``schema_factory``.
-            text_field_extractor: Callable extracting embed-text from a SchemaT
-                (e.g. ``lambda x: x.name``). Mutually exclusive with
-                ``text_field``.
+            text_field_extractor: Either a registered extractor *name* (see
+                :data:`TEXT_FIELD_EXTRACTORS`, e.g. ``"concat_comparable_fields"``
+                -- serializable) or a callable extracting embed-text from a
+                SchemaT (e.g. ``lambda x: x.name`` -- opaque, not serializable).
+                A registered name (or one of the registered callables) round-trips
+                in :attr:`config`; an unregistered callable does not. Mutually
+                exclusive with ``text_field``.
             text_field: Attribute name to read embed-text from each entity.
                 Mutually exclusive with ``text_field_extractor``.
             k_neighbors: Number of nearest neighbors per entity. Higher = better
@@ -277,15 +325,21 @@ class VectorBlocker(Blocker[SchemaT]):
             assert schema_factory is not None  # narrowed by the guard above
             self.schema_factory = schema_factory
 
-        # Text axis: declarative form records the field name to read.
+        # Text axis: a declarative form records what serializes -- the field NAME
+        # (``text_field``) or the registered extractor NAME
+        # (``text_field_extractor="..."``). A bare callable extractor stays opaque
+        # (it runs, but ``_extractor_name`` is None so ``config`` refuses it).
         self._text_field: str | None = text_field
+        self._extractor_name: str | None = None
         self.text_field_extractor: Callable[[SchemaT], str]
         if text_field is not None:
             field = text_field
             self.text_field_extractor = lambda entity: str(getattr(entity, field))
         else:
             assert text_field_extractor is not None  # narrowed by the guard
-            self.text_field_extractor = text_field_extractor
+            self.text_field_extractor, self._extractor_name = resolve_named(
+                text_field_extractor, TEXT_FIELD_EXTRACTORS, kind="text_field_extractor"
+            )
 
         self.vector_index = vector_index
         self.k_neighbors = k_neighbors
@@ -295,7 +349,9 @@ class VectorBlocker(Blocker[SchemaT]):
     def config(self) -> dict[str, object]:
         """Serializable construction config for the registry.
 
-        Returns a mapping with the schema type name, the text field, the
+        Returns a mapping with the schema type name, the text axis (either
+        ``text_field`` -- a field name -- or ``text_field_extractor`` -- a
+        registered extractor name; the unused one is ``None``), the
         ``k_neighbors`` / ``query_prompt`` knobs, and the vector index nested as
         a :class:`~langres.core.serialization.ComponentSpec` (the index's own
         ``type_name`` + ``config``). The index's out-of-band state (e.g. a built
@@ -303,16 +359,22 @@ class VectorBlocker(Blocker[SchemaT]):
         :class:`~langres.core.serialization.SerializableState`, not here.
 
         Raises:
-            ValueError: If the blocker was built with a ``schema_factory`` or a
-                ``text_field_extractor`` (opaque callables). Construct with
-                ``schema=`` and ``text_field=`` to persist.
+            ValueError: If the blocker was built with a ``schema_factory`` or an
+                *unregistered* ``text_field_extractor`` callable (opaque callables
+                can't round-trip). Construct with ``schema=`` and either
+                ``text_field=`` or a registered ``text_field_extractor`` name to
+                persist.
         """
-        if self._schema_type_name is None or self._text_field is None:
+        if self._schema_type_name is None or (
+            self._text_field is None and self._extractor_name is None
+        ):
             raise ValueError(
-                "VectorBlocker built with 'schema_factory' or "
-                "'text_field_extractor' is not serializable (callables cannot "
-                "round-trip through config); construct with schema= and "
-                "text_field= to persist."
+                "VectorBlocker built with 'schema_factory' or an unregistered "
+                "'text_field_extractor' callable is not serializable (callables "
+                "cannot round-trip through config); construct with schema= and "
+                "either text_field='<field>' or a registered text_field_extractor "
+                "name (see TEXT_FIELD_EXTRACTORS, e.g. 'concat_comparable_fields') "
+                "to persist."
             )
 
         index_type = _index_type_name(self.vector_index)
@@ -323,6 +385,7 @@ class VectorBlocker(Blocker[SchemaT]):
         return {
             "schema_type_name": self._schema_type_name,
             "text_field": self._text_field,
+            "text_field_extractor": self._extractor_name,
             "k_neighbors": self.k_neighbors,
             "query_prompt": self.query_prompt,
             "vector_index": index_spec,
@@ -344,7 +407,9 @@ class VectorBlocker(Blocker[SchemaT]):
         Args:
             config: A mapping as produced by :attr:`config` (the
                 ``"vector_index"`` value may be a ``ComponentSpec`` or its
-                ``model_dump()`` dict).
+                ``model_dump()`` dict). Exactly one of ``"text_field"`` /
+                ``"text_field_extractor"`` is non-``None``; a pre-named-extractor
+                artifact carries only ``"text_field"``.
             state_dir: Directory holding the index's persisted state. Required
                 only when the reconstructed index is a ``SerializableState``.
 
@@ -365,10 +430,16 @@ class VectorBlocker(Blocker[SchemaT]):
         if isinstance(index, SerializableState) and state_dir is not None:
             index.load_state(state_dir)
 
+        # Rebuild whichever text axis was declarative. ``.get`` (not ``[]``) for
+        # ``text_field_extractor`` so a pre-named-extractor artifact -- which has
+        # no such key -- loads via ``text_field`` unchanged.
+        text_field = config["text_field"]
+        extractor_name = config.get("text_field_extractor")
         return cls(
             vector_index=index,
             schema=schema,  # type: ignore[arg-type]
-            text_field=str(config["text_field"]),
+            text_field=str(text_field) if text_field is not None else None,
+            text_field_extractor=str(extractor_name) if extractor_name is not None else None,
             k_neighbors=int(config["k_neighbors"]),  # type: ignore[call-overload]
             query_prompt=(
                 str(config["query_prompt"]) if config["query_prompt"] is not None else None

--- a/src/langres/core/matchers/llm_judge.py
+++ b/src/langres/core/matchers/llm_judge.py
@@ -28,6 +28,7 @@ from langres.clients.openrouter import parse_openrouter_billing
 from langres.core.model_ref import ModelRef, backend_for, normalize_model_ref, to_config
 from langres.core.models import ERCandidate, PairwiseJudgement
 from langres.core.matcher import Matcher, SchemaT
+from langres.core.named_callable import resolve_named
 from langres.core.registry import register
 from langres.core.reports import ScoreInspectionReport, _inspect_scores_impl
 from langres.tracking.runs import current_run
@@ -228,38 +229,6 @@ RECORD_SERIALIZERS: dict[str, Callable[[Any], str]] = {
     "json": default_record_serializer,
     "colval": colval_serializer,
 }
-
-
-def _resolve_named(
-    value: Callable[..., Any] | str | None,
-    registry: dict[str, Callable[..., Any]],
-    *,
-    kind: str,
-    default_name: str,
-) -> tuple[Callable[..., Any], str | None]:
-    """Resolve a parser/serializer given by name, callable, or ``None``.
-
-    Returns ``(callable, name)`` where ``name`` is the registered name to
-    serialize in :attr:`LLMMatcher.config` -- ``None`` for a custom callable that
-    is not in ``registry`` (documented as non-serializable: it reverts to the
-    default on load).
-
-    Raises:
-        ValueError: For an unknown name, listing the registered ones.
-    """
-    if value is None:
-        return registry[default_name], default_name
-    if isinstance(value, str):
-        resolved = registry.get(value)
-        if resolved is None:
-            raise ValueError(
-                f"unknown {kind} name {value!r}; registered names: "
-                f"{', '.join(sorted(registry))}. Pass a callable for a custom "
-                f"{kind} (it will not serialize in config)."
-            )
-        return resolved, value
-    name = next((n for n, fn in registry.items() if fn is value), None)
-    return value, name
 
 
 class _RateLimiter:
@@ -572,10 +541,10 @@ class LLMMatcher(Matcher[SchemaT]):
         self.system_prompt = system_prompt
         self.on_parse_error = on_parse_error
         self.confidence = confidence
-        self._parse, self._parser_name = _resolve_named(
+        self._parse, self._parser_name = resolve_named(
             response_parser, RESPONSE_PARSERS, kind="response_parser", default_name="score"
         )
-        self._serialize, self._serializer_name = _resolve_named(
+        self._serialize, self._serializer_name = resolve_named(
             record_serializer, RECORD_SERIALIZERS, kind="record_serializer", default_name="json"
         )
         self.prompt_template = (

--- a/src/langres/core/named_callable.py
+++ b/src/langres/core/named_callable.py
@@ -1,0 +1,72 @@
+"""``resolve_named``: the named-callable serialization seam.
+
+A langres component that takes a pluggable *callable* -- an LLM
+``response_parser`` / ``record_serializer``
+(:mod:`langres.core.matchers.llm_judge`), a blocker ``text_field_extractor``
+(:mod:`langres.core.blockers.vector`) -- faces one problem when it has to
+``save``/``load``: a bare callable cannot round-trip through JSON config. The
+house pattern -- shared here so every such seam resolves the SAME way, rather
+than each inventing its own -- is a module-level ``{name: callable}`` registry
+plus this resolver:
+
+- a **registered name** (a ``str``) resolves to its callable and serializes back
+  as that name;
+- a **registered callable** (the function object) is reverse-looked-up to its
+  name, so passing the function still serializes;
+- an **unregistered callable** works at runtime but serializes as ``None`` -- it
+  reverts to the caller's default on load (documented, never silent);
+- ``None`` falls back to ``default_name`` (the registry's default entry), for a
+  seam that has one.
+
+This is a stdlib-only leaf -- it imports nothing from ``langres`` -- so both the
+``[llm]`` matcher and the ``[semantic]`` blocker reuse ONE mechanism without
+coupling the two extras' modules to each other.
+"""
+
+from collections.abc import Callable
+from typing import Any
+
+
+def resolve_named(
+    value: Callable[..., Any] | str | None,
+    registry: dict[str, Callable[..., Any]],
+    *,
+    kind: str,
+    default_name: str | None = None,
+) -> tuple[Callable[..., Any], str | None]:
+    """Resolve a callable given by registered name, callable, or ``None``.
+
+    Returns ``(callable, name)`` where ``name`` is the registered name to
+    serialize in the component's ``config`` -- ``None`` for a custom callable
+    that is not in ``registry`` (documented as non-serializable: it reverts to
+    the default on load).
+
+    Args:
+        value: A registered name, a callable, or ``None``.
+        registry: The ``{name: callable}`` registry to resolve against.
+        kind: Human-readable noun for error messages (e.g. ``"response_parser"``).
+        default_name: The registry key used when ``value`` is ``None``. Pass it
+            for a seam that HAS a default (parsers/serializers); omit it for a
+            seam where the callable is required and ``None`` is a caller error
+            (the blocker extractor, whose absence routes to ``text_field=``
+            instead and so never reaches this resolver with ``None``).
+
+    Raises:
+        ValueError: For an unknown name (listing the registered ones), or for
+            ``value=None`` with no ``default_name``.
+    """
+    if value is None:
+        if default_name is None:
+            raise ValueError(f"a {kind} is required (no default registered)")
+        return registry[default_name], default_name
+    if isinstance(value, str):
+        resolved = registry.get(value)
+        if resolved is None:
+            raise ValueError(
+                f"unknown {kind} name {value!r}; registered names: "
+                f"{', '.join(sorted(registry))}. Pass a callable for a custom "
+                f"{kind} (it will not serialize in config)."
+            )
+        return resolved, value
+    name = next((n for n, fn in registry.items() if fn is value), None)
+    return value, name

--- a/tests/architectures/test_w4_proofs.py
+++ b/tests/architectures/test_w4_proofs.py
@@ -606,51 +606,57 @@ class TestReviewFoundRegressions:
             "openrouter/deepseek/deepseek-chat"
         )
 
-    def test_vector_llm_cascade_save_fails_with_a_followable_reason(self) -> None:
-        """The gap is real; the message must be about the user's model, not ours.
+    def test_vector_llm_cascade_now_saves_and_reloads_as_itself(
+        self, tmp_path: pathlib.Path
+    ) -> None:
+        """The gap is closed: ``save`` no longer raises, and the model round-trips.
 
-        `VectorLLMCascade` cannot persist: its `VectorBlocker` holds a
-        `text_field_extractor` closure. Unfixed, the user got VectorBlocker's own
-        error telling them to "construct with schema= and text_field=" -- but they
-        never constructed the VectorBlocker, `_topology` did. This pins the honest
-        failure until the named-extractor seam lands.
+        This replaces the two proofs that pinned the old ``NotImplementedError``.
+        The blocker's multi-field blocking text is now a NAMED, registered
+        extractor (``concat_comparable_fields``) rather than a closure, so it
+        serializes as a name and reloads intact -- and the whole cascade inherits
+        ``ERModel.save``. Fast (offline): the embedder loads its model only on the
+        first ``encode``, and construction/save/load never embed. No LLM call.
         """
-        model = VectorLLMCascade(llm="openrouter/openai/gpt-4o-mini", schema=Company)
-        with pytest.raises(NotImplementedError, match="cannot be saved yet"):
-            model.save("unreachable")
+        original = VectorLLMCascade(
+            llm="openrouter/openai/gpt-4o-mini",
+            embedder="all-MiniLM-L6-v2",
+            schema=Company,
+        )
+        original.save(tmp_path / "m")  # no longer raises
 
-    def test_save_error_names_every_required_arg_of_the_escape_hatch(self) -> None:
-        """The advice must RUN. It told users to do something that TypeErrors.
+        loaded = ERModel.load(tmp_path / "m")
 
-        The message's escape hatch is a hand-built `VectorBlocker` with a named
-        `text_field=` instead of the closure. As shipped it read
-        ``VectorBlocker(schema=..., text_field=...)`` -- which raises
-        ``TypeError: missing 1 required positional argument: 'vector_index'``.
-        Advice a user cannot copy is worse than none: it costs them the round-trip
-        to discover our error message is wrong.
+        # Back as ITSELF, with byte-identical config -- the named extractor is in it.
+        assert type(loaded) is VectorLLMCascade
+        assert loaded.config_dict() == original.config_dict()
+        manifest = (tmp_path / "m" / "resolver.json").read_text()
+        assert '"model_class": "vector_llm_cascade"' in manifest
+        assert "concat_comparable_fields" in manifest
+        # Idempotent: re-saving the loaded model reproduces the artifact exactly.
+        loaded.save(tmp_path / "m2")
+        assert (tmp_path / "m2" / "resolver.json").read_text() == (
+            tmp_path / "m" / "resolver.json"
+        ).read_text()
 
-        This asserts the message names every REQUIRED parameter, derived from the
-        live signature rather than hard-coded, so adding a required arg to
-        `VectorBlocker` fails here instead of silently rotting the message again.
+    @pytest.mark.slow  # embeds records with a real SentenceTransformer ([semantic])
+    def test_vector_llm_cascade_reload_blocks_identically(self, tmp_path: pathlib.Path) -> None:
+        """A round-trip that reconstructs a museum piece is not a round-trip.
+
+        Blocking candidates are a pure function of the extractor's text, so this
+        is the end-to-end guarantee that the named extractor reproduces the old
+        closure's blocking. Compares ``candidates()`` (blocking only -- no LLM
+        spend) before vs after a save/load.
         """
-        import inspect
+        original = VectorLLMCascade(
+            llm="openrouter/openai/gpt-4o-mini",
+            embedder="all-MiniLM-L6-v2",
+            schema=Company,
+        )
+        original.save(tmp_path / "m")
+        loaded = ERModel.load(tmp_path / "m")
 
-        from langres.core.blockers.vector import VectorBlocker
+        def pairs(model: Any) -> set[frozenset[str]]:
+            return {frozenset({c.left.id, c.right.id}) for c in model.candidates(RECORDS)}
 
-        model = VectorLLMCascade(llm="openrouter/openai/gpt-4o-mini", schema=Company)
-        try:
-            model.save("unreachable")
-        except NotImplementedError as exc:
-            message = str(exc)
-
-        required = [
-            name
-            for name, p in inspect.signature(VectorBlocker.__init__).parameters.items()
-            if name != "self" and p.default is inspect.Parameter.empty
-        ]
-        assert required, "VectorBlocker grew no required args -- rewrite this proof"
-        for name in required:
-            assert f"{name}=" in message, (
-                f"save()'s advice omits required VectorBlocker arg {name!r}; a user "
-                f"copying it hits a TypeError. Message: {message}"
-            )
+        assert pairs(loaded) == pairs(original)

--- a/tests/architectures/test_w4_proofs.py
+++ b/tests/architectures/test_w4_proofs.py
@@ -529,7 +529,9 @@ class TestReviewFoundRegressions:
     * The proofs round-trip only ``FuzzyString`` -- the one architecture with no
       backbones -- so ``VectorLLMCascade``'s ``save`` and its reconstruction path
       were never executed at all. That gap is exactly where two of the three
-      lived.
+      lived. (W3-f later *closed* the ``save`` gap -- the two proofs that pinned
+      its ``NotImplementedError`` are now the round-trip proofs at the end of
+      this class.)
     * ``ERModel.schema`` was asserted nowhere, so a property that returned
       ``None`` for every model in the library looked fine.
     """

--- a/tests/core/blockers/test_vector_config.py
+++ b/tests/core/blockers/test_vector_config.py
@@ -19,7 +19,12 @@ from typing import Any
 import numpy as np
 import pytest
 
-from langres.core.blockers.vector import VectorBlocker
+from langres.core.blockers.vector import (
+    TEXT_FIELD_EXTRACTORS,
+    VectorBlocker,
+    concat_comparable_fields,
+)
+from langres.core.comparators import StringComparator
 from langres.core.indexes.vector_index import inverse_distances_to_similarities
 from langres.core.models import CompanySchema
 from langres.core.registry import get_component, register
@@ -303,6 +308,132 @@ def test_from_config_without_state_dir_when_not_serializable() -> None:
 
     after = list(rebuilt.stream(COMPANY_DATA))
     assert len(after) > 0
+
+
+# ---------------------------------------------------------------------------
+# Named multi-field text_field_extractor (the serializable replacement for the
+# embedding-architecture closure -- the seam that makes VectorLLMCascade.save()
+# round-trip).
+# ---------------------------------------------------------------------------
+
+#: Records with a second comparable field populated, so ``concat_comparable_fields``
+#: has more than one field to join (name + address, both str on CompanySchema).
+MULTI_FIELD_DATA = [
+    {"id": "a", "name": "Acme", "address": "1 Main St"},
+    {"id": "b", "name": "Beta", "address": "2 Oak Ave"},
+    {"id": "c", "name": "Gamma", "address": "3 Pine Rd"},
+]
+
+
+def test_concat_comparable_fields_reproduces_the_closure_byte_for_byte() -> None:
+    """The named extractor equals the old inline closure on every entity.
+
+    The old embedding architectures built ``text_field_extractor=extract`` where
+    ``extract`` closed over ``[spec.name for spec in
+    StringComparator.from_schema(schema).feature_specs]``. Blocking candidates are
+    a pure function of this text, so a single differing character would change
+    which pairs are generated. This pins byte-identity against that exact closure.
+    """
+    field_names = [spec.name for spec in StringComparator.from_schema(CompanySchema).feature_specs]
+
+    def old_closure(entity: Any) -> str:
+        parts = [str(getattr(entity, n)) for n in field_names if getattr(entity, n, None)]
+        return " ".join(parts)
+
+    entities = [
+        CompanySchema(id="1", name="Acme Corporation", address="1 Main St"),
+        CompanySchema(id="2", name="Acme Corp", address=None),  # None field skipped
+        CompanySchema(id="3", name="", address="99 X St"),  # empty field skipped
+        CompanySchema(id="4", name="Solo", address=None, phone=None, website=None),
+        CompanySchema(id="5", name="A", address="B", phone="C", website="D"),
+    ]
+    for entity in entities:
+        assert concat_comparable_fields(entity) == old_closure(entity)
+
+
+def test_named_extractor_serializes_by_name() -> None:
+    """A registered extractor name round-trips in config; text_field stays None."""
+    blocker = VectorBlocker(
+        schema=CompanySchema,
+        text_field_extractor="concat_comparable_fields",
+        vector_index=_build_index(),
+        k_neighbors=2,
+    )
+
+    config = blocker.config
+
+    assert config["text_field_extractor"] == "concat_comparable_fields"
+    assert config["text_field"] is None
+    # And the resolved callable is the registered one, producing multi-field text.
+    entity = CompanySchema(id="x", name="Acme", address="1 Main St")
+    assert blocker.text_field_extractor(entity) == "Acme 1 Main St"
+
+
+def test_named_extractor_config_from_config_roundtrip(tmp_path: Path) -> None:
+    """config -> from_config with a NAMED extractor reproduces candidates + text."""
+    blocker = VectorBlocker(
+        schema=CompanySchema,
+        text_field_extractor="concat_comparable_fields",
+        vector_index=_FakeSerializableIndex(label="companies"),
+        k_neighbors=2,
+    )
+    blocker.vector_index.create_index(
+        [concat_comparable_fields(CompanySchema(**r)) for r in MULTI_FIELD_DATA]
+    )  # type: ignore[arg-type]
+
+    config = blocker.config
+    state_dir = tmp_path / "index"
+    state_dir.mkdir()
+    assert isinstance(blocker.vector_index, SerializableState)
+    blocker.vector_index.save_state(state_dir)
+
+    json_config: dict[str, Any] = dict(config)
+    json_config["vector_index"] = config["vector_index"].model_dump()
+
+    rebuilt = VectorBlocker.from_config(json_config, state_dir=state_dir)
+
+    # The reconstructed blocker uses the SAME named extractor, so identical text.
+    for record in MULTI_FIELD_DATA:
+        entity = CompanySchema(**record)  # type: ignore[arg-type]
+        assert rebuilt.text_field_extractor(entity) == blocker.text_field_extractor(entity)
+
+    before = [(c.left.id, c.right.id, c.similarity_score) for c in blocker.stream(MULTI_FIELD_DATA)]
+    after = [(c.left.id, c.right.id, c.similarity_score) for c in rebuilt.stream(MULTI_FIELD_DATA)]
+    assert before == after
+    assert len(after) > 0
+
+
+def test_passing_the_registered_callable_serializes_by_name() -> None:
+    """Passing the function object (not its name) still serializes by name.
+
+    resolve_named reverse-looks-up a registered callable to its key, so a caller
+    who imports ``concat_comparable_fields`` and passes it gets a serializable
+    blocker -- identical to passing the string.
+    """
+    blocker = VectorBlocker(
+        schema=CompanySchema,
+        text_field_extractor=concat_comparable_fields,
+        vector_index=_build_index(),
+        k_neighbors=2,
+    )
+
+    assert blocker.config["text_field_extractor"] == "concat_comparable_fields"
+
+
+def test_unknown_extractor_name_raises() -> None:
+    """An unregistered extractor NAME fails fast, listing the registered ones."""
+    with pytest.raises(ValueError, match="unknown text_field_extractor name"):
+        VectorBlocker(
+            schema=CompanySchema,
+            text_field_extractor="does_not_exist",
+            vector_index=_build_index(),
+            k_neighbors=2,
+        )
+
+
+def test_concat_comparable_fields_is_the_only_registered_extractor() -> None:
+    """Guard the registry contract: the one extractor the architectures rely on."""
+    assert TEXT_FIELD_EXTRACTORS["concat_comparable_fields"] is concat_comparable_fields
 
 
 def test_config_raises_for_unregistered_index() -> None:

--- a/tests/core/test_named_callable.py
+++ b/tests/core/test_named_callable.py
@@ -1,0 +1,68 @@
+"""Unit tests for the shared named-callable resolution seam.
+
+``resolve_named`` is the one mechanism both the ``[llm]`` matcher
+(``response_parser``/``record_serializer``) and the ``[semantic]`` blocker
+(``text_field_extractor``) use to accept a callable by name, by value, or by
+default -- and to serialize it back by name. These pin every branch directly,
+independent of either consumer.
+"""
+
+from typing import Any
+
+import pytest
+
+from langres.core.named_callable import resolve_named
+
+
+def _a(x: str) -> str:  # pragma: no cover - identity, never called here
+    return x
+
+
+def _b(x: str) -> str:  # pragma: no cover - identity, never called here
+    return x
+
+
+REGISTRY: dict[str, Any] = {"a": _a, "b": _b}
+
+
+def test_registered_name_resolves_to_its_callable_and_serializes_as_the_name() -> None:
+    fn, name = resolve_named("a", REGISTRY, kind="thing")
+    assert fn is _a
+    assert name == "a"
+
+
+def test_registered_callable_is_reverse_looked_up_to_its_name() -> None:
+    """Passing the function object still serializes (by reverse lookup)."""
+    fn, name = resolve_named(_b, REGISTRY, kind="thing")
+    assert fn is _b
+    assert name == "b"
+
+
+def test_unregistered_callable_resolves_but_serializes_as_none() -> None:
+    """A custom callable works at runtime but has no serializable name."""
+
+    def custom(x: str) -> str:  # pragma: no cover - identity, never called
+        return x
+
+    fn, name = resolve_named(custom, REGISTRY, kind="thing")
+    assert fn is custom
+    assert name is None
+
+
+def test_none_with_default_falls_back_to_the_default_entry() -> None:
+    fn, name = resolve_named(None, REGISTRY, kind="thing", default_name="a")
+    assert fn is _a
+    assert name == "a"
+
+
+def test_none_without_default_raises() -> None:
+    """A seam with no default (the blocker extractor) treats None as an error."""
+    with pytest.raises(ValueError, match="a thing is required"):
+        resolve_named(None, REGISTRY, kind="thing")
+
+
+def test_unknown_name_raises_and_lists_the_registered_names() -> None:
+    with pytest.raises(ValueError, match="unknown thing name 'zzz'") as exc:
+        resolve_named("zzz", REGISTRY, kind="thing")
+    # The message lists the registered names, sorted, to guide the caller.
+    assert "a, b" in str(exc.value)

--- a/tools/refactor_target_packages.json
+++ b/tools/refactor_target_packages.json
@@ -163,6 +163,7 @@
     "langres.core.metrics": "metrics",
     "langres.core.model_ref": "core",
     "langres.core.models": "core",
+    "langres.core.named_callable": "core",
     "langres.core.op": "core",
     "langres.core.op_adapters": "architectures",
     "langres.core.pairs": "core",


### PR DESCRIPTION
## What

`VectorLLMCascade.save()` raised `NotImplementedError`: its `VectorBlocker` was built with a **closure** `text_field_extractor` (blocking text = every comparable string field concatenated), and a closure can't round-trip through JSON config. This makes the paid architecture persist like every other one, by replacing the closure with a **named, registered** extractor.

## How

- **New leaf `core/named_callable.py`** — `resolve_named(value, registry, *, kind, default_name=None) -> (callable, name)`, **lifted verbatim** from `llm_judge.py`'s private `_resolve_named` so the `[llm]` matcher and the `[semantic]` blocker share **one** named-callable seam. Kept in a stdlib-only leaf (imports nothing from langres) so reusing it does **not** couple the two extras' modules — importing `_resolve_named` from `llm_judge` would have pulled litellm into a pure-semantic `VectorBlocker`. `llm_judge.py` now imports it (2 call sites unchanged in behavior).
- **`core/blockers/vector.py`** — `concat_comparable_fields(entity)` (the named extractor) + `TEXT_FIELD_EXTRACTORS` registry, mirroring `RESPONSE_PARSERS`/`RECORD_SERIALIZERS`. `VectorBlocker.text_field_extractor` now accepts `Callable | str | None` (a registered name serializes; a bare callable stays opaque as before). `config` serializes the extractor by name; `from_config` reconstructs it (old `text_field`-only artifacts still load via `.get`).
- **`architectures/vector_llm_cascade.py`** — `_topology` passes `text_field_extractor="concat_comparable_fields"`; the `save()` override is **deleted** (inherits `ERModel.save`); docstring warning updated.

## Byte-parity (load-bearing)

`concat_comparable_fields` reproduces the old closure **byte-for-byte**: same field set (`StringComparator.from_schema(schema).feature_specs` — the `str | None` fields except `id`, in declaration order), same `str()`-cast, same falsy-skip, same `" ".join`. A named module-level function can't close over a per-schema list, so it derives the set from `type(entity)` at call time — identical because the blocker's `schema_factory` builds `schema` instances (`schema_to_factory`). A focused test asserts equality against the exact old closure across present/None/empty/multi-field records. Blocking candidates are a pure function of this text, so byte-identity = identical candidate generation.

## Proof

- Fast: `VectorLLMCascade(...).save()` → `ERModel.load()` → identical `config_dict()` + idempotent re-save; manifest carries `concat_comparable_fields`; `save()` no longer raises. (Embedder is lazy — no model download.)
- Slow (`@pytest.mark.slow`): real embedder, `candidates()` blocking identical before vs after save/load.
- Behavior run: save → fresh load → identical blocking pairs on real records; artifact is `resolver.json` only (weightless).

## Scope note

`core/resolver.py:_build_embedding_blocker` (the `matcher="embedding"` `Resolver.from_schema` path) has the **same** closure and could adopt `text_field_extractor="concat_comparable_fields"` to become serializable too — left out of scope here; flagged as a follow-up.

## Gates
- Full fast suite: **3787 passed, 2 skipped, 0 failed**.
- Import budget / tangle / graph (incl. completeness gate): green — heavy deps stay out of bare `import langres`; SCC unchanged.
- `mypy --strict` (changed files), `ruff format --check` / `ruff check`: clean.
- `named_callable.py` 100% coverage; all new `vector.py` lines covered.

#193

https://claude.ai/code/session_011XYuhyiigi1Bw2YnWCxMr9
