### PR TITLE
feat(core): generalized Op-chain spine — optional explicit topology (#193 PR-A)

### DIFF
--- a/src/langres/core/_model_run.py
+++ b/src/langres/core/_model_run.py
@@ -57,7 +57,7 @@ mid-pull.
 """
 
 import logging
-from collections.abc import Iterator
+from collections.abc import Iterator, Sequence
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, cast
 
@@ -65,7 +65,7 @@ from langres.core._model_state import ModelState
 from langres.core.blockers.composite import CompositeBlocker
 from langres.core.clusterer import Clusterer
 from langres.core.fit import CalibratorFitMixin
-from langres.core.inputs import check_no_duplicate_ids
+from langres.core.inputs import check_no_duplicate_ids, normalize_records
 from langres.tracking.judgement_log import JudgementLog, LoggingMatcher
 from langres.core.models import (
     ERCandidate,
@@ -73,7 +73,7 @@ from langres.core.models import (
     PairwiseJudgement,
     predicted_match,
 )
-from langres.core.op import Score, Source, ThresholdSelect
+from langres.core.op import Op, Score, Source, ThresholdSelect
 from langres.core.op_adapters import (
     BlockerSource,
     ClustererStage,
@@ -132,25 +132,33 @@ def _coerce_log(log: "JudgementLog | str | Path | None") -> JudgementLog | None:
     return JudgementLog(log)
 
 
-def _run_stages(records: list[Any], stages: list[Source[Any] | Score[Any]]) -> Pairs[Any]:
-    """Fold ``forward`` across ``stages`` to turn ``records`` into a scored ``Pairs``.
+def _run_stages(records: list[Any], stages: Sequence[Source[Any] | Op[Any]]) -> Pairs[Any]:
+    """Fold ``forward`` across ``stages`` to turn ``records`` into a ``Pairs``.
 
-    The generic driver behind :meth:`ModelRun._candidates` and
-    :meth:`ModelRun._scored_pairs`. Both stage lists it is handed --
-    :meth:`ModelRun._stages` (full) and its matcher-free prefix
-    :meth:`ModelRun._block_compare_stages` -- lead with the
-    :class:`~langres.core.op.Source` (records -> pairs) and continue with
-    :class:`~langres.core.op.Score`\\ s (pairs -> pairs), so the fold walks
-    ``Records -> Pairs -> ... -> Pairs``. The two narrowing ``cast``\\ s
-    encode that Source-first shape (which the factories guarantee) precisely --
-    ``Source.forward`` takes records while ``Score.forward`` takes a ``Pairs``, so
-    the heterogeneous first stage cannot share one loosely-typed loop variable
-    with the rest, and the cast is a typed assertion of the shape, not an ``Any``.
+    The generic driver behind :meth:`ModelRun._candidates`,
+    :meth:`ModelRun._scored_pairs` (both derived-slot and explicit-chain). Every
+    stage list it is handed leads with the :class:`~langres.core.op.Source`
+    (records -> pairs) and continues with :class:`~langres.core.op.Op`\\ s
+    (pairs -> pairs), so the fold walks ``Records -> Pairs -> ... -> Pairs``.
+
+    The body element type is :class:`~langres.core.op.Op`, **not** ``Score``: an
+    explicit chain (:meth:`~langres.core._model_state.ModelState.from_topology`)
+    interleaves :class:`~langres.core.op.Select`\\ s among the Scores, and a
+    ``Select`` is an ``Op`` but not a ``Score``. Narrowing the loop element to
+    ``Score`` would exclude them; ``Op`` admits every body stage while keeping the
+    fold precisely typed. The parameter is a covariant ``Sequence`` so the classic
+    factories' ``list[Source | Score]`` still passes (``Score`` is an ``Op``).
+
+    The two narrowing ``cast``\\ s encode the Source-first shape the factories
+    guarantee -- ``Source.forward`` takes records while ``Op.forward`` takes a
+    ``Pairs``, so the heterogeneous first stage cannot share one loosely-typed loop
+    variable with the rest, and the cast is a typed assertion of the shape, not an
+    ``Any``.
     """
-    source, *scores = stages
+    source, *body = stages
     pairs = cast(Source[Any], source).forward(records)
-    for score in scores:
-        pairs = cast(Score[Any], score).forward(pairs)
+    for op in body:
+        pairs = cast(Op[Any], op).forward(pairs)
     return pairs
 
 
@@ -386,7 +394,17 @@ class ModelRun(ModelState):
         clusterer thresholds on a real probability. Pure pass-through otherwise.
         Calibration is a per-score transform applied in the spine, NOT an Op
         adapter (kept here through W3-c).
+
+        **Explicit chain (``_ops`` set).** Folds the chain's Source + body Ops
+        (Scores AND Selects, up to but excluding the terminal ClusterStage --
+        :meth:`_cluster` runs that). No ``_ensure_index_built`` (the chain's
+        ``BlockerSource`` owns only index-free sources this wave; a
+        ``VectorBlocker``-sourced chain would need index wiring, deferred) and no
+        calibrator (``from_topology`` rejects one -- a ``CalibratorScore`` Op is a
+        later wave). ``log`` is not threaded into a fixed pre-built chain.
         """
+        if self._ops is not None:
+            return _run_stages(records, [self._chain_source(), *self._chain_body()])
         self._ensure_index_built(records)
         pairs = _run_stages(records, self._stages(log=log))
         if self.calibrator is not None:
@@ -496,7 +514,16 @@ class ModelRun(ModelState):
         ``scored_pairs`` must already be calibrated (callers pass
         :meth:`_scored_pairs`'s output), so the cut thresholds the CALIBRATED
         score, exactly as the clusterer did.
+
+        **Explicit chain (``_ops`` set).** The chain's own terminal ClusterStage
+        IS the exit -- its match cut is already a body ``ThresholdSelect`` and its
+        ``ClustererStage`` already carries the (zeroed) clusterer -- so this runs
+        that ClusterStage on ``scored_pairs`` directly, with **no** extra
+        ThresholdSelect / :meth:`_closure_clusterer` wrap. Adding either would
+        double-cut and silently diverge.
         """
+        if self._ops is not None:
+            return self._chain_cluster_stage().forward(scored_pairs)
         selected: Pairs[Any] = ThresholdSelect(self.clusterer.threshold).forward(scored_pairs)
         return ClustererStage(self._closure_clusterer()).forward(selected)
 
@@ -586,6 +613,11 @@ class ModelRun(ModelState):
                 score_type="none",
                 threshold=None,
             )
+        # Explicit-chain model: no ``module``/``clusterer`` slot to read, so the
+        # front-door reads (threshold/backbone) come from the chain (see
+        # _dedupe_explicit). ``log`` is not threaded into a fixed pre-built chain.
+        if self._ops is not None:
+            return self._dedupe_explicit(records)
         normalized = self._prepare(records)
         check_no_duplicate_ids([record["id"] for record in normalized])
         pairs = self._scored_pairs(normalized, log=_coerce_log(log))
@@ -651,6 +683,12 @@ class ModelRun(ModelState):
                 ``compare`` owes its caller a verdict and will not fabricate one.
             BudgetExceeded: If scoring this pair would cross the spend cap.
         """
+        # Explicit-chain model: fold ONLY the chain's Score ops on the pair (skip
+        # its Selects, so an abstaining pair is not cut before we can raise) and
+        # gate on the chain's terminal ThresholdSelect (see _compare_explicit).
+        # ``log`` is not threaded into a fixed pre-built chain.
+        if self._ops is not None:
+            return self._compare_explicit(left, right)
         normalized = self._prepare([left, right])
         pair = self._pair_candidate(normalized)
         scored = self._matcher_score(log=_coerce_log(log)).forward(pair)
@@ -721,6 +759,120 @@ class ModelRun(ModelState):
             candidate = candidate.model_copy(
                 update={"comparison": self.comparator.compare(left_entity, right_entity)}
             )
+        return Pairs.from_candidates([candidate])
+
+    # ------------------------------------------------------------------
+    # The explicit-chain front door (``_ops`` set) -- the else branch of
+    # dedupe/compare. Split out so the classic ``is None`` bodies above stay
+    # byte-verbatim. Everything here reads the chain, never the four slots.
+    # ------------------------------------------------------------------
+
+    def _dedupe_explicit(self, records: list[dict[str, Any]]) -> DedupeResult:
+        """``dedupe`` over an explicit Op chain.
+
+        Normalizes via the chain's Source schema (the ONE input contract, same as
+        :meth:`_prepare`'s), runs the chain (Source + body Ops via
+        :meth:`_scored_pairs`, then the terminal ClusterStage via :meth:`_cluster`,
+        both dispatched on ``_ops``), and reports the chain's own effective cut
+        (:meth:`_chain_threshold`) and :attr:`backbone` -- there is no single
+        ``clusterer``/``module`` slot. ``score_type`` stays row-derived (the first
+        scored row's own family), exactly as the classic path.
+        """
+        _schema, normalized = normalize_records(records, self._chain_source_schema())
+        check_no_duplicate_ids([record["id"] for record in normalized])
+        pairs = self._scored_pairs(normalized)
+        clusters = self._cluster(pairs)
+        score_type = next(
+            (row.score_type for row in pairs.rows if row.score_type is not None), None
+        )
+        return DedupeResult(
+            clusters,
+            architecture=type(self).__name__,
+            backbone=self.backbone,
+            score_type=score_type if score_type is not None else "unknown",
+            threshold=self._chain_threshold(),
+        )
+
+    def _compare_explicit(self, left: dict[str, Any], right: dict[str, Any]) -> LinkVerdict:
+        """``compare`` over an explicit Op chain.
+
+        Folds ONLY the chain's :class:`~langres.core.op.Score` ops on the single
+        pair (:meth:`~langres.core._model_state.ModelState._chain_body_scores`) --
+        the Selects are deliberately skipped, because a body
+        :class:`~langres.core.op.ThresholdSelect` would drop an abstaining pair
+        before this method can raise :class:`~langres.core.models.MatcherAbstainedError`
+        (the whole reason ``compare`` differs from ``dedupe``). Gates the resulting
+        judgement on the chain's terminal ThresholdSelect threshold.
+        """
+        _schema, normalized = normalize_records([left, right], self._chain_source_schema())
+        pair = self._chain_pair_candidate(normalized)
+        scored = pair
+        for score in self._chain_body_scores():
+            scored = score.forward(scored)
+        scored_rows = [row for row in scored.rows if row.score_type is not None]
+        if not scored_rows:
+            raise RuntimeError(
+                "the explicit chain's Score ops produced no judgement for this pair; every "
+                "candidate must yield exactly one PairwiseJudgement. This indicates a bug in the "
+                "chain's matcher Score."
+            )
+        judgement = scored_rows[0].to_judgement()
+
+        threshold = self._chain_threshold()
+        if threshold is None:
+            raise RuntimeError(
+                "compare() needs a match cut to gate on, but this explicit chain has no terminal "
+                "ThresholdSelect. Fix: add a ThresholdSelect before the ClusterStage, or compare "
+                "via dedupe()."
+            )
+        predicted = predicted_match(judgement, threshold)
+        if predicted is None:
+            raise MatcherAbstainedError(
+                "the explicit chain's matcher abstained (no decision and no score) on this pair, "
+                "so compare() cannot return a verdict. An LLMMatcher abstains when its response "
+                "fails to parse (the default on_parse_error='abstain'); pass "
+                "on_parse_error='raise' to surface the parse failure, or catch "
+                "MatcherAbstainedError."
+            )
+        return LinkVerdict(
+            match=predicted,
+            score=judgement.score,
+            reasoning=judgement.reasoning,
+            architecture=type(self).__name__,
+            backbone=self.backbone,
+            score_type=judgement.score_type,
+            threshold=threshold,
+            judgement=judgement,
+        )
+
+    def _chain_pair_candidate(self, records: list[dict[str, Any]]) -> Pairs[Any]:
+        """The ONE pair for :meth:`_compare_explicit` -- the chain-Source analogue of
+        :meth:`_pair_candidate`.
+
+        Runs the chain's Source and keeps the first blocked pair; builds the pair
+        directly (from the Source's schema) if the Source yields nothing, because
+        blocking must never veto a ``compare`` verdict (see :meth:`compare`). The
+        comparator vector is NOT attached here -- folding the chain's Score ops
+        (which includes any ``ComparatorScore``) attaches it, unlike the slot-based
+        :meth:`_pair_candidate`.
+        """
+        pairs = self._chain_source().forward(records)
+        if pairs.rows:
+            return Pairs(store=pairs.store, rows=pairs.rows[:1])
+
+        from langres.core.blockers.all_pairs import schema_to_factory
+
+        schema = self._chain_source_schema()
+        if schema is None:
+            raise RuntimeError(
+                "the explicit chain's Source yielded no candidate for this pair and exposes no "
+                "schema, so compare() cannot build the pair directly. Use a Source whose blocker "
+                "carries a schema (AllPairsBlocker, VectorBlocker, KeyBlocker), or compare via "
+                "dedupe()."
+            )
+        factory = schema_to_factory(schema)
+        left_entity, right_entity = (factory(record) for record in records)
+        candidate = ERCandidate(left=left_entity, right=right_entity, blocker_name="compare")
         return Pairs.from_candidates([candidate])
 
     def _ensure_index_built(self, records: list[Any]) -> None:

--- a/src/langres/core/_model_run.py
+++ b/src/langres/core/_model_run.py
@@ -397,11 +397,15 @@ class ModelRun(ModelState):
 
         **Explicit chain (``_ops`` set).** Folds the chain's Source + body Ops
         (Scores AND Selects, up to but excluding the terminal ClusterStage --
-        :meth:`_cluster` runs that). No ``_ensure_index_built`` (the chain's
-        ``BlockerSource`` owns only index-free sources this wave; a
-        ``VectorBlocker``-sourced chain would need index wiring, deferred) and no
-        calibrator (``from_topology`` rejects one -- a ``CalibratorScore`` Op is a
-        later wave). ``log`` is not threaded into a fixed pre-built chain.
+        :meth:`_cluster` runs that). This path does NOT call
+        :meth:`_ensure_index_built` (a four-slot convenience), so a
+        ``VectorBlocker``-backed Source must carry a PRE-BUILT index: if its index
+        is missing, ``blocker.stream`` raises loud (``RuntimeError: Index not
+        built``) on the first fold here -- it never silently yields empty
+        candidates. ``from_topology`` documents this; the shipped rerankers source
+        from ``AllPairsBlocker`` (no index). No calibrator either
+        (``from_topology`` rejects one -- a ``CalibratorScore`` Op is a later wave).
+        ``log`` is not threaded into a fixed pre-built chain.
         """
         if self._ops is not None:
             return _run_stages(records, [self._chain_source(), *self._chain_body()])

--- a/src/langres/core/_model_state.py
+++ b/src/langres/core/_model_state.py
@@ -29,6 +29,7 @@ from langres.core.inputs import normalize_records
 from langres.core.matcher import Matcher
 from langres.core.op import (
     ClusterStage,
+    Finalize,
     Op,
     Score,
     Sequential,
@@ -36,6 +37,7 @@ from langres.core.op import (
     Stage,
     ThresholdSelect,
 )
+from langres.core.op_adapters import MatcherScore
 from langres.core.spend import SpendMonitor
 from langres.core.spend_cap import SpendCappedMatcher, effective_budget
 
@@ -339,26 +341,50 @@ class ModelState:
         chain.
 
         The chain's wiring is validated at construction via :class:`~langres.core.op.Sequential`
-        (Source first, then Ops, then a ClusterStage, optionally a Finalize -- a
-        Select over a vector score is rejected), and it must carry exactly one
-        terminal :class:`~langres.core.op.ClusterStage` so ``resolve``/``dedupe``
-        have a phase-1 exit.
+        (Source first, then Ops, then a ClusterStage -- a Select over a vector
+        score is rejected), and it must carry exactly one terminal
+        :class:`~langres.core.op.ClusterStage` so ``resolve``/``dedupe`` have a
+        phase-1 exit.
+
+        **The spend cap is ENFORCED here, not merely documented.** Every
+        :class:`~langres.core.op_adapters.MatcherScore` in the chain is auto-wrapped
+        so its matcher bills through this model's shared
+        :class:`~langres.core.spend.SpendMonitor` (the classic four-slot path does
+        the same at scoring time). A caller who already wrapped their matcher in a
+        :class:`~langres.core.spend_cap.SpendCappedMatcher` is left alone (no
+        double-wrap). This closes the off-ledger hole the ``.module.forward``
+        AST-ban cannot see: a paid explicit-chain Score can no longer bill past
+        ``budget_usd`` (the option-a money guarantee -- budget + at most one further
+        call -- holds on every explicit-chain ``resolve``). See
+        :meth:`_secure_chain_scores`. **Deferred, with no money hole:** the
+        per-call ``JudgementLog`` (``dedupe(log=)``) is NOT threaded into an
+        explicit chain's Scores (its Ops are fixed pre-built objects); only the LOG
+        is deferred -- the cap is not.
+
+        **A terminal ``Finalize`` is rejected** (deferred, same pattern as the
+        calibrator reject): the explicit exit runs the ClusterStage and stops, so a
+        ``Finalize`` would be silently dropped. Rejecting it loud beats a silent
+        drop until a later wave executes it. **A ``VectorBlocker`` Source must carry
+        a pre-built index:** the explicit run path does not call
+        ``_ensure_index_built`` (that is a four-slot convenience), so a
+        vector-backed Source with an unbuilt index raises loud from
+        ``blocker.stream`` on the first ``resolve`` -- build the index before
+        passing the blocker (the shipped rerankers use ``AllPairsBlocker``).
 
         Args:
             ops: The explicit chain, in pipeline order (a Source, zero+ Ops
-                including Selects, one terminal ClusterStage, optional Finalize).
-                **Any paid Score in the chain must already wrap its matcher in a
-                :class:`~langres.core.spend_cap.SpendCappedMatcher`** -- the
-                ``.module.forward`` AST-ban only catches the literal slot call, so
-                nothing mechanical stops an explicit-chain Score from billing
-                off-ledger. Share this model's ledger by passing that same
-                ``monitor=`` here.
+                including Selects, one terminal ClusterStage). Each
+                ``MatcherScore``'s matcher is auto-capped through this model's
+                ledger; a paid ``Score`` that is *not* a ``MatcherScore`` (e.g. a
+                ``GroupwiseMatcherScore``, which this door cannot auto-cap) must
+                already wrap its matcher in a
+                :class:`~langres.core.spend_cap.SpendCappedMatcher`, else it is
+                rejected rather than allowed to bill off-ledger.
             budget_usd: Spend cap for this instance's lifetime (see
                 :meth:`__init__`). Mutually exclusive with ``monitor``.
             monitor: An existing :class:`~langres.core.spend.SpendMonitor` to adopt
-                as this model's ledger -- pass the SAME monitor the chain's
-                ``SpendCappedMatcher`` wraps, so the model's budget genuinely caps
-                the chain. Mutually exclusive with ``budget_usd``.
+                as this model's ledger -- the chain's Scores are capped through it.
+                Mutually exclusive with ``budget_usd``.
             calibrator: **Rejected.** Calibration is a bespoke per-score transform
                 that only the classic path applies; a ``CalibratorScore`` Op is a
                 later wave, so an explicit chain must express any score mapping as
@@ -369,8 +395,9 @@ class ModelState:
 
         Raises:
             ValueError: If ``calibrator`` is given, if both ``budget_usd`` and
-                ``monitor`` are given, if the chain is mis-wired, or if it does not
-                carry exactly one terminal ClusterStage.
+                ``monitor`` are given, if the chain is mis-wired, if it carries a
+                ``Finalize`` or an uncapped paid non-``MatcherScore`` Score, or if
+                it does not carry exactly one terminal ClusterStage.
         """
         if calibrator is not None:
             raise ValueError(
@@ -390,6 +417,13 @@ class ModelState:
         # first, Ops (pairs -> pairs) in the middle, a ClusterStage, an optional
         # Finalize -- and NO Select over a non-orderable vector score.
         Sequential(chain)
+        if any(isinstance(stage, Finalize) for stage in chain):
+            raise ValueError(
+                "from_topology() does not run a terminal Finalize yet: the explicit exit runs the "
+                "ClusterStage and stops, so a Finalize would be silently dropped. Executing a "
+                "chain Finalize is a later wave. Fix: end the chain at the ClusterStage (the "
+                "shipped rerankers need no Finalize), or apply canonicalization outside the chain."
+            )
         cluster_stages = [stage for stage in chain if isinstance(stage, ClusterStage)]
         if len(cluster_stages) != 1:
             raise ValueError(
@@ -402,8 +436,56 @@ class ModelState:
         if monitor is not None:
             # Adopt the caller's ledger so the model's cap IS the chain's cap.
             model._spend_monitor = monitor
-        model._ops = chain
+        # Enforce the spend cap on the chain's paid Scores (fix: was documented,
+        # not enforced -- a raw MatcherScore billed off-ledger). Do this AFTER the
+        # monitor is finalized so every wrap shares this model's one ledger.
+        model._ops = model._secure_chain_scores(chain)
         return model
+
+    def _secure_chain_scores(self, chain: list[Stage]) -> list[Stage]:
+        """Auto-cap the chain's paid Scores through this model's :class:`SpendMonitor`.
+
+        The classic four-slot path wraps its matcher in a
+        :class:`~langres.core.spend_cap.SpendCappedMatcher` at scoring time; an
+        explicit chain must get the SAME guarantee or a paid Score bills off-ledger
+        (the ``.module.forward`` AST-ban only catches the literal slot call). So for
+        every :class:`~langres.core.op_adapters.MatcherScore` whose matcher is not
+        already spend-capped, rebuild it around
+        ``SpendCappedMatcher(matcher, monitor=self._spend_monitor)`` -- a Score whose
+        matcher a caller already capped is left untouched (``isinstance`` guard, no
+        double-wrap). A *paid* Score this door cannot auto-cap -- any other ``Score``
+        that still carries a raw ``Matcher`` (e.g. a ``GroupwiseMatcherScore``, whose
+        ``forward_groups`` bypasses the cap's per-judgement metering) -- is rejected
+        rather than allowed to run uncapped.
+
+        Returns:
+            A new chain list with the same wiring, every ``MatcherScore`` capped.
+        """
+        secured: list[Stage] = []
+        for stage in chain:
+            if isinstance(stage, MatcherScore):
+                if isinstance(stage.matcher, SpendCappedMatcher):
+                    secured.append(stage)  # caller already capped it -- leave alone
+                else:
+                    secured.append(
+                        MatcherScore(
+                            SpendCappedMatcher(stage.matcher, monitor=self._spend_monitor),
+                            out_space=stage.out_space,
+                        )
+                    )
+                continue
+            if isinstance(stage, Score):
+                held = getattr(stage, "matcher", None)
+                if isinstance(held, Matcher) and not isinstance(held, SpendCappedMatcher):
+                    raise ValueError(
+                        f"from_topology() cannot enforce the spend cap on a "
+                        f"{type(stage).__name__}: only a MatcherScore is auto-capped, and this "
+                        "door refuses to run an uncapped paid Score off-ledger. Fix: wrap its "
+                        "matcher in SpendCappedMatcher(matcher, monitor=...) yourself, or express "
+                        "the scoring as a MatcherScore."
+                    )
+            secured.append(stage)
+        return secured
 
     def _topology(self, schema: type[BaseModel]) -> dict[str, Any]:
         """Build this architecture's components for ``schema``. The subclass hook.

--- a/src/langres/core/_model_state.py
+++ b/src/langres/core/_model_state.py
@@ -502,9 +502,10 @@ class ModelState:
                     f"from_topology() cannot cap a {type(stage).__name__}: it declares Spending "
                     "(it may bill a paid model) but is not a MatcherScore, so this door cannot "
                     "route its billing through the model ledger (a SpendCappedMatcher meters "
-                    "Matcher.forward, not e.g. GroupwiseMatcher.forward_groups). It refuses to run "
-                    "an uncapped paid Score off-ledger. Fix: express the scoring as a MatcherScore, "
-                    "or cap its paid work through a model-monitor SpendCappedMatcher yourself."
+                    "Matcher.forward, not e.g. GroupwiseMatcher.forward_groups -- pre-capping its "
+                    "matcher would NOT help). It refuses to run an uncapped paid Score off-ledger. "
+                    "Fix: express the scoring as a MatcherScore (the only Spending Score this door "
+                    "can route onto the ledger)."
                 )
             matcher = stage.matcher
             if isinstance(matcher, SpendCappedMatcher):

--- a/src/langres/core/_model_state.py
+++ b/src/langres/core/_model_state.py
@@ -34,6 +34,7 @@ from langres.core.op import (
     Score,
     Sequential,
     Source,
+    Spending,
     Stage,
     ThresholdSelect,
 )
@@ -346,20 +347,27 @@ class ModelState:
         :class:`~langres.core.op.ClusterStage` so ``resolve``/``dedupe`` have a
         phase-1 exit.
 
-        **The spend cap is ENFORCED here, not merely documented.** Every
-        :class:`~langres.core.op_adapters.MatcherScore` in the chain is auto-wrapped
-        so its matcher bills through this model's shared
+        **The spend cap is ENFORCED here, not merely documented**, via an
+        allowlist keyed on the :class:`~langres.core.op.Spending` marker (a Score
+        DECLARES it may bill). Every ``Spending``
+        :class:`~langres.core.op_adapters.MatcherScore` is auto-wrapped so its
+        matcher bills through this model's shared
         :class:`~langres.core.spend.SpendMonitor` (the classic four-slot path does
-        the same at scoring time). A caller who already wrapped their matcher in a
-        :class:`~langres.core.spend_cap.SpendCappedMatcher` is left alone (no
-        double-wrap). This closes the off-ledger hole the ``.module.forward``
-        AST-ban cannot see: a paid explicit-chain Score can no longer bill past
-        ``budget_usd`` (the option-a money guarantee -- budget + at most one further
-        call -- holds on every explicit-chain ``resolve``). See
-        :meth:`_secure_chain_scores`. **Deferred, with no money hole:** the
-        per-call ``JudgementLog`` (``dedupe(log=)``) is NOT threaded into an
-        explicit chain's Scores (its Ops are fixed pre-built objects); only the LOG
-        is deferred -- the cap is not.
+        the same at scoring time); a matcher a caller already wrapped is left alone
+        **only if** its ``SpendCappedMatcher`` shares this model's monitor -- a
+        foreign monitor is rejected, since it would bill a different budget and
+        "one model ledger" would be false. A ``Spending`` Score the door cannot
+        wrap (anything other than a ``MatcherScore``) is rejected rather than run
+        off-ledger; a non-``Spending`` Score (a free ``ComparatorScore``, any
+        Select) passes untouched. This closes the off-ledger hole the
+        ``.module.forward`` AST-ban cannot see: a paid explicit-chain Score can no
+        longer bill past ``budget_usd`` (the option-a money guarantee -- budget +
+        at most one further call -- holds on every explicit-chain ``resolve``). See
+        :meth:`_secure_chain_scores`, whose docstring states the residual limit (a
+        custom Score that bills without declaring ``Spending`` is the author's own
+        bug). **Deferred, with no money hole:** the per-call ``JudgementLog``
+        (``dedupe(log=)``) is NOT threaded into an explicit chain's Scores (its Ops
+        are fixed pre-built objects); only the LOG is deferred -- the cap is not.
 
         **A terminal ``Finalize`` is rejected** (deferred, same pattern as the
         calibrator reject): the explicit exit runs the ClusterStage and stops, so a
@@ -373,13 +381,14 @@ class ModelState:
 
         Args:
             ops: The explicit chain, in pipeline order (a Source, zero+ Ops
-                including Selects, one terminal ClusterStage). Each
+                including Selects, one terminal ClusterStage). Each ``Spending``
                 ``MatcherScore``'s matcher is auto-capped through this model's
-                ledger; a paid ``Score`` that is *not* a ``MatcherScore`` (e.g. a
-                ``GroupwiseMatcherScore``, which this door cannot auto-cap) must
-                already wrap its matcher in a
-                :class:`~langres.core.spend_cap.SpendCappedMatcher`, else it is
-                rejected rather than allowed to bill off-ledger.
+                ledger (or verified to already share it). A ``Spending`` Score the
+                door cannot wrap (e.g. a ``GroupwiseMatcherScore``), or a
+                ``MatcherScore`` subclass the door cannot faithfully rebuild, is
+                rejected rather than allowed to bill off-ledger; the caller pre-caps
+                its matcher through the model monitor instead. Free
+                (non-``Spending``) Scores pass untouched.
             budget_usd: Spend cap for this instance's lifetime (see
                 :meth:`__init__`). Mutually exclusive with ``monitor``.
             monitor: An existing :class:`~langres.core.spend.SpendMonitor` to adopt
@@ -443,48 +452,86 @@ class ModelState:
         return model
 
     def _secure_chain_scores(self, chain: list[Stage]) -> list[Stage]:
-        """Auto-cap the chain's paid Scores through this model's :class:`SpendMonitor`.
+        """Guarantee every paid Score in the chain bills through THIS model's ledger.
 
         The classic four-slot path wraps its matcher in a
-        :class:`~langres.core.spend_cap.SpendCappedMatcher` at scoring time; an
-        explicit chain must get the SAME guarantee or a paid Score bills off-ledger
-        (the ``.module.forward`` AST-ban only catches the literal slot call). So for
-        every :class:`~langres.core.op_adapters.MatcherScore` whose matcher is not
-        already spend-capped, rebuild it around
-        ``SpendCappedMatcher(matcher, monitor=self._spend_monitor)`` -- a Score whose
-        matcher a caller already capped is left untouched (``isinstance`` guard, no
-        double-wrap). A *paid* Score this door cannot auto-cap -- any other ``Score``
-        that still carries a raw ``Matcher`` (e.g. a ``GroupwiseMatcherScore``, whose
-        ``forward_groups`` bypasses the cap's per-judgement metering) -- is rejected
-        rather than allowed to run uncapped.
+        :class:`~langres.core.spend_cap.SpendCappedMatcher` sharing one
+        :class:`SpendMonitor` at scoring time; an explicit chain must get the SAME
+        guarantee or a paid Score bills off-ledger (the ``.module.forward`` AST-ban
+        only catches the literal slot call). The rule is an **allowlist** keyed on
+        the :class:`~langres.core.op.Spending` marker -- a declared intent, not
+        attribute-sniffing, which as a denylist rotted open (a custom Score billing
+        via a differently-named attribute slipped through):
+
+        - A non-:class:`~langres.core.op.Spending` stage (a free ``ComparatorScore``,
+          any Select, the Source/ClusterStage) is trusted and passes untouched.
+        - A ``Spending`` :class:`~langres.core.op_adapters.MatcherScore`:
+
+          * matcher already a ``SpendCappedMatcher`` -> it MUST share
+            ``self._spend_monitor`` (identity). Same ledger: left alone. A
+            **foreign** monitor is rejected -- it would bill a different budget, so
+            "one model ledger" would be false and total spend could exceed
+            ``budget_usd``.
+          * matcher raw AND the Score is exactly ``MatcherScore`` -> rebuild it
+            around ``SpendCappedMatcher(matcher, monitor=self._spend_monitor)``.
+          * matcher raw AND the Score is a ``MatcherScore`` *subclass* -> rejected:
+            rebuilding to base ``MatcherScore`` would silently drop the subclass's
+            own state (codex Q3). The author pre-caps its matcher with the model
+            monitor instead.
+
+        - Any OTHER ``Spending`` Score (e.g. a ``GroupwiseMatcherScore``, whose
+          ``forward_groups`` bypasses a ``SpendCappedMatcher``'s per-judgement
+          metering) -> rejected. The door cannot force it onto the ledger, and it
+          will not run an uncapped paid Score.
+
+        The residual limit is honest (see :class:`~langres.core.op.Spending`): a
+        custom Score that bills WITHOUT declaring ``Spending`` is the author's own
+        bug -- the door cannot introspect an arbitrary ``forward()`` body.
 
         Returns:
-            A new chain list with the same wiring, every ``MatcherScore`` capped.
+            A new chain list, same wiring, every ``Spending`` Score capped through
+            ``self._spend_monitor`` (or the whole chain rejected).
         """
         secured: list[Stage] = []
         for stage in chain:
-            if isinstance(stage, MatcherScore):
-                if isinstance(stage.matcher, SpendCappedMatcher):
-                    secured.append(stage)  # caller already capped it -- leave alone
-                else:
-                    secured.append(
-                        MatcherScore(
-                            SpendCappedMatcher(stage.matcher, monitor=self._spend_monitor),
-                            out_space=stage.out_space,
-                        )
-                    )
+            if not isinstance(stage, Spending):
+                secured.append(stage)  # free (or a boundary stage) -- trust and pass
                 continue
-            if isinstance(stage, Score):
-                held = getattr(stage, "matcher", None)
-                if isinstance(held, Matcher) and not isinstance(held, SpendCappedMatcher):
+            if not isinstance(stage, MatcherScore):
+                raise ValueError(
+                    f"from_topology() cannot cap a {type(stage).__name__}: it declares Spending "
+                    "(it may bill a paid model) but is not a MatcherScore, so this door cannot "
+                    "route its billing through the model ledger (a SpendCappedMatcher meters "
+                    "Matcher.forward, not e.g. GroupwiseMatcher.forward_groups). It refuses to run "
+                    "an uncapped paid Score off-ledger. Fix: express the scoring as a MatcherScore, "
+                    "or cap its paid work through a model-monitor SpendCappedMatcher yourself."
+                )
+            matcher = stage.matcher
+            if isinstance(matcher, SpendCappedMatcher):
+                if matcher.monitor is not self._spend_monitor:
                     raise ValueError(
-                        f"from_topology() cannot enforce the spend cap on a "
-                        f"{type(stage).__name__}: only a MatcherScore is auto-capped, and this "
-                        "door refuses to run an uncapped paid Score off-ledger. Fix: wrap its "
-                        "matcher in SpendCappedMatcher(matcher, monitor=...) yourself, or express "
-                        "the scoring as a MatcherScore."
+                        "from_topology() got a pre-capped MatcherScore whose SpendCappedMatcher "
+                        "uses a monitor other than this model's ledger, so its spend would never "
+                        "count against the model budget ('one model ledger' would be false). Fix: "
+                        "pass that monitor as from_topology(monitor=...), or hand a raw matcher and "
+                        "let the door cap it."
                     )
-            secured.append(stage)
+                secured.append(stage)  # same ledger -- leave the caller's object alone
+            elif type(stage) is MatcherScore:
+                secured.append(
+                    MatcherScore(
+                        SpendCappedMatcher(matcher, monitor=self._spend_monitor),
+                        out_space=stage.out_space,
+                    )
+                )
+            else:
+                raise ValueError(
+                    f"from_topology() cannot faithfully spend-cap a MatcherScore subclass "
+                    f"({type(stage).__name__}): rebuilding it as a base MatcherScore to inject the "
+                    "cap would silently drop the subclass's own state. Fix: pre-cap its matcher "
+                    "with SpendCappedMatcher(matcher, monitor=...) sharing the model monitor "
+                    "(pass that monitor as from_topology(monitor=...))."
+                )
         return secured
 
     def _topology(self, schema: type[BaseModel]) -> dict[str, Any]:

--- a/src/langres/core/_model_state.py
+++ b/src/langres/core/_model_state.py
@@ -27,8 +27,17 @@ from langres.core.fit import CalibratorFitMixin
 from langres.training.fit_report import FitReport
 from langres.core.inputs import normalize_records
 from langres.core.matcher import Matcher
+from langres.core.op import (
+    ClusterStage,
+    Op,
+    Score,
+    Sequential,
+    Source,
+    Stage,
+    ThresholdSelect,
+)
 from langres.core.spend import SpendMonitor
-from langres.core.spend_cap import effective_budget
+from langres.core.spend_cap import SpendCappedMatcher, effective_budget
 
 logger = logging.getLogger(__name__)
 
@@ -160,6 +169,15 @@ class ModelState:
         self._comparator: Comparator[Any] | None = None
         self._module: Matcher[Any] | None = None
         self._clusterer: Clusterer | None = None
+        # An OPTIONAL explicit Op chain (epic #193, PR-A). ``None`` -> this is a
+        # classic four-slot topology and every run/read below takes its
+        # slot-derived path unchanged; a list -> this model runs the explicit
+        # chain instead (set ONLY by :meth:`from_topology`). A ``Stage`` is a
+        # ``Source | Op | ClusterStage | Finalize`` (op.py's union): the Source
+        # (records -> pairs), the body Ops (pairs -> pairs, INCLUDING Selects),
+        # then the terminal ClusterStage (pairs -> clusters) and an optional
+        # Finalize. All classic construction doors leave it ``None``.
+        self._ops: list[Stage] | None = None
 
     @property
     def blocker(self) -> Blocker[Any]:
@@ -298,6 +316,95 @@ class ModelState:
         )
         return model
 
+    @classmethod
+    def from_topology(
+        cls,
+        *,
+        ops: Sequence[Stage],
+        budget_usd: float | None = None,
+        monitor: SpendMonitor | None = None,
+        calibrator: CalibratorFitMixin | None = None,
+    ) -> Self:
+        """Build a model that runs an EXPLICIT Op chain instead of the four slots.
+
+        The breaking-change door of the final wave (epic #193, PR-A): where
+        :meth:`from_components` wires a classic four-slot topology (which the run
+        path *derives* an Op chain from), this door takes the chain **directly** --
+        so a model can express a topology the four slots cannot (a Score after a
+        Select, a second matcher, a retrieval-only prefix). Like
+        :meth:`from_components` it bypasses ``__init__`` (``__new__`` + the shared
+        state setup), then stores the chain in ``self._ops`` and leaves the four
+        slots empty. Every method dispatches on ``self._ops``: ``None`` (every
+        classic door) runs the slot-derived path unchanged; a list walks this
+        chain.
+
+        The chain's wiring is validated at construction via :class:`~langres.core.op.Sequential`
+        (Source first, then Ops, then a ClusterStage, optionally a Finalize -- a
+        Select over a vector score is rejected), and it must carry exactly one
+        terminal :class:`~langres.core.op.ClusterStage` so ``resolve``/``dedupe``
+        have a phase-1 exit.
+
+        Args:
+            ops: The explicit chain, in pipeline order (a Source, zero+ Ops
+                including Selects, one terminal ClusterStage, optional Finalize).
+                **Any paid Score in the chain must already wrap its matcher in a
+                :class:`~langres.core.spend_cap.SpendCappedMatcher`** -- the
+                ``.module.forward`` AST-ban only catches the literal slot call, so
+                nothing mechanical stops an explicit-chain Score from billing
+                off-ledger. Share this model's ledger by passing that same
+                ``monitor=`` here.
+            budget_usd: Spend cap for this instance's lifetime (see
+                :meth:`__init__`). Mutually exclusive with ``monitor``.
+            monitor: An existing :class:`~langres.core.spend.SpendMonitor` to adopt
+                as this model's ledger -- pass the SAME monitor the chain's
+                ``SpendCappedMatcher`` wraps, so the model's budget genuinely caps
+                the chain. Mutually exclusive with ``budget_usd``.
+            calibrator: **Rejected.** Calibration is a bespoke per-score transform
+                that only the classic path applies; a ``CalibratorScore`` Op is a
+                later wave, so an explicit chain must express any score mapping as
+                its own Score. Passing one raises.
+
+        Returns:
+            A model wired to run ``ops``, ready to ``resolve``/``dedupe``/``compare``.
+
+        Raises:
+            ValueError: If ``calibrator`` is given, if both ``budget_usd`` and
+                ``monitor`` are given, if the chain is mis-wired, or if it does not
+                carry exactly one terminal ClusterStage.
+        """
+        if calibrator is not None:
+            raise ValueError(
+                "from_topology() does not accept a calibrator: calibration is a bespoke "
+                "per-score transform only the classic four-slot path applies (a CalibratorScore "
+                "Op is a later wave). Fix: express any score mapping as a Score in the chain, or "
+                "build the classic path with from_components(...)."
+            )
+        if monitor is not None and budget_usd is not None:
+            raise ValueError(
+                "pass budget_usd= or monitor=, not both: a SpendMonitor already carries its own "
+                f"budget (${monitor.budget_usd:.2f}), so budget_usd={budget_usd!r} would silently "
+                "lose. Pass the monitor the chain's SpendCappedMatcher already shares."
+            )
+        chain = list(ops)
+        # Reuse the one wiring guard rather than a second, decoupled check: a Source
+        # first, Ops (pairs -> pairs) in the middle, a ClusterStage, an optional
+        # Finalize -- and NO Select over a non-orderable vector score.
+        Sequential(chain)
+        cluster_stages = [stage for stage in chain if isinstance(stage, ClusterStage)]
+        if len(cluster_stages) != 1:
+            raise ValueError(
+                f"from_topology() needs exactly one terminal ClusterStage (pairs -> clusters) so "
+                f"resolve()/dedupe() have a phase-1 exit, but the chain has {len(cluster_stages)}. "
+                "Fix: end the chain with exactly one ClusterStage."
+            )
+        model = cls.__new__(cls)
+        model._init_state(budget_usd=budget_usd)
+        if monitor is not None:
+            # Adopt the caller's ledger so the model's cap IS the chain's cap.
+            model._spend_monitor = monitor
+        model._ops = chain
+        return model
+
     def _topology(self, schema: type[BaseModel]) -> dict[str, Any]:
         """Build this architecture's components for ``schema``. The subclass hook.
 
@@ -350,9 +457,89 @@ class ModelState:
         weights in the scoring slot (pure string similarity) rather than
         fabricating an identity. An architecture whose backbone lives elsewhere
         (e.g. in the blocker's embedder) overrides this to say so.
+
+        For an explicit-chain model (``_ops`` set) there is no ``module`` slot, so
+        it reads the chain's own scoring matcher instead (:meth:`_chain_scoring_matcher`,
+        unwrapped past its spend cap), and ``None`` when that matcher exposes no
+        ``model``.
         """
+        if self._ops is not None:
+            matcher = self._chain_scoring_matcher()
+            candidate = getattr(matcher, "model", None) if matcher is not None else None
+            return candidate if isinstance(candidate, str) else None
         candidate = getattr(self.module, "model", None)
         return candidate if isinstance(candidate, str) else None
+
+    # ------------------------------------------------------------------
+    # Explicit-chain readers (``_ops`` set) -- the chain is the source of
+    # truth, so these parse it instead of reading the four slots. Every one
+    # asserts ``_ops`` is set; callers guard on ``self._ops is not None``.
+    # ``from_topology`` (via Sequential) guarantees the shape they assume:
+    # a Source first, Ops in the middle, exactly one ClusterStage.
+    # ------------------------------------------------------------------
+
+    def _require_ops(self) -> list[Stage]:
+        assert self._ops is not None  # callers guard on ``self._ops is not None``
+        return self._ops
+
+    def _chain_source(self) -> Source[Any]:
+        """The chain's Source (records -> pairs) -- ``ops[0]``, guaranteed a Source."""
+        source = self._require_ops()[0]
+        assert isinstance(source, Source)  # Sequential requires a Source first
+        return source
+
+    def _chain_body(self) -> list[Op[Any]]:
+        """The body Ops (Scores AND Selects). Every ``Op`` in the chain is a body Op:
+        the Source, ClusterStage and Finalize are not ``Op``\\ s, so this filter picks
+        out exactly the pairs -> pairs middle."""
+        return [stage for stage in self._require_ops() if isinstance(stage, Op)]
+
+    def _chain_body_scores(self) -> list[Score[Any]]:
+        """The body's Score ops only (skips Selects) -- what ``compare`` folds on one pair."""
+        return [op for op in self._chain_body() if isinstance(op, Score)]
+
+    def _chain_cluster_stage(self) -> ClusterStage[Any]:
+        """The chain's terminal ClusterStage (from_topology guarantees exactly one)."""
+        for stage in self._require_ops():
+            if isinstance(stage, ClusterStage):
+                return stage
+        raise AssertionError("explicit chain has no ClusterStage")  # from_topology guards this
+
+    def _chain_threshold(self) -> float | None:
+        """The terminal :class:`~langres.core.op.ThresholdSelect`'s threshold -- the chain's
+        match cut -- or ``None`` if the chain has no ThresholdSelect. The LAST one wins."""
+        threshold: float | None = None
+        for op in self._chain_body():
+            if isinstance(op, ThresholdSelect):
+                threshold = op.threshold
+        return threshold
+
+    def _chain_scoring_matcher(self) -> Matcher[Any] | None:
+        """The chain's last matcher-``Score``'s matcher, unwrapped past its spend cap.
+
+        The chain's paid Scores wrap their matcher in a
+        :class:`~langres.core.spend_cap.SpendCappedMatcher` (that wrapper has no
+        ``model``), so peel it to expose the real matcher for :attr:`backbone`. A
+        matcher-Score is a Score carrying a ``matcher`` attribute (``MatcherScore`` /
+        ``GroupwiseMatcherScore``); a ``ComparatorScore`` carries ``comparator``, not
+        ``matcher``, so it is skipped.
+        """
+        matcher: Matcher[Any] | None = None
+        for op in self._chain_body():
+            candidate = getattr(op, "matcher", None)
+            if isinstance(op, Score) and isinstance(candidate, Matcher):
+                matcher = candidate
+        if isinstance(matcher, SpendCappedMatcher):
+            return matcher._module  # peel the cap; the wrapped matcher owns ``model``
+        return matcher
+
+    def _chain_source_schema(self) -> type[BaseModel] | None:
+        """The schema the chain's Source blocks against (for front-door normalization),
+        or ``None`` when the Source carries none (an opaque ``schema_factory`` blocker)."""
+        blocker = getattr(self._chain_source(), "blocker", None)
+        if isinstance(blocker, Blocker):
+            return blocker.schema
+        return None
 
     def _require_bound(self, action: str) -> None:
         """Raise a directed error if this model has no components yet."""

--- a/src/langres/core/_model_state.py
+++ b/src/langres/core/_model_state.py
@@ -503,7 +503,9 @@ class ModelState:
         for stage in self._require_ops():
             if isinstance(stage, ClusterStage):
                 return stage
-        raise AssertionError("explicit chain has no ClusterStage")  # from_topology guards this
+        raise AssertionError(  # pragma: no cover - from_topology guarantees exactly one
+            "explicit chain has no ClusterStage"
+        )
 
     def _chain_threshold(self) -> float | None:
         """The terminal :class:`~langres.core.op.ThresholdSelect`'s threshold -- the chain's

--- a/src/langres/core/op.py
+++ b/src/langres/core/op.py
@@ -289,6 +289,32 @@ class Score(Op[SchemaT]):
         self.out_space: OutSpace = out_space
 
 
+class Spending:
+    """Marker a :class:`Score` sets to DECLARE it may bill (call a paid model).
+
+    This is an **allowlist for money**, read by the explicit-chain door
+    (``ERModel.from_topology`` → ``_secure_chain_scores``): a ``Spending`` Score
+    MUST be capped through the model's ``SpendMonitor`` or the door rejects the
+    chain; a non-``Spending`` Score is trusted free and passes. ``MatcherScore``
+    and ``GroupwiseMatcherScore`` are ``Spending`` (they hold a paid ``Matcher``);
+    ``ComparatorScore`` (string features) and any free scalarizer are not.
+
+    Why a declared marker and not attribute-sniffing: the door used to look for a
+    ``.matcher`` attribute, which is a *denylist* — it rots open. A custom Score
+    that bills via a differently-named attribute, or by calling an LLM inside its
+    own ``forward()``, slipped through uncapped. Declaring intent flips it to
+    fail-safe: an undeclared paid Score is refused billing by omission.
+
+    **Residual limit, stated honestly:** the door cannot introspect an arbitrary
+    ``forward()`` body, so it cannot *force* a ``Spending`` Score it does not know
+    how to wrap (anything other than a ``MatcherScore``) onto the ledger — it can
+    only reject it. A custom paid Score MUST both set ``Spending`` AND route its
+    paid work through a model-monitor ``SpendCappedMatcher`` (i.e. be a
+    ``MatcherScore``, or pre-cap its matcher with the model's monitor). A Score
+    that bills without declaring ``Spending`` is the author's own bug.
+    """
+
+
 class Select(Op[SchemaT]):
     """The select role: "same scores, fewer rows".
 

--- a/src/langres/core/op_adapters.py
+++ b/src/langres/core/op_adapters.py
@@ -52,7 +52,15 @@ from langres.core.clusterer import Clusterer
 from langres.core.comparator import Comparator
 from langres.core.groups import derive_groups_from_pairs
 from langres.core.matcher import GroupwiseMatcher, Matcher
-from langres.core.op import ClusterStage, Finalize, OutSpace, Records, Score, Source
+from langres.core.op import (
+    ClusterStage,
+    Finalize,
+    OutSpace,
+    Records,
+    Score,
+    Source,
+    Spending,
+)
 from langres.core.pairs import PairRow, Pairs
 
 if TYPE_CHECKING:
@@ -182,8 +190,11 @@ class ComparatorScore(Score[SchemaT], Generic[SchemaT]):
         return Pairs(store=pairs.store, rows=rows)
 
 
-class MatcherScore(Score[SchemaT], Generic[SchemaT]):
+class MatcherScore(Score[SchemaT], Spending, Generic[SchemaT]):
     """:class:`~langres.core.op.Score` adapter over a legacy pairwise :class:`~langres.core.matcher.Matcher`.
+
+    ``Spending`` (declares it may bill): the wrapped ``Matcher`` can be a paid LLM,
+    so the explicit-chain door caps it through the model's ``SpendMonitor``.
 
     Bridges ``matcher.forward(Iterator[ERCandidate]) -> Iterator[PairwiseJudgement]``:
     the incoming ``Pairs`` is projected to candidates
@@ -227,8 +238,13 @@ class MatcherScore(Score[SchemaT], Generic[SchemaT]):
         return _rescore(pairs, judgements)
 
 
-class GroupwiseMatcherScore(Score[SchemaT], Generic[SchemaT]):
+class GroupwiseMatcherScore(Score[SchemaT], Spending, Generic[SchemaT]):
     """:class:`~langres.core.op.Score` adapter over a :class:`~langres.core.matcher.GroupwiseMatcher`.
+
+    ``Spending`` (declares it may bill): its ``GroupwiseMatcher`` can be a paid
+    set-wise LLM. The explicit-chain door cannot auto-cap it (a
+    ``SpendCappedMatcher`` meters ``forward``, not the ``forward_groups`` this
+    adapter calls), so ``from_topology`` rejects it rather than run it off-ledger.
 
     A group-scope ``Score`` (``scope="group"``, ``out_space="prob_group_llm"``):
     it derives per-anchor groups from the ``Pairs``'s candidates

--- a/tests/parity/_explicit_chain_fixture.py
+++ b/tests/parity/_explicit_chain_fixture.py
@@ -1,0 +1,203 @@
+"""Reusable explicit-chain fixtures for the epic #193 generalized spine (PR-A on).
+
+A SYNTHETIC, ``$0``, offline explicit Op chain built via
+:meth:`~langres.core._model_state.ModelState.from_topology` -- the *else* branch
+of the generalized spine, the topology the four legacy slots cannot express (a
+Score after a Select, a second matcher).
+
+Two things make it honest without spending a cent:
+
+- **Its Scores are spend-capped.** Any paid Score reached via an explicit chain
+  must wrap its matcher in a :class:`~langres.core.spend_cap.SpendCappedMatcher`
+  sharing the model's ledger -- the ``.module.forward`` AST-ban only catches the
+  literal slot call, so nothing mechanical stops an explicit-chain Score from
+  billing off-ledger. The chain and the model share ONE
+  :class:`~langres.core.spend.SpendMonitor` (passed to ``from_topology(monitor=)``).
+- **The "paid" matcher is a fake** stamping a made-up ``cost_usd`` (no network, no
+  key -- exactly like ``tests/core/test_resolver_spend_cap.py``), so the ledger
+  moves under a real budget without real spend.
+
+Reused by the later persist PR (a ``from_topology`` chain must ``save``/``load``),
+so the builders here stay clean and importable.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable, Iterator
+from typing import Any
+
+from pydantic import BaseModel
+
+from langres.core.blockers.all_pairs import AllPairsBlocker
+from langres.core.blockers.key import KeyBlocker
+from langres.core.clusterer import Clusterer
+from langres.core.comparators import StringComparator
+from langres.core.matcher import Matcher
+from langres.core.models import ERCandidate, PairwiseJudgement
+from langres.core.op import Stage, ThresholdSelect, TopKSelect
+from langres.core.op_adapters import (
+    BlockerSource,
+    ClustererStage,
+    ComparatorScore,
+    MatcherScore,
+)
+from langres.core.resolver import ERModel
+from langres.core.score_type import ScoreType
+from langres.core.spend import SpendMonitor
+from langres.core.spend_cap import SpendCappedMatcher, effective_budget
+
+
+class ChainCo(BaseModel):
+    """The tiny two-field entity the fixtures resolve."""
+
+    id: str
+    name: str | None = None
+
+
+#: Two Acme duplicates ({a1, a2}), one Beta and one Gamma singleton -- so a
+#: name-equality matcher merges exactly {a1, a2}.
+RECORDS: list[dict[str, Any]] = [
+    {"id": "a1", "name": "Acme"},
+    {"id": "a2", "name": "Acme"},
+    {"id": "b1", "name": "Beta"},
+    {"id": "c1", "name": "Gamma"},
+]
+
+#: The match cut every fixture chain thresholds at.
+THRESHOLD = 0.5
+
+
+class CostedNameMatcher(Matcher[Any]):
+    """``$0`` fake matcher: scores ``1.0`` iff the two names match else ``0.0``.
+
+    Tags a chosen ``score_type`` and stamps a made-up ``cost_usd`` so the spend
+    ledger moves under a real budget -- the cost is fabricated, there is no
+    network and no key (the same technique as ``test_resolver_spend_cap``). An
+    optional ``model`` is advertised so :attr:`~langres.core._model_state.ModelState.backbone`
+    reporting through the chain can be exercised.
+    """
+
+    def __init__(
+        self,
+        *,
+        cost_each: float = 0.0,
+        score_type: ScoreType = "prob_llm",
+        model: str | None = None,
+    ) -> None:
+        self._cost_each = cost_each
+        self._score_type: ScoreType = score_type
+        self.produced = 0
+        #: Advertised backbone id (``None`` = weightless, like a string matcher).
+        self.model: str | None = model
+
+    def forward(self, candidates: Iterator[ERCandidate[Any]]) -> Iterator[PairwiseJudgement]:
+        for candidate in candidates:
+            self.produced += 1
+            yield PairwiseJudgement(
+                left_id=str(candidate.left.id),
+                right_id=str(candidate.right.id),
+                score=1.0 if candidate.left.name == candidate.right.name else 0.0,
+                score_type=self._score_type,
+                decision_step="costed_name",
+                provenance={"cost_usd": self._cost_each},
+            )
+
+    def inspect_scores(self, judgements: list[PairwiseJudgement], sample_size: int = 10) -> Any:
+        raise NotImplementedError
+
+
+def _capped(matcher: Matcher[Any], monitor: SpendMonitor) -> SpendCappedMatcher:
+    """Wrap ``matcher`` in the model's spend cap (share ONE ledger)."""
+    return SpendCappedMatcher(matcher, monitor=monitor)
+
+
+def chain_ops(
+    monitor: SpendMonitor,
+    *,
+    threshold: float = THRESHOLD,
+    cost_each: float = 0.0,
+    model: str | None = None,
+    source: Callable[[], Any] | None = None,
+    with_comparator: bool = True,
+) -> tuple[list[Stage], CostedNameMatcher]:
+    """A canonical spend-capped explicit chain and its raw matcher.
+
+    ``BlockerSource -> [ComparatorScore] -> MatcherScore(SpendCapped(costed)) ->
+    ThresholdSelect -> ClustererStage(Clusterer(0.0))`` -- the match cut is the
+    explicit ThresholdSelect and the clusterer runs pure transitive closure over
+    the survivors. Returns the ops and the raw ``CostedNameMatcher`` so a test can
+    read ``matcher.produced``.
+    """
+    matcher = CostedNameMatcher(cost_each=cost_each, model=model)
+    build_source = source if source is not None else (lambda: AllPairsBlocker(schema=ChainCo))
+    ops: list[Stage] = [BlockerSource(build_source())]
+    if with_comparator:
+        ops.append(ComparatorScore(StringComparator.from_schema(ChainCo)))
+    ops += [
+        MatcherScore(_capped(matcher, monitor), out_space="prob_llm"),
+        ThresholdSelect(threshold),
+        ClustererStage(Clusterer(threshold=0.0)),
+    ]
+    return ops, matcher
+
+
+def build_explicit_chain_model(
+    *, budget_usd: float = 1.0, cost_each: float = 0.05, model: str | None = None
+) -> tuple[ERModel, SpendMonitor, CostedNameMatcher]:
+    """The canonical explicit-chain model + its shared ledger + its raw matcher."""
+    monitor = SpendMonitor(budget_usd=effective_budget(budget_usd))
+    ops, matcher = chain_ops(monitor, cost_each=cost_each, model=model)
+    return ERModel.from_topology(ops=ops, monitor=monitor), monitor, matcher
+
+
+def build_score_after_select_model(*, budget_usd: float = 1.0, k: int = 5) -> ERModel:
+    """A chain exercising Score-after-Select: a cheap ``sim_cos`` student, a
+    ``TopKSelect`` prune, then an escalated ``prob_llm`` matcher, then the cut."""
+    monitor = SpendMonitor(budget_usd=effective_budget(budget_usd))
+    ops: list[Stage] = [
+        BlockerSource(AllPairsBlocker(schema=ChainCo)),
+        MatcherScore(_capped(CostedNameMatcher(score_type="sim_cos"), monitor), out_space="sim_cos"),
+        TopKSelect(k=k),
+        MatcherScore(_capped(CostedNameMatcher(score_type="prob_llm"), monitor), out_space="prob_llm"),
+        ThresholdSelect(THRESHOLD),
+        ClustererStage(Clusterer(threshold=0.0)),
+    ]
+    return ERModel.from_topology(ops=ops, monitor=monitor)
+
+
+def build_no_threshold_chain_model(*, budget_usd: float = 1.0) -> ERModel:
+    """A chain with NO terminal ThresholdSelect: the cut lives in the ClusterStage's
+    clusterer instead. Exercises ``dedupe``'s ``threshold=None`` report and
+    ``compare``'s no-cut guard."""
+    monitor = SpendMonitor(budget_usd=effective_budget(budget_usd))
+    ops: list[Stage] = [
+        BlockerSource(AllPairsBlocker(schema=ChainCo)),
+        MatcherScore(_capped(CostedNameMatcher(), monitor), out_space="prob_llm"),
+        ClustererStage(Clusterer(threshold=THRESHOLD)),
+    ]
+    return ERModel.from_topology(ops=ops, monitor=monitor)
+
+
+def build_key_source_model(*, budget_usd: float = 1.0) -> ERModel:
+    """A chain whose Source is a ``KeyBlocker`` (blocks on name), so ``compare`` on
+    two DIFFERENT-name records yields no candidate and must build the pair directly
+    (exercises the ``_chain_pair_candidate`` fallback)."""
+    monitor = SpendMonitor(budget_usd=effective_budget(budget_usd))
+    ops, _matcher = chain_ops(
+        monitor,
+        source=lambda: KeyBlocker(schema=ChainCo, key_field="name"),
+        with_comparator=False,
+    )
+    return ERModel.from_topology(ops=ops, monitor=monitor)
+
+
+def build_factory_source_model(*, budget_usd: float = 1.0) -> ERModel:
+    """A chain whose Source blocker carries no schema (an opaque ``schema_factory``),
+    so ``_chain_source_schema`` is ``None`` and the front door infers a schema."""
+    monitor = SpendMonitor(budget_usd=effective_budget(budget_usd))
+    ops, _matcher = chain_ops(
+        monitor,
+        source=lambda: AllPairsBlocker(schema_factory=lambda record: ChainCo(**record)),
+        with_comparator=False,
+    )
+    return ERModel.from_topology(ops=ops, monitor=monitor)

--- a/tests/parity/_explicit_chain_fixture.py
+++ b/tests/parity/_explicit_chain_fixture.py
@@ -106,6 +106,27 @@ class CostedNameMatcher(Matcher[Any]):
         raise NotImplementedError
 
 
+class AbstainingMatcher(Matcher[Any]):
+    """``$0`` fake that abstains on every pair: a stamped ``score_type`` but neither a
+    ``score`` nor a ``decision``. Used to exercise ``compare``'s
+    :class:`~langres.core.models.MatcherAbstainedError` path on an explicit chain."""
+
+    def forward(self, candidates: Iterator[ERCandidate[Any]]) -> Iterator[PairwiseJudgement]:
+        for candidate in candidates:
+            yield PairwiseJudgement(
+                left_id=str(candidate.left.id),
+                right_id=str(candidate.right.id),
+                score=None,
+                score_type="prob_llm",
+                decision=None,
+                decision_step="abstain",
+                provenance={},
+            )
+
+    def inspect_scores(self, judgements: list[PairwiseJudgement], sample_size: int = 10) -> Any:
+        raise NotImplementedError
+
+
 def _capped(matcher: Matcher[Any], monitor: SpendMonitor) -> SpendCappedMatcher:
     """Wrap ``matcher`` in the model's spend cap (share ONE ledger)."""
     return SpendCappedMatcher(matcher, monitor=monitor)
@@ -156,9 +177,13 @@ def build_score_after_select_model(*, budget_usd: float = 1.0, k: int = 5) -> ER
     monitor = SpendMonitor(budget_usd=effective_budget(budget_usd))
     ops: list[Stage] = [
         BlockerSource(AllPairsBlocker(schema=ChainCo)),
-        MatcherScore(_capped(CostedNameMatcher(score_type="sim_cos"), monitor), out_space="sim_cos"),
+        MatcherScore(
+            _capped(CostedNameMatcher(score_type="sim_cos"), monitor), out_space="sim_cos"
+        ),
         TopKSelect(k=k),
-        MatcherScore(_capped(CostedNameMatcher(score_type="prob_llm"), monitor), out_space="prob_llm"),
+        MatcherScore(
+            _capped(CostedNameMatcher(score_type="prob_llm"), monitor), out_space="prob_llm"
+        ),
         ThresholdSelect(THRESHOLD),
         ClustererStage(Clusterer(threshold=0.0)),
     ]
@@ -200,4 +225,17 @@ def build_factory_source_model(*, budget_usd: float = 1.0) -> ERModel:
         source=lambda: AllPairsBlocker(schema_factory=lambda record: ChainCo(**record)),
         with_comparator=False,
     )
+    return ERModel.from_topology(ops=ops, monitor=monitor)
+
+
+def build_abstaining_chain_model(*, budget_usd: float = 1.0) -> ERModel:
+    """A chain whose matcher abstains on every pair -- so ``compare`` raises
+    :class:`~langres.core.models.MatcherAbstainedError` rather than fabricating a verdict."""
+    monitor = SpendMonitor(budget_usd=effective_budget(budget_usd))
+    ops: list[Stage] = [
+        BlockerSource(AllPairsBlocker(schema=ChainCo)),
+        MatcherScore(_capped(AbstainingMatcher(), monitor), out_space="prob_llm"),
+        ThresholdSelect(THRESHOLD),
+        ClustererStage(Clusterer(threshold=0.0)),
+    ]
     return ERModel.from_topology(ops=ops, monitor=monitor)

--- a/tests/parity/_explicit_chain_fixture.py
+++ b/tests/parity/_explicit_chain_fixture.py
@@ -7,12 +7,16 @@ Score after a Select, a second matcher).
 
 Two things make it honest without spending a cent:
 
-- **Its Scores are spend-capped.** Any paid Score reached via an explicit chain
-  must wrap its matcher in a :class:`~langres.core.spend_cap.SpendCappedMatcher`
-  sharing the model's ledger -- the ``.module.forward`` AST-ban only catches the
-  literal slot call, so nothing mechanical stops an explicit-chain Score from
-  billing off-ledger. The chain and the model share ONE
-  :class:`~langres.core.spend.SpendMonitor` (passed to ``from_topology(monitor=)``).
+- **Its Scores are spend-capped by the door, from RAW matchers.** These builders
+  pass an *unwrapped* matcher into each ``MatcherScore`` on purpose:
+  ``from_topology`` is what enforces the cap, auto-wrapping every ``MatcherScore``
+  in a :class:`~langres.core.spend_cap.SpendCappedMatcher` sharing the model's
+  ledger. That is the guarantee under test -- a paid explicit-chain Score can no
+  longer bill off-ledger even when the caller forgot to wrap it (the
+  ``.module.forward`` AST-ban only catches the literal slot call). The chain and
+  the model share ONE :class:`~langres.core.spend.SpendMonitor` (passed to
+  ``from_topology(monitor=)``). ``build_precapped_chain_model`` covers the other
+  branch: a matcher the caller already wrapped is left alone (no double-wrap).
 - **The "paid" matcher is a fake** stamping a made-up ``cost_usd`` (no network, no
   key -- exactly like ``tests/core/test_resolver_spend_cap.py``), so the ledger
   moves under a real budget without real spend.
@@ -127,13 +131,7 @@ class AbstainingMatcher(Matcher[Any]):
         raise NotImplementedError
 
 
-def _capped(matcher: Matcher[Any], monitor: SpendMonitor) -> SpendCappedMatcher:
-    """Wrap ``matcher`` in the model's spend cap (share ONE ledger)."""
-    return SpendCappedMatcher(matcher, monitor=monitor)
-
-
 def chain_ops(
-    monitor: SpendMonitor,
     *,
     threshold: float = THRESHOLD,
     cost_each: float = 0.0,
@@ -141,13 +139,14 @@ def chain_ops(
     source: Callable[[], Any] | None = None,
     with_comparator: bool = True,
 ) -> tuple[list[Stage], CostedNameMatcher]:
-    """A canonical spend-capped explicit chain and its raw matcher.
+    """A canonical explicit chain (with a RAW matcher) and that matcher.
 
-    ``BlockerSource -> [ComparatorScore] -> MatcherScore(SpendCapped(costed)) ->
-    ThresholdSelect -> ClustererStage(Clusterer(0.0))`` -- the match cut is the
-    explicit ThresholdSelect and the clusterer runs pure transitive closure over
-    the survivors. Returns the ops and the raw ``CostedNameMatcher`` so a test can
-    read ``matcher.produced``.
+    ``BlockerSource -> [ComparatorScore] -> MatcherScore(costed) -> ThresholdSelect
+    -> ClustererStage(Clusterer(0.0))`` -- the match cut is the explicit
+    ThresholdSelect and the clusterer runs pure transitive closure over the
+    survivors. The matcher is passed UNWRAPPED: ``from_topology`` is what caps it.
+    Returns the ops and the raw ``CostedNameMatcher`` so a test can read
+    ``matcher.produced``.
     """
     matcher = CostedNameMatcher(cost_each=cost_each, model=model)
     build_source = source if source is not None else (lambda: AllPairsBlocker(schema=ChainCo))
@@ -155,7 +154,7 @@ def chain_ops(
     if with_comparator:
         ops.append(ComparatorScore(StringComparator.from_schema(ChainCo)))
     ops += [
-        MatcherScore(_capped(matcher, monitor), out_space="prob_llm"),
+        MatcherScore(matcher, out_space="prob_llm"),
         ThresholdSelect(threshold),
         ClustererStage(Clusterer(threshold=0.0)),
     ]
@@ -165,25 +164,44 @@ def chain_ops(
 def build_explicit_chain_model(
     *, budget_usd: float = 1.0, cost_each: float = 0.05, model: str | None = None
 ) -> tuple[ERModel, SpendMonitor, CostedNameMatcher]:
-    """The canonical explicit-chain model + its shared ledger + its raw matcher."""
+    """The canonical explicit-chain model + its shared ledger + its raw matcher.
+
+    The matcher goes in raw; ``from_topology(monitor=)`` caps it, so the returned
+    model's Score bills through ``monitor``.
+    """
     monitor = SpendMonitor(budget_usd=effective_budget(budget_usd))
-    ops, matcher = chain_ops(monitor, cost_each=cost_each, model=model)
+    ops, matcher = chain_ops(cost_each=cost_each, model=model)
     return ERModel.from_topology(ops=ops, monitor=monitor), monitor, matcher
+
+
+def build_precapped_chain_model(
+    *, budget_usd: float = 1.0
+) -> tuple[ERModel, SpendMonitor, SpendCappedMatcher]:
+    """A chain whose ``MatcherScore`` matcher the CALLER already wrapped in a
+    :class:`~langres.core.spend_cap.SpendCappedMatcher` -- so ``from_topology`` must
+    leave it alone (no double-wrap). Returns the model, its ledger, and the exact
+    capped matcher so a test can assert identity is preserved."""
+    monitor = SpendMonitor(budget_usd=effective_budget(budget_usd))
+    capped = SpendCappedMatcher(CostedNameMatcher(), monitor=monitor)
+    ops: list[Stage] = [
+        BlockerSource(AllPairsBlocker(schema=ChainCo)),
+        MatcherScore(capped, out_space="prob_llm"),
+        ThresholdSelect(THRESHOLD),
+        ClustererStage(Clusterer(threshold=0.0)),
+    ]
+    return ERModel.from_topology(ops=ops, monitor=monitor), monitor, capped
 
 
 def build_score_after_select_model(*, budget_usd: float = 1.0, k: int = 5) -> ERModel:
     """A chain exercising Score-after-Select: a cheap ``sim_cos`` student, a
-    ``TopKSelect`` prune, then an escalated ``prob_llm`` matcher, then the cut."""
+    ``TopKSelect`` prune, then an escalated ``prob_llm`` matcher, then the cut.
+    Both matchers go in raw; the door caps each."""
     monitor = SpendMonitor(budget_usd=effective_budget(budget_usd))
     ops: list[Stage] = [
         BlockerSource(AllPairsBlocker(schema=ChainCo)),
-        MatcherScore(
-            _capped(CostedNameMatcher(score_type="sim_cos"), monitor), out_space="sim_cos"
-        ),
+        MatcherScore(CostedNameMatcher(score_type="sim_cos"), out_space="sim_cos"),
         TopKSelect(k=k),
-        MatcherScore(
-            _capped(CostedNameMatcher(score_type="prob_llm"), monitor), out_space="prob_llm"
-        ),
+        MatcherScore(CostedNameMatcher(score_type="prob_llm"), out_space="prob_llm"),
         ThresholdSelect(THRESHOLD),
         ClustererStage(Clusterer(threshold=0.0)),
     ]
@@ -197,7 +215,7 @@ def build_no_threshold_chain_model(*, budget_usd: float = 1.0) -> ERModel:
     monitor = SpendMonitor(budget_usd=effective_budget(budget_usd))
     ops: list[Stage] = [
         BlockerSource(AllPairsBlocker(schema=ChainCo)),
-        MatcherScore(_capped(CostedNameMatcher(), monitor), out_space="prob_llm"),
+        MatcherScore(CostedNameMatcher(), out_space="prob_llm"),
         ClustererStage(Clusterer(threshold=THRESHOLD)),
     ]
     return ERModel.from_topology(ops=ops, monitor=monitor)
@@ -209,7 +227,6 @@ def build_key_source_model(*, budget_usd: float = 1.0) -> ERModel:
     (exercises the ``_chain_pair_candidate`` fallback)."""
     monitor = SpendMonitor(budget_usd=effective_budget(budget_usd))
     ops, _matcher = chain_ops(
-        monitor,
         source=lambda: KeyBlocker(schema=ChainCo, key_field="name"),
         with_comparator=False,
     )
@@ -221,7 +238,6 @@ def build_factory_source_model(*, budget_usd: float = 1.0) -> ERModel:
     so ``_chain_source_schema`` is ``None`` and the front door infers a schema."""
     monitor = SpendMonitor(budget_usd=effective_budget(budget_usd))
     ops, _matcher = chain_ops(
-        monitor,
         source=lambda: AllPairsBlocker(schema_factory=lambda record: ChainCo(**record)),
         with_comparator=False,
     )
@@ -234,7 +250,7 @@ def build_abstaining_chain_model(*, budget_usd: float = 1.0) -> ERModel:
     monitor = SpendMonitor(budget_usd=effective_budget(budget_usd))
     ops: list[Stage] = [
         BlockerSource(AllPairsBlocker(schema=ChainCo)),
-        MatcherScore(_capped(AbstainingMatcher(), monitor), out_space="prob_llm"),
+        MatcherScore(AbstainingMatcher(), out_space="prob_llm"),
         ThresholdSelect(THRESHOLD),
         ClustererStage(Clusterer(threshold=0.0)),
     ]

--- a/tests/parity/test_explicit_chain_spine_w3.py
+++ b/tests/parity/test_explicit_chain_spine_w3.py
@@ -26,7 +26,7 @@ from langres.core.fit import CalibratorFitMixin
 from langres.core.groups import ERCandidateGroup
 from langres.core.matcher import GroupwiseMatcher
 from langres.core.models import MatcherAbstainedError, PairwiseJudgement
-from langres.core.op import Clusters, Finalize, Stage, ThresholdSelect
+from langres.core.op import Clusters, Finalize, Score, Spending, Stage, ThresholdSelect
 from langres.core.op_adapters import (
     BlockerSource,
     ClustererStage,
@@ -169,10 +169,10 @@ def test_from_topology_leaves_an_already_capped_matcher_alone() -> None:
     assert model._spend_monitor is monitor
 
 
-def test_from_topology_rejects_an_uncappable_paid_score() -> None:
-    """A paid Score the door cannot auto-cap (a GroupwiseMatcherScore, whose
-    ``forward_groups`` bypasses the cap's per-judgement metering) is rejected rather
-    than allowed to bill off-ledger -- unless the caller pre-capped its matcher."""
+def test_from_topology_rejects_a_spending_score_it_cannot_cap() -> None:
+    """A Spending Score the door cannot wrap (a GroupwiseMatcherScore, whose
+    ``forward_groups`` bypasses a SpendCappedMatcher's per-judgement metering) is
+    rejected rather than allowed to bill off-ledger."""
 
     class _NullGroupwiseMatcher(GroupwiseMatcher[Any]):
         def forward_groups(
@@ -187,8 +187,96 @@ def test_from_topology_rejects_an_uncappable_paid_score() -> None:
         ThresholdSelect(THRESHOLD),
         ClustererStage(Clusterer(threshold=0.0)),
     ]
-    with pytest.raises(ValueError, match="cannot enforce the spend cap"):
+    with pytest.raises(ValueError, match="cannot cap a GroupwiseMatcherScore"):
         ERModel.from_topology(ops=ops, monitor=monitor)
+
+
+def test_from_topology_rejects_a_foreign_monitor_precap() -> None:
+    """A pre-capped MatcherScore whose cap uses a DIFFERENT monitor than the model
+    ledger is rejected: its spend would never count against the model budget, so
+    'one model ledger' would be false and total spend could exceed budget_usd."""
+    model_ledger = SpendMonitor(budget_usd=1.0)
+    foreign = SpendMonitor(budget_usd=1.0)  # a different ledger the model never sees
+    ops: list[Stage] = [
+        BlockerSource(AllPairsBlocker(schema=ChainCo)),
+        MatcherScore(
+            SpendCappedMatcher(CostedNameMatcher(), monitor=foreign), out_space="prob_llm"
+        ),
+        ThresholdSelect(THRESHOLD),
+        ClustererStage(Clusterer(threshold=0.0)),
+    ]
+    with pytest.raises(ValueError, match="monitor other than this model's ledger"):
+        ERModel.from_topology(ops=ops, monitor=model_ledger)
+
+
+def test_from_topology_rejects_a_spending_score_that_bills_via_a_hidden_attr() -> None:
+    """The allowlist is fail-safe against a custom Spending Score that holds its paid
+    matcher under a differently-named attribute (the denylist that sniffed ``.matcher``
+    would have let this bill uncapped): declared Spending + not a MatcherScore -> reject."""
+
+    class _HiddenBillingScore(Score[Any], Spending):
+        """A paid Score whose matcher lives at ``.judge`` (not ``.matcher``)."""
+
+        def __init__(self) -> None:
+            super().__init__(scope="pair", out_space="prob_llm")
+            self.judge = CostedNameMatcher(cost_each=0.6)  # would bill uncapped if run
+
+        def forward(self, pairs: Any) -> Any:  # never called: rejected at from_topology
+            raise NotImplementedError
+
+    ops: list[Stage] = [
+        BlockerSource(AllPairsBlocker(schema=ChainCo)),
+        _HiddenBillingScore(),
+        ThresholdSelect(THRESHOLD),
+        ClustererStage(Clusterer(threshold=0.0)),
+    ]
+    with pytest.raises(ValueError, match="cannot cap a _HiddenBillingScore"):
+        ERModel.from_topology(ops=ops, budget_usd=1.0)
+
+
+def test_from_topology_admits_a_free_non_spending_custom_score() -> None:
+    """A legitimate FREE custom Score (does not declare Spending) passes untouched and
+    the chain runs -- the allowlist must not over-restrict free scalarizers."""
+
+    class _FreePassthroughScore(Score[Any]):  # NOT Spending -> trusted free
+        def __init__(self) -> None:
+            super().__init__(scope="pair", out_space="prob_llm")
+
+        def forward(self, pairs: Any) -> Any:
+            return pairs  # a no-op transform on the scored rows
+
+    ops: list[Stage] = [
+        BlockerSource(AllPairsBlocker(schema=ChainCo)),
+        MatcherScore(CostedNameMatcher(), out_space="prob_llm"),
+        _FreePassthroughScore(),
+        ThresholdSelect(THRESHOLD),
+        ClustererStage(Clusterer(threshold=0.0)),
+    ]
+    model = ERModel.from_topology(ops=ops, budget_usd=1.0)
+    assert _canonical(model.resolve(RECORDS)) == [["a1", "a2"]]
+
+
+def test_from_topology_rejects_a_raw_matcherscore_subclass() -> None:
+    """A MatcherScore SUBCLASS carrying a raw matcher is rejected: rebuilding it as a
+    base MatcherScore to inject the cap would silently drop the subclass's own state
+    (codex Q3). A pre-capped subclass sharing the model monitor is fine (covered
+    elsewhere); only the raw-matcher rebuild is refused."""
+
+    class _TaggedMatcherScore(MatcherScore[Any]):
+        """A MatcherScore subclass with extra state the base rebuild would lose."""
+
+        def __init__(self, matcher: Any, *, out_space: Any, tag: str) -> None:
+            super().__init__(matcher, out_space=out_space)
+            self.tag = tag
+
+    ops: list[Stage] = [
+        BlockerSource(AllPairsBlocker(schema=ChainCo)),
+        _TaggedMatcherScore(CostedNameMatcher(), out_space="prob_llm", tag="keep-me"),
+        ThresholdSelect(THRESHOLD),
+        ClustererStage(Clusterer(threshold=0.0)),
+    ]
+    with pytest.raises(ValueError, match="cannot faithfully spend-cap a MatcherScore subclass"):
+        ERModel.from_topology(ops=ops, budget_usd=1.0)
 
 
 def test_compare_matches_and_nonmatches() -> None:

--- a/tests/parity/test_explicit_chain_spine_w3.py
+++ b/tests/parity/test_explicit_chain_spine_w3.py
@@ -1,0 +1,246 @@
+"""The generalized Op-chain spine's *else* branch (epic #193, PR-A).
+
+``ERModel`` can now run an EXPLICIT Op chain the four legacy slots cannot express,
+built via :meth:`~langres.core._model_state.ModelState.from_topology`. Every
+shipped architecture leaves ``_ops`` ``None`` and hits the unchanged classic
+branch (pinned by the ``tests/parity/test_behavior_parity_*`` goldens); this file
+covers the new ``else`` branch end to end.
+
+All ``$0``/offline: a fake cost-stamping matcher (no network, no key), so the
+spend ledger moves under a real budget without real spend. The chains are built
+by :mod:`tests.parity._explicit_chain_fixture`, which the later persist PR reuses.
+"""
+
+from __future__ import annotations
+
+from typing import cast
+
+import pytest
+
+from langres.core.blockers.all_pairs import AllPairsBlocker
+from langres.core.clusterer import Clusterer
+from langres.core.fit import CalibratorFitMixin
+from langres.core.models import MatcherAbstainedError
+from langres.core.op import Stage, ThresholdSelect
+from langres.core.op_adapters import BlockerSource, ClustererStage, MatcherScore
+from langres.core.resolver import ERModel
+from langres.core.spend import SpendMonitor
+from langres.core.spend_cap import SpendCappedMatcher
+
+from tests.parity._explicit_chain_fixture import (
+    RECORDS,
+    THRESHOLD,
+    ChainCo,
+    CostedNameMatcher,
+    build_explicit_chain_model,
+    build_factory_source_model,
+    build_key_source_model,
+    build_no_threshold_chain_model,
+    build_score_after_select_model,
+    chain_ops,
+)
+
+
+def _record(record_id: str) -> dict[str, object]:
+    return next(record for record in RECORDS if record["id"] == record_id)
+
+
+def _canonical(clusters: list[set[str]]) -> list[list[str]]:
+    return sorted(sorted(cluster) for cluster in clusters)
+
+
+# ----------------------------------------------------------------------
+# resolve / dedupe / compare run correctly through the explicit chain
+# ----------------------------------------------------------------------
+
+
+def test_resolve_runs_the_explicit_chain() -> None:
+    """resolve() folds Source + body Ops, then the terminal ClusterStage."""
+    model, _monitor, _matcher = build_explicit_chain_model()
+    assert _canonical(model.resolve(RECORDS)) == [["a1", "a2"]]
+
+
+def test_dedupe_reports_chain_threshold_and_backbone() -> None:
+    """dedupe()'s self-describing metadata comes from the chain, not the (empty) slots.
+
+    threshold = the terminal ThresholdSelect's; backbone = the chain's scoring
+    matcher's (None -- the fake advertises no model); score_type stays row-derived.
+    """
+    model, _monitor, _matcher = build_explicit_chain_model()
+    result = model.dedupe(RECORDS)
+
+    assert _canonical(list(result)) == [["a1", "a2"]]
+    assert result.architecture == "ERModel"
+    assert result.backbone is None
+    assert result.score_type == "prob_llm"
+    assert result.threshold == THRESHOLD
+
+
+def test_dedupe_backbone_reads_chain_matcher_model() -> None:
+    """backbone unwraps the chain's SpendCappedMatcher to report the real matcher's model."""
+    model, _monitor, _matcher = build_explicit_chain_model(model="fake/model")
+    assert model.dedupe(RECORDS).backbone == "fake/model"
+
+
+def test_compare_matches_and_nonmatches() -> None:
+    """compare() folds only the chain's Score ops and gates on its ThresholdSelect."""
+    model, _monitor, _matcher = build_explicit_chain_model()
+
+    match = model.compare(_record("a1"), _record("a2"))
+    assert match.match is True
+    assert match.score == 1.0
+    assert match.threshold == THRESHOLD
+    assert match.architecture == "ERModel"
+
+    nonmatch = model.compare(_record("a1"), _record("b1"))
+    assert nonmatch.match is False
+    assert nonmatch.score == 0.0
+
+
+def test_dedupe_short_circuits_below_two_records() -> None:
+    """The < 2 short-circuit runs before any chain walk (no scoring, threshold None)."""
+    model, _monitor, matcher = build_explicit_chain_model()
+    result = model.dedupe([_record("a1")])
+    assert list(result) == []
+    assert result.threshold is None
+    assert matcher.produced == 0
+
+
+# ----------------------------------------------------------------------
+# the spend cap is a semantic guard on the explicit chain
+# ----------------------------------------------------------------------
+
+
+def test_spend_monitor_is_the_models_ledger_and_is_hit() -> None:
+    """An explicit-chain paid Score routes through the model's shared SpendMonitor.
+
+    4 records -> 6 AllPairs candidates at $0.05 -> $0.30 on the SAME ledger the
+    model caps with. Mutation check: drop the SpendCappedMatcher wrap in the
+    fixture and ``spent`` stays 0.
+    """
+    model, monitor, matcher = build_explicit_chain_model(cost_each=0.05)
+    model.resolve(RECORDS)
+
+    assert model._spend_monitor is monitor
+    assert matcher.produced == 6
+    assert monitor.spent == pytest.approx(0.30)
+
+
+def test_explicit_chain_budget_trips_and_carries_partials() -> None:
+    """The shared budget bounds the explicit chain: a run past it raises BudgetExceeded."""
+    from langres.core.spend import BudgetExceeded
+
+    # 6 pairs at $0.60 -> the first trips a $1.00 budget after two paid calls.
+    model, _monitor, _matcher = build_explicit_chain_model(budget_usd=1.0, cost_each=0.6)
+    with pytest.raises(BudgetExceeded):
+        model.resolve(RECORDS)
+
+
+# ----------------------------------------------------------------------
+# Score-after-Select, and the no-single-slot reads
+# ----------------------------------------------------------------------
+
+
+def test_score_after_select_chain_runs() -> None:
+    """A Score after a Select (TopKSelect between two MatcherScores) is walked correctly."""
+    model = build_score_after_select_model()
+    assert _canonical(model.resolve(RECORDS)) == [["a1", "a2"]]
+    # The last MatcherScore's family wins the row-derived report.
+    assert model.dedupe(RECORDS).score_type == "prob_llm"
+
+
+def test_chain_without_threshold_select_reports_none_threshold() -> None:
+    """A chain whose cut lives in the ClusterStage clusterer still resolves, and
+    dedupe honestly reports threshold=None (there is no terminal ThresholdSelect)."""
+    model = build_no_threshold_chain_model()
+    assert _canonical(model.resolve(RECORDS)) == [["a1", "a2"]]
+    assert model.dedupe(RECORDS).threshold is None
+
+
+def test_compare_without_a_cut_raises() -> None:
+    """compare() needs a match cut; a chain with no ThresholdSelect raises a directed error."""
+    model = build_no_threshold_chain_model()
+    with pytest.raises(RuntimeError, match="no terminal ThresholdSelect"):
+        model.compare(_record("a1"), _record("a2"))
+
+
+def test_compare_builds_the_pair_when_the_source_vetoes_it() -> None:
+    """Blocking must not veto a compare verdict: a KeyBlocker source that yields no
+    candidate for two different-name records still gets a scored, gated verdict."""
+    model = build_key_source_model()
+    verdict = model.compare(_record("a1"), _record("b1"))  # different names -> no key bucket
+    assert verdict.match is False
+    assert verdict.score == 0.0
+
+
+def test_factory_source_chain_infers_schema() -> None:
+    """A Source blocker with no schema (opaque schema_factory) -> the front door infers one."""
+    model = build_factory_source_model()
+    assert _canonical(model.resolve(RECORDS)) == [["a1", "a2"]]
+    assert _canonical(list(model.dedupe(RECORDS))) == [["a1", "a2"]]
+
+
+# ----------------------------------------------------------------------
+# from_topology door: the directed rejections
+# ----------------------------------------------------------------------
+
+
+def test_from_topology_rejects_a_calibrator() -> None:
+    """Calibration is a classic-path-only bespoke transform; an explicit chain rejects it."""
+    monitor = SpendMonitor(budget_usd=1.0)
+    ops, _matcher = chain_ops(monitor)
+    with pytest.raises(ValueError, match="does not accept a calibrator"):
+        ERModel.from_topology(ops=ops, calibrator=cast(CalibratorFitMixin, object()))
+
+
+def test_from_topology_rejects_monitor_and_budget_together() -> None:
+    """A monitor already carries its budget; passing budget_usd too is ambiguous."""
+    monitor = SpendMonitor(budget_usd=1.0)
+    ops, _matcher = chain_ops(monitor)
+    with pytest.raises(ValueError, match="not both"):
+        ERModel.from_topology(ops=ops, monitor=monitor, budget_usd=2.0)
+
+
+def test_from_topology_requires_exactly_one_cluster_stage() -> None:
+    """resolve()/dedupe() need a phase-1 exit: no ClusterStage (or two) is refused."""
+    monitor = SpendMonitor(budget_usd=1.0)
+    no_stage: list[Stage] = [
+        BlockerSource(AllPairsBlocker(schema=ChainCo)),
+        MatcherScore(SpendCappedMatcher(CostedNameMatcher(), monitor=monitor), out_space="prob_llm"),
+    ]
+    with pytest.raises(ValueError, match="exactly one terminal ClusterStage"):
+        ERModel.from_topology(ops=no_stage, monitor=monitor)
+
+    two_stages: list[Stage] = [
+        BlockerSource(AllPairsBlocker(schema=ChainCo)),
+        MatcherScore(SpendCappedMatcher(CostedNameMatcher(), monitor=monitor), out_space="prob_llm"),
+        ThresholdSelect(THRESHOLD),
+        ClustererStage(Clusterer(threshold=0.0)),
+        ClustererStage(Clusterer(threshold=0.0)),
+    ]
+    with pytest.raises(ValueError, match="exactly one terminal ClusterStage"):
+        ERModel.from_topology(ops=two_stages, monitor=SpendMonitor(budget_usd=1.0))
+
+
+def test_from_topology_rejects_a_miswired_chain() -> None:
+    """The Sequential wiring guard runs at construction (here: no Source first)."""
+    monitor = SpendMonitor(budget_usd=1.0)
+    miswired: list[Stage] = [
+        MatcherScore(SpendCappedMatcher(CostedNameMatcher(), monitor=monitor), out_space="prob_llm"),
+        ClustererStage(Clusterer(threshold=0.0)),
+    ]
+    with pytest.raises(ValueError, match="must start with a Source"):
+        ERModel.from_topology(ops=miswired, monitor=monitor)
+
+
+# ----------------------------------------------------------------------
+# the classic path is untouched (the is-None branch still works)
+# ----------------------------------------------------------------------
+
+
+def test_classic_slot_model_still_runs_and_leaves_ops_none() -> None:
+    """A component-wired ERModel keeps _ops None and takes the unchanged classic path."""
+    model = ERModel.from_schema(ChainCo, matcher="string", threshold=THRESHOLD)
+    assert model._ops is None
+    assert _canonical(model.resolve(RECORDS)) == [["a1", "a2"]]
+    assert model.compare(_record("a1"), _record("a2")).match is True

--- a/tests/parity/test_explicit_chain_spine_w3.py
+++ b/tests/parity/test_explicit_chain_spine_w3.py
@@ -17,12 +17,22 @@ from typing import cast
 
 import pytest
 
+from collections.abc import Iterator
+from typing import Any
+
 from langres.core.blockers.all_pairs import AllPairsBlocker
 from langres.core.clusterer import Clusterer
 from langres.core.fit import CalibratorFitMixin
-from langres.core.models import MatcherAbstainedError
-from langres.core.op import Stage, ThresholdSelect
-from langres.core.op_adapters import BlockerSource, ClustererStage, MatcherScore
+from langres.core.groups import ERCandidateGroup
+from langres.core.matcher import GroupwiseMatcher
+from langres.core.models import MatcherAbstainedError, PairwiseJudgement
+from langres.core.op import Clusters, Finalize, Stage, ThresholdSelect
+from langres.core.op_adapters import (
+    BlockerSource,
+    ClustererStage,
+    GroupwiseMatcherScore,
+    MatcherScore,
+)
 from langres.core.resolver import ERModel
 from langres.core.spend import SpendMonitor
 from langres.core.spend_cap import SpendCappedMatcher
@@ -37,6 +47,7 @@ from tests.parity._explicit_chain_fixture import (
     build_factory_source_model,
     build_key_source_model,
     build_no_threshold_chain_model,
+    build_precapped_chain_model,
     build_score_after_select_model,
     chain_ops,
 )
@@ -50,6 +61,12 @@ def _canonical(clusters: list[set[str]]) -> list[list[str]]:
     return sorted(sorted(cluster) for cluster in clusters)
 
 
+def _chain_matcher_scores(model: ERModel) -> list[MatcherScore[Any]]:
+    """The MatcherScores stored on the model's explicit chain (post from_topology)."""
+    assert model._ops is not None
+    return [stage for stage in model._ops if isinstance(stage, MatcherScore)]
+
+
 # ----------------------------------------------------------------------
 # resolve / dedupe / compare run correctly through the explicit chain
 # ----------------------------------------------------------------------
@@ -59,6 +76,21 @@ def test_resolve_runs_the_explicit_chain() -> None:
     """resolve() folds Source + body Ops, then the terminal ClusterStage."""
     model, _monitor, _matcher = build_explicit_chain_model()
     assert _canonical(model.resolve(RECORDS)) == [["a1", "a2"]]
+
+
+def test_predict_runs_the_explicit_chain() -> None:
+    """predict() reaches the explicit ``_scored_pairs`` branch (via ``_judgements``).
+
+    On a chain whose cut lives in the ClusterStage (no body ThresholdSelect to
+    prune), predict returns one judgement per candidate -- 6 AllPairs pairs -- and
+    the two Acmes are the matching pair.
+    """
+    model = build_no_threshold_chain_model()
+    judgements = model.predict(RECORDS)
+
+    assert len(judgements) == 6  # 4 records -> 6 AllPairs candidates, all scored
+    a1_a2 = next(j for j in judgements if {j.left_id, j.right_id} == {"a1", "a2"})
+    assert a1_a2.score == 1.0
 
 
 def test_dedupe_reports_chain_threshold_and_backbone() -> None:
@@ -83,10 +115,15 @@ def test_dedupe_backbone_reads_chain_matcher_model() -> None:
     assert model.dedupe(RECORDS).backbone == "fake/model"
 
 
-def test_from_topology_budget_and_uncapped_matcher_backbone() -> None:
-    """The ``budget_usd`` door (no shared ``monitor``) works, and backbone reads a
-    matcher-Score whose matcher is NOT spend-capped (there is no cap to peel)."""
-    raw = CostedNameMatcher(model="raw/model")  # deliberately NOT wrapped in SpendCappedMatcher
+def test_from_topology_caps_a_raw_matcher_via_the_budget_door() -> None:
+    """The ``budget_usd`` door (no shared ``monitor``) auto-caps a RAW matcher-Score.
+
+    The caller passes an UNWRAPPED matcher; ``from_topology`` must wrap it in a
+    ``SpendCappedMatcher`` on this model's ledger, so the stored Score is capped and
+    backbone still peels the cap to report the real model. This is the enforcement
+    the ``.module.forward`` AST-ban cannot see on the explicit path.
+    """
+    raw = CostedNameMatcher(model="raw/model")  # NOT wrapped -- the door must wrap it
     ops: list[Stage] = [
         BlockerSource(AllPairsBlocker(schema=ChainCo)),
         MatcherScore(raw, out_space="prob_llm"),
@@ -94,8 +131,64 @@ def test_from_topology_budget_and_uncapped_matcher_backbone() -> None:
         ClustererStage(Clusterer(threshold=0.0)),
     ]
     model = ERModel.from_topology(ops=ops, budget_usd=1.0)
+
+    # The door enforced the cap: the stored Score now holds a SpendCappedMatcher
+    # wrapping the caller's raw matcher, sharing the model's ledger.
+    (stored,) = _chain_matcher_scores(model)
+    assert isinstance(stored.matcher, SpendCappedMatcher)
+    assert stored.matcher._module is raw
+    assert stored.matcher.monitor is model._spend_monitor
+
     assert _canonical(model.resolve(RECORDS)) == [["a1", "a2"]]
-    assert model.dedupe(RECORDS).backbone == "raw/model"
+    assert model.dedupe(RECORDS).backbone == "raw/model"  # backbone peels the door's cap
+
+
+def test_from_topology_enforces_the_cap_on_a_raw_matcher() -> None:
+    """The money guarantee holds even when the caller forgets to wrap: a chain built
+    with a RAW paid matcher still trips BudgetExceeded (the door capped it)."""
+    from langres.core.spend import BudgetExceeded
+
+    raw = CostedNameMatcher(cost_each=0.6)  # 6 pairs at $0.60 overruns a $1.00 budget
+    ops: list[Stage] = [
+        BlockerSource(AllPairsBlocker(schema=ChainCo)),
+        MatcherScore(raw, out_space="prob_llm"),
+        ThresholdSelect(THRESHOLD),
+        ClustererStage(Clusterer(threshold=0.0)),
+    ]
+    model = ERModel.from_topology(ops=ops, budget_usd=1.0)
+    with pytest.raises(BudgetExceeded):
+        model.resolve(RECORDS)
+
+
+def test_from_topology_leaves_an_already_capped_matcher_alone() -> None:
+    """A matcher the caller already wrapped is NOT double-wrapped: the stored Score
+    holds the caller's exact SpendCappedMatcher object."""
+    model, monitor, capped = build_precapped_chain_model()
+    (stored,) = _chain_matcher_scores(model)
+    assert stored.matcher is capped
+    assert model._spend_monitor is monitor
+
+
+def test_from_topology_rejects_an_uncappable_paid_score() -> None:
+    """A paid Score the door cannot auto-cap (a GroupwiseMatcherScore, whose
+    ``forward_groups`` bypasses the cap's per-judgement metering) is rejected rather
+    than allowed to bill off-ledger -- unless the caller pre-capped its matcher."""
+
+    class _NullGroupwiseMatcher(GroupwiseMatcher[Any]):
+        def forward_groups(
+            self, groups: Iterator[ERCandidateGroup[Any]]
+        ) -> Iterator[PairwiseJudgement]:
+            return iter(())  # never called: from_topology rejects the chain first
+
+    monitor = SpendMonitor(budget_usd=1.0)
+    ops: list[Stage] = [
+        BlockerSource(AllPairsBlocker(schema=ChainCo)),
+        GroupwiseMatcherScore(_NullGroupwiseMatcher()),
+        ThresholdSelect(THRESHOLD),
+        ClustererStage(Clusterer(threshold=0.0)),
+    ]
+    with pytest.raises(ValueError, match="cannot enforce the spend cap"):
+        ERModel.from_topology(ops=ops, monitor=monitor)
 
 
 def test_compare_matches_and_nonmatches() -> None:
@@ -131,8 +224,9 @@ def test_spend_monitor_is_the_models_ledger_and_is_hit() -> None:
     """An explicit-chain paid Score routes through the model's shared SpendMonitor.
 
     4 records -> 6 AllPairs candidates at $0.05 -> $0.30 on the SAME ledger the
-    model caps with. Mutation check: drop the SpendCappedMatcher wrap in the
-    fixture and ``spent`` stays 0.
+    model caps with. The fixture passes a RAW matcher, so this also proves
+    ``from_topology`` wired the door's auto-cap onto the model's ledger (no manual
+    wrap in the fixture at all).
     """
     model, monitor, matcher = build_explicit_chain_model(cost_each=0.05)
     model.resolve(RECORDS)
@@ -211,8 +305,7 @@ def test_factory_source_chain_infers_schema() -> None:
 
 def test_from_topology_rejects_a_calibrator() -> None:
     """Calibration is a classic-path-only bespoke transform; an explicit chain rejects it."""
-    monitor = SpendMonitor(budget_usd=1.0)
-    ops, _matcher = chain_ops(monitor)
+    ops, _matcher = chain_ops()
     with pytest.raises(ValueError, match="does not accept a calibrator"):
         ERModel.from_topology(ops=ops, calibrator=cast(CalibratorFitMixin, object()))
 
@@ -220,9 +313,23 @@ def test_from_topology_rejects_a_calibrator() -> None:
 def test_from_topology_rejects_monitor_and_budget_together() -> None:
     """A monitor already carries its budget; passing budget_usd too is ambiguous."""
     monitor = SpendMonitor(budget_usd=1.0)
-    ops, _matcher = chain_ops(monitor)
+    ops, _matcher = chain_ops()
     with pytest.raises(ValueError, match="not both"):
         ERModel.from_topology(ops=ops, monitor=monitor, budget_usd=2.0)
+
+
+def test_from_topology_rejects_a_finalize() -> None:
+    """A terminal Finalize would be silently dropped by the explicit exit (which stops
+    at the ClusterStage), so from_topology rejects it loud (deferred, not silent)."""
+
+    class _IdentityFinalize(Finalize):
+        def forward(self, clusters: Clusters) -> Clusters:
+            return clusters  # never reached: from_topology rejects the chain first
+
+    ops, _matcher = chain_ops()
+    ops.append(_IdentityFinalize())
+    with pytest.raises(ValueError, match="does not run a terminal Finalize"):
+        ERModel.from_topology(ops=ops, budget_usd=1.0)
 
 
 def test_from_topology_requires_a_terminal_cluster_stage() -> None:

--- a/tests/parity/test_explicit_chain_spine_w3.py
+++ b/tests/parity/test_explicit_chain_spine_w3.py
@@ -32,6 +32,7 @@ from tests.parity._explicit_chain_fixture import (
     THRESHOLD,
     ChainCo,
     CostedNameMatcher,
+    build_abstaining_chain_model,
     build_explicit_chain_model,
     build_factory_source_model,
     build_key_source_model,
@@ -164,6 +165,14 @@ def test_compare_without_a_cut_raises() -> None:
         model.compare(_record("a1"), _record("a2"))
 
 
+def test_compare_raises_on_an_abstaining_chain_matcher() -> None:
+    """compare() owes a verdict: an abstaining chain matcher raises MatcherAbstainedError
+    (the Selects are skipped, so the abstaining pair reaches the gate rather than being cut)."""
+    model = build_abstaining_chain_model()
+    with pytest.raises(MatcherAbstainedError):
+        model.compare(_record("a1"), _record("a2"))
+
+
 def test_compare_builds_the_pair_when_the_source_vetoes_it() -> None:
     """Blocking must not veto a compare verdict: a KeyBlocker source that yields no
     candidate for two different-name records still gets a scored, gated verdict."""
@@ -201,32 +210,46 @@ def test_from_topology_rejects_monitor_and_budget_together() -> None:
         ERModel.from_topology(ops=ops, monitor=monitor, budget_usd=2.0)
 
 
-def test_from_topology_requires_exactly_one_cluster_stage() -> None:
-    """resolve()/dedupe() need a phase-1 exit: no ClusterStage (or two) is refused."""
+def test_from_topology_requires_a_terminal_cluster_stage() -> None:
+    """resolve()/dedupe() need a phase-1 exit: a Sequential-valid chain with no
+    ClusterStage (it ends in Scores) is refused by from_topology's own count check
+    -- the one thing Sequential does not enforce."""
     monitor = SpendMonitor(budget_usd=1.0)
     no_stage: list[Stage] = [
         BlockerSource(AllPairsBlocker(schema=ChainCo)),
-        MatcherScore(SpendCappedMatcher(CostedNameMatcher(), monitor=monitor), out_space="prob_llm"),
+        MatcherScore(
+            SpendCappedMatcher(CostedNameMatcher(), monitor=monitor), out_space="prob_llm"
+        ),
     ]
     with pytest.raises(ValueError, match="exactly one terminal ClusterStage"):
         ERModel.from_topology(ops=no_stage, monitor=monitor)
 
+
+def test_from_topology_rejects_a_second_cluster_stage_at_the_wiring_guard() -> None:
+    """Two ClusterStages can't both sit terminally -- Sequential catches the carrier
+    mismatch (a ClusterStage consumes 'pairs', the first produced 'clusters') before
+    the count check ever runs."""
+    monitor = SpendMonitor(budget_usd=1.0)
     two_stages: list[Stage] = [
         BlockerSource(AllPairsBlocker(schema=ChainCo)),
-        MatcherScore(SpendCappedMatcher(CostedNameMatcher(), monitor=monitor), out_space="prob_llm"),
+        MatcherScore(
+            SpendCappedMatcher(CostedNameMatcher(), monitor=monitor), out_space="prob_llm"
+        ),
         ThresholdSelect(THRESHOLD),
         ClustererStage(Clusterer(threshold=0.0)),
         ClustererStage(Clusterer(threshold=0.0)),
     ]
-    with pytest.raises(ValueError, match="exactly one terminal ClusterStage"):
-        ERModel.from_topology(ops=two_stages, monitor=SpendMonitor(budget_usd=1.0))
+    with pytest.raises(ValueError, match="out of pipeline order"):
+        ERModel.from_topology(ops=two_stages, monitor=monitor)
 
 
 def test_from_topology_rejects_a_miswired_chain() -> None:
     """The Sequential wiring guard runs at construction (here: no Source first)."""
     monitor = SpendMonitor(budget_usd=1.0)
     miswired: list[Stage] = [
-        MatcherScore(SpendCappedMatcher(CostedNameMatcher(), monitor=monitor), out_space="prob_llm"),
+        MatcherScore(
+            SpendCappedMatcher(CostedNameMatcher(), monitor=monitor), out_space="prob_llm"
+        ),
         ClustererStage(Clusterer(threshold=0.0)),
     ]
     with pytest.raises(ValueError, match="must start with a Source"):

--- a/tests/parity/test_explicit_chain_spine_w3.py
+++ b/tests/parity/test_explicit_chain_spine_w3.py
@@ -169,6 +169,33 @@ def test_from_topology_leaves_an_already_capped_matcher_alone() -> None:
     assert model._spend_monitor is monitor
 
 
+def test_from_topology_leaves_a_precapped_matcherscore_subclass_alone() -> None:
+    """A MatcherScore SUBCLASS whose matcher is already capped through the model
+    monitor takes the leave-alone branch (no rebuild, so its subclass state survives)
+    -- the rebuild-reject fires only for a subclass with a RAW matcher."""
+
+    class _TaggedMatcherScore(MatcherScore[Any]):
+        def __init__(self, matcher: Any, *, out_space: Any, tag: str) -> None:
+            super().__init__(matcher, out_space=out_space)
+            self.tag = tag
+
+    monitor = SpendMonitor(budget_usd=1.0)
+    capped = SpendCappedMatcher(CostedNameMatcher(), monitor=monitor)
+    subclass_score = _TaggedMatcherScore(capped, out_space="prob_llm", tag="keep-me")
+    ops: list[Stage] = [
+        BlockerSource(AllPairsBlocker(schema=ChainCo)),
+        subclass_score,
+        ThresholdSelect(THRESHOLD),
+        ClustererStage(Clusterer(threshold=0.0)),
+    ]
+    model = ERModel.from_topology(ops=ops, monitor=monitor)
+
+    (stored,) = _chain_matcher_scores(model)
+    assert stored is subclass_score  # same object -- not rebuilt, subclass state intact
+    assert subclass_score.tag == "keep-me"  # subclass state survived (no base rebuild)
+    assert stored.matcher is capped
+
+
 def test_from_topology_rejects_a_spending_score_it_cannot_cap() -> None:
     """A Spending Score the door cannot wrap (a GroupwiseMatcherScore, whose
     ``forward_groups`` bypasses a SpendCappedMatcher's per-judgement metering) is
@@ -245,14 +272,19 @@ def test_from_topology_admits_a_free_non_spending_custom_score() -> None:
         def forward(self, pairs: Any) -> Any:
             return pairs  # a no-op transform on the scored rows
 
+    free = _FreePassthroughScore()
     ops: list[Stage] = [
         BlockerSource(AllPairsBlocker(schema=ChainCo)),
         MatcherScore(CostedNameMatcher(), out_space="prob_llm"),
-        _FreePassthroughScore(),
+        free,
         ThresholdSelect(THRESHOLD),
         ClustererStage(Clusterer(threshold=0.0)),
     ]
     model = ERModel.from_topology(ops=ops, budget_usd=1.0)
+    # The door must PRESERVE the free stage (not silently drop it): same object, same
+    # position (index 2). A no-op forward() alone would pass even if it were dropped.
+    assert model._ops is not None
+    assert model._ops[2] is free
     assert _canonical(model.resolve(RECORDS)) == [["a1", "a2"]]
 
 

--- a/tests/parity/test_explicit_chain_spine_w3.py
+++ b/tests/parity/test_explicit_chain_spine_w3.py
@@ -83,6 +83,21 @@ def test_dedupe_backbone_reads_chain_matcher_model() -> None:
     assert model.dedupe(RECORDS).backbone == "fake/model"
 
 
+def test_from_topology_budget_and_uncapped_matcher_backbone() -> None:
+    """The ``budget_usd`` door (no shared ``monitor``) works, and backbone reads a
+    matcher-Score whose matcher is NOT spend-capped (there is no cap to peel)."""
+    raw = CostedNameMatcher(model="raw/model")  # deliberately NOT wrapped in SpendCappedMatcher
+    ops: list[Stage] = [
+        BlockerSource(AllPairsBlocker(schema=ChainCo)),
+        MatcherScore(raw, out_space="prob_llm"),
+        ThresholdSelect(THRESHOLD),
+        ClustererStage(Clusterer(threshold=0.0)),
+    ]
+    model = ERModel.from_topology(ops=ops, budget_usd=1.0)
+    assert _canonical(model.resolve(RECORDS)) == [["a1", "a2"]]
+    assert model.dedupe(RECORDS).backbone == "raw/model"
+
+
 def test_compare_matches_and_nonmatches() -> None:
     """compare() folds only the chain's Score ops and gates on its ThresholdSelect."""
     model, _monitor, _matcher = build_explicit_chain_model()


### PR DESCRIPTION
## PR-A: the generalized Op-chain spine (epic #193, final wave)

Adds an **optional explicit `Op` chain** an `ERModel` can run — the breaking-change spine that lets a model express a topology the four legacy slots can't (a Score after a Select, a second matcher). **Byte-parity for every shipped architecture**: they all leave `_ops is None` and hit the unchanged classic branch.

### What changed
- **`_model_state.py`** — `self._ops: list[Stage] | None = None` (classic doors leave it `None`); a `from_topology(*, ops, budget_usd=, monitor=, calibrator=)` door parallel to `from_components` (`__new__` + init state + set `_ops`), validating wiring via the existing `Sequential` guard and requiring exactly one terminal `ClusterStage`; explicit-chain readers (`_chain_source/_body/_body_scores/_cluster_stage/_threshold/_scoring_matcher/_source_schema`); `backbone` generalized to read the chain's scoring matcher (unwrapped past its spend cap) when there is no `module` slot.
- **`_model_run.py`** — `_run_stages` widened to `Sequence[Source | Op]` (deliberately **`Op`, not `Score`**, so Selects in the body are admitted; classic `list[Source|Score]` still passes via `Sequence` covariance, no `Any`). Dispatch added to `_scored_pairs`/`_cluster`/`dedupe`/`compare` — the classic `is None` branch is **byte-verbatim** (the explicit path is a prepended early-return into `_dedupe_explicit`/`_compare_explicit`). `resolve` is unchanged (it already composes the two dispatched helpers).

### Traps honored
1. **Type narrowing** — `_run_stages` widened to `Op`; `mypy --strict` clean, no `Any` escape.
2. **No double-cut** — an explicit chain's `_cluster` runs *only* its terminal `ClusterStage`; no extra `ThresholdSelect`/`_closure_clusterer` (that's classic-only).
3. **`compare` skips the chain's Selects** — folds only the body `Score` ops on the single pair, so an abstaining pair reaches the gate and raises `MatcherAbstainedError` (a body `ThresholdSelect` would drop it first). Gates on the terminal `ThresholdSelect.threshold`.
4. **Spend cap is a semantic guard** — the fixture wraps every explicit-chain Score in `SpendCappedMatcher(monitor=model._spend_monitor)`; `from_topology(monitor=)` adopts that shared ledger. Test proves an explicit-chain paid Score bills the model's monitor (`spent == $0.30` over 6 pairs; `model._spend_monitor is monitor`) and that the shared budget trips.
- `from_topology(ops=..., calibrator=...)` raises a directed error (a `CalibratorScore` Op is a later wave; calibration stays a classic-path-only transform).

### Tests (`tests/parity/test_explicit_chain_spine_w3.py` + reusable `_explicit_chain_fixture.py`)
`$0`/offline (fake cost-stamping matcher, no network/key). Covers resolve/dedupe/compare through the explicit path, Score-after-Select (`TopKSelect` between two `MatcherScore`s), `threshold=None` reporting + `compare`'s no-cut guard, the blocking-veto fallback (KeyBlocker source), schema inference (factory source), abstain → `MatcherAbstainedError`, the shared-ledger spend proof, and `from_topology`'s directed rejections (calibrator / monitor+budget / missing-ClusterStage / mis-wired). The fixture is importable and reused by the later persist PR.

### Gates
- All four parity goldens green (`test_behavior_parity_w0`, `test_behavior_parity_cascade_w3d`, `test_groupwise_spine_w3a`, `test_match_cut_correlation_w3d`) + legacy artifact load — behavior byte-identical.
- Spend-cap AST-ban (`test_resolver_spend_cap`) green; import gates (`budget`/`tangle`/`graph`) green.
- Full CI-matching fast suite: **3807 passed, 2 skipped**. `mypy --strict` + `ruff` clean. No new `core/*` module (no `refactor_target_packages.json` change).
- New-code coverage: `_model_state.py` 98%; the only new-uncovered lines are 3 defensive guards mirroring pre-existing uncovered classic guards.

https://claude.ai/code/session_011XYuhyiigi1Bw2YnWCxMr9
