### PR TITLE
feat(core): persist v2 — explicit Op-chain round-trip (#193 PR-B)

### DIFF
--- a/src/langres/core/_artifacts.py
+++ b/src/langres/core/_artifacts.py
@@ -236,7 +236,9 @@ def op_spec(stage: Stage) -> OpSpec:
     """
     role, params, component = _stage_serialization(stage)
     component_spec_obj = (
-        component_spec(component, slot=_ROLE_COMPONENT_SLOT[role]) if component is not None else None
+        component_spec(component, slot=_ROLE_COMPONENT_SLOT[role])
+        if component is not None
+        else None
     )
     return OpSpec(role=role, params=params, component=component_spec_obj)
 

--- a/src/langres/core/_artifacts.py
+++ b/src/langres/core/_artifacts.py
@@ -27,12 +27,20 @@ reconstructed by its registered ``type_name``.
 
 import inspect
 from pathlib import Path
-from typing import Any, TypeGuard
+from typing import Any, TypeGuard, cast
 
 from pydantic import BaseModel
 
+from langres.core.op import OutSpace, Stage, ThresholdSelect, TopKSelect
+from langres.core.op_adapters import (
+    BlockerSource,
+    ClustererStage,
+    ComparatorScore,
+    MatcherScore,
+)
 from langres.core.registry import get_component
-from langres.core.serialization import ComponentSpec, SerializableState
+from langres.core.serialization import ComponentSpec, OpSpec, SerializableState
+from langres.core.spend_cap import SpendCappedMatcher
 
 
 def component_config_dict(obj: object) -> dict[str, object]:
@@ -137,3 +145,165 @@ def rebuild_component(spec: ComponentSpec, state_dir: Path | None = None) -> Any
     if not accepts_state_dir and isinstance(component, SerializableState) and has_state(state_dir):
         component.load_state(state_dir)
     return component
+
+
+# ----------------------------------------------------------------------------------
+# Explicit Op-chain adapters (#193, persist v2): the OpSpec analogue of
+# component_spec / rebuild_component. A classic four-slot model serializes each
+# slot with the pair above; an explicit-chain model
+# (:meth:`~langres.core._model_state.ModelState.from_topology`) serializes each
+# :class:`~langres.core.op.Stage` with the pair below. These import ``op`` /
+# ``op_adapters`` / ``spend_cap``, which is why they live HERE (the ``architectures``
+# tier that already imports those) and NOT in the ``serialization`` leaf that owns
+# the pure :class:`~langres.core.serialization.OpSpec` data model.
+# ----------------------------------------------------------------------------------
+
+#: role -> the classic slot name stamped on a stage's *nested* ComponentSpec. The
+#: slot is cosmetic in the ops path (``rebuild_op`` rebuilds by role, and
+#: ``rebuild_component`` ignores ``ComponentSpec.slot``), but naming it after the
+#: classic slot keeps the on-disk json legible.
+_ROLE_COMPONENT_SLOT: dict[str, str] = {
+    "blocker_source": "blocker",
+    "comparator_score": "comparator",
+    "matcher_score": "module",
+    "clusterer_stage": "clusterer",
+}
+
+
+def _stage_serialization(stage: Stage) -> tuple[str, dict[str, object], object | None]:
+    """The ``(role, params, nested_component)`` an explicit-chain stage serializes to.
+
+    The ONE dispatch shared by :func:`op_spec` (which builds the
+    :class:`~langres.core.serialization.OpSpec`) and :func:`op_state_owner` (which
+    finds the sidecar owner) — so the two can never disagree on which stages are
+    serializable, or on which component a stage carries.
+
+    A :class:`~langres.core.op_adapters.MatcherScore` is **unwrapped**: its nested
+    component is the *raw inner* matcher, never the
+    :class:`~langres.core.spend_cap.SpendCappedMatcher` wrapper (which holds a live
+    per-model :class:`~langres.core.spend.SpendMonitor` and has no registry
+    ``type_name``). ``from_topology`` re-wraps the raw matcher against a fresh
+    monitor on load, so the budget/monitor are deliberately not persisted.
+
+    Raises:
+        TypeError: (F3) for a stage this door cannot faithfully round-trip — a
+            ``MatcherScore`` *subclass* (rebuilding it as a base ``MatcherScore``
+            would silently drop the subclass's own state, exactly as
+            ``from_topology`` rejects on re-secure), a ``GroupwiseMatcherScore`` or
+            any other ``Spending`` Score ``from_topology`` also refuses, or a
+            ``Finalize`` (``from_topology`` does not run one). Failing loud at save
+            time beats writing a spec that load cannot rebuild.
+    """
+    if isinstance(stage, BlockerSource):
+        return "blocker_source", {}, stage.blocker
+    if isinstance(stage, ComparatorScore):
+        return "comparator_score", {}, stage.comparator
+    # ``type(stage) is MatcherScore`` (not isinstance): a subclass must be rejected
+    # below, since rebuild would drop its extra state (mirrors _secure_chain_scores).
+    if type(stage) is MatcherScore:
+        matcher = stage.matcher
+        inner = matcher._module if isinstance(matcher, SpendCappedMatcher) else matcher
+        return "matcher_score", {"out_space": stage.out_space}, inner
+    if isinstance(stage, ThresholdSelect):
+        return "threshold_select", {"threshold": stage.threshold}, None
+    if isinstance(stage, TopKSelect):
+        return "topk_select", {"k": stage.k}, None
+    if isinstance(stage, ClustererStage):
+        return "clusterer_stage", {}, stage.clusterer
+    raise TypeError(
+        f"op_spec() cannot serialize a {type(stage).__name__}: only BlockerSource, "
+        "ComparatorScore, a base MatcherScore, ThresholdSelect, TopKSelect and ClustererStage "
+        "round-trip. A MatcherScore subclass / GroupwiseMatcherScore / Finalize is rejected "
+        "(from_topology would reject or drop it on re-secure anyway). Fix: express the chain "
+        "with the round-trippable stages, or pre-cap a paid matcher into a base MatcherScore."
+    )
+
+
+def op_spec(stage: Stage) -> OpSpec:
+    """Serialize one explicit-chain :class:`~langres.core.op.Stage` into an
+    :class:`~langres.core.serialization.OpSpec`.
+
+    Records the stage's role, its role-specific scalar params, and (for a stage
+    that adapts a legacy component) that component as a nested
+    :class:`~langres.core.serialization.ComponentSpec` via :func:`component_spec`.
+    A ``MatcherScore``'s matcher is serialized RAW (unwrapped past any spend cap);
+    see :func:`_stage_serialization` for the unwrap and the F3 rejection rules.
+
+    Raises:
+        TypeError: If ``stage`` is not one of the round-trippable stage types, or
+            its nested component lacks a registry ``type_name`` (both surface the
+            same fail-loud-at-save contract as :func:`component_spec`).
+    """
+    role, params, component = _stage_serialization(stage)
+    component_spec_obj = (
+        component_spec(component, slot=_ROLE_COMPONENT_SLOT[role]) if component is not None else None
+    )
+    return OpSpec(role=role, params=params, component=component_spec_obj)
+
+
+def op_state_owner(stage: Stage) -> SerializableState | None:
+    """The out-of-band-state owner of an explicit-chain stage, if any.
+
+    The sidecar seam ``save`` walks per stage (keyed by ordinal ``op{i}``). It
+    delegates to :func:`state_owner` on the SAME nested component :func:`op_spec`
+    serializes, so a ``BlockerSource`` over a built ``VectorBlocker`` writes/reads
+    its index sidecar exactly as the classic blocker slot does. A Select carries no
+    component and owns no state; the shipped rerankers source from
+    ``AllPairsBlocker`` and own none either. Called only after ``_build_manifest``
+    has already validated every stage via :func:`op_spec`, so it never meets an
+    unserializable stage.
+    """
+    _role, _params, component = _stage_serialization(stage)
+    return state_owner(component) if component is not None else None
+
+
+def _require_op_component(spec: OpSpec) -> ComponentSpec:
+    """Return ``spec.component``, or raise on a malformed component-bearing OpSpec."""
+    if spec.component is None:
+        raise ValueError(
+            f"OpSpec role {spec.role!r} requires a nested component to rebuild, but the spec "
+            "carries none. Fix: this role must be written with component=component_spec(...)."
+        )
+    return spec.component
+
+
+def rebuild_op(spec: OpSpec, *, state_dir: Path) -> Stage:
+    """Rebuild an explicit-chain :class:`~langres.core.op.Stage` from its
+    :class:`~langres.core.serialization.OpSpec`.
+
+    The reverse of :func:`op_spec`: dispatches on ``spec.role``, rebuilds any
+    nested component via :func:`rebuild_component` (restoring its sidecar state from
+    ``state_dir``), and reconstructs the stage. A ``matcher_score`` is rebuilt
+    around the **raw** inner matcher — ``from_topology`` re-wraps it in a
+    :class:`~langres.core.spend_cap.SpendCappedMatcher` sharing the reloaded model's
+    fresh ledger, so the cap is re-established on load rather than persisted.
+
+    Args:
+        spec: The stage spec to rebuild.
+        state_dir: The per-stage sidecar directory (``op{i}``) any stateful nested
+            component restores from.
+
+    Raises:
+        ValueError: If ``spec.role`` is unknown, or a component-bearing role's
+            ``component`` is missing (a malformed manifest).
+    """
+    if spec.role == "blocker_source":
+        return BlockerSource(rebuild_component(_require_op_component(spec), state_dir=state_dir))
+    if spec.role == "comparator_score":
+        return ComparatorScore(rebuild_component(_require_op_component(spec), state_dir=state_dir))
+    if spec.role == "matcher_score":
+        return MatcherScore(
+            rebuild_component(_require_op_component(spec), state_dir=state_dir),
+            out_space=cast(OutSpace, spec.params["out_space"]),
+        )
+    if spec.role == "threshold_select":
+        return ThresholdSelect(cast(float, spec.params["threshold"]))
+    if spec.role == "topk_select":
+        return TopKSelect(cast(int, spec.params["k"]))
+    if spec.role == "clusterer_stage":
+        return ClustererStage(rebuild_component(_require_op_component(spec), state_dir=state_dir))
+    raise ValueError(
+        f"rebuild_op() got an unknown OpSpec role {spec.role!r}. Known roles: "
+        "blocker_source, comparator_score, matcher_score, threshold_select, topk_select, "
+        "clusterer_stage. The artifact was likely written by a newer langres."
+    )

--- a/src/langres/core/_exports/_resolver.py
+++ b/src/langres/core/_exports/_resolver.py
@@ -29,6 +29,7 @@ from langres.core.serialization import (
     ARTIFACT_VERSION,
     ArtifactManifest,
     ComponentSpec,
+    OpSpec,
     SerializableState,
 )
 
@@ -43,6 +44,7 @@ __all__ = [
     "get_schema",
     "LinkVerdict",
     "model_type_name",
+    "OpSpec",
     "register",
     "register_model",
     "register_schema",

--- a/src/langres/core/_model_persist.py
+++ b/src/langres/core/_model_persist.py
@@ -17,10 +17,22 @@ from pathlib import Path
 from typing import Any
 
 from langres._version import __version__ as LANGRES_VERSION
-from langres.core._artifacts import component_spec, rebuild_component, state_owner
+from langres.core._artifacts import (
+    component_spec,
+    op_spec,
+    op_state_owner,
+    rebuild_component,
+    rebuild_op,
+    state_owner,
+)
 from langres.core._model_state import ModelState
 from langres.core.registry import model_type_name
-from langres.core.serialization import ARTIFACT_VERSION, ArtifactManifest, ComponentSpec
+from langres.core.serialization import (
+    ARTIFACT_VERSION,
+    CLASSIC_ARTIFACT_VERSION,
+    ArtifactManifest,
+    ComponentSpec,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -52,24 +64,46 @@ class ModelPersistence(ModelState):
         """Assemble the in-memory :class:`ArtifactManifest` (no disk I/O).
 
         Shared by :meth:`save` (which writes it, plus sidecars) and
-        :meth:`config_dict` (which returns it as a dict). Serializes each slot
-        component into a :class:`ComponentSpec` via
-        :func:`~langres.core._artifacts.component_spec`, which raises
-        :class:`TypeError` for a component lacking a registry ``type_name`` —
-        that error is intentional and not swallowed here.
+        :meth:`config_dict` (which returns it as a dict). Branches on the model's
+        topology:
+
+        - **Classic four-slot** (``self._ops is None``): serializes each slot into
+          a :class:`ComponentSpec` via
+          :func:`~langres.core._artifacts.component_spec` and stamps
+          :data:`~langres.core.serialization.CLASSIC_ARTIFACT_VERSION` (``"1"``).
+          Deliberately NOT :data:`~langres.core.serialization.ARTIFACT_VERSION`
+          (now ``"2"``): a classic save's on-disk bytes — and the ``recipe_id``
+          derived from its ``config_dict`` — must not restamp when the reader's max
+          advances (F1).
+        - **Explicit Op chain** (``self._ops is not None``): serializes each stage
+          into an :class:`~langres.core.serialization.OpSpec` via
+          :func:`~langres.core._artifacts.op_spec` and stamps ``ARTIFACT_VERSION``
+          (``"2"``).
+
+        Either builder raises :class:`TypeError` for a component/stage lacking a
+        registry ``type_name`` (or an unserializable stage) — intentional, not
+        swallowed here.
 
         Also stamps ``model_class`` with this class's registered model name so a
         named architecture survives ``save``/``load``. It is ``None`` for the
         base ``Resolver`` and for any unregistered subclass — see
         :func:`~langres.core.registry.model_type_name`.
         """
+        model_class = model_type_name(type(self))
+        if self._ops is not None:
+            return ArtifactManifest(
+                artifact_version=ARTIFACT_VERSION,
+                langres_version=LANGRES_VERSION,
+                model_class=model_class,
+                ops=[op_spec(stage) for stage in self._ops],
+            )
         components = [
             component_spec(component, slot=slot_name) for slot_name, component in self._slots()
         ]
         return ArtifactManifest(
-            artifact_version=ARTIFACT_VERSION,
+            artifact_version=CLASSIC_ARTIFACT_VERSION,
             langres_version=LANGRES_VERSION,
-            model_class=model_type_name(type(self)),
+            model_class=model_class,
             components=components,
         )
 
@@ -99,14 +133,20 @@ class ModelPersistence(ModelState):
         :meth:`save`, not through this dict).
 
         Returns:
-            A plain, JSON-serializable dict with a single ``components`` key: the
-            ordered slot specs (each a ``type_name`` + ``config``). No version
-            fields — see above.
+            A plain, JSON-serializable dict with a single key: ``components`` for a
+            classic four-slot model (the ordered slot specs, each a ``type_name`` +
+            ``config``) or ``ops`` for an explicit-chain model (the ordered stage
+            specs). No version fields — see above.
 
         Raises:
-            TypeError: If a slot component lacks a registry ``type_name`` (same
-                contract as :meth:`save`; not swallowed).
+            TypeError: If a slot component / stage lacks a registry ``type_name``
+                (same contract as :meth:`save`; not swallowed).
         """
+        # The explicit-chain snapshot keys on ``ops``; the classic snapshot returns
+        # the byte-identical ``{"components": ...}`` dict it always has, so a classic
+        # model's recipe_id never forks (F2 — the crown invariant).
+        if self._ops is not None:
+            return {"ops": self._build_manifest().model_dump()["ops"]}
         return {"components": self._build_manifest().model_dump()["components"]}
 
     def save(self, path: str | Path) -> None:
@@ -123,27 +163,56 @@ class ModelPersistence(ModelState):
         ``model_class`` when it has one, so :meth:`load` can rebuild the same
         architecture rather than a plain ``Resolver``.
 
+        An **explicit-chain** model (``self._ops is not None``, epic #193 persist
+        v2) writes the same ``resolver.json`` with an ``ops`` list instead of
+        ``components``, and keys any sidecars by stage **ordinal** (``op{i}``)
+        rather than slot name. Its paid Scores are serialized RAW (the spend cap is
+        unwrapped, never written); ``load`` re-establishes the cap via
+        ``from_topology``.
+
         Args:
             path: Directory to write the artifact into (created if absent).
         """
         out_dir = Path(path)
         out_dir.mkdir(parents=True, exist_ok=True)
 
+        # Build first: op_spec / component_spec raise on an unserializable
+        # stage/component BEFORE any file is written (no half-written artifact).
         manifest = self._build_manifest()
-        for slot_name, component in self._slots():
-            owner = state_owner(component)
-            if owner is not None:
-                state_dir = out_dir / slot_name
-                state_dir.mkdir(parents=True, exist_ok=True)
-                owner.save_state(state_dir)
-                # A SerializableState owner with nothing to persist (e.g. a
-                # VectorBlocker whose index was never built) writes no files;
-                # drop the empty sidecar so load() doesn't later try to read a
-                # missing state file from a dir that only signals "has state".
-                if not any(state_dir.iterdir()):
-                    state_dir.rmdir()
+        if self._ops is not None:
+            # Explicit chain: a stage has no slot name, so sidecars key by ORDINAL.
+            # Same state_owner/has_state seam via op_state_owner (a built
+            # VectorBlocker Source is the one stateful case in practice).
+            for index, stage in enumerate(self._ops):
+                owner = op_state_owner(stage)
+                if owner is not None:
+                    state_dir = out_dir / f"op{index}"
+                    state_dir.mkdir(parents=True, exist_ok=True)
+                    owner.save_state(state_dir)
+                    if not any(state_dir.iterdir()):
+                        state_dir.rmdir()
+            # Drop the (empty) ``components`` field from the explicit artifact.
+            payload = manifest.model_dump_json(indent=2, exclude={"components"})
+        else:
+            for slot_name, component in self._slots():
+                owner = state_owner(component)
+                if owner is not None:
+                    state_dir = out_dir / slot_name
+                    state_dir.mkdir(parents=True, exist_ok=True)
+                    owner.save_state(state_dir)
+                    # A SerializableState owner with nothing to persist (e.g. a
+                    # VectorBlocker whose index was never built) writes no files;
+                    # drop the empty sidecar so load() doesn't later try to read a
+                    # missing state file from a dir that only signals "has state".
+                    if not any(state_dir.iterdir()):
+                        state_dir.rmdir()
+            # Exclude the ``ops`` field (defaults to None) so a classic
+            # resolver.json stays byte-identical to pre-#193 — without this every
+            # classic save would gain an ``"ops": null`` line and fork the frozen
+            # legacy bytes (F1 / the crown invariant).
+            payload = manifest.model_dump_json(indent=2, exclude={"ops"})
 
-        (out_dir / _MANIFEST_FILENAME).write_text(manifest.model_dump_json(indent=2))
+        (out_dir / _MANIFEST_FILENAME).write_text(payload)
         logger.info("Saved Resolver artifact to %s", out_dir)
 
     @classmethod
@@ -164,9 +233,13 @@ class ModelPersistence(ModelState):
         cycles. So this returns the parts; the leaf picks the class and assembles.
 
         Returns:
-            The validated manifest, and the ``from_components`` kwargs
-            (``blocker``/``comparator``/``matcher``/``clusterer``/``calibrator``)
-            rebuilt from it.
+            The validated manifest, and the load kwargs. For a classic four-slot
+            artifact that is the ``from_components`` kwargs
+            (``blocker``/``comparator``/``matcher``/``clusterer``/``calibrator``);
+            for an explicit-chain artifact (``manifest.ops is not None``, persist
+            v2) it is ``{"ops": [<rebuilt Stage>, ...]}`` for ``from_topology`` —
+            the leaf in :meth:`~langres.core.resolver.ERModel.load` dispatches on
+            which key is present.
 
         Raises:
             ValueError: If the artifact's ``artifact_version`` is unreadable by
@@ -175,6 +248,16 @@ class ModelPersistence(ModelState):
         in_dir = Path(path)
         manifest = ArtifactManifest.model_validate_json((in_dir / _MANIFEST_FILENAME).read_text())
         cls._check_versions(manifest)
+
+        # Explicit Op chain (persist v2): rebuild each stage by ordinal, restoring
+        # any per-stage sidecar (op{i}). Each MatcherScore comes back with its RAW
+        # matcher; the leaf's from_topology re-wraps the cap against a fresh ledger.
+        if manifest.ops is not None:
+            ops = [
+                rebuild_op(spec, state_dir=in_dir / f"op{index}")
+                for index, spec in enumerate(manifest.ops)
+            ]
+            return manifest, {"ops": ops}
 
         # Map specs back to slots self-describingly. Each spec written by a
         # current ``save`` carries its ``slot`` name, so a registered subclass
@@ -240,21 +323,32 @@ class ModelPersistence(ModelState):
 
     @staticmethod
     def _check_versions(manifest: ArtifactManifest) -> None:
-        """Validate artifact compatibility; raise on an unreadably-new artifact.
+        """Validate artifact compatibility; raise outside the readable version window.
 
-        ``ARTIFACT_VERSION`` is a monotonic integer-valued string bumped on an
-        incompatible layout change. Each bump breaks the config schema, so only
-        an artifact at the *exact* supported layout is readable: a *newer* layout
-        (this build is too old), an *older* layout (predates an incompatible
-        bump), or a malformed/non-integer layout are all hard errors — without
-        this guard an older artifact would fall through to a raw ``KeyError`` on
-        the changed config. A ``langres_version`` mismatch is logged as a
-        warning, not a failure — configs are forward-compatible *within* a layout
-        version.
+        ``ARTIFACT_VERSION`` (the reader's max, ``"2"``) is a monotonic
+        integer-valued string. The reader accepts any layout in the **window**
+        ``[CLASSIC_ARTIFACT_VERSION, ARTIFACT_VERSION]`` = ``[1, 2]``:
+
+        - **Too new** (``> ARTIFACT_VERSION``): this build cannot read a layout it
+          predates — a hard "upgrade langres" error.
+        - **Below the window** (``< 1``, e.g. a pre-M0.5 ``"0"`` with incompatible
+          configs): a hard "predates the readable layout" error, rather than
+          falling through to a raw ``KeyError`` on the changed config.
+        - **Malformed/non-integer**: a hard error.
+
+        The change #193 made here: v1 is now *inside* the window (v2 is an
+        **additive** layout — it only adds an ``ops`` list — so a v1
+        ``components`` artifact still reads unchanged). Before, ``artifact_v <
+        current_v`` rejected every older layout; that was correct only while each
+        bump was config-breaking, which v1→v2 is not.
+
+        A ``langres_version`` mismatch is logged as a warning, not a failure —
+        configs are forward-compatible *within* the window.
         """
         try:
             artifact_v = int(manifest.artifact_version)
             current_v = int(ARTIFACT_VERSION)
+            min_v = int(CLASSIC_ARTIFACT_VERSION)
         except ValueError:  # malformed/non-integer layout version -> incompatible.
             raise ValueError(
                 f"Artifact version {manifest.artifact_version!r} differs from "
@@ -265,11 +359,12 @@ class ModelPersistence(ModelState):
                 f"Artifact version {manifest.artifact_version!r} is newer than this "
                 f"langres build supports ({ARTIFACT_VERSION!r}); upgrade langres to load it."
             )
-        if artifact_v < current_v:
+        if artifact_v < min_v:
             raise ValueError(
                 f"Artifact version {manifest.artifact_version!r} predates the supported "
-                f"layout ({ARTIFACT_VERSION!r}) and is no longer readable (the config "
-                f"schema changed incompatibly); re-save with this langres build."
+                f"layout (readable range {CLASSIC_ARTIFACT_VERSION!r}..{ARTIFACT_VERSION!r}) and "
+                f"is no longer readable (the config schema changed incompatibly); re-save with "
+                f"this langres build."
             )
         if manifest.langres_version != LANGRES_VERSION:
             logger.warning(

--- a/src/langres/core/resolver.py
+++ b/src/langres/core/resolver.py
@@ -1202,6 +1202,13 @@ class ERModel(ModelRun, ModelPersistence):
         ``from_components`` for why building-from-config beats replaying
         constructor args, and for the one invariant it asks of an architecture.
 
+        An **explicit-chain** artifact (epic #193 persist v2, an ``ops`` list
+        instead of ``components``) reconstructs through
+        :meth:`~langres.core._model_state.ModelState.from_topology` instead, which
+        re-secures each raw ``MatcherScore`` against a fresh default-budget
+        :class:`~langres.core.spend.SpendMonitor` -- the spend cap is re-established
+        on load, never persisted.
+
         Args:
             path: Directory containing ``resolver.json`` and any sidecars.
 
@@ -1216,7 +1223,7 @@ class ERModel(ModelRun, ModelPersistence):
                 process has not registered (usually: its module was never
                 imported).
         """
-        manifest, components = cls._read_artifact(path)
+        manifest, payload = cls._read_artifact(path)
 
         # Reconstruct the class the artifact says it is, so a named architecture
         # round-trips as itself instead of decaying into a plain Resolver. Absent
@@ -1236,9 +1243,18 @@ class ERModel(ModelRun, ModelPersistence):
                 f"subclass; register_model is for ERModel subclasses (architectures)."
             )
         # No cast needed: the issubclass guard above narrows ``target`` to
-        # ``type[ERModel]`` for the type checker. from_components (NOT the class's
-        # own __init__) is what lets an architecture keep an ergonomic signature.
-        return target.from_components(**components)
+        # ``type[ERModel]`` for the type checker.
+        #
+        # Explicit Op chain (persist v2): ``_read_artifact`` returns ``{"ops": [...]}``
+        # of RAW-matcher stages -> from_topology, which re-secures every paid Score
+        # against a FRESH default-budget monitor (the budget is a run policy, not
+        # architecture, and is deliberately not persisted -- exactly as
+        # from_components refuses to bake in a saved budget). Otherwise the classic
+        # four-slot kwargs -> from_components (NOT the class's own __init__, so an
+        # architecture keeps its ergonomic signature).
+        if "ops" in payload:
+            return target.from_topology(ops=payload["ops"])
+        return target.from_components(**payload)
 
 
 #: The pre-W4 name for :class:`ERModel`, kept as a plain alias.

--- a/src/langres/core/serialization.py
+++ b/src/langres/core/serialization.py
@@ -10,8 +10,15 @@ Two things live here:
    doing so would force Qdrant/hybrid/reranking indexes to implement it.
 
 2. The artifact manifest types — the typed shape of ``resolver.json`` so
-   save/load (Wave 3) has a contract: :class:`ComponentSpec`,
-   :class:`ArtifactManifest`, and the :data:`ARTIFACT_VERSION` constant.
+   save/load has a contract: :class:`ComponentSpec` (a classic four-slot
+   component), :class:`OpSpec` (an explicit-chain stage), :class:`ArtifactManifest`,
+   and the :data:`ARTIFACT_VERSION` / :data:`CLASSIC_ARTIFACT_VERSION` constants.
+
+This is a ``core`` leaf: it imports only pydantic + stdlib and MUST NOT import
+:mod:`~langres.core.op` / :mod:`~langres.core.op_adapters`. The op↔spec *instance*
+adapters (``op_spec`` / ``rebuild_op``, which reach into those modules) live in
+:mod:`langres.core._artifacts`, a tier that already imports them — so the on-disk
+data contract stays a dependency-free leaf.
 """
 
 from pathlib import Path
@@ -19,8 +26,18 @@ from typing import Protocol, runtime_checkable
 
 from pydantic import BaseModel, Field
 
-# Bump when the on-disk artifact layout changes incompatibly.
-ARTIFACT_VERSION = "1"
+#: The **classic four-slot** on-disk layout, frozen at ``"1"``. A classic
+#: (``self._ops is None``) save always stamps this, so its bytes — and the
+#: ``recipe_id`` derived from its ``config_dict`` — never fork when the reader's
+#: max advances. Do NOT bump this: bumping :data:`ARTIFACT_VERSION` (the reader's
+#: max) is how a new *additive* layout ships without restamping classic artifacts.
+CLASSIC_ARTIFACT_VERSION = "1"
+
+#: The reader's **maximum** supported layout. Bumped ``"1"`` → ``"2"`` when the
+#: explicit Op-chain layout (an ``ops`` list instead of ``components``) landed
+#: (#193, persist v2). The reader accepts any layout in ``[1, ARTIFACT_VERSION]``;
+#: only an explicit-chain (``self._ops is not None``) save stamps ``"2"``.
+ARTIFACT_VERSION = "2"
 
 
 @runtime_checkable
@@ -69,12 +86,56 @@ class ComponentSpec(BaseModel):
     config: dict[str, object]
 
 
+class OpSpec(BaseModel):
+    """Serialized record of one **explicit-chain** stage in the manifest.
+
+    The explicit-chain (:meth:`~langres.core._model_state.ModelState.from_topology`)
+    analogue of :class:`ComponentSpec`: where a classic four-slot model serializes
+    each slot as a ``ComponentSpec`` under ``ArtifactManifest.components``, an
+    explicit-chain model serializes each :class:`~langres.core.op.Stage` as an
+    ``OpSpec`` under :attr:`ArtifactManifest.ops`.
+
+    Kept a pure data model beside ``ComponentSpec`` (this module is a leaf that
+    imports only pydantic/stdlib). The op↔spec instance adapters that build one
+    from a live stage and reverse it — ``op_spec`` / ``rebuild_op``, which import
+    :mod:`~langres.core.op` / :mod:`~langres.core.op_adapters` — live in
+    :mod:`langres.core._artifacts`.
+
+    Attributes:
+        role: The stage's role tag, e.g. ``"blocker_source"``,
+            ``"comparator_score"``, ``"matcher_score"``, ``"threshold_select"``,
+            ``"topk_select"``, ``"clusterer_stage"`` — how ``rebuild_op`` knows
+            which adapter to reconstruct.
+        params: Role-specific scalar parameters (e.g. ``{"threshold": 0.5}`` for a
+            ThresholdSelect, ``{"k": 10}`` for a TopKSelect, ``{"out_space":
+            "prob_llm"}`` for a MatcherScore). Empty for a role carrying no scalar
+            of its own.
+        component: The nested legacy component (blocker / comparator / matcher /
+            clusterer) the stage adapts, as a :class:`ComponentSpec` — or ``None``
+            for a component-free stage (a Select carries only ``params``). A
+            spend-cap wrapper is deliberately never serialized here: a
+            ``MatcherScore``'s spec records the *raw inner* matcher, and
+            ``from_topology`` re-wraps it on load.
+    """
+
+    role: str
+    params: dict[str, object] = Field(default_factory=dict)
+    component: ComponentSpec | None = None
+
+
 class ArtifactManifest(BaseModel):
     """Typed shape of ``resolver.json``.
 
+    Carries **either** ``components`` (the classic four-slot layout) **or** ``ops``
+    (the explicit Op-chain layout, #193 persist v2) — never meaningfully both. A
+    classic save writes ``components`` and omits ``ops``; an explicit-chain save
+    writes ``ops`` and omits ``components``. ``ops`` defaults to ``None`` so an old
+    v1 ``resolver.json`` (which has no ``ops`` key) validates straight onto the
+    classic read path.
+
     Attributes:
         artifact_version: Layout version of the artifact (see
-            :data:`ARTIFACT_VERSION`).
+            :data:`ARTIFACT_VERSION` / :data:`CLASSIC_ARTIFACT_VERSION`).
         langres_version: The ``langres.__version__`` that wrote the artifact.
         model_class: Registered name of the Resolver *subclass* that wrote the
             artifact (see ``langres.core.registry.register_model``), so a named
@@ -86,7 +147,13 @@ class ArtifactManifest(BaseModel):
             bump would make ``Resolver._check_versions`` reject existing 0.3.0
             artifacts in *both* directions (it raises on older *and* newer) for
             no gain.
-        components: Ordered component specs composing the Resolver.
+        components: Ordered component specs composing a **classic four-slot**
+            Resolver. Empty for an explicit-chain artifact (which uses ``ops``).
+        ops: Ordered stage specs composing an **explicit Op chain**
+            (:meth:`~langres.core._model_state.ModelState.from_topology`), or
+            ``None`` for the classic four-slot layout. ``None`` by design so a
+            pre-#193 v1 ``resolver.json`` — which has no ``ops`` key — validates to
+            ``None`` and reads through the classic ``components`` path unchanged.
         checksums: Optional sidecar checksum map (filename -> checksum) for
             out-of-band state files written by :class:`SerializableState`
             components. Empty when no component has out-of-band state.
@@ -95,5 +162,6 @@ class ArtifactManifest(BaseModel):
     artifact_version: str
     langres_version: str
     model_class: str | None = None
-    components: list[ComponentSpec]
+    components: list[ComponentSpec] = Field(default_factory=list)
+    ops: list[OpSpec] | None = None
     checksums: dict[str, str] = Field(default_factory=dict)

--- a/tests/core/test_persist_v2_explicit_chain.py
+++ b/tests/core/test_persist_v2_explicit_chain.py
@@ -1,0 +1,390 @@
+"""Persist v2: an explicit Op-chain model (``from_topology``) round-trips through
+``save``/``load`` — while the classic four-slot path stays byte-identical (#193 PR-B).
+
+The crown invariant is the *classic* byte-parity pinned by
+``tests/parity/test_behavior_parity_*`` + ``tests/test_resolver_config_dict.py`` +
+``tests/parity/test_legacy_load_w0.py``. This file adds the v2 half: a synthetic,
+``$0`` explicit chain (reusing ``tests/parity/_explicit_chain_fixture.py``) saves,
+reloads in a fresh interpreter state, and reproduces its dedupe — with its paid
+Score re-secured on load and its spend cap unwrapped (never persisted) on save.
+"""
+
+from __future__ import annotations
+
+import json
+from collections.abc import Iterator
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from langres.core._artifacts import op_spec, rebuild_op
+from langres.core.blocker import Blocker
+from langres.core.clusterer import Clusterer
+from langres.core.groups import ERCandidateGroup
+from langres.core.matcher import GroupwiseMatcher
+from langres.core.models import ERCandidate, PairwiseJudgement
+from langres.core.op import Finalize, Stage, ThresholdSelect
+from langres.core.op_adapters import (
+    BlockerSource,
+    ClustererStage,
+    GroupwiseMatcherScore,
+    MatcherScore,
+)
+from langres.core.registry import register
+from langres.core.resolver import ERModel
+from langres.core.results import DedupeResult
+from langres.core.serialization import ArtifactManifest, ComponentSpec, OpSpec
+from langres.core.spend_cap import SpendCappedMatcher
+from tests.parity._explicit_chain_fixture import (
+    RECORDS,
+    THRESHOLD,
+    CostedNameMatcher,
+    build_explicit_chain_model,
+    build_score_after_select_model,
+    chain_ops,
+)
+
+
+def _canonical(result: DedupeResult) -> list[list[str]]:
+    return sorted(sorted(cluster) for cluster in result)
+
+
+def _matcher_score(model: ERModel) -> MatcherScore[Any]:
+    assert model._ops is not None
+    return next(op for op in model._ops if isinstance(op, MatcherScore))
+
+
+# ----------------------------------------------------------------------------------
+# 1. v2 round-trip: save -> load -> identical dedupe + re-secured chain
+# ----------------------------------------------------------------------------------
+
+
+def test_v2_round_trip_reproduces_dedupe_and_metadata(tmp_path: Path) -> None:
+    """A ``from_topology`` chain saves, reloads, and dedupes IDENTICALLY —
+    clusters, ``score_type``, ``threshold`` and ``backbone`` all match."""
+    model, _monitor, _matcher = build_explicit_chain_model(model="test/backbone-x")
+    before = model.dedupe(RECORDS)
+
+    model.save(tmp_path)
+    loaded = ERModel.load(tmp_path)
+    after = loaded.dedupe(RECORDS)
+
+    assert _canonical(before) == _canonical(after) == [["a1", "a2"]]
+    assert before.score_type == after.score_type == "prob_llm"
+    assert before.threshold == after.threshold == THRESHOLD
+    assert before.backbone == after.backbone == "test/backbone-x"
+    # resolve() (the low-level exit) reproduces too.
+    assert sorted(sorted(c) for c in loaded.resolve(RECORDS)) == [["a1", "a2"]]
+
+
+def test_v2_round_trip_reestablishes_the_spend_cap(tmp_path: Path) -> None:
+    """The loaded chain's ``MatcherScore`` is re-secured: its matcher is a
+    ``SpendCappedMatcher`` on the LOADED model's fresh ledger — the door re-wrapped
+    the raw matcher that was serialized (budget/monitor deliberately not persisted)."""
+    model, _monitor, _matcher = build_explicit_chain_model()
+    model.save(tmp_path)
+    loaded = ERModel.load(tmp_path)
+
+    capped = _matcher_score(loaded).matcher
+    assert isinstance(capped, SpendCappedMatcher)
+    # Shares the loaded model's ONE ledger (a fresh default-budget monitor).
+    assert capped.monitor is loaded._spend_monitor
+    # The wrapped inner matcher is the RAW fixture matcher, faithfully rebuilt.
+    assert isinstance(capped._module, CostedNameMatcher)
+
+
+def test_v2_round_trip_multi_score_chain(tmp_path: Path) -> None:
+    """A Score-after-Select chain (two MatcherScores + a TopKSelect) round-trips:
+    every stage returns, in order, and every paid Score is re-secured."""
+    model = build_score_after_select_model()
+    before = model.dedupe(RECORDS)
+
+    model.save(tmp_path)
+    loaded = ERModel.load(tmp_path)
+
+    assert loaded._ops is not None
+    assert [type(op).__name__ for op in loaded._ops] == [type(op).__name__ for op in model._ops]
+    assert _canonical(loaded.dedupe(RECORDS)) == _canonical(before)
+    # BOTH matcher Scores re-wrapped against the loaded model's one ledger.
+    for op in loaded._ops:
+        if isinstance(op, MatcherScore):
+            assert isinstance(op.matcher, SpendCappedMatcher)
+            assert op.matcher.monitor is loaded._spend_monitor
+
+
+# ----------------------------------------------------------------------------------
+# 2. Unwrap-on-save: the artifact carries the RAW matcher, no cap/monitor/budget leak
+# ----------------------------------------------------------------------------------
+
+
+def test_saved_json_carries_raw_matcher_and_leaks_no_cap(tmp_path: Path) -> None:
+    """The saved ``resolver.json`` records the RAW matcher's ``type_name`` under the
+    ``matcher_score`` op — never the ``SpendCappedMatcher`` wrapper — and no
+    monitor/budget leaks into the artifact."""
+    model, _monitor, _matcher = build_explicit_chain_model()
+    model.save(tmp_path)
+
+    text = (tmp_path / "resolver.json").read_text()
+    manifest = json.loads(text)
+
+    assert manifest["artifact_version"] == "2"
+    assert "components" not in manifest  # explicit artifact drops the classic key
+    ms_op = next(op for op in manifest["ops"] if op["role"] == "matcher_score")
+    assert ms_op["component"]["type_name"] == "costed_name_matcher"
+    assert ms_op["params"] == {"out_space": "prob_llm"}
+
+    # The live-monitor wrapper and the budget are NEVER serialized.
+    for leaked in ("SpendCappedMatcher", "spend_capped", "monitor", "budget"):
+        assert leaked not in text, f"artifact leaked {leaked!r}"
+
+
+# ----------------------------------------------------------------------------------
+# 3. Classic byte-parity (the crown invariant) is untouched
+# ----------------------------------------------------------------------------------
+
+
+def _classic_resolver() -> ERModel:
+    from langres.core.blockers import AllPairsBlocker
+    from langres.core.comparators import StringComparator
+    from langres.core.matchers import WeightedAverageMatcher
+    from langres.core.models import CompanySchema
+
+    comparator = StringComparator.from_schema(CompanySchema)
+    return ERModel(
+        blocker=AllPairsBlocker(schema=CompanySchema),
+        comparator=comparator,
+        matcher=WeightedAverageMatcher(feature_specs=comparator.feature_specs),
+        clusterer=Clusterer(threshold=0.7),
+    )
+
+
+def test_classic_save_has_no_ops_key_and_stamps_v1(tmp_path: Path) -> None:
+    """A classic four-slot save is byte-unchanged: it stamps ``"1"`` and its
+    ``resolver.json`` carries NO ``ops`` key (F1 + the crown byte-invariant)."""
+    _classic_resolver().save(tmp_path)
+    manifest = json.loads((tmp_path / "resolver.json").read_text())
+
+    assert manifest["artifact_version"] == "1"
+    assert "ops" not in manifest
+    assert [c["slot"] for c in manifest["components"]] == [
+        "blocker",
+        "comparator",
+        "module",
+        "clusterer",
+    ]
+
+
+def test_classic_config_dict_shape_unchanged() -> None:
+    """A classic ``config_dict`` still returns ``{"components": ...}`` only — no
+    ``ops`` key — so its ``recipe_id`` never forks (F2)."""
+    snapshot = _classic_resolver().config_dict()
+    assert set(snapshot.keys()) == {"components"}
+
+
+def test_explicit_config_dict_keys_on_ops() -> None:
+    """An explicit-chain ``config_dict`` keys on ``ops`` (never ``components``)."""
+    model, _m, _mt = build_explicit_chain_model()
+    snapshot = model.config_dict()
+    assert set(snapshot.keys()) == {"ops"}
+    assert isinstance(snapshot["ops"], list)
+
+
+# ----------------------------------------------------------------------------------
+# 4. Version window: v1 reads on v2, v3 rejected, explicit stamps v2
+# ----------------------------------------------------------------------------------
+
+
+def test_explicit_save_stamps_v2_classic_stamps_v1(tmp_path: Path) -> None:
+    """Explicit save stamps ``"2"``; classic save stamps ``"1"`` — from the written json."""
+    build_explicit_chain_model()[0].save(tmp_path / "explicit")
+    _classic_resolver().save(tmp_path / "classic")
+
+    explicit = json.loads((tmp_path / "explicit" / "resolver.json").read_text())
+    classic = json.loads((tmp_path / "classic" / "resolver.json").read_text())
+    assert explicit["artifact_version"] == "2"
+    assert classic["artifact_version"] == "1"
+
+
+def test_v1_artifact_loads_on_v2_langres(tmp_path: Path) -> None:
+    """A v1 (classic) artifact loads on this v2-reader build unchanged — v2 is an
+    additive layout, so v1 is inside the readable window (the #193 gate change)."""
+    _classic_resolver().save(tmp_path)
+    assert json.loads((tmp_path / "resolver.json").read_text())["artifact_version"] == "1"
+    reloaded = ERModel.load(tmp_path)
+    assert reloaded.clusterer.threshold == 0.7
+
+
+def test_v3_artifact_is_rejected(tmp_path: Path) -> None:
+    """A strictly-newer layout (``"3"``) is a hard 'upgrade langres' error."""
+    build_explicit_chain_model()[0].save(tmp_path)
+    manifest_path = tmp_path / "resolver.json"
+    manifest = json.loads(manifest_path.read_text())
+    manifest["artifact_version"] = "3"
+    manifest_path.write_text(json.dumps(manifest))
+
+    with pytest.raises(ValueError, match="newer than this langres build"):
+        ERModel.load(tmp_path)
+
+
+# ----------------------------------------------------------------------------------
+# 5. F3: op_spec fails loud on a stage it cannot faithfully round-trip
+# ----------------------------------------------------------------------------------
+
+
+class _SubMatcherScore(MatcherScore[Any]):
+    """A MatcherScore SUBCLASS — rebuilding it as a base MatcherScore would drop its
+    (hypothetical) own state, so op_spec must reject it rather than write a lossy spec."""
+
+
+class _FakeGroupwise(GroupwiseMatcher[Any]):
+    def forward_groups(
+        self, groups: Iterator[ERCandidateGroup[Any]]
+    ) -> Iterator[PairwiseJudgement]:
+        return iter([])  # never runs; op_spec rejects the stage before any scoring
+
+
+class _FakeFinalize(Finalize):
+    def forward(self, clusters: list[set[str]]) -> list[set[str]]:
+        return clusters
+
+
+def test_op_spec_rejects_matcher_score_subclass() -> None:
+    stage = _SubMatcherScore(CostedNameMatcher(), out_space="prob_llm")
+    with pytest.raises(TypeError, match="cannot serialize"):
+        op_spec(stage)
+
+
+def test_op_spec_rejects_groupwise_matcher_score() -> None:
+    with pytest.raises(TypeError, match="cannot serialize"):
+        op_spec(GroupwiseMatcherScore(_FakeGroupwise()))
+
+
+def test_op_spec_rejects_finalize() -> None:
+    with pytest.raises(TypeError, match="cannot serialize"):
+        op_spec(_FakeFinalize())
+
+
+def test_op_spec_rejects_unregistered_inner_matcher() -> None:
+    """An unregistered raw matcher (no ``type_name``) fails loud at save via the
+    nested ``component_spec`` — the same fail-loud contract as the classic path."""
+
+    class _Unregistered(CostedNameMatcher):
+        type_name = None  # type: ignore[assignment]  # shadow the registered name
+
+    with pytest.raises(TypeError, match="not serializable"):
+        op_spec(MatcherScore(_Unregistered(), out_space="prob_llm"))
+
+
+# ----------------------------------------------------------------------------------
+# 6. rebuild_op malformed-spec guards
+# ----------------------------------------------------------------------------------
+
+
+def test_rebuild_op_rejects_unknown_role(tmp_path: Path) -> None:
+    with pytest.raises(ValueError, match="unknown OpSpec role"):
+        rebuild_op(OpSpec(role="not_a_role"), state_dir=tmp_path)
+
+
+def test_rebuild_op_rejects_missing_component(tmp_path: Path) -> None:
+    with pytest.raises(ValueError, match="requires a nested component"):
+        rebuild_op(OpSpec(role="matcher_score", params={"out_space": "prob_llm"}), state_dir=tmp_path)
+
+
+# ----------------------------------------------------------------------------------
+# 7. F5: an explicit-chain sidecar (VectorBlocker-style stateful Source) round-trips
+# ----------------------------------------------------------------------------------
+
+
+@register("persist_v2_marker_blocker")
+class _MarkerBlocker(Blocker[Any]):
+    """A minimal ``SerializableState`` blocker standing in for a built ``VectorBlocker``
+    Source: it persists a marker file (its 'index') to a sidecar and restores it, so
+    the ordinal-``op{i}`` sidecar path is exercised without faiss/torch."""
+
+    type_name = "persist_v2_marker_blocker"
+
+    def __init__(self, *, marker: str = "built-index") -> None:
+        self._marker = marker
+        self.restored: str | None = None
+
+    def stream(self, data: list[Any]) -> Iterator[ERCandidate[Any]]:
+        return iter([])  # unused in this save/load-only test
+
+    @property
+    def config(self) -> dict[str, object]:
+        return {}
+
+    @classmethod
+    def from_config(cls, config: dict[str, object]) -> "_MarkerBlocker":
+        return cls()
+
+    def save_state(self, state_dir: Path) -> None:
+        (state_dir / "index.marker").write_text(self._marker)
+
+    def load_state(self, state_dir: Path) -> None:
+        self.restored = (state_dir / "index.marker").read_text()
+
+
+def test_explicit_sidecar_state_round_trips_by_ordinal(tmp_path: Path) -> None:
+    """A stateful Source writes/reads its sidecar under ``op0`` (ordinal, not slot
+    name); load restores its out-of-band state (F5)."""
+    ops: list[Stage] = [
+        BlockerSource(_MarkerBlocker()),
+        MatcherScore(CostedNameMatcher(), out_space="prob_llm"),
+        ThresholdSelect(THRESHOLD),
+        ClustererStage(Clusterer(threshold=0.0)),
+    ]
+    ERModel.from_topology(ops=ops).save(tmp_path)
+
+    # The sidecar is keyed by ordinal, not slot name.
+    assert (tmp_path / "op0" / "index.marker").read_text() == "built-index"
+
+    loaded = ERModel.load(tmp_path)
+    assert loaded._ops is not None
+    source = loaded._ops[0]
+    assert isinstance(source, BlockerSource)
+    assert isinstance(source.blocker, _MarkerBlocker)
+    assert source.blocker.restored == "built-index"  # out-of-band state restored
+
+
+def test_stateless_explicit_chain_writes_no_sidecar(tmp_path: Path) -> None:
+    """The shipped-style chain (AllPairsBlocker Source) owns no state, so save
+    writes only ``resolver.json`` — no ``op{i}`` sidecar dirs."""
+    ops, _matcher = chain_ops()
+    ERModel.from_topology(ops=ops).save(tmp_path)
+
+    children = sorted(p.name for p in tmp_path.iterdir())
+    assert children == ["resolver.json"]
+
+
+# ----------------------------------------------------------------------------------
+# 8. op_spec / rebuild_op agree on every round-trippable stage (spec-level parity)
+# ----------------------------------------------------------------------------------
+
+
+def test_op_spec_round_trips_every_stage_kind(tmp_path: Path) -> None:
+    """Each stage of the canonical chain survives op_spec -> serialize -> rebuild_op,
+    and every produced OpSpec validates through the manifest (json boundary)."""
+    ops, _matcher = chain_ops()
+    specs = [op_spec(stage) for stage in ops]
+
+    # Roles, in order, match the canonical chain.
+    assert [s.role for s in specs] == [
+        "blocker_source",
+        "comparator_score",
+        "matcher_score",
+        "threshold_select",
+        "clusterer_stage",
+    ]
+    # Round-trips through the manifest json (the OpSpec data contract).
+    manifest = ArtifactManifest(artifact_version="2", langres_version="test", ops=specs)
+    restored = ArtifactManifest.model_validate_json(manifest.model_dump_json())
+    assert restored.ops == specs
+    assert isinstance(restored.ops[0].component, ComponentSpec)
+
+    rebuilt = [rebuild_op(spec, state_dir=tmp_path / f"op{i}") for i, spec in enumerate(specs)]
+    assert [type(stage).__name__ for stage in rebuilt] == [type(stage).__name__ for stage in ops]
+    threshold_stage = rebuilt[3]
+    assert isinstance(threshold_stage, ThresholdSelect)
+    assert threshold_stage.threshold == THRESHOLD

--- a/tests/core/test_persist_v2_explicit_chain.py
+++ b/tests/core/test_persist_v2_explicit_chain.py
@@ -288,7 +288,9 @@ def test_rebuild_op_rejects_unknown_role(tmp_path: Path) -> None:
 
 def test_rebuild_op_rejects_missing_component(tmp_path: Path) -> None:
     with pytest.raises(ValueError, match="requires a nested component"):
-        rebuild_op(OpSpec(role="matcher_score", params={"out_space": "prob_llm"}), state_dir=tmp_path)
+        rebuild_op(
+            OpSpec(role="matcher_score", params={"out_space": "prob_llm"}), state_dir=tmp_path
+        )
 
 
 # ----------------------------------------------------------------------------------
@@ -311,6 +313,11 @@ class _MarkerBlocker(Blocker[Any]):
     def stream(self, data: list[Any]) -> Iterator[ERCandidate[Any]]:
         return iter([])  # unused in this save/load-only test
 
+    def inspect_candidates(
+        self, candidates: list[ERCandidate[Any]], entities: list[Any], sample_size: int = 10
+    ) -> Any:
+        raise NotImplementedError  # unused in this save/load-only test
+
     @property
     def config(self) -> dict[str, object]:
         return {}
@@ -320,7 +327,10 @@ class _MarkerBlocker(Blocker[Any]):
         return cls()
 
     def save_state(self, state_dir: Path) -> None:
-        (state_dir / "index.marker").write_text(self._marker)
+        # An empty marker persists NOTHING — mirrors a VectorBlocker whose index
+        # was never built (a SerializableState owner with nothing to write).
+        if self._marker:
+            (state_dir / "index.marker").write_text(self._marker)
 
     def load_state(self, state_dir: Path) -> None:
         self.restored = (state_dir / "index.marker").read_text()
@@ -346,6 +356,27 @@ def test_explicit_sidecar_state_round_trips_by_ordinal(tmp_path: Path) -> None:
     assert isinstance(source, BlockerSource)
     assert isinstance(source.blocker, _MarkerBlocker)
     assert source.blocker.restored == "built-index"  # out-of-band state restored
+
+
+def test_explicit_empty_sidecar_is_dropped(tmp_path: Path) -> None:
+    """A stateful Source that persists NOTHING (e.g. an unbuilt VectorBlocker index)
+    leaves no ``op{i}`` dir behind — the empty sidecar is removed, so load never
+    tries to read a missing state file."""
+    ops: list[Stage] = [
+        BlockerSource(_MarkerBlocker(marker="")),  # writes no state file
+        MatcherScore(CostedNameMatcher(), out_space="prob_llm"),
+        ThresholdSelect(THRESHOLD),
+        ClustererStage(Clusterer(threshold=0.0)),
+    ]
+    ERModel.from_topology(ops=ops).save(tmp_path)
+
+    assert not (tmp_path / "op0").exists()  # empty sidecar dropped
+    loaded = ERModel.load(tmp_path)
+    assert loaded._ops is not None
+    source = loaded._ops[0]
+    assert isinstance(source, BlockerSource)
+    assert isinstance(source.blocker, _MarkerBlocker)
+    assert source.blocker.restored is None  # no state to restore
 
 
 def test_stateless_explicit_chain_writes_no_sidecar(tmp_path: Path) -> None:

--- a/tests/core/test_serialization.py
+++ b/tests/core/test_serialization.py
@@ -2,23 +2,30 @@
 
 Covers:
 - SerializableState Protocol (the optional heavy-component capability)
-- ComponentSpec / ArtifactManifest typed models
-- ARTIFACT_VERSION constant
+- ComponentSpec / OpSpec / ArtifactManifest typed models
+- ARTIFACT_VERSION / CLASSIC_ARTIFACT_VERSION constants
 """
 
 from pathlib import Path
 
 from langres.core.serialization import (
     ARTIFACT_VERSION,
+    CLASSIC_ARTIFACT_VERSION,
     ArtifactManifest,
     ComponentSpec,
+    OpSpec,
     SerializableState,
 )
 
 
 class TestArtifactVersion:
-    def test_artifact_version_is_one(self) -> None:
-        assert ARTIFACT_VERSION == "1"
+    def test_reader_max_is_two(self) -> None:
+        # Bumped "1" -> "2" when the explicit Op-chain layout landed (#193 persist v2).
+        assert ARTIFACT_VERSION == "2"
+
+    def test_classic_layout_frozen_at_one(self) -> None:
+        # The classic four-slot layout never restamps, so its bytes/recipe_id hold.
+        assert CLASSIC_ARTIFACT_VERSION == "1"
 
 
 class TestComponentSpec:
@@ -36,6 +43,24 @@ class TestComponentSpec:
         assert spec.config_version == "1"
 
 
+class TestOpSpec:
+    def test_round_trip_with_component(self) -> None:
+        spec = OpSpec(
+            role="matcher_score",
+            params={"out_space": "prob_llm"},
+            component=ComponentSpec(type_name="costed_name_matcher", config={"cost_each": 0.0}),
+        )
+        restored = OpSpec.model_validate_json(spec.model_dump_json())
+        assert restored == spec
+
+    def test_params_and_component_default_empty(self) -> None:
+        # A Select carries only its role + params; component defaults to None.
+        spec = OpSpec(role="threshold_select", params={"threshold": 0.5})
+        assert spec.component is None
+        # An entirely bare spec is valid too (params default to {}).
+        assert OpSpec(role="x").params == {}
+
+
 class TestArtifactManifest:
     def test_construct_and_round_trip(self) -> None:
         manifest = ArtifactManifest(
@@ -48,8 +73,38 @@ class TestArtifactManifest:
         )
         restored = ArtifactManifest.model_validate_json(manifest.model_dump_json())
         assert restored == manifest
-        assert restored.artifact_version == "1"
+        assert restored.artifact_version == ARTIFACT_VERSION
         assert len(restored.components) == 2
+        assert restored.ops is None  # a components manifest carries no ops
+
+    def test_ops_round_trip(self) -> None:
+        manifest = ArtifactManifest(
+            artifact_version=ARTIFACT_VERSION,
+            langres_version="0.1.0",
+            ops=[
+                OpSpec(
+                    role="blocker_source",
+                    component=ComponentSpec(type_name="all_pairs_blocker", config={}),
+                ),
+                OpSpec(role="threshold_select", params={"threshold": 0.5}),
+            ],
+        )
+        restored = ArtifactManifest.model_validate_json(manifest.model_dump_json())
+        assert restored == manifest
+        assert restored.ops is not None
+        assert restored.components == []  # an ops manifest carries no components
+
+    def test_ops_defaults_none_so_old_v1_json_reads_classic(self) -> None:
+        # A pre-#193 v1 resolver.json (components, no ``ops`` key) validates with
+        # ops=None -> the classic read path (F4).
+        legacy_json = (
+            '{"artifact_version": "1", "langres_version": "0.3.0", "model_class": null, '
+            '"components": [{"type_name": "clusterer", "config": {"threshold": 0.7}}], '
+            '"checksums": {}}'
+        )
+        manifest = ArtifactManifest.model_validate_json(legacy_json)
+        assert manifest.ops is None
+        assert len(manifest.components) == 1
 
     def test_checksums_optional_default_empty(self) -> None:
         manifest = ArtifactManifest(

--- a/tests/parity/_explicit_chain_fixture.py
+++ b/tests/parity/_explicit_chain_fixture.py
@@ -28,7 +28,7 @@ so the builders here stay clean and importable.
 from __future__ import annotations
 
 from collections.abc import Callable, Iterator
-from typing import Any
+from typing import Any, ClassVar, cast
 
 from pydantic import BaseModel
 
@@ -39,6 +39,7 @@ from langres.core.comparators import StringComparator
 from langres.core.matcher import Matcher
 from langres.core.models import ERCandidate, PairwiseJudgement
 from langres.core.op import Stage, ThresholdSelect, TopKSelect
+from langres.core.registry import register
 from langres.core.op_adapters import (
     BlockerSource,
     ClustererStage,
@@ -71,6 +72,7 @@ RECORDS: list[dict[str, Any]] = [
 THRESHOLD = 0.5
 
 
+@register("costed_name_matcher")
 class CostedNameMatcher(Matcher[Any]):
     """``$0`` fake matcher: scores ``1.0`` iff the two names match else ``0.0``.
 
@@ -79,7 +81,15 @@ class CostedNameMatcher(Matcher[Any]):
     network and no key (the same technique as ``test_resolver_spend_cap``). An
     optional ``model`` is advertised so :attr:`~langres.core._model_state.ModelState.backbone`
     reporting through the chain can be exercised.
+
+    **Registry-serializable** (``type_name`` + ``config``/``from_config``, epic
+    #193 persist PR-B): the persist PR must ``save``/``load`` a ``from_topology``
+    chain, and every stage's nested component has to round-trip through the
+    component registry. ``produced`` is runtime state, not config, so a reloaded
+    matcher starts at ``0`` -- correct, it has scored nothing yet.
     """
+
+    type_name: ClassVar[str] = "costed_name_matcher"
 
     def __init__(
         self,
@@ -93,6 +103,20 @@ class CostedNameMatcher(Matcher[Any]):
         self.produced = 0
         #: Advertised backbone id (``None`` = weightless, like a string matcher).
         self.model: str | None = model
+
+    @property
+    def config(self) -> dict[str, object]:
+        """Serializable construction config (no ``produced`` -- that is runtime state)."""
+        return {"cost_each": self._cost_each, "score_type": self._score_type, "model": self.model}
+
+    @classmethod
+    def from_config(cls, config: dict[str, object]) -> "CostedNameMatcher":
+        """Rebuild from :attr:`config`."""
+        return cls(
+            cost_each=float(cast(float, config["cost_each"])),
+            score_type=cast(ScoreType, config["score_type"]),
+            model=cast("str | None", config["model"]),
+        )
 
     def forward(self, candidates: Iterator[ERCandidate[Any]]) -> Iterator[PairwiseJudgement]:
         for candidate in candidates:


### PR DESCRIPTION
## PR-B — persist v2: explicit Op-chain (`_ops`) round-trip (#193)

Adds **persist v2** so a `from_topology(ops=[...])` model (`self._ops` set)
`save`s/`load`s, without changing the classic four-slot on-disk format or
forking any `recipe_id`. **Classic (`self._ops is None`) save/load bytes and
`recipe_id` stay byte-identical** — the crown invariant.

### Design (by layer)
- **`serialization.py`** (a `core` leaf, pydantic/stdlib only — no `op` import):
  new pure data model `OpSpec { role, params, component: ComponentSpec | None }`
  beside `ComponentSpec`; `ArtifactManifest.ops: list[OpSpec] | None = None`
  (**F4** — an old v1 json with no `ops` key validates to the classic path).
  `ARTIFACT_VERSION "1" -> "2"` (reader max) + new `CLASSIC_ARTIFACT_VERSION "1"`.
- **`_artifacts.py`** (`architectures` tier — may import `op`/`op_adapters`/`spend_cap`):
  the op↔spec *instance* adapters `op_spec` / `rebuild_op` (+ `op_state_owner`
  sidecar seam). A `MatcherScore` is **unwrapped on save** — its `SpendCappedMatcher`
  (a live per-model monitor, unserializable) is peeled and the **raw inner matcher**
  serialized; `from_topology` re-wraps against a fresh ledger on load. Budget/monitor
  are deliberately **not** persisted. **F3**: `op_spec` raises `TypeError` on a stage
  it cannot faithfully round-trip (a `MatcherScore` subclass, a `GroupwiseMatcherScore`,
  a `Finalize`) — fail loud at save.
- **`_model_persist.py`**: `_build_manifest` / `config_dict` / `save` / `_read_artifact`
  branch on `self._ops`. **F1** classic keeps stamping `"1"`; explicit stamps `"2"`.
  **F2** classic `config_dict` returns the byte-identical `{"components": …}`; explicit
  keys on `{"ops": …}`. Classic dump excludes the new `ops` field so its bytes are
  unchanged. **F5** explicit sidecars key by ordinal (`op{i}`) via the same
  `state_owner`/`has_state` seam. `_check_versions` now accepts the window
  `[CLASSIC_ARTIFACT_VERSION, ARTIFACT_VERSION]` = `[1, 2]`.
- **`resolver.load`**: dispatches on the payload shape — `{"ops": …}` →
  `from_topology(ops=…)`, else `from_components(**…)`.

### Note for review — version gate
The brief said "drop the `artifact_v < current_v` rejection branch". I implemented
the equivalent **window** `[1, 2]` (reject `< 1` "predates", reject `> 2` "upgrade")
rather than a bare drop: this makes v1 read on v2 (the actual requirement, since v2
is an *additive* layout) **and** keeps a genuinely-incompatible pre-M0.5 `"0"`
artifact failing with a clean error instead of a raw `KeyError` — so the existing
`test_resolver_load_rejects_older_artifact` (v0) stays green.

### Tests (core tier, 95–100%)
New `tests/core/test_persist_v2_explicit_chain.py` (21 tests): v2 round-trip
(identical dedupe/resolve + re-secured `_ops` cap on the loaded model's ledger),
multi-Score chain, unwrap-on-save (raw `type_name` in json, no cap/monitor/budget
leak), classic byte-parity untouched, version range (v1-on-v2 loads, v3 rejected,
classic stamps "1"/explicit "2"), F3 fail-loud, F5 ordinal sidecar (write+restore
and empty-drop), spec-level op_spec↔rebuild_op parity. Updated
`tests/core/test_serialization.py` for the version bump + `OpSpec`. The PR-A fixture
`CostedNameMatcher` is now registry-serializable (its own docstring anticipated this).

### Gates (all green)
- Full fast suite (`-m "not integration and not slow and not finetune"`, `--all-extras`):
  **3842 passed, 2 skipped**.
- Crown invariant: 4 parity goldens + `test_legacy_load_w0` + `test_resolver_config_dict`
  + `test_resolver_roundtrip` version tests — green.
- `mypy --strict` (`--all-extras`): clean. `ruff format --check` + `ruff check`: clean.
- Import gates (tangle/graph/budget): 87 passed — `serialization.py` gained NO `op`
  edge, `_artifacts.py→op_adapters` adds no cycle, no new module (no
  `refactor_target_packages.json` entry needed).
- Coverage: `_artifacts.py` / `_model_persist.py` / `serialization.py` = **100%**;
  `resolver.py` misses are pre-existing fit/embedding lines outside the `load` change.

https://claude.ai/code/session_011XYuhyiigi1Bw2YnWCxMr9
