### PR TITLE
feat(architectures): reranker — a Score-after-Select topology (#193 PR-C)

### DIFF
--- a/src/langres/architectures/__init__.py
+++ b/src/langres/architectures/__init__.py
@@ -46,6 +46,7 @@ to normalize a record identically; that is exactly what a contract is for.
 """
 
 from langres.architectures.fuzzy_string import FuzzyString
+from langres.architectures.reranker import Reranker
 from langres.architectures.vector_llm_cascade import VectorLLMCascade
 
-__all__ = ["FuzzyString", "VectorLLMCascade"]
+__all__ = ["FuzzyString", "Reranker", "VectorLLMCascade"]

--- a/src/langres/architectures/reranker.py
+++ b/src/langres/architectures/reranker.py
@@ -1,0 +1,183 @@
+"""``Reranker``: retrieve-then-rerank -- a Score AFTER a Select. $0, offline, no key.
+
+One architecture, one file, deliberately self-contained -- see
+:mod:`langres.architectures` for why this file repeats topology that other
+architectures also build.
+
+**Why this class exists.** The four fixed slots (blocker -> comparator -> matcher
+-> clusterer) pin the matcher to ONE position, before the clusterer. A *reranker*
+scores twice -- a cheap first pass, a TOP-K prune, then a richer rescore of the
+survivors -- so its second ``Score`` sits AFTER a ``Select``. That topology is
+inexpressible in four fixed slots. ``Reranker`` builds it through the PUBLIC
+:meth:`~langres.core._model_state.ModelState.from_topology` door as an explicit Op
+chain, adding **no** core change: it is the expressiveness payoff of epic #193.
+"""
+
+from __future__ import annotations
+
+from typing import ClassVar, Self
+
+from pydantic import BaseModel
+
+from langres.core.blockers.all_pairs import AllPairsBlocker
+from langres.core.clusterer import Clusterer
+from langres.core.comparators import StringComparator
+from langres.core.matchers.weighted_average import WeightedAverageMatcher
+from langres.core.op import Stage, ThresholdSelect, TopKSelect
+from langres.core.op_adapters import (
+    BlockerSource,
+    ClustererStage,
+    ComparatorScore,
+    MatcherScore,
+)
+from langres.core.registry import register_model
+from langres.core.resolver import ERModel
+
+__all__ = ["Reranker"]
+
+
+@register_model("reranker")
+class Reranker(ERModel):
+    """Retrieve-then-rerank: a cheap first pass, a top-k prune, then a richer rescore.
+
+    **The Score-after-Select architecture.** It runs offline, needs no API key,
+    touches no network, and is deterministic -- the same records give the same
+    clusters every time. It exists to demonstrate a topology the four fixed slots
+    cannot place: a second ``Score`` AFTER a ``Select``::
+
+        from langres.architectures import Reranker
+        from langres.core.models import CompanySchema
+
+        model = Reranker.for_schema(CompanySchema, k=5, threshold=0.85)
+        clusters = model.dedupe(records)
+
+    Topology (an explicit 7-op chain, built via the public
+    :meth:`~langres.core._model_state.ModelState.from_topology` door -- **not** the
+    four-slot ``_topology`` hook the other architectures use):
+
+    ==================  ========================================================
+    1 source            ``BlockerSource(AllPairsBlocker)`` -- every pair, O(N^2)
+    2 score (vector)    ``ComparatorScore(StringComparator)`` -- per-feature
+                        ``ComparisonVector`` (``out_space="vector"``), score left
+                        unset
+    3 score (scalar)    ``MatcherScore(WeightedAverageMatcher, first feature)`` --
+                        the CHEAP first pass; overwrites the vector with a scalar
+                        BEFORE the select (so the select is legal)
+    4 select            ``TopKSelect(k)`` -- keep each anchor's k best by the cheap
+                        score
+    5 score (scalar)    ``MatcherScore(WeightedAverageMatcher, all features)`` --
+                        the RERANK: rescores the survivors on the full evidence.
+                        **This is the Score after the Select.**
+    6 select            ``ThresholdSelect(threshold)`` -- the match cut
+    7 cluster           ``ClustererStage(Clusterer(0.0))`` -- pure transitive
+                        closure over the survivors (the cut already ran at step 6)
+    ==================  ========================================================
+
+    **The two passes are a different feature subset, on purpose.** Both
+    ``WeightedAverageMatcher``\\ s read the SAME per-feature ``ComparisonVector``
+    the ``ComparatorScore`` attached once at step 2 -- they differ only in which
+    features they weight. The cheap pass scores on the schema's **first** comparable
+    field alone (a coarse single-signal retrieve, like matching on a name); the
+    rerank scores on **all** comparable fields (the full evidence). So a pair that
+    is a cheap-pass winner (its first field matches) can be demoted by the rerank
+    (its other fields disagree) -- which is exactly what separates a same-name /
+    different-address near-duplicate. The rerank meaningfully changes the ranking
+    whenever the schema has **>= 2** comparable fields; with one field the two
+    passes coincide (a degenerate but still-legal reranker).
+
+    **On quality, honestly:** like ``FuzzyString`` this is unsupervised fuzzy
+    matching, so it over-merges on unlabeled data -- the rerank narrows that, it
+    does not cure it. Calibrate the threshold against labels before trusting it on
+    anything that matters.
+
+    **It persists with zero core change.** ``save()``/``load()`` round-trip through
+    the explicit-chain persist path (epic #193 persist v2): the manifest stores an
+    ``ops`` list, ``model_class="reranker"`` is stamped, and a loaded artifact comes
+    back a ``Reranker`` whose paid Scores are re-secured against a fresh spend
+    ledger. Both ``WeightedAverageMatcher``\\ s are pure-data (their
+    ``feature_specs`` serialize via ``config``/``from_config``), and the
+    ``AllPairsBlocker`` references its schema by name -- so nothing here is a
+    closure and the whole chain reloads intact. Pass a real ``schema`` (not an
+    inferred one) for anything you intend to ``save``.
+
+    Args:
+        schema: The entity schema. **Required** at construction -- a reranker is an
+            explicit Op chain, so there is no lazy schema-inference (contrast
+            ``FuzzyString``, whose ``_topology`` defers binding until first use).
+        k: The number of survivors ``TopKSelect`` keeps per anchor after the cheap
+            first pass.
+        threshold: The match cut on the reranked (full-evidence) score.
+        budget_usd: Spend cap for this model's lifetime. Present for symmetry and
+            metered like any other model's -- but this architecture reports $0 per
+            pair (free string matchers only), so the cap can never trip.
+    """
+
+    #: Refuses every fit kind. A reranker's identity is its two-pass Op chain, and
+    #: every fit kind repoints a single matcher slot -- which an explicit-chain
+    #: model does not have (it has two matcher Scores, not one ``module`` slot). So
+    #: there is nothing coherent for ``fit`` to repoint without changing what the
+    #: class means; refuse all, exactly as ``VectorLLMCascade`` does for its own
+    #: (different) reason. See ``ERModel.accepted_method_kinds``.
+    accepted_method_kinds: ClassVar[frozenset[str] | None] = frozenset()
+
+    @classmethod
+    def for_schema(
+        cls,
+        schema: type[BaseModel],
+        *,
+        k: int,
+        threshold: float,
+        budget_usd: float | None = None,
+    ) -> Self:
+        """Build a ``Reranker`` for ``schema`` as an explicit 7-op chain.
+
+        Named ``for_schema`` rather than ``from_schema`` deliberately: the inherited
+        :meth:`~langres.core.resolver.ERModel.from_schema` builds the classic
+        FOUR-SLOT pipeline (one matcher position), which is the opposite of what a
+        reranker is. This constructor derives the comparable features from
+        ``schema`` the way the other architectures do, assembles the two-pass chain,
+        and wires it through the public
+        :meth:`~langres.core._model_state.ModelState.from_topology` door -- so the
+        four slots stay empty and the model runs the explicit chain.
+
+        Args:
+            schema: The entity schema (required -- see the class docstring).
+            k: Survivors ``TopKSelect`` keeps per anchor after the cheap pass.
+            threshold: The match cut on the reranked score.
+            budget_usd: Spend cap for the instance's lifetime (``None`` -> the
+                default; this architecture cannot spend regardless).
+
+        Returns:
+            A ``Reranker`` wired to run the explicit chain, ready to
+            ``dedupe``/``compare``.
+
+        Raises:
+            NoComparableFeatures: If ``schema`` yields no comparable string field
+                (raised by :meth:`StringComparator.from_schema`).
+        """
+        # ONE comparator, attached once (step 2); both passes read the vectors it
+        # produces. The cheap pass weights the FIRST comparable field alone (a
+        # coarse retrieve); the rerank weights ALL of them (the full evidence).
+        comparator: StringComparator[BaseModel] = StringComparator.from_schema(schema)
+        first_pass = [comparator.feature_specs[0]]
+        full_pass = comparator.feature_specs
+
+        ops: list[Stage] = [
+            BlockerSource(AllPairsBlocker(schema=schema)),
+            ComparatorScore(comparator),
+            # The cheap scalar OVERWRITES the vector score before the Select, so the
+            # TopKSelect is over an orderable scalar (Sequential rejects a Select on
+            # a vector out_space).
+            MatcherScore(
+                WeightedAverageMatcher(feature_specs=first_pass), out_space="heuristic"
+            ),
+            TopKSelect(k),
+            # The Score AFTER the Select -- the reranker. A different feature subset
+            # from pass 1, so it genuinely re-ranks the survivors.
+            MatcherScore(
+                WeightedAverageMatcher(feature_specs=full_pass), out_space="heuristic"
+            ),
+            ThresholdSelect(threshold),
+            ClustererStage(Clusterer(threshold=0.0)),
+        ]
+        return cls.from_topology(ops=ops, budget_usd=budget_usd)

--- a/src/langres/architectures/reranker.py
+++ b/src/langres/architectures/reranker.py
@@ -168,15 +168,11 @@ class Reranker(ERModel):
             # The cheap scalar OVERWRITES the vector score before the Select, so the
             # TopKSelect is over an orderable scalar (Sequential rejects a Select on
             # a vector out_space).
-            MatcherScore(
-                WeightedAverageMatcher(feature_specs=first_pass), out_space="heuristic"
-            ),
+            MatcherScore(WeightedAverageMatcher(feature_specs=first_pass), out_space="heuristic"),
             TopKSelect(k),
             # The Score AFTER the Select -- the reranker. A different feature subset
             # from pass 1, so it genuinely re-ranks the survivors.
-            MatcherScore(
-                WeightedAverageMatcher(feature_specs=full_pass), out_space="heuristic"
-            ),
+            MatcherScore(WeightedAverageMatcher(feature_specs=full_pass), out_space="heuristic"),
             ThresholdSelect(threshold),
             ClustererStage(Clusterer(threshold=0.0)),
         ]

--- a/tests/architectures/test_reranker.py
+++ b/tests/architectures/test_reranker.py
@@ -1,0 +1,244 @@
+"""Proofs for the ``Reranker`` architecture -- epic #193 PR-C, the expressiveness payoff.
+
+``Reranker`` (``src/langres/architectures/reranker.py``) exists to demonstrate ONE
+claim: a topology the four fixed slots cannot express -- a ``Score`` AFTER a
+``Select`` (a rerank) -- is now expressible AND persistable through the PUBLIC
+:meth:`~langres.core._model_state.ModelState.from_topology` door, with **zero core
+change**. Every test here is written to fail if that claim breaks:
+
+- **golden** -- the two-pass chain recovers the true duplicate structure a
+  single-pass (name-only) matcher over-merges. Fails if the rerank stops running
+  or the chain mis-wires.
+- **persist** -- save -> load (fresh) round-trips as a ``Reranker`` (not a plain
+  ``Resolver``) with an identical resolution and a RE-SECURED spend cap. Fails if
+  persist v2 drops the ``model_class`` stamp, the ops, or the cap.
+- **score-after-select** -- the rerank (pass 2, AFTER the ``TopKSelect``)
+  DEMOTES a cheap-pass winner the four-slot core would have merged. This is the
+  topology doing something four fixed slots could not.
+- **wiring** -- constructing the reranker does not raise from ``Sequential``: the
+  cheap scalar ``Score`` overwrites the comparator's vector before the ``Select``,
+  so the ``Select`` is over an orderable scalar (a Select on a vector is illegal).
+
+All $0, deterministic, offline -- rapidfuzz string similarity only, no LLM, no
+network. ``CompanySchema`` has five fields (``id`` excluded); the first comparable
+field is ``name``, so the cheap pass scores on name alone and the rerank adds
+``address`` -- exactly the same-name / different-address trap that separates a
+real duplicate from a coincidental name clash.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from langres.architectures import Reranker
+from langres.architectures.reranker import Reranker as RerankerDirect
+from langres.core.blockers.all_pairs import AllPairsBlocker
+from langres.core.clusterer import Clusterer
+from langres.core.comparators import StringComparator
+from langres.core.matchers.weighted_average import WeightedAverageMatcher
+from langres.core.models import CompanySchema
+from langres.core.op import Score, Select, ThresholdSelect, TopKSelect
+from langres.core.op_adapters import BlockerSource, ClustererStage, ComparatorScore, MatcherScore
+from langres.core.registry import model_type_name
+from langres.core.resolver import ERModel
+from langres.core.serialization import ArtifactManifest
+from langres.core.spend_cap import SpendCappedMatcher
+
+# --------------------------------------------------------------------------------------
+# Fixed $0 dataset. Acme/Globex are true duplicates (same name AND same address);
+# Initech is the TRAP -- same name, DIFFERENT address, so a name-only pass merges it
+# but a name+address rerank keeps it apart. Soylent is a singleton.
+# --------------------------------------------------------------------------------------
+
+RECORDS: list[dict[str, object]] = [
+    {"id": "a1", "name": "Acme Inc", "address": "1 Main St"},
+    {"id": "a2", "name": "Acme Inc", "address": "1 Main St"},
+    {"id": "g1", "name": "Globex Corp", "address": "500 Oak Ave"},
+    {"id": "g2", "name": "Globex Corp", "address": "500 Oak Ave"},
+    {"id": "i1", "name": "Initech", "address": "5 North Ave"},
+    {"id": "i2", "name": "Initech", "address": "820 South Blvd"},
+    {"id": "s1", "name": "Soylent Foods", "address": "7 Green Way"},
+]
+
+#: The only true duplicate merges. The trap ``{i1, i2}`` is deliberately NOT here.
+TRUE_MERGES = [["a1", "a2"], ["g1", "g2"]]
+
+K = 3
+THRESHOLD = 0.85
+
+
+def _merges(clusters: list[set[str]]) -> list[list[str]]:
+    """Order-independent view of the non-singleton clusters (the actual merges)."""
+    return sorted(sorted(cluster) for cluster in clusters if len(cluster) > 1)
+
+
+def _pass1_only_baseline() -> ERModel:
+    """The name-only single-pass baseline, as an explicit chain (no rerank).
+
+    ``BlockerSource -> ComparatorScore -> MatcherScore(name only) -> ThresholdSelect
+    -> ClustererStage`` -- the four-slot shape (one matcher position). It is the
+    control the reranker is measured against: same blocking, comparator, threshold
+    and clusterer, the ONLY difference being the missing ``TopKSelect`` + second
+    (full-evidence) ``Score``.
+    """
+    comparator = StringComparator.from_schema(CompanySchema)
+    cheap = [comparator.feature_specs[0]]
+    ops = [
+        BlockerSource(AllPairsBlocker(schema=CompanySchema)),
+        ComparatorScore(comparator),
+        MatcherScore(WeightedAverageMatcher(feature_specs=cheap), out_space="heuristic"),
+        ThresholdSelect(THRESHOLD),
+        ClustererStage(Clusterer(threshold=0.0)),
+    ]
+    return ERModel.from_topology(ops=ops)
+
+
+def test_reranker_is_an_explicit_seven_op_chain() -> None:
+    """The reranker runs an explicit Op chain (``_ops`` set), not the four slots.
+
+    The seven roles are exactly the Score-after-Select topology the four-slot core
+    cannot place: the SECOND ``MatcherScore`` sits AFTER the ``TopKSelect``.
+    """
+    model = Reranker.for_schema(CompanySchema, k=K, threshold=THRESHOLD)
+    assert model._ops is not None  # explicit chain, not slot-derived
+    roles = [type(stage).__name__ for stage in model._ops]
+    assert roles == [
+        "BlockerSource",
+        "ComparatorScore",
+        "MatcherScore",
+        "TopKSelect",
+        "MatcherScore",
+        "ThresholdSelect",
+        "ClustererStage",
+    ]
+    # A Score genuinely AFTER a Select -- the crux.
+    topk_index = roles.index("TopKSelect")
+    assert roles.index("MatcherScore", topk_index) > topk_index
+
+
+def test_golden_dedupe_recovers_true_duplicate_structure() -> None:
+    """GOLDEN: the reranker recovers exactly the true duplicates, dropping the trap.
+
+    The name-only baseline over-merges Initech (same name, different address); the
+    two-pass reranker rescores the survivors on name+address and keeps them apart.
+    """
+    result = Reranker.for_schema(CompanySchema, k=K, threshold=THRESHOLD).dedupe(RECORDS)
+    assert _merges(result) == TRUE_MERGES
+    # Self-describing result metadata (from the chain, not a slot).
+    assert result.architecture == "Reranker"
+    assert result.score_type == "heuristic"
+    assert result.threshold == THRESHOLD
+    assert result.backbone is None  # free string matchers -- nothing with weights
+
+
+def test_score_after_select_rerank_demotes_a_cheap_pass_winner() -> None:
+    """The topology does something four fixed slots could NOT: a Score after a Select.
+
+    The trap pair ``{i1, i2}`` is a *cheap-pass winner* -- name-only similarity 1.0,
+    which clears the threshold -- so the single-pass baseline merges it. The reranker
+    keeps it as a top-k survivor and then the SECOND ``Score`` (name+address, after
+    the ``TopKSelect``) demotes it below the cut. The two pipelines share every knob
+    but that inserted rescore, so the divergence IS the Score-after-Select payoff.
+    """
+    baseline = _merges(_pass1_only_baseline().dedupe(RECORDS))
+    reranker = _merges(Reranker.for_schema(CompanySchema, k=K, threshold=THRESHOLD).dedupe(RECORDS))
+
+    # The single-pass baseline over-merges the trap; the reranker does not.
+    assert ["i1", "i2"] in baseline
+    assert ["i1", "i2"] not in reranker
+    # The reranker only DROPPED the wrong merge -- it invented none.
+    assert all(group in baseline for group in reranker)
+    assert len(reranker) < len(baseline)
+    assert reranker == TRUE_MERGES
+
+
+def test_construction_wires_a_legal_sequential_scalar_before_the_select() -> None:
+    """WIRING: constructing does not raise from ``Sequential``.
+
+    ``Sequential`` rejects a ``Select`` over a vector score (a ``ComparisonVector``
+    is not orderable). The reranker is legal because the cheap ``MatcherScore``
+    (a scalar ``"heuristic"``) overwrites the ``ComparatorScore``'s vector BEFORE the
+    ``TopKSelect``. This test pins that ordering: the vector Score precedes the
+    scalarizing Score, which precedes the first Select.
+    """
+    model = Reranker.for_schema(CompanySchema, k=K, threshold=THRESHOLD)  # no raise == wired
+    assert model._ops is not None
+    ops = model._ops
+
+    comparator_score = next(i for i, s in enumerate(ops) if isinstance(s, ComparatorScore))
+    first_scalarizer = next(
+        i for i, s in enumerate(ops) if isinstance(s, Score) and not isinstance(s, ComparatorScore)
+    )
+    first_select = next(i for i, s in enumerate(ops) if isinstance(s, Select))
+
+    # vector Score  ->  scalar Score  ->  Select : the scalar cut the vector first.
+    assert comparator_score < first_scalarizer < first_select
+    assert isinstance(ops[comparator_score], ComparatorScore)  # out_space="vector"
+    assert isinstance(ops[first_select], TopKSelect)
+
+
+def test_persist_round_trips_as_a_reranker_with_a_resecured_cap(tmp_path: Path) -> None:
+    """PERSIST v2: save -> load (fresh) is a ``Reranker`` with an identical resolution.
+
+    Exercises the whole persist-v2 path for a real architecture: the manifest stamps
+    ``model_class="reranker"`` and an ``ops`` list, ``load`` rebuilds the class the
+    artifact names, and ``from_topology`` re-establishes the spend cap on the loaded
+    chain (the cap is a run policy, re-wrapped fresh, never persisted).
+    """
+    model = Reranker.for_schema(CompanySchema, k=K, threshold=THRESHOLD)
+    original = _merges(model.dedupe(RECORDS))
+    assert original == TRUE_MERGES  # sanity: we saved a working model
+
+    out = tmp_path / "reranker_artifact"
+    model.save(out)
+
+    # The on-disk manifest names the architecture and carries an explicit chain.
+    manifest = ArtifactManifest.model_validate_json((out / "resolver.json").read_text())
+    assert manifest.model_class == "reranker"
+    assert manifest.ops is not None and manifest.components == []
+
+    # A FRESH load (via the base class) reconstructs the Reranker, not a plain Resolver.
+    loaded = ERModel.load(out)
+    assert isinstance(loaded, Reranker)
+    assert model_type_name(type(loaded)) == "reranker"
+    assert loaded._ops is not None
+
+    # Identical resolution after the round-trip.
+    assert _merges(loaded.dedupe(RECORDS)) == original
+    assert _merges(loaded.resolve(RECORDS)) == original
+
+    # The cap was re-secured: the loaded scoring MatcherScore holds a
+    # SpendCappedMatcher sharing THIS loaded model's ledger (not a persisted one).
+    matcher_scores = [s for s in loaded._ops if isinstance(s, MatcherScore)]
+    scoring = matcher_scores[-1]  # the rerank Score
+    assert isinstance(scoring.matcher, SpendCappedMatcher)
+    assert scoring.matcher.monitor is loaded._spend_monitor
+
+
+def test_compare_gates_on_the_reranked_score(tmp_path: Path) -> None:
+    """``compare`` folds the chain's Scores (both passes) and gates on the rerank cut.
+
+    A true duplicate matches; the same-name / different-address trap does not --
+    because ``compare`` scores on the FULL evidence (name+address), exactly as the
+    rerank does in ``dedupe``. Blocking never vetoes the pair.
+    """
+    model = Reranker.for_schema(CompanySchema, k=K, threshold=THRESHOLD)
+    dup = model.compare(
+        {"id": "a1", "name": "Acme Inc", "address": "1 Main St"},
+        {"id": "a2", "name": "Acme Inc", "address": "1 Main St"},
+    )
+    trap = model.compare(
+        {"id": "i1", "name": "Initech", "address": "5 North Ave"},
+        {"id": "i2", "name": "Initech", "address": "820 South Blvd"},
+    )
+    assert dup.match is True
+    assert trap.match is False
+    assert dup.score_type == "heuristic" and dup.threshold == THRESHOLD
+
+
+def test_reranker_is_exported_from_the_package() -> None:
+    """The architecture is reachable both ways it is documented (package + module)."""
+    assert Reranker is RerankerDirect
+    from langres.architectures import __all__ as arch_all
+
+    assert "Reranker" in arch_all


### PR DESCRIPTION
## PR-C: the reranker — the expressiveness payoff of epic #193

Proves that a topology the four fixed slots **cannot** express — a `Score` **after** a `Select` (a rerank) — is now expressible **and** persistable through the public `from_topology` door PR-A shipped, with **zero core change**. The only files touched are additive.

### What it adds
- **`src/langres/architectures/reranker.py`** — `@register_model("reranker") class Reranker(ERModel)`. A `Reranker.for_schema(schema, *, k, threshold, budget_usd=None)` classmethod builds an explicit **7-op chain** and wires it via `cls.from_topology(ops=...)` — it does **not** use `_topology` (which returns the four slots). Named `for_schema` to avoid colliding with `ERModel.from_schema` (the four-slot door).
- **`src/langres/architectures/__init__.py`** — export `Reranker` (mirrors `FuzzyString` / `VectorLLMCascade`).
- **`tests/architectures/test_reranker.py`** — 7 deterministic, $0, offline proofs.

### The 7-op chain (schema-general — no hard-coded field names)
```
BlockerSource(AllPairsBlocker)            # 1 source: every pair
ComparatorScore(StringComparator)         # 2 score: per-feature vector (out_space="vector")
MatcherScore(WeightedAverageMatcher,      # 3 score: CHEAP first pass — first comparable
             first feature) heuristic     #          field only; overwrites the vector scalar
TopKSelect(k)                             # 4 select: keep each anchor's k best (cheap score)
MatcherScore(WeightedAverageMatcher,      # 5 score: RERANK — all comparable fields.
             all features) heuristic      #          THE SCORE AFTER THE SELECT.
ThresholdSelect(threshold)                # 6 select: the match cut
ClustererStage(Clusterer(0.0))            # 7 cluster: pure transitive closure
```
Both passes read the **same** `ComparisonVector` the `ComparatorScore` attaches once; they differ only in which features they weight (first field alone vs. all fields). The cheap scalar (step 3) overwrites the comparator's vector before the `TopKSelect`, so the Select is over an orderable scalar — legal `Sequential` wiring. Uses the registered, serializable `WeightedAverageMatcher` (not a lambda matcher), so the whole chain round-trips.

### Zero core change
No `src/langres/core/*.py` file is modified — that IS the proof. `model_class="reranker"` is stamped on save (persist v2's `_build_manifest` for `_ops` models), so a saved reranker reloads as a `Reranker` with its paid Scores re-secured against a fresh spend ledger.

### Gates (all green, local)
- New reranker tests: **7 passed**
- Full fast suite (`-m "not integration and not slow and not finetune"`): **3849 passed, 2 skipped, 109 deselected**, coverage **98.27%** (floor 90%); `reranker.py` **100%**
- Parity goldens + `test_legacy_load_w0` + import gates (budget/tangle/graph): **128 passed, 7 skipped** (no core touched → parity untouched; new module covered by the `langres.architectures` prefix in `tools/refactor_target_packages.json`, no JSON change needed)
- `mypy --strict`: clean · `ruff check` + `format`: clean

### How the golden proves the Score-after-Select payoff
On a fixed dataset, the same-name / different-address pair `{i1,i2}` is a **pass-1 winner** (name-only similarity 1.0, clears the threshold) — so a single-pass baseline merges it. The reranker keeps it as a top-k survivor, then the **second** `MatcherScore` (name+address, **after** the `TopKSelect`) demotes it below the cut. Same blocker/comparator/threshold/clusterer — the only variable is that inserted rescore — so the reranker recovers `[[a1,a2],[g1,g2]]` while the baseline over-merges `[[a1,a2],[g1,g2],[i1,i2]]`. The rerank changed the outcome, which four fixed slots could not do.

https://claude.ai/code/session_011XYuhyiigi1Bw2YnWCxMr9
