### PR TITLE
test: stabilize baseline verification

### DIFF
--- a/src/langres/core/matchers/dspy_judge.py
+++ b/src/langres/core/matchers/dspy_judge.py
@@ -517,7 +517,7 @@ class DSPyMatcher(Matcher[SchemaT]):
                     reflection_lm = (
                         dspy.LM(reflection_model) if reflection_model else self._get_lm()
                     )
-                    gepa_budget = (
+                    gepa_budget: dict[str, int | str] = (
                         {"max_metric_calls": max_metric_calls}
                         if max_metric_calls is not None
                         else {"auto": auto}

--- a/tests/tracking/test_trackio_tracker.py
+++ b/tests/tracking/test_trackio_tracker.py
@@ -181,7 +181,11 @@ class TestHfSyncCredentialGuard:
         self, fake_trackio: _FakeTrackio, monkeypatch: pytest.MonkeyPatch
     ) -> None:
         monkeypatch.setattr(huggingface_hub, "get_token", lambda: None)
-        tracker = TrackioTracker(Settings(), space_id="acme/langres-runs")
+        # Isolate the no-token case from a developer's real project ``.env``.
+        # ``Settings()`` intentionally loads that file, so using it here makes
+        # this negative-path test fail whenever the checkout has HF_TOKEN set.
+        settings = Settings(hf_token=None, _env_file=None)  # type: ignore[call-arg]
+        tracker = TrackioTracker(settings, space_id="acme/langres-runs")
 
         with pytest.raises(ValueError, match=r"acme/langres-runs.*HF_TOKEN"):
             tracker.start_run(_context())


### PR DESCRIPTION
## Summary
- isolate the missing-HF-token test from a developer's project `.env`
- make the DSPy GEPA budget union explicit so strict mypy can infer both supported shapes

## Verification
- `/Users/davidgraf/work/langres/.venv/bin/mypy src` — 192 source files clean
- focused credential-guard test passes
- Ruff check and formatting pass

This is a small prerequisite PR for the research execution foundation integration branch.