### PR TITLE
Add retrieval research recipes

### DIFF
--- a/docs/reference/architectures.md
+++ b/docs/reference/architectures.md
@@ -23,6 +23,55 @@ to run: `FuzzyString` has no paid slot to fill, and `VectorLLMCascade` only bill
 you because you named an `llm=`. Choosing the model is your job, not a
 heuristic's.
 
+## Research recipes
+
+The research front door names topology in the same vocabulary as the model
+ecosystem:
+
+| Recipe | Topology |
+|---|---|
+| `Retrieve` | Retrieve → threshold → Cluster |
+| `RetrieveRerank` | Retrieve → Rerank → threshold → Cluster |
+| `RetrieveLLM` | Retrieve → top-k → LLM Generate/Parse → Cluster |
+| `RetrieveRerankLLM` | Retrieve → Rerank → top-k → LLM Generate/Parse → Cluster |
+
+Each model slot accepts either a resource object or a model reference. The
+resource name describes what it does, while the following `Select` determines
+how its score is used. The same `Reranker` works before a top-k candidate cut or
+before a final threshold; there are no separate blocker and matcher reranker
+classes.
+
+```python
+from langres.architectures import RetrieveRerankLLM
+
+architecture = RetrieveRerankLLM(
+    embedder="sentence-transformers/all-MiniLM-L6-v2",
+    reranker="cross-encoder/ms-marco-MiniLM-L6-v2",
+    llm={"base": "openai/gpt-4o-mini", "kind": "api"},
+    retrieve_k=50,
+    llm_k=10,
+)
+```
+
+Recipes infer a schema from records on their first `.dedupe()` or `.compare()`
+call. Pass `schema=YourPydanticModel` explicitly when saving an artifact; an
+inferred runtime schema is intentionally ephemeral.
+
+`architecture.resources` returns every slot as `dict[str, ModelRef]`.
+`architecture.backbone` remains compatibility sugar only for `Retrieve`, the
+one recipe with exactly one model. Multi-model recipes return `None` rather than
+hiding two of their resources.
+
+API, endpoint, Hugging Face, and local LLM references all use the same `llm=`
+slot; `ModelRef.kind` chooses served versus in-process execution. Every recipe
+ends in the existing transitive-closure `Clusterer` by default and accepts a
+custom existing `clusterer=`. This milestone adds no clustering algorithm.
+Advanced users can compose the same `langres.resources.Retrieve`, `Rerank`,
+`Generate`, and `Parse` operations through `ERModel.from_topology()`; the
+experiment path does not dispatch on recipe names.
+
+::: langres.architectures.retrieval
+
 ::: langres.architectures.fuzzy_string
 
 ::: langres.architectures.vector_llm_cascade

--- a/docs/reference/architectures.md
+++ b/docs/reference/architectures.md
@@ -32,8 +32,8 @@ ecosystem:
 |---|---|
 | `Retrieve` | Retrieve → threshold → Cluster |
 | `RetrieveRerank` | Retrieve → Rerank → threshold → Cluster |
-| `RetrieveLLM` | Retrieve → top-k → LLM Generate/Parse → Cluster |
-| `RetrieveRerankLLM` | Retrieve → Rerank → top-k → LLM Generate/Parse → Cluster |
+| `RetrieveLLM` | Retrieve → top-k → LLM Generate/Parse → `ThresholdSelect(0.5)` → Cluster |
+| `RetrieveRerankLLM` | Retrieve → Rerank → top-k → LLM Generate/Parse → `ThresholdSelect(0.5)` → Cluster |
 
 Each model slot accepts either a resource object or a model reference. The
 resource name describes what it does, while the following `Select` determines

--- a/docs/reference/architectures.md
+++ b/docs/reference/architectures.md
@@ -60,6 +60,10 @@ inferred runtime schema is intentionally ephemeral.
 `Retrieve` and `RetrieveRerank` validate `threshold` in `[0, 1]`. For the paid
 recipes, `dedupe(..., log=...)` and `compare(..., log=...)` record each parsed
 LLM decision, including its model, usage/cost provenance, verdict, and stage id.
+Pass either `budget_usd=` for a recipe-local cap or `monitor=` to adopt an
+existing `SpendMonitor`. Experiment factories use `monitor=` so every recipe in
+a matrix charges the same cumulative ledger; the two arguments are mutually
+exclusive.
 
 `architecture.resources` returns every slot as `dict[str, ModelRef]`.
 `architecture.backbone` remains compatibility sugar only for `Retrieve`, the

--- a/docs/reference/architectures.md
+++ b/docs/reference/architectures.md
@@ -65,7 +65,10 @@ hiding two of their resources.
 API, endpoint, Hugging Face, and local LLM references all use the same `llm=`
 slot; `ModelRef.kind` chooses served versus in-process execution. Every recipe
 ends in the existing transitive-closure `Clusterer` by default and accepts a
-custom existing `clusterer=`. This milestone adds no clustering algorithm.
+custom existing `clusterer=`. The recipe's `Select` owns the one match cut, so
+the supplied clusterer's algorithm is reused with a threshold-free copy; the
+caller's clusterer object is not mutated. This milestone adds no clustering
+algorithm.
 Advanced users can compose the same `langres.resources.Retrieve`, `Rerank`,
 `Generate`, and `Parse` operations through `ERModel.from_topology()`; the
 experiment path does not dispatch on recipe names.

--- a/docs/reference/architectures.md
+++ b/docs/reference/architectures.md
@@ -57,6 +57,10 @@ Recipes infer a schema from records on their first `.dedupe()` or `.compare()`
 call. Pass `schema=YourPydanticModel` explicitly when saving an artifact; an
 inferred runtime schema is intentionally ephemeral.
 
+`Retrieve` and `RetrieveRerank` validate `threshold` in `[0, 1]`. For the paid
+recipes, `dedupe(..., log=...)` and `compare(..., log=...)` record each parsed
+LLM decision, including its model, usage/cost provenance, verdict, and stage id.
+
 `architecture.resources` returns every slot as `dict[str, ModelRef]`.
 `architecture.backbone` remains compatibility sugar only for `Retrieve`, the
 one recipe with exactly one model. Multi-model recipes return `None` rather than

--- a/examples/README.md
+++ b/examples/README.md
@@ -27,6 +27,9 @@ flywheel harvest → closed-loop flywheel → person:
 
 - **`quickstart_models.py`** — dedupe records with zero labels in a handful of
   lines by naming a model: `FuzzyString`, the $0, offline, no-key architecture.
+- **`research_recipes.py`** — the research vocabulary in one zero-network
+  example: Retrieve → Rerank → LLM → Cluster, with one reusable resource per
+  model slot and no blocker/matcher-specific wrappers.
 - **`basic_usage.py`** — the foundational data contracts (`CompanySchema`,
   `ERCandidate`, `PairwiseJudgement`).
 - **`deduplication_example.py`** — end-to-end entity resolution on a

--- a/examples/research_recipes.py
+++ b/examples/research_recipes.py
@@ -1,0 +1,33 @@
+"""Try the Retrieve/Rerank/LLM recipe vocabulary offline with fake resources."""
+
+from langres.architectures import RetrieveRerankLLM
+from langres.resources import FakeEmbedder, FakeLLM, FakeReranker
+
+records = [
+    {"id": "a", "name": "Acme"},
+    {"id": "b", "name": "ACME"},
+    {"id": "c", "name": "Globex"},
+]
+
+architecture = RetrieveRerankLLM(
+    embedder=FakeEmbedder(),
+    reranker=FakeReranker(
+        scores={
+            '["a","b"]': 0.95,
+            '["a","c"]': 0.10,
+            '["b","c"]': 0.20,
+        }
+    ),
+    llm=FakeLLM(
+        responses={
+            '["a","b"]': "MATCH",
+            '["a","c"]': "NO_MATCH",
+            '["b","c"]': "NO_MATCH",
+        }
+    ),
+    retrieve_k=2,
+    llm_k=2,
+)
+
+print(architecture.resources)
+print(architecture.dedupe(records))

--- a/src/langres/architectures/__init__.py
+++ b/src/langres/architectures/__init__.py
@@ -26,16 +26,15 @@ that is a new architecture wearing a flag. Write the new class.
 
 Why these files repeat each other (and why that is not a bug)
 -------------------------------------------------------------
-**Each architecture is one self-contained, readable file, and DRY is
-deliberately suspended inside this package** -- the policy transformers applies
-to ``modeling_*.py``, for the same reason. An architecture file is meant to be
-*read end to end* by someone deciding whether this is the model they want, and
-then copied as the starting point for their own. A shared ``_build_blocker()``
-helper would save a few lines and cost exactly the property that makes these
-files worth having: you would have to read three files to learn what one model
-does, and a change made for one architecture would silently reshape the others.
-So ``fuzzy_string.py`` and ``vector_llm_cascade.py`` both build their own
-comparator and their own text extractor, on purpose.
+**Topology stays readable in one place, and DRY is deliberately suspended for
+the wiring itself** -- the policy transformers applies to ``modeling_*.py``, for
+the same reason. Standalone architectures have self-contained files; the four
+closely related retrieval recipes are co-located as one readable family, but
+each concrete class still spells out its own ordered operations. A shared
+``_build_pipeline(flags=...)`` helper would save a few lines and hide the
+property that makes these models worth naming: which stages actually run.
+Likewise, ``fuzzy_string.py`` and ``vector_llm_cascade.py`` both build their own
+comparator and text extractor on purpose.
 
 **The anti-DRY licence stops at the package boundary.** It covers *topology* --
 which components this model wires and how. It does **not** cover contracts:
@@ -45,8 +44,42 @@ input normalization (:mod:`langres.core.inputs`), the result types
 to normalize a record identically; that is exactly what a contract is for.
 """
 
+import importlib
+from typing import TYPE_CHECKING, Any
+
 from langres.architectures.fuzzy_string import FuzzyString
 from langres.architectures.reranker import Reranker
 from langres.architectures.vector_llm_cascade import VectorLLMCascade
 
-__all__ = ["FuzzyString", "Reranker", "VectorLLMCascade"]
+if TYPE_CHECKING:
+    from langres.architectures.retrieval import (
+        Retrieve,
+        RetrieveLLM,
+        RetrieveRerank,
+        RetrieveRerankLLM,
+    )
+
+_LAZY_SYMBOLS = {
+    name: "langres.architectures.retrieval"
+    for name in ("Retrieve", "RetrieveLLM", "RetrieveRerank", "RetrieveRerankLLM")
+}
+
+__all__ = [
+    "FuzzyString",
+    "Reranker",
+    "Retrieve",
+    "RetrieveLLM",
+    "RetrieveRerank",
+    "RetrieveRerankLLM",
+    "VectorLLMCascade",
+]
+
+
+def __getattr__(name: str) -> Any:
+    """Resolve research recipes without loading their resource adapters eagerly."""
+    module_name = _LAZY_SYMBOLS.get(name)
+    if module_name is None:
+        raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+    value = getattr(importlib.import_module(module_name), name)
+    globals()[name] = value
+    return value

--- a/src/langres/architectures/retrieval.py
+++ b/src/langres/architectures/retrieval.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from copy import copy
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, ClassVar, TypeAlias, cast
 
@@ -49,7 +50,11 @@ def _llm(value: LLMLike) -> LLM:
 
 
 def _cluster_stage(clusterer: Clusterer | None) -> ClustererStage[Any]:
-    return ClustererStage(clusterer if clusterer is not None else Clusterer(threshold=0.0))
+    if clusterer is None:
+        return ClustererStage(Clusterer(threshold=0.0))
+    threshold_free = copy(clusterer)
+    threshold_free.threshold = 0.0
+    return ClustererStage(threshold_free)
 
 
 class _ResearchRecipe(ERModel):
@@ -94,9 +99,10 @@ class _ResearchRecipe(ERModel):
         log: JudgementLog | str | Path | None = None,
     ) -> DedupeResult:
         """Infer a schema before the base front door chooses its topology path."""
+        prepared = records
         if len(records) >= 2 and self._ops is None:
-            self._prepare(records)
-        return super().dedupe(records, log=log)
+            prepared = self._prepare(records)
+        return super().dedupe(prepared, log=log)
 
     def compare(
         self,
@@ -106,9 +112,10 @@ class _ResearchRecipe(ERModel):
         log: JudgementLog | str | Path | None = None,
     ) -> LinkVerdict:
         """Infer a schema before the base front door chooses its topology path."""
+        prepared = [left, right]
         if self._ops is None:
-            self._prepare([left, right])
-        return super().compare(left, right, log=log)
+            prepared = self._prepare(prepared)
+        return super().compare(prepared[0], prepared[1], log=log)
 
     @property
     def resources(self) -> dict[str, ModelRef]:

--- a/src/langres/architectures/retrieval.py
+++ b/src/langres/architectures/retrieval.py
@@ -17,6 +17,7 @@ from langres.core.pairs import Pairs
 from langres.core.registry import register_model
 from langres.core.resolver import ERModel
 from langres.core.results import DedupeResult, LinkVerdict
+from langres.core.spend import SpendMonitor
 from langres.resources import (
     CrossEncoderReranker,
     Embedder,
@@ -109,12 +110,20 @@ class _ResearchRecipe(ERModel):
         *,
         schema: type[BaseModel] | None,
         budget_usd: float | None,
+        monitor: SpendMonitor | None,
     ) -> None:
+        if monitor is not None and budget_usd is not None:
+            raise ValueError(
+                "pass budget_usd= or monitor=, not both: the supplied SpendMonitor already "
+                "carries the shared experiment budget"
+            )
         self._declared_resources = {
             slot: resource.model_ref for slot, resource in resources.items()
         }
         self._resource_values = resources
         self._init_state(budget_usd=budget_usd)
+        if monitor is not None:
+            self._spend_monitor = monitor
         if schema is not None:
             self._bind(schema)
 
@@ -223,6 +232,7 @@ class Retrieve(_ResearchRecipe):
         text_field: str | None = None,
         clusterer: Clusterer | None = None,
         budget_usd: float | None = None,
+        monitor: SpendMonitor | None = None,
     ) -> None:
         _validate_threshold(threshold)
         self.retrieve_k = retrieve_k
@@ -233,6 +243,7 @@ class Retrieve(_ResearchRecipe):
             {"embedder": _embedder(embedder)},
             schema=schema,
             budget_usd=budget_usd,
+            monitor=monitor,
         )
 
     def _recipe_ops(self, schema: type[BaseModel]) -> list[Stage]:
@@ -264,6 +275,7 @@ class RetrieveRerank(_ResearchRecipe):
         text_field: str | None = None,
         clusterer: Clusterer | None = None,
         budget_usd: float | None = None,
+        monitor: SpendMonitor | None = None,
     ) -> None:
         _validate_threshold(threshold)
         self.retrieve_k = retrieve_k
@@ -277,6 +289,7 @@ class RetrieveRerank(_ResearchRecipe):
             },
             schema=schema,
             budget_usd=budget_usd,
+            monitor=monitor,
         )
 
     def _recipe_ops(self, schema: type[BaseModel]) -> list[Stage]:
@@ -310,6 +323,7 @@ class RetrieveLLM(_ResearchRecipe):
         text_field: str | None = None,
         clusterer: Clusterer | None = None,
         budget_usd: float | None = None,
+        monitor: SpendMonitor | None = None,
     ) -> None:
         if llm_k <= 0:
             raise ValueError("llm_k must be positive")
@@ -324,6 +338,7 @@ class RetrieveLLM(_ResearchRecipe):
             },
             schema=schema,
             budget_usd=budget_usd,
+            monitor=monitor,
         )
 
     def _recipe_ops(self, schema: type[BaseModel]) -> list[Stage]:
@@ -360,6 +375,7 @@ class RetrieveRerankLLM(_ResearchRecipe):
         text_field: str | None = None,
         clusterer: Clusterer | None = None,
         budget_usd: float | None = None,
+        monitor: SpendMonitor | None = None,
     ) -> None:
         if llm_k <= 0:
             raise ValueError("llm_k must be positive")
@@ -375,6 +391,7 @@ class RetrieveRerankLLM(_ResearchRecipe):
             },
             schema=schema,
             budget_usd=budget_usd,
+            monitor=monitor,
         )
 
     def _recipe_ops(self, schema: type[BaseModel]) -> list[Stage]:

--- a/src/langres/architectures/retrieval.py
+++ b/src/langres/architectures/retrieval.py
@@ -1,0 +1,319 @@
+"""Four named retrieval recipes over the shared resource Op algebra."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import TYPE_CHECKING, Any, ClassVar, TypeAlias, cast
+
+from pydantic import BaseModel
+
+from langres.core.clusterer import Clusterer
+from langres.core.model_ref import ModelRef
+from langres.core.op import Stage, ThresholdSelect, TopKSelect
+from langres.core.op_adapters import ClustererStage
+from langres.core.registry import register_model
+from langres.core.resolver import ERModel
+from langres.core.results import DedupeResult, LinkVerdict
+from langres.resources import (
+    CrossEncoderReranker,
+    Embedder,
+    Generate,
+    LLM,
+    Parse,
+    Rerank,
+    Reranker,
+    Retrieve as RetrieveOp,
+    SentenceTransformer,
+    llm_from_model_ref,
+)
+
+if TYPE_CHECKING:
+    from langres.tracking.judgement_log import JudgementLog
+
+ResourceRef: TypeAlias = str | dict[str, str] | ModelRef
+EmbedderLike: TypeAlias = Embedder | ResourceRef
+RerankerLike: TypeAlias = Reranker | ResourceRef
+LLMLike: TypeAlias = LLM | ResourceRef
+
+
+def _embedder(value: EmbedderLike) -> Embedder:
+    return value if isinstance(value, Embedder) else SentenceTransformer(value)
+
+
+def _reranker(value: RerankerLike) -> Reranker:
+    return value if isinstance(value, Reranker) else CrossEncoderReranker(value)
+
+
+def _llm(value: LLMLike) -> LLM:
+    return value if isinstance(value, LLM) else llm_from_model_ref(value)
+
+
+def _cluster_stage(clusterer: Clusterer | None) -> ClustererStage[Any]:
+    return ClustererStage(clusterer if clusterer is not None else Clusterer(threshold=0.0))
+
+
+class _ResearchRecipe(ERModel):
+    """Shared inspection sugar; each concrete class still spells out its topology."""
+
+    accepted_method_kinds: ClassVar[frozenset[str] | None] = frozenset()
+
+    def _initialize_recipe(
+        self,
+        resources: dict[str, Embedder | Reranker | LLM],
+        *,
+        schema: type[BaseModel] | None,
+        budget_usd: float | None,
+    ) -> None:
+        self._declared_resources = {
+            slot: resource.model_ref for slot, resource in resources.items()
+        }
+        self._resource_values = resources
+        self._init_state(budget_usd=budget_usd)
+        if schema is not None:
+            self._bind(schema)
+
+    def _adopt_topology(
+        self,
+        ops: list[Stage],
+    ) -> None:
+        built = type(self).from_topology(ops=ops, monitor=self._spend_monitor)
+        self.__dict__ = built.__dict__
+
+    def _recipe_ops(self, schema: type[BaseModel]) -> list[Stage]:
+        raise NotImplementedError
+
+    def _bind(self, schema: type[BaseModel]) -> None:
+        """Build this recipe's explicit topology once schema is known."""
+        if not self.is_bound:
+            self._adopt_topology(self._recipe_ops(schema))
+
+    def dedupe(
+        self,
+        records: list[dict[str, Any]],
+        *,
+        log: JudgementLog | str | Path | None = None,
+    ) -> DedupeResult:
+        """Infer a schema before the base front door chooses its topology path."""
+        if len(records) >= 2 and self._ops is None:
+            self._prepare(records)
+        return super().dedupe(records, log=log)
+
+    def compare(
+        self,
+        left: dict[str, Any],
+        right: dict[str, Any],
+        *,
+        log: JudgementLog | str | Path | None = None,
+    ) -> LinkVerdict:
+        """Infer a schema before the base front door chooses its topology path."""
+        if self._ops is None:
+            self._prepare([left, right])
+        return super().compare(left, right, log=log)
+
+    @property
+    def resources(self) -> dict[str, ModelRef]:
+        """Every model-bearing slot in this recipe, derived from the live Ops."""
+        if self._ops is None:
+            return dict(self._declared_resources)
+        slots: dict[str, ModelRef] = {}
+        for stage in self._require_ops():
+            if isinstance(stage, RetrieveOp):
+                slots["embedder"] = stage.resource.model_ref
+            elif isinstance(stage, Rerank):
+                slots["reranker"] = stage.resource.model_ref
+            elif isinstance(stage, Generate):
+                slots["llm"] = stage.resource.model_ref
+        return slots
+
+    @property
+    def backbone(self) -> str | None:
+        """Compatibility sugar only when the recipe has exactly one model slot."""
+        resources = self.resources
+        if len(resources) != 1:
+            return None
+        return next(iter(resources.values())).base
+
+
+@register_model("retrieve")
+class Retrieve(_ResearchRecipe):
+    """Embed, retrieve nearest neighbours, threshold, and cluster."""
+
+    def __init__(
+        self,
+        *,
+        embedder: EmbedderLike,
+        schema: type[BaseModel] | None = None,
+        retrieve_k: int = 20,
+        threshold: float = 0.5,
+        text_field: str | None = None,
+        clusterer: Clusterer | None = None,
+        budget_usd: float | None = None,
+    ) -> None:
+        self.retrieve_k = retrieve_k
+        self.threshold = threshold
+        self.text_field = text_field
+        self.clusterer_override = clusterer
+        self._initialize_recipe(
+            {"embedder": _embedder(embedder)},
+            schema=schema,
+            budget_usd=budget_usd,
+        )
+
+    def _recipe_ops(self, schema: type[BaseModel]) -> list[Stage]:
+        embedder = cast(Embedder, self._resource_values["embedder"])
+        return [
+            RetrieveOp(
+                embedder,
+                schema=schema,
+                k=self.retrieve_k,
+                text_field=self.text_field,
+            ),
+            ThresholdSelect(self.threshold),
+            _cluster_stage(self.clusterer_override),
+        ]
+
+
+@register_model("retrieve_rerank")
+class RetrieveRerank(_ResearchRecipe):
+    """Retrieve, rescore with one reusable Reranker, threshold, and cluster."""
+
+    def __init__(
+        self,
+        *,
+        embedder: EmbedderLike,
+        reranker: RerankerLike,
+        schema: type[BaseModel] | None = None,
+        retrieve_k: int = 20,
+        threshold: float = 0.5,
+        text_field: str | None = None,
+        clusterer: Clusterer | None = None,
+        budget_usd: float | None = None,
+    ) -> None:
+        self.retrieve_k = retrieve_k
+        self.threshold = threshold
+        self.text_field = text_field
+        self.clusterer_override = clusterer
+        self._initialize_recipe(
+            {
+                "embedder": _embedder(embedder),
+                "reranker": _reranker(reranker),
+            },
+            schema=schema,
+            budget_usd=budget_usd,
+        )
+
+    def _recipe_ops(self, schema: type[BaseModel]) -> list[Stage]:
+        embedder = cast(Embedder, self._resource_values["embedder"])
+        reranker = cast(Reranker, self._resource_values["reranker"])
+        return [
+            RetrieveOp(
+                embedder,
+                schema=schema,
+                k=self.retrieve_k,
+                text_field=self.text_field,
+            ),
+            Rerank(reranker),
+            ThresholdSelect(self.threshold),
+            _cluster_stage(self.clusterer_override),
+        ]
+
+
+@register_model("retrieve_llm")
+class RetrieveLLM(_ResearchRecipe):
+    """Retrieve candidates, ask one LLM, parse decisions, and cluster."""
+
+    def __init__(
+        self,
+        *,
+        embedder: EmbedderLike,
+        llm: LLMLike,
+        schema: type[BaseModel] | None = None,
+        retrieve_k: int = 20,
+        llm_k: int = 5,
+        text_field: str | None = None,
+        clusterer: Clusterer | None = None,
+        budget_usd: float | None = None,
+    ) -> None:
+        self.retrieve_k = retrieve_k
+        self.llm_k = llm_k
+        self.text_field = text_field
+        self.clusterer_override = clusterer
+        self._initialize_recipe(
+            {
+                "embedder": _embedder(embedder),
+                "llm": _llm(llm),
+            },
+            schema=schema,
+            budget_usd=budget_usd,
+        )
+
+    def _recipe_ops(self, schema: type[BaseModel]) -> list[Stage]:
+        embedder = cast(Embedder, self._resource_values["embedder"])
+        llm = cast(LLM, self._resource_values["llm"])
+        return [
+            RetrieveOp(
+                embedder,
+                schema=schema,
+                k=self.retrieve_k,
+                text_field=self.text_field,
+            ),
+            TopKSelect(self.llm_k),
+            Generate(llm),
+            Parse(),
+            ThresholdSelect(0.5),
+            _cluster_stage(self.clusterer_override),
+        ]
+
+
+@register_model("retrieve_rerank_llm")
+class RetrieveRerankLLM(_ResearchRecipe):
+    """Retrieve, rerank, prune, ask one LLM, parse decisions, and cluster."""
+
+    def __init__(
+        self,
+        *,
+        embedder: EmbedderLike,
+        reranker: RerankerLike,
+        llm: LLMLike,
+        schema: type[BaseModel] | None = None,
+        retrieve_k: int = 20,
+        llm_k: int = 5,
+        text_field: str | None = None,
+        clusterer: Clusterer | None = None,
+        budget_usd: float | None = None,
+    ) -> None:
+        self.retrieve_k = retrieve_k
+        self.llm_k = llm_k
+        self.text_field = text_field
+        self.clusterer_override = clusterer
+        self._initialize_recipe(
+            {
+                "embedder": _embedder(embedder),
+                "reranker": _reranker(reranker),
+                "llm": _llm(llm),
+            },
+            schema=schema,
+            budget_usd=budget_usd,
+        )
+
+    def _recipe_ops(self, schema: type[BaseModel]) -> list[Stage]:
+        embedder = cast(Embedder, self._resource_values["embedder"])
+        reranker = cast(Reranker, self._resource_values["reranker"])
+        llm = cast(LLM, self._resource_values["llm"])
+        return [
+            RetrieveOp(
+                embedder,
+                schema=schema,
+                k=self.retrieve_k,
+                text_field=self.text_field,
+            ),
+            Rerank(reranker),
+            TopKSelect(self.llm_k),
+            Generate(llm),
+            Parse(),
+            ThresholdSelect(0.5),
+            _cluster_stage(self.clusterer_override),
+        ]
+
+
+__all__ = ["Retrieve", "RetrieveLLM", "RetrieveRerank", "RetrieveRerankLLM"]

--- a/src/langres/architectures/retrieval.py
+++ b/src/langres/architectures/retrieval.py
@@ -10,8 +10,10 @@ from pydantic import BaseModel
 
 from langres.core.clusterer import Clusterer
 from langres.core.model_ref import ModelRef
-from langres.core.op import Stage, ThresholdSelect, TopKSelect
+from langres.core.models import predicted_match
+from langres.core.op import Op, Stage, ThresholdSelect, TopKSelect
 from langres.core.op_adapters import ClustererStage
+from langres.core.pairs import Pairs
 from langres.core.registry import register_model
 from langres.core.resolver import ERModel
 from langres.core.results import DedupeResult, LinkVerdict
@@ -57,6 +59,45 @@ def _cluster_stage(clusterer: Clusterer | None) -> ClustererStage[Any]:
     return ClustererStage(threshold_free)
 
 
+def _validate_threshold(threshold: float) -> None:
+    if not 0.0 <= threshold <= 1.0:
+        raise ValueError("threshold must be between 0.0 and 1.0")
+
+
+class _LoggingParse(Parse[Any]):
+    """Per-call Parse wrapper that records paid LLM decisions."""
+
+    def __init__(
+        self,
+        parse: Parse[Any],
+        *,
+        log: JudgementLog,
+        threshold: float | None,
+        model: str | None,
+        stage_id: str,
+    ) -> None:
+        super().__init__(parse.parser, on_parse_error=parse.on_parse_error)
+        self._log = log
+        self._threshold = threshold
+        self._model = model
+        self._stage_id = stage_id
+
+    def forward(self, pairs: Pairs[Any]) -> Pairs[Any]:
+        parsed = super().forward(pairs)
+        for row in parsed.rows:
+            judgement = row.to_judgement()
+            verdict = (
+                predicted_match(judgement, self._threshold) if self._threshold is not None else None
+            )
+            self._log.append(
+                judgement,
+                verdict=verdict,
+                model=self._model,
+                stage_id=self._stage_id,
+            )
+        return parsed
+
+
 class _ResearchRecipe(ERModel):
     """Shared inspection sugar; each concrete class still spells out its topology."""
 
@@ -86,6 +127,33 @@ class _ResearchRecipe(ERModel):
 
     def _recipe_ops(self, schema: type[BaseModel]) -> list[Stage]:
         raise NotImplementedError
+
+    def _explicit_body(self, *, log: JudgementLog | None = None) -> list[Op[Any]]:
+        """Add per-call logging around LLM Parse decisions without mutating topology."""
+        body = super()._explicit_body(log=log)
+        if log is None:
+            return body
+        wrapped: list[Op[Any]] = []
+        for body_index, op in enumerate(body):
+            if not isinstance(op, Parse):
+                wrapped.append(op)
+                continue
+            model = None
+            for upstream in reversed(body[:body_index]):
+                model = self._stage_resource_ref(upstream)
+                if model is not None:
+                    break
+            threshold = self._direct_log_threshold(body, body_index)
+            wrapped.append(
+                _LoggingParse(
+                    op,
+                    log=log,
+                    threshold=threshold,
+                    model=model,
+                    stage_id=self._execution_step(op, body_index + 1).stage_id,
+                )
+            )
+        return wrapped
 
     def _bind(self, schema: type[BaseModel]) -> None:
         """Build this recipe's explicit topology once schema is known."""
@@ -156,6 +224,7 @@ class Retrieve(_ResearchRecipe):
         clusterer: Clusterer | None = None,
         budget_usd: float | None = None,
     ) -> None:
+        _validate_threshold(threshold)
         self.retrieve_k = retrieve_k
         self.threshold = threshold
         self.text_field = text_field
@@ -196,6 +265,7 @@ class RetrieveRerank(_ResearchRecipe):
         clusterer: Clusterer | None = None,
         budget_usd: float | None = None,
     ) -> None:
+        _validate_threshold(threshold)
         self.retrieve_k = retrieve_k
         self.threshold = threshold
         self.text_field = text_field

--- a/src/langres/architectures/retrieval.py
+++ b/src/langres/architectures/retrieval.py
@@ -234,6 +234,8 @@ class RetrieveLLM(_ResearchRecipe):
         clusterer: Clusterer | None = None,
         budget_usd: float | None = None,
     ) -> None:
+        if llm_k <= 0:
+            raise ValueError("llm_k must be positive")
         self.retrieve_k = retrieve_k
         self.llm_k = llm_k
         self.text_field = text_field
@@ -282,6 +284,8 @@ class RetrieveRerankLLM(_ResearchRecipe):
         clusterer: Clusterer | None = None,
         budget_usd: float | None = None,
     ) -> None:
+        if llm_k <= 0:
+            raise ValueError("llm_k must be positive")
         self.retrieve_k = retrieve_k
         self.llm_k = llm_k
         self.text_field = text_field

--- a/src/langres/core/_model_run.py
+++ b/src/langres/core/_model_run.py
@@ -1125,8 +1125,13 @@ class ModelRun(ModelState):
         _schema, normalized = normalize_records([left, right], self._chain_source_schema())
         pair = self._chain_pair_candidate(normalized)
         current = pair
-        judgement: PairwiseJudgement | None = None
-        backbone: str | None = None
+        source_scored_rows = [row for row in pair.rows if row.score_type is not None]
+        judgement: PairwiseJudgement | None = (
+            source_scored_rows[0].to_judgement() if source_scored_rows else None
+        )
+        backbone: str | None = (
+            self._stage_resource_ref(self._chain_source()) if judgement is not None else None
+        )
         threshold: float | None = None
         for op in self._explicit_body(log=log):
             if isinstance(op, ThresholdSelect):

--- a/src/langres/core/_model_run.py
+++ b/src/langres/core/_model_run.py
@@ -181,6 +181,36 @@ def _run_stages(records: list[Any], stages: Sequence[Source[Any] | Op[Any]]) -> 
     return pairs
 
 
+def _run_stages_with_last_score_type(
+    records: list[Any],
+    stages: Sequence[Source[Any] | Op[Any]],
+) -> tuple[Pairs[Any], str | None]:
+    """Run a pair pipeline while retaining its last observed score family.
+
+    Selection can legitimately remove every row after scoring. In that case the
+    final carrier cannot describe the score family that produced the negative
+    result, so callers that expose run metadata must retain it before the rows
+    disappear.
+    """
+    source, *body = stages
+    source_stage = cast(Source[Any], source)
+    source_stage.prepare(records)
+    pairs = source_stage.forward(records)
+    score_type = next(
+        (row.score_type for row in pairs.rows if row.score_type is not None),
+        None,
+    )
+    for op in body:
+        pairs = cast(Op[Any], op).forward(pairs)
+        current_score_type = next(
+            (row.score_type for row in pairs.rows if row.score_type is not None),
+            None,
+        )
+        if current_score_type is not None:
+            score_type = current_score_type
+    return pairs, score_type
+
+
 class ModelRun(ModelState):
     """The run path of an ``ERModel``: candidates, scoring, clustering, front door."""
 
@@ -1095,11 +1125,11 @@ class ModelRun(ModelState):
         """
         _schema, normalized = normalize_records(records, self._chain_source_schema())
         check_no_duplicate_ids([record["id"] for record in normalized])
-        pairs = self._scored_pairs(normalized, log=log)
-        clusters = self._cluster(pairs)
-        score_type = next(
-            (row.score_type for row in pairs.rows if row.score_type is not None), None
+        pairs, score_type = _run_stages_with_last_score_type(
+            normalized,
+            [self._chain_source(), *self._explicit_body(log=log)],
         )
+        clusters = self._cluster(pairs)
         return DedupeResult(
             clusters,
             architecture=type(self).__name__,

--- a/src/langres/core/registry.py
+++ b/src/langres/core/registry.py
@@ -120,6 +120,18 @@ _LAZY_OP_SERIALIZER_MODULES: dict[str, str] = {
     "generate": "langres.resources.op_adapters",
     "parse": "langres.resources.op_adapters",
     "rerank": "langres.resources.op_adapters",
+    "retrieve": "langres.resources.retrieve",
+}
+
+# Named research recipes stay off the eager root-import path because importing
+# their topology module also imports the resource Op adapters. Loading a saved
+# recipe in a fresh process still needs to recover its exact ERModel subclass,
+# so resolve these trusted built-ins by registered model name on demand.
+_LAZY_MODEL_MODULES: dict[str, str] = {
+    "retrieve": "langres.architectures.retrieval",
+    "retrieve_llm": "langres.architectures.retrieval",
+    "retrieve_rerank": "langres.architectures.retrieval",
+    "retrieve_rerank_llm": "langres.architectures.retrieval",
 }
 
 
@@ -376,17 +388,15 @@ def get_model(type_name: str) -> type:
     import cycle. ``tests/test_import_tangle.py`` counts that edge; ``get_component``
     returns a bare ``type`` for the same reason.
 
-    .. note::
-       There is no lazy ``type_name -> module`` map for models yet (contrast
-       :data:`_LAZY_COMPONENT_MODULES`), because no model is registered anywhere
-       yet — W4 lands the architectures. If W4 puts them off the eager-import
-       path, it needs the same saved-artifact safety net, or a fresh process
-       loading such an artifact will raise :class:`UnknownModelType` here.
+    Built-in models kept off the eager import path resolve through the closed
+    :data:`_LAZY_MODEL_MODULES` map. Artifacts cannot supply import paths.
 
     Raises:
         UnknownModelType: If ``type_name`` is not registered. The message lists
             the available models and a did-you-mean suggestion.
     """
+    if type_name not in _MODEL_REGISTRY and type_name in _LAZY_MODEL_MODULES:
+        importlib.import_module(_LAZY_MODEL_MODULES[type_name])
     if type_name not in _MODEL_REGISTRY:
         available = sorted(_MODEL_REGISTRY)
         suggestions = difflib.get_close_matches(type_name, available, n=3)

--- a/src/langres/resources/__init__.py
+++ b/src/langres/resources/__init__.py
@@ -35,6 +35,7 @@ from langres.resources.op_adapters import (
     parse_binary_response,
     parse_score_response,
 )
+from langres.resources.retrieve import Retrieve
 from langres.resources.sentence_transformers import (
     CrossEncoderReranker,
     SentenceTransformer,
@@ -65,6 +66,7 @@ __all__ = [
     "RerankRequest",
     "Reranker",
     "RerankerRuntimeConfig",
+    "Retrieve",
     "ResourceRuntimeConfig",
     "SentenceTransformer",
     "SentenceTransformerRuntimeConfig",

--- a/src/langres/resources/op_adapters.py
+++ b/src/langres/resources/op_adapters.py
@@ -7,7 +7,7 @@ import math
 import re
 from collections.abc import Callable, Iterator
 from pathlib import Path
-from typing import Any, Generic, Literal, TypeVar
+from typing import Any, Generic, Literal, TypeVar, cast
 
 from pydantic import BaseModel, ConfigDict, model_validator
 
@@ -423,7 +423,7 @@ class Parse(Score[SchemaT], Generic[SchemaT]):
             raise ValueError("Parse config requires on_parse_error='abstain' or 'raise'")
         return cls(
             parser,
-            on_parse_error=on_parse_error,
+            on_parse_error=cast(Literal["abstain", "raise"], on_parse_error),
         )
 
     def _envelope(self, row: PairRow[SchemaT]) -> GenerationEnvelope:

--- a/src/langres/resources/retrieve.py
+++ b/src/langres/resources/retrieve.py
@@ -101,7 +101,11 @@ class Retrieve(Source[SchemaT], Generic[SchemaT]):
         """Embed records once and emit the union of their top-k cosine neighbours."""
         entities = [self._factory(record) for record in records]
         ids = [str(entity.id) for entity in entities]  # type: ignore[attr-defined]
-        require_unique_ids(ids, field="record ids", operation="Retrieve")
+        # ``ERModel.compare(a, a)`` deliberately permits a self-comparison. Its
+        # retrieval Source sees two positions with the same stable id, while
+        # dedupe rejects duplicate ids before entering the Source.
+        if not (len(ids) == 2 and ids[0] == ids[1]):
+            require_unique_ids(ids, field="record ids", operation="Retrieve")
         store = dict(zip(ids, entities, strict=True))
         if len(entities) < 2:
             return Pairs(store=store, rows=[])

--- a/src/langres/resources/retrieve.py
+++ b/src/langres/resources/retrieve.py
@@ -127,15 +127,29 @@ class Retrieve(Source[SchemaT], Generic[SchemaT]):
         similarities = normalized @ normalized.T
         np.fill_diagonal(similarities, -np.inf)
 
-        selected: dict[tuple[str, str], float] = {}
+        positions = {entity_id: index for index, entity_id in enumerate(ids)}
+        selected: dict[tuple[str, str], tuple[str, str, float]] = {}
         limit = min(self.k, len(entities) - 1)
         for index, row in enumerate(similarities):
             neighbours = np.argsort(-row, kind="stable")[:limit]
             for neighbour in neighbours:
-                left_id, right_id = sorted((ids[index], ids[int(neighbour)]))
-                pair = (left_id, right_id)
+                first_id, second_id = ids[index], ids[int(neighbour)]
+                pair = (
+                    (first_id, second_id)
+                    if first_id <= second_id
+                    else (second_id, first_id)
+                )
+                left_id, right_id = sorted(
+                    (first_id, second_id),
+                    key=positions.__getitem__,
+                )
                 score = float(np.clip(row[int(neighbour)], 0.0, 1.0))
-                selected[pair] = max(score, selected.get(pair, 0.0))
+                prior = selected.get(pair)
+                selected[pair] = (
+                    left_id,
+                    right_id,
+                    max(score, prior[2] if prior is not None else 0.0),
+                )
 
         provenance = {
             "retrieve": {
@@ -156,7 +170,7 @@ class Retrieve(Source[SchemaT], Generic[SchemaT]):
                 decision_step="retrieve",
                 provenance=provenance,
             )
-            for (left_id, right_id), score in sorted(selected.items())
+            for _, (left_id, right_id, score) in sorted(selected.items())
         ]
         return Pairs(store=store, rows=rows)
 

--- a/src/langres/resources/retrieve.py
+++ b/src/langres/resources/retrieve.py
@@ -131,7 +131,6 @@ class Retrieve(Source[SchemaT], Generic[SchemaT]):
         similarities = normalized @ normalized.T
         np.fill_diagonal(similarities, -np.inf)
 
-        positions = {entity_id: index for index, entity_id in enumerate(ids)}
         selected: dict[tuple[str, str], tuple[str, str, float]] = {}
         limit = min(self.k, len(entities) - 1)
         for index, row in enumerate(similarities):
@@ -143,15 +142,11 @@ class Retrieve(Source[SchemaT], Generic[SchemaT]):
                     if first_id <= second_id
                     else (second_id, first_id)
                 )
-                left_id, right_id = sorted(
-                    (first_id, second_id),
-                    key=positions.__getitem__,
-                )
                 score = float(np.clip(row[int(neighbour)], 0.0, 1.0))
                 prior = selected.get(pair)
                 selected[pair] = (
-                    left_id,
-                    right_id,
+                    prior[0] if prior is not None else first_id,
+                    prior[1] if prior is not None else second_id,
                     max(score, prior[2] if prior is not None else 0.0),
                 )
 

--- a/src/langres/resources/retrieve.py
+++ b/src/langres/resources/retrieve.py
@@ -52,8 +52,10 @@ class Retrieve(Source[SchemaT], Generic[SchemaT]):
         self.k = k
         self.text_field = text_field
         self._factory = schema_to_factory(schema)
-        self._default_fields = tuple(
-            spec.name for spec in StringComparator.from_schema(schema).feature_specs
+        self._default_fields = (
+            ()
+            if text_field is not None
+            else tuple(spec.name for spec in StringComparator.from_schema(schema).feature_specs)
         )
 
     @property

--- a/src/langres/resources/retrieve.py
+++ b/src/langres/resources/retrieve.py
@@ -101,10 +101,14 @@ class Retrieve(Source[SchemaT], Generic[SchemaT]):
         """Embed records once and emit the union of their top-k cosine neighbours."""
         entities = [self._factory(record) for record in records]
         ids = [str(entity.id) for entity in entities]  # type: ignore[attr-defined]
-        # ``ERModel.compare(a, a)`` deliberately permits a self-comparison. Its
-        # retrieval Source sees two positions with the same stable id, while
-        # dedupe rejects duplicate ids before entering the Source.
-        if not (len(ids) == 2 and ids[0] == ids[1]):
+        # ``ERModel.compare(a, a)`` deliberately permits a self-comparison. Only
+        # equal entities may share the stable id here: distinct records with one
+        # id would collapse in the id-keyed store and make downstream resources
+        # compare one of them to itself.
+        is_self_compare = (
+            len(entities) == 2 and ids[0] == ids[1] and entities[0] == entities[1]
+        )
+        if not is_self_compare:
             require_unique_ids(ids, field="record ids", operation="Retrieve")
         store = dict(zip(ids, entities, strict=True))
         if len(entities) < 2:

--- a/src/langres/resources/retrieve.py
+++ b/src/langres/resources/retrieve.py
@@ -1,0 +1,201 @@
+"""Embedding-backed retrieval as the first Source in an explicit topology."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any, Generic, TypeVar
+
+import numpy as np
+from pydantic import BaseModel, ConfigDict, Field
+
+from langres.core.blockers.all_pairs import register_schema_idempotent, schema_to_factory
+from langres.core.comparators import StringComparator
+from langres.core.model_ref import to_config
+from langres.core.op import Records, Source
+from langres.core.pairs import PairRow, Pairs
+from langres.core.registry import (
+    OpSerializer,
+    get_schema,
+    register_op_serializer,
+)
+from langres.resources.base import Embedder, require_unique_ids
+
+SchemaT = TypeVar("SchemaT", bound=BaseModel)
+
+
+class Retrieve(Source[SchemaT], Generic[SchemaT]):
+    """Retrieve each record's nearest neighbours with one Embedder resource.
+
+    Retrieval owns candidate generation and its heuristic cosine score. It does
+    not decide whether that score is used for a top-k prune, a final threshold,
+    or input to a downstream Rerank/LLM stage; following Select operations own
+    those roles.
+    """
+
+    def __init__(
+        self,
+        resource: Embedder,
+        *,
+        schema: type[SchemaT],
+        k: int = 20,
+        text_field: str | None = None,
+    ) -> None:
+        if k <= 0:
+            raise ValueError("Retrieve.k must be positive")
+        if text_field is not None and text_field not in schema.model_fields:
+            raise ValueError(
+                f"Retrieve text_field {text_field!r} is not declared by {schema.__name__}"
+            )
+        self.resource = resource
+        self._schema = schema
+        self._schema_name = register_schema_idempotent(schema)
+        self.k = k
+        self.text_field = text_field
+        self._factory = schema_to_factory(schema)
+        self._default_fields = tuple(
+            spec.name for spec in StringComparator.from_schema(schema).feature_specs
+        )
+
+    @property
+    def schema(self) -> type[BaseModel]:
+        """The declarative entity schema used to normalize retrieval records."""
+        return self._schema
+
+    @property
+    def config(self) -> dict[str, object]:
+        """Safe scalar topology parameters; the Embedder is a nested resource."""
+        return {
+            "schema_name": self._schema_name,
+            "k": self.k,
+            "text_field": self.text_field,
+        }
+
+    @classmethod
+    def from_config(
+        cls,
+        resource: Embedder,
+        config: dict[str, object],
+    ) -> "Retrieve[Any]":
+        """Rebuild around a validated Embedder resource."""
+        schema = get_schema(str(config["schema_name"]))
+        text_field = config["text_field"]
+        return Retrieve(
+            resource,
+            schema=schema,
+            k=int(config["k"]),  # type: ignore[call-overload]
+            text_field=str(text_field) if text_field is not None else None,
+        )
+
+    def _text(self, entity: SchemaT) -> str:
+        if self.text_field is not None:
+            return str(getattr(entity, self.text_field))
+        return " ".join(
+            str(getattr(entity, field))
+            for field in self._default_fields
+            if getattr(entity, field, None)
+        )
+
+    def forward(self, records: Records) -> Pairs[SchemaT]:
+        """Embed records once and emit the union of their top-k cosine neighbours."""
+        entities = [self._factory(record) for record in records]
+        ids = [str(entity.id) for entity in entities]  # type: ignore[attr-defined]
+        require_unique_ids(ids, field="record ids", operation="Retrieve")
+        store = dict(zip(ids, entities, strict=True))
+        if len(entities) < 2:
+            return Pairs(store=store, rows=[])
+
+        batch = self.resource.embed([self._text(entity) for entity in entities])
+        if batch.model_ref != self.resource.model_ref:
+            raise ValueError(
+                "Embedder returned a batch with a different model_ref from the resource"
+            )
+        vectors = np.asarray(batch.vectors, dtype=np.float32)
+        if vectors.ndim != 2 or vectors.shape[0] != len(entities):
+            raise ValueError(
+                "Embedder must return one 2D vector row per retrieval record; "
+                f"got shape {vectors.shape} for {len(entities)} records"
+            )
+        norms = np.linalg.norm(vectors, axis=1, keepdims=True)
+        normalized = np.divide(
+            vectors,
+            norms,
+            out=np.zeros_like(vectors),
+            where=norms != 0,
+        )
+        similarities = normalized @ normalized.T
+        np.fill_diagonal(similarities, -np.inf)
+
+        selected: dict[tuple[str, str], float] = {}
+        limit = min(self.k, len(entities) - 1)
+        for index, row in enumerate(similarities):
+            neighbours = np.argsort(-row, kind="stable")[:limit]
+            for neighbour in neighbours:
+                left_id, right_id = sorted((ids[index], ids[int(neighbour)]))
+                pair = (left_id, right_id)
+                score = float(np.clip(row[int(neighbour)], 0.0, 1.0))
+                selected[pair] = max(score, selected.get(pair, 0.0))
+
+        provenance = {
+            "retrieve": {
+                "model_ref": to_config(batch.model_ref),
+                "runtime": self.resource.runtime_config.model_dump(mode="json"),
+                "embedding": (
+                    batch.facts.model_dump(mode="json") if batch.facts is not None else None
+                ),
+            }
+        }
+        rows: list[PairRow[SchemaT]] = [
+            PairRow(
+                left_id=left_id,
+                right_id=right_id,
+                blocker_name="retrieve",
+                score=score,
+                score_type="heuristic",
+                decision_step="retrieve",
+                provenance=provenance,
+            )
+            for (left_id, right_id), score in sorted(selected.items())
+        ]
+        return Pairs(store=store, rows=rows)
+
+
+class _RetrieveParams(BaseModel):
+    model_config = ConfigDict(extra="forbid", strict=True)
+
+    schema_name: str = Field(min_length=1)
+    k: int = Field(gt=0)
+    text_field: str | None = None
+
+
+def _dump_retrieve(stage: object) -> tuple[dict[str, object], object | None]:
+    if not isinstance(stage, Retrieve):
+        raise TypeError("retrieve serializer requires an exact Retrieve operation")
+    return stage.config, stage.resource
+
+
+def _load_retrieve(
+    params: dict[str, object],
+    component: object | None,
+    _state_dir: Path,
+) -> Retrieve[Any]:
+    if not isinstance(component, Embedder):
+        raise TypeError("OpSpec role 'retrieve' requires an Embedder resource")
+    return Retrieve.from_config(component, params)
+
+
+def _validate_retrieve(params: dict[str, object]) -> dict[str, object]:
+    return _RetrieveParams.model_validate(params).model_dump()
+
+
+register_op_serializer(
+    OpSerializer(
+        role="retrieve",
+        op_type=Retrieve,
+        dump=_dump_retrieve,
+        load=_load_retrieve,
+        component_slot="resource",
+        validate_params=_validate_retrieve,
+    )
+)
+
+__all__ = ["Retrieve"]

--- a/tests/architectures/test_research_recipes.py
+++ b/tests/architectures/test_research_recipes.py
@@ -131,6 +131,27 @@ def test_all_four_recipes_run_with_zero_network_resources() -> None:
     assert _canonical(retrieve_rerank_llm) == [["a", "b"]]
 
 
+def test_all_negative_llm_recipe_preserves_its_score_type() -> None:
+    recipe = RetrieveLLM(
+        embedder=FakeEmbedder(),
+        llm=FakeLLM(
+            responses={
+                '["a","b"]': "NO_MATCH",
+                '["a","c"]': "NO_MATCH",
+                '["b","c"]': "NO_MATCH",
+            }
+        ),
+        schema=CompanySchema,
+        retrieve_k=2,
+        llm_k=2,
+    )
+
+    result = recipe.dedupe(RECORDS)
+
+    assert result == []
+    assert result.score_type == "prob_llm"
+
+
 def test_recipe_resources_are_complete_and_backbone_is_singular_sugar() -> None:
     embedder = FakeEmbedder()
     reranker = FakeReranker()

--- a/tests/architectures/test_research_recipes.py
+++ b/tests/architectures/test_research_recipes.py
@@ -24,6 +24,7 @@ from langres.core.models import CompanySchema
 from langres.core.op import ThresholdSelect, TopKSelect
 from langres.core.op_adapters import ClustererStage
 from langres.core.resolver import ERModel
+from langres.tracking.judgement_log import JudgementLog
 from langres.resources import (
     FakeEmbedder,
     FakeLLM,
@@ -472,3 +473,61 @@ def test_llm_recipes_reject_nonpositive_candidate_caps() -> None:
             schema=CompanySchema,
             llm_k=-1,
         )
+
+
+@pytest.mark.parametrize("recipe_type", [Retrieve, RetrieveRerank])
+@pytest.mark.parametrize("threshold", [-0.1, 1.1])
+def test_retrieval_recipes_reject_out_of_range_thresholds(
+    recipe_type: type[Retrieve] | type[RetrieveRerank],
+    threshold: float,
+) -> None:
+    kwargs = {
+        "embedder": FakeEmbedder(),
+        "schema": CompanySchema,
+        "threshold": threshold,
+    }
+    if recipe_type is RetrieveRerank:
+        kwargs["reranker"] = FakeReranker()
+
+    with pytest.raises(ValueError, match="threshold must be between"):
+        recipe_type(**kwargs)  # type: ignore[arg-type]
+
+
+@pytest.mark.parametrize("with_reranker", [False, True])
+def test_llm_recipe_parse_decisions_are_written_to_judgement_log(
+    tmp_path: Path,
+    with_reranker: bool,
+) -> None:
+    log = JudgementLog(tmp_path / "judgements.jsonl")
+    if with_reranker:
+        recipe: RetrieveLLM | RetrieveRerankLLM = RetrieveRerankLLM(
+            embedder=FakeEmbedder(),
+            reranker=FakeReranker(scores=RERANK_SCORES),
+            llm=FakeLLM(responses=LLM_RESPONSES),
+            schema=CompanySchema,
+            retrieve_k=2,
+            llm_k=2,
+        )
+    else:
+        recipe = RetrieveLLM(
+            embedder=FakeEmbedder(),
+            llm=FakeLLM(responses=LLM_RESPONSES),
+            schema=CompanySchema,
+            retrieve_k=2,
+            llm_k=2,
+        )
+
+    recipe.dedupe(RECORDS, log=log)
+
+    rows = log.read()
+    assert len(rows) == 3
+    assert {row["verdict"] for row in rows} == {False, True}
+    assert {row["decision_step"] for row in rows} == {"llm_parse"}
+    assert {row["model"] for row in rows} == {"./fake/llm"}
+    assert all(row["stage_id"] is not None for row in rows)
+
+    compare_log = JudgementLog(tmp_path / "compare.jsonl")
+    verdict = recipe.compare(RECORDS[0], RECORDS[1], log=compare_log)
+    [compare_row] = compare_log.read()
+    assert compare_row["verdict"] is verdict.match
+    assert compare_row["decision_step"] == "llm_parse"

--- a/tests/architectures/test_research_recipes.py
+++ b/tests/architectures/test_research_recipes.py
@@ -7,6 +7,8 @@ import subprocess
 import sys
 from pathlib import Path
 
+from pydantic import BaseModel
+
 from langres.architectures import (
     Retrieve,
     RetrieveLLM,
@@ -44,6 +46,10 @@ LLM_RESPONSES = {
     '["a","c"]': "NO_MATCH",
     '["b","c"]': "NO_MATCH",
 }
+
+
+class _IdentifierOnly(BaseModel):
+    id: str
 
 
 def _canonical(model: ERModel) -> list[list[str]]:
@@ -279,3 +285,16 @@ def test_recipe_infers_schema_on_first_run_and_exposes_resources_before_binding(
     assert recipe.resources == {"embedder": embedder.model_ref}
     assert _canonical(recipe) == [["a", "b", "c"]]
     assert recipe.schema is not None
+
+
+def test_explicit_retrieval_text_field_does_not_require_default_comparable_fields() -> None:
+    retrieve = RetrieveOp(
+        FakeEmbedder(),
+        schema=_IdentifierOnly,
+        text_field="id",
+        k=1,
+    )
+
+    pairs = retrieve.forward([{"id": "a"}, {"id": "b"}])
+
+    assert [(row.left_id, row.right_id) for row in pairs.rows] == [("a", "b")]

--- a/tests/architectures/test_research_recipes.py
+++ b/tests/architectures/test_research_recipes.py
@@ -28,6 +28,8 @@ from langres.resources import (
     FakeEmbedder,
     FakeLLM,
     FakeReranker,
+    GenerationBatch,
+    GenerationRequest,
     Generate,
     EmbeddingBatch,
     Parse,
@@ -74,6 +76,16 @@ class _RecordingEmbedder(FakeEmbedder):
     def embed(self, texts: Sequence[str]) -> EmbeddingBatch:
         self.texts.append(tuple(texts))
         return super().embed(texts)
+
+
+class _CountingLLM(FakeLLM):
+    def __init__(self) -> None:
+        super().__init__()
+        self.calls = 0
+
+    def generate(self, requests: Sequence[GenerationRequest]) -> GenerationBatch:
+        self.calls += len(requests)
+        return super().generate(requests)
 
 
 def _canonical(model: ERModel) -> list[list[str]]:
@@ -422,6 +434,26 @@ def test_retrieve_compare_accepts_the_same_record_on_both_sides() -> None:
 
     assert verdict.match is True
     assert verdict.score == 1.0
+
+
+def test_retrieve_rejects_distinct_records_with_one_id_before_downstream_models() -> None:
+    reranker = FakeReranker()
+    llm = _CountingLLM()
+    recipe = RetrieveRerankLLM(
+        embedder=FakeEmbedder(),
+        reranker=reranker,
+        llm=llm,
+        schema=CompanySchema,
+    )
+
+    with pytest.raises(ValueError, match="duplicate ids"):
+        recipe.compare(
+            {"id": "same", "name": "Alpha"},
+            {"id": "same", "name": "Beta"},
+        )
+
+    assert reranker.calls == 0
+    assert llm.calls == 0
 
 
 def test_llm_recipes_reject_nonpositive_candidate_caps() -> None:

--- a/tests/architectures/test_research_recipes.py
+++ b/tests/architectures/test_research_recipes.py
@@ -66,6 +66,16 @@ class _FixedEmbedder(FakeEmbedder):
         return EmbeddingBatch(vectors=self._vectors, model_ref=self.model_ref)
 
 
+class _RecordingEmbedder(FakeEmbedder):
+    def __init__(self) -> None:
+        super().__init__()
+        self.texts: list[tuple[str, ...]] = []
+
+    def embed(self, texts: Sequence[str]) -> EmbeddingBatch:
+        self.texts.append(tuple(texts))
+        return super().embed(texts)
+
+
 def _canonical(model: ERModel) -> list[list[str]]:
     return sorted(sorted(cluster) for cluster in model.dedupe(RECORDS))
 
@@ -203,7 +213,7 @@ def test_same_reranker_instance_conforms_before_different_selects() -> None:
 
 
 def test_recipe_accepts_a_custom_downstream_clusterer() -> None:
-    clusterer = Clusterer(threshold=0.0)
+    clusterer = Clusterer(threshold=0.7)
     recipe = Retrieve(
         embedder=FakeEmbedder(),
         schema=CompanySchema,
@@ -212,7 +222,10 @@ def test_recipe_accepts_a_custom_downstream_clusterer() -> None:
 
     assert recipe._ops is not None
     stage = next(stage for stage in recipe._ops if isinstance(stage, ClustererStage))
-    assert stage.clusterer is clusterer
+    assert type(stage.clusterer) is type(clusterer)
+    assert stage.clusterer is not clusterer
+    assert stage.clusterer.threshold == 0.0
+    assert clusterer.threshold == 0.7
 
 
 def test_production_recipe_topology_round_trips_without_loading_weights(
@@ -301,6 +314,32 @@ def test_recipe_infers_schema_on_first_run_and_exposes_resources_before_binding(
     assert recipe.schema is not None
 
 
+def test_schema_inference_reuses_coerced_records_for_first_dedupe() -> None:
+    embedder = _RecordingEmbedder()
+    recipe = Retrieve(embedder=embedder, retrieve_k=1, threshold=0.0)
+
+    recipe.dedupe(
+        [
+            {"id": "a", "name": 123, "missing": float("nan")},
+            {"id": "b", "name": 124, "missing": float("nan")},
+        ]
+    )
+
+    assert embedder.texts == [("123", "124")]
+
+
+def test_schema_inference_reuses_coerced_records_for_first_compare() -> None:
+    embedder = _RecordingEmbedder()
+    recipe = Retrieve(embedder=embedder, threshold=0.0)
+
+    recipe.compare(
+        {"id": "a", "name": 123, "missing": float("nan")},
+        {"id": "b", "name": 124, "missing": float("nan")},
+    )
+
+    assert embedder.texts == [("123", "124")]
+
+
 def test_explicit_retrieval_text_field_does_not_require_default_comparable_fields() -> None:
     retrieve = RetrieveOp(
         FakeEmbedder(),
@@ -327,29 +366,49 @@ def test_retrieve_compare_returns_false_when_source_score_is_below_threshold() -
     assert verdict.score == 0.0
 
 
-def test_retrieve_preserves_input_anchor_for_downstream_topk() -> None:
+def test_retrieve_preserves_reverse_hit_anchor_for_downstream_topk() -> None:
     retrieve = RetrieveOp(
         _FixedEmbedder(
             [
                 [1.0, 0.0],
-                [0.9, 0.1],
-                [0.9, -0.1],
+                [0.99, 0.1],
+                [0.7, -0.7],
             ]
         ),
         schema=CompanySchema,
-        k=2,
+        k=1,
     )
     records = [
-        {"id": "z", "name": "Zed"},
         {"id": "a", "name": "Alpha"},
         {"id": "b", "name": "Beta"},
+        {"id": "z", "name": "Zed"},
     ]
 
     candidates = retrieve.forward(records)
     selected = TopKSelect[CompanySchema](1).forward(candidates)
 
-    assert any(row.left_id == "z" for row in candidates.rows)
-    assert sum("z" in (row.left_id, row.right_id) for row in selected.rows) == 1
+    assert ("z", "a") in [(row.left_id, row.right_id) for row in candidates.rows]
+    assert ("z", "a") in [(row.left_id, row.right_id) for row in selected.rows]
+
+
+def test_recipe_clusterer_runs_after_the_recipe_cut_without_a_second_threshold() -> None:
+    custom_clusterer = Clusterer(threshold=0.9)
+    recipe = Retrieve(
+        embedder=_FixedEmbedder([[1.0, 0.0], [0.8, 0.6]]),
+        schema=CompanySchema,
+        threshold=0.5,
+        clusterer=custom_clusterer,
+    )
+
+    verdict = recipe.compare(RECORDS[0], RECORDS[1])
+    result = recipe.dedupe(RECORDS[:2])
+    stage = next(stage for stage in recipe._require_ops() if isinstance(stage, ClustererStage))
+
+    assert verdict.match is True
+    assert result == [{"a", "b"}]
+    assert stage.clusterer is not custom_clusterer
+    assert stage.clusterer.threshold == 0.0
+    assert custom_clusterer.threshold == 0.9
 
 
 def test_retrieve_compare_accepts_the_same_record_on_both_sides() -> None:

--- a/tests/architectures/test_research_recipes.py
+++ b/tests/architectures/test_research_recipes.py
@@ -24,6 +24,7 @@ from langres.core.models import CompanySchema
 from langres.core.op import ThresholdSelect, TopKSelect
 from langres.core.op_adapters import ClustererStage
 from langres.core.resolver import ERModel
+from langres.core.spend import SpendMonitor
 from langres.tracking.judgement_log import JudgementLog
 from langres.resources import (
     FakeEmbedder,
@@ -150,6 +151,29 @@ def test_all_negative_llm_recipe_preserves_its_score_type() -> None:
 
     assert result == []
     assert result.score_type == "prob_llm"
+
+
+def test_recipe_adopts_the_experiment_spend_monitor_exactly() -> None:
+    monitor = SpendMonitor(budget_usd=2.0)
+    recipe = RetrieveLLM(
+        embedder=FakeEmbedder(),
+        llm=FakeLLM(responses=LLM_RESPONSES),
+        schema=CompanySchema,
+        monitor=monitor,
+    )
+
+    generate = next(stage for stage in recipe._require_ops() if isinstance(stage, Generate))
+
+    assert recipe._spend_monitor is monitor
+    assert generate.spend_monitor is monitor
+
+    with pytest.raises(ValueError, match="budget_usd= or monitor="):
+        Retrieve(
+            embedder=FakeEmbedder(),
+            schema=CompanySchema,
+            budget_usd=1.0,
+            monitor=monitor,
+        )
 
 
 def test_recipe_resources_are_complete_and_backbone_is_singular_sugar() -> None:

--- a/tests/architectures/test_research_recipes.py
+++ b/tests/architectures/test_research_recipes.py
@@ -5,8 +5,10 @@ from __future__ import annotations
 import os
 import subprocess
 import sys
+from collections.abc import Sequence
 from pathlib import Path
 
+import numpy as np
 from pydantic import BaseModel
 
 from langres.architectures import (
@@ -26,6 +28,7 @@ from langres.resources import (
     FakeLLM,
     FakeReranker,
     Generate,
+    EmbeddingBatch,
     Parse,
     Rerank,
     Retrieve as RetrieveOp,
@@ -50,6 +53,16 @@ LLM_RESPONSES = {
 
 class _IdentifierOnly(BaseModel):
     id: str
+
+
+class _FixedEmbedder(FakeEmbedder):
+    def __init__(self, vectors: list[list[float]]) -> None:
+        super().__init__(dimension=len(vectors[0]))
+        self._vectors = np.asarray(vectors, dtype=np.float32)
+
+    def embed(self, texts: Sequence[str]) -> EmbeddingBatch:
+        assert len(texts) == len(self._vectors)
+        return EmbeddingBatch(vectors=self._vectors, model_ref=self.model_ref)
 
 
 def _canonical(model: ERModel) -> list[list[str]]:
@@ -298,3 +311,41 @@ def test_explicit_retrieval_text_field_does_not_require_default_comparable_field
     pairs = retrieve.forward([{"id": "a"}, {"id": "b"}])
 
     assert [(row.left_id, row.right_id) for row in pairs.rows] == [("a", "b")]
+
+
+def test_retrieve_compare_returns_false_when_source_score_is_below_threshold() -> None:
+    recipe = Retrieve(
+        embedder=_FixedEmbedder([[1.0, 0.0], [-1.0, 0.0]]),
+        schema=CompanySchema,
+        threshold=0.5,
+    )
+
+    verdict = recipe.compare(RECORDS[0], RECORDS[1])
+
+    assert verdict.match is False
+    assert verdict.score == 0.0
+
+
+def test_retrieve_preserves_input_anchor_for_downstream_topk() -> None:
+    retrieve = RetrieveOp(
+        _FixedEmbedder(
+            [
+                [1.0, 0.0],
+                [0.9, 0.1],
+                [0.9, -0.1],
+            ]
+        ),
+        schema=CompanySchema,
+        k=2,
+    )
+    records = [
+        {"id": "z", "name": "Zed"},
+        {"id": "a", "name": "Alpha"},
+        {"id": "b", "name": "Beta"},
+    ]
+
+    candidates = retrieve.forward(records)
+    selected = TopKSelect[CompanySchema](1).forward(candidates)
+
+    assert any(row.left_id == "z" for row in candidates.rows)
+    assert sum("z" in (row.left_id, row.right_id) for row in selected.rows) == 1

--- a/tests/architectures/test_research_recipes.py
+++ b/tests/architectures/test_research_recipes.py
@@ -9,6 +9,7 @@ from collections.abc import Sequence
 from pathlib import Path
 
 import numpy as np
+import pytest
 from pydantic import BaseModel
 
 from langres.architectures import (
@@ -349,3 +350,34 @@ def test_retrieve_preserves_input_anchor_for_downstream_topk() -> None:
 
     assert any(row.left_id == "z" for row in candidates.rows)
     assert sum("z" in (row.left_id, row.right_id) for row in selected.rows) == 1
+
+
+def test_retrieve_compare_accepts_the_same_record_on_both_sides() -> None:
+    recipe = Retrieve(
+        embedder=_FixedEmbedder([[1.0, 0.0], [1.0, 0.0]]),
+        schema=CompanySchema,
+        threshold=0.5,
+    )
+
+    verdict = recipe.compare(RECORDS[0], RECORDS[0])
+
+    assert verdict.match is True
+    assert verdict.score == 1.0
+
+
+def test_llm_recipes_reject_nonpositive_candidate_caps() -> None:
+    with pytest.raises(ValueError, match="llm_k must be positive"):
+        RetrieveLLM(
+            embedder=FakeEmbedder(),
+            llm=FakeLLM(),
+            schema=CompanySchema,
+            llm_k=0,
+        )
+    with pytest.raises(ValueError, match="llm_k must be positive"):
+        RetrieveRerankLLM(
+            embedder=FakeEmbedder(),
+            reranker=FakeReranker(),
+            llm=FakeLLM(),
+            schema=CompanySchema,
+            llm_k=-1,
+        )

--- a/tests/architectures/test_research_recipes.py
+++ b/tests/architectures/test_research_recipes.py
@@ -1,0 +1,281 @@
+"""Zero-network proofs for the four research recipe factories."""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+from langres.architectures import (
+    Retrieve,
+    RetrieveLLM,
+    RetrieveRerank,
+    RetrieveRerankLLM,
+)
+from langres.core.clusterer import Clusterer
+from langres.core.model_ref import ModelRef
+from langres.core.models import CompanySchema
+from langres.core.op import ThresholdSelect, TopKSelect
+from langres.core.op_adapters import ClustererStage
+from langres.core.resolver import ERModel
+from langres.resources import (
+    FakeEmbedder,
+    FakeLLM,
+    FakeReranker,
+    Generate,
+    Parse,
+    Rerank,
+    Retrieve as RetrieveOp,
+)
+
+RECORDS = [
+    {"id": "a", "name": "Acme"},
+    {"id": "b", "name": "ACME"},
+    {"id": "c", "name": "Globex"},
+]
+RERANK_SCORES = {
+    '["a","b"]': 0.95,
+    '["a","c"]': 0.1,
+    '["b","c"]': 0.2,
+}
+LLM_RESPONSES = {
+    '["a","b"]': "MATCH",
+    '["a","c"]': "NO_MATCH",
+    '["b","c"]': "NO_MATCH",
+}
+
+
+def _canonical(model: ERModel) -> list[list[str]]:
+    return sorted(sorted(cluster) for cluster in model.dedupe(RECORDS))
+
+
+def test_all_four_recipes_run_with_zero_network_resources() -> None:
+    embedder = FakeEmbedder()
+
+    retrieve = Retrieve(
+        embedder=embedder,
+        schema=CompanySchema,
+        retrieve_k=2,
+        threshold=0.0,
+    )
+    retrieve_rerank = RetrieveRerank(
+        embedder=embedder,
+        reranker=FakeReranker(scores=RERANK_SCORES),
+        schema=CompanySchema,
+        retrieve_k=2,
+        threshold=0.8,
+    )
+    retrieve_llm = RetrieveLLM(
+        embedder=embedder,
+        llm=FakeLLM(responses=LLM_RESPONSES),
+        schema=CompanySchema,
+        retrieve_k=2,
+        llm_k=2,
+    )
+    retrieve_rerank_llm = RetrieveRerankLLM(
+        embedder=embedder,
+        reranker=FakeReranker(scores=RERANK_SCORES),
+        llm=FakeLLM(responses=LLM_RESPONSES),
+        schema=CompanySchema,
+        retrieve_k=2,
+        llm_k=2,
+    )
+
+    assert _canonical(retrieve) == [["a", "b", "c"]]
+    assert _canonical(retrieve_rerank) == [["a", "b"]]
+    assert _canonical(retrieve_llm) == [["a", "b"]]
+    assert _canonical(retrieve_rerank_llm) == [["a", "b"]]
+
+
+def test_recipe_resources_are_complete_and_backbone_is_singular_sugar() -> None:
+    embedder = FakeEmbedder()
+    reranker = FakeReranker()
+    llm = FakeLLM()
+
+    retrieve = Retrieve(embedder=embedder, schema=CompanySchema)
+    retrieve_rerank = RetrieveRerank(
+        embedder=embedder,
+        reranker=reranker,
+        schema=CompanySchema,
+    )
+    retrieve_llm = RetrieveLLM(
+        embedder=embedder,
+        llm=llm,
+        schema=CompanySchema,
+    )
+    retrieve_rerank_llm = RetrieveRerankLLM(
+        embedder=embedder,
+        reranker=reranker,
+        llm=llm,
+        schema=CompanySchema,
+    )
+
+    assert retrieve.resources == {"embedder": embedder.model_ref}
+    assert retrieve.backbone == embedder.model_ref.base
+    assert retrieve_rerank.resources == {
+        "embedder": embedder.model_ref,
+        "reranker": reranker.model_ref,
+    }
+    assert retrieve_llm.resources == {
+        "embedder": embedder.model_ref,
+        "llm": llm.model_ref,
+    }
+    assert retrieve_rerank_llm.resources == {
+        "embedder": embedder.model_ref,
+        "reranker": reranker.model_ref,
+        "llm": llm.model_ref,
+    }
+    assert retrieve_rerank.backbone is None
+    assert retrieve_llm.backbone is None
+    assert retrieve_rerank_llm.backbone is None
+
+
+def test_api_and_local_llm_refs_share_one_recipe_contract() -> None:
+    api = RetrieveLLM(
+        embedder=FakeEmbedder(),
+        llm=ModelRef(base="openai/gpt-4o-mini", kind="api"),
+        schema=CompanySchema,
+    )
+    local = RetrieveLLM(
+        embedder=FakeEmbedder(),
+        llm=ModelRef(base="./models/tiny", kind="local"),
+        schema=CompanySchema,
+    )
+
+    assert api.resources["llm"].kind == "api"
+    assert local.resources["llm"].kind == "local"
+    assert type(api) is type(local) is RetrieveLLM
+
+
+def test_same_reranker_instance_conforms_before_different_selects() -> None:
+    embedder = FakeEmbedder()
+    reranker = FakeReranker(scores=RERANK_SCORES)
+    recipe = RetrieveRerank(
+        embedder=embedder,
+        reranker=reranker,
+        schema=CompanySchema,
+        retrieve_k=2,
+        threshold=0.8,
+    )
+    custom = ERModel.from_topology(
+        ops=[
+            RetrieveOp(embedder, schema=CompanySchema, k=2),
+            Rerank(reranker),
+            TopKSelect(1),
+            ThresholdSelect(0.0),
+            ClustererStage(Clusterer(threshold=0.0)),
+        ]
+    )
+
+    assert recipe._ops is not None
+    assert custom._ops is not None
+    assert next(stage for stage in recipe._ops if isinstance(stage, Rerank)).resource is reranker
+    assert next(stage for stage in custom._ops if isinstance(stage, Rerank)).resource is reranker
+    assert [step.spec.role for step in custom.execution_plan().steps] == [
+        "retrieve",
+        "rerank",
+        "topk_select",
+        "threshold_select",
+        "clusterer_stage",
+    ]
+    assert custom.execute(RECORDS).pairs.rows
+
+
+def test_recipe_accepts_a_custom_downstream_clusterer() -> None:
+    clusterer = Clusterer(threshold=0.0)
+    recipe = Retrieve(
+        embedder=FakeEmbedder(),
+        schema=CompanySchema,
+        clusterer=clusterer,
+    )
+
+    assert recipe._ops is not None
+    stage = next(stage for stage in recipe._ops if isinstance(stage, ClustererStage))
+    assert stage.clusterer is clusterer
+
+
+def test_production_recipe_topology_round_trips_without_loading_weights(
+    tmp_path: Path,
+) -> None:
+    recipe = RetrieveRerankLLM(
+        embedder=ModelRef(base="org/embedder", kind="hf", revision="embed-sha"),
+        reranker=ModelRef(base="org/reranker", kind="hf", revision="rerank-sha"),
+        llm=ModelRef(base="org/llm", kind="hf", revision="llm-sha"),
+        schema=CompanySchema,
+        retrieve_k=20,
+        llm_k=5,
+    )
+
+    recipe.save(tmp_path)
+    loaded = ERModel.load(tmp_path)
+
+    assert type(loaded) is RetrieveRerankLLM
+    assert loaded.resources == recipe.resources
+    assert [step.spec.role for step in loaded.execution_plan().steps] == [
+        "retrieve",
+        "rerank",
+        "topk_select",
+        "generate",
+        "parse",
+        "threshold_select",
+        "clusterer_stage",
+    ]
+
+
+def test_production_recipe_loads_as_exact_class_in_a_fresh_process(
+    tmp_path: Path,
+) -> None:
+    recipe = RetrieveRerankLLM(
+        embedder=ModelRef(base="org/embedder", kind="hf", revision="embed-sha"),
+        reranker=ModelRef(base="org/reranker", kind="hf", revision="rerank-sha"),
+        llm=ModelRef(base="org/llm", kind="hf", revision="llm-sha"),
+        schema=CompanySchema,
+    )
+    recipe.save(tmp_path)
+
+    script = """
+import sys
+from pathlib import Path
+
+assert "langres.architectures.retrieval" not in sys.modules
+from langres.core import ERModel
+assert "langres.architectures.retrieval" not in sys.modules
+
+model = ERModel.load(Path(sys.argv[1]))
+assert type(model).__name__ == "RetrieveRerankLLM"
+assert model.resources["embedder"].revision == "embed-sha"
+assert model.resources["reranker"].revision == "rerank-sha"
+assert model.resources["llm"].revision == "llm-sha"
+assert [step.spec.role for step in model.execution_plan().steps] == [
+    "retrieve",
+    "rerank",
+    "topk_select",
+    "generate",
+    "parse",
+    "threshold_select",
+    "clusterer_stage",
+]
+"""
+    result = subprocess.run(
+        [sys.executable, "-c", script, str(tmp_path)],
+        capture_output=True,
+        text=True,
+        check=False,
+        env={
+            **os.environ,
+            "PYTHONPATH": str(Path(__file__).parents[2] / "src"),
+        },
+    )
+
+    assert result.returncode == 0, result.stderr
+
+
+def test_recipe_infers_schema_on_first_run_and_exposes_resources_before_binding() -> None:
+    embedder = FakeEmbedder()
+    recipe = Retrieve(embedder=embedder, retrieve_k=2, threshold=0.0)
+
+    assert recipe.schema is None
+    assert recipe.resources == {"embedder": embedder.model_ref}
+    assert _canonical(recipe) == [["a", "b", "c"]]
+    assert recipe.schema is not None


### PR DESCRIPTION
## Summary

- add the four named `Retrieve`, `RetrieveRerank`, `RetrieveLLM`, and `RetrieveRerankLLM` recipe factories over the shared resource operation algebra
- add an embedding-backed `Retrieve` source with strict, fail-closed topology persistence
- expose complete `resources` mappings and singular `backbone` compatibility sugar
- keep API and local LLM references behind the same `llm=` contract and reuse the same `Reranker` resource before either top-k or threshold selection
- preserve optional schema inference for first-run DX, with explicit schema guidance for persisted artifacts
- document the vocabulary and add an offline zero-network example

## Validation

- `166 passed, 1 skipped, 1 deselected` across recipes, resources, explicit topology persistence/execution, import budget, and import-tangle tests
- `ruff check src tests/architectures/test_research_recipes.py examples/research_recipes.py`
- `mypy src`
- offline `examples/research_recipes.py`

The complete local suite was attempted but three pre-existing unmarked Hugging Face download tests block in this network-restricted environment. Branch CI is the authoritative full gate.

## Scope

This PR does not change the experiment runner/cache replay implementation or Hugging Face Hub transport, and it adds no clustering algorithm.