### PR TITLE
Add safe Hugging Face model lifecycle

### DIFF
--- a/.claude/rules/component-design.md
+++ b/.claude/rules/component-design.md
@@ -135,6 +135,14 @@ a model is the user's job, not a heuristic's. The real layering is:)
    - **Not yet built** (roadmap, don't reference as existing): a general
      `Optimizer` (only `langres.autoresearch.blocker_optimizer.BlockerOptimizer`
      exists).
+   - **Hub transport is not core.** `langres.hub` is an outer adapter around the
+     unchanged `ERModel.save` / `ERModel.load` persistence contract. The pure
+     artifact envelope validates an exact file allowlist and immutable
+     provenance, while `huggingface_hub` is imported lazily only for remote
+     operations. Core may own transport-neutral `ArtifactSource` provenance and
+     its convenience methods may dynamically dispatch to the public adapter,
+     but core has no static Hub dependency and must never execute
+     artifact-controlled Python imports/remote code.
 
 ## Key Design Principles
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -82,6 +82,7 @@ langres/
 │   │   └── base.py, miners.py, models.py, labelers.py, bootstrapper.py, report.py, _pairs.py  # gold-set cold-start: Miner/Labeler, HardNegativeMiner, GoldPair/GoldSet, Bootstrapper, BootstrapReport
 │   ├── training/       # fitting/calibrating a matcher (what PRODUCES a tuned model, NOT ER modelling — beside core, like report/): finetune (QLoRA, [finetune] lazy), calibration (derive_threshold/Calibrator, [trained]), fit_report (FitReport), methods_prompt (Bootstrap/MIPRO/GEPA), methods_calibrate (Platt/Isotonic). core → training is non-zero by design (resolver.fit + _exports/_training) — see tests/test_import_tangle.py
 │   ├── methods.py      # method registry / _make_module_builder (benchmark path)
+│   ├── hub.py          # safe save_pretrained/from_pretrained/push_to_hub adapter
 │   ├── clients/        # OpenRouter client, SpendMonitor, pricing
 │   ├── metrics/        # ER metrics + diagnostics (metrics/analysis/debugging/diagnostics) — they SCORE a resolution, not the modelling contract, so beside core; public via langres.eval, back-compat shims at core.metrics/.analysis/.debugging/.diagnostics
 │   ├── benchmarks/     # ER benchmark HARNESS (internal plumbing) — runner.py (run_method(s)→BenchmarkTable) + judge_eval.py (evaluate/evaluate_judge_on_candidates, BudgetedModuleRunner). __init__ exports NOTHING (import-light). Reached ONLY via langres.data.get_benchmark(...) + langres.eval.evaluate(...); depends ONE-WAY on the benchmark SPEC in data/benchmark.py. Old core.benchmark path = TEMPORARY W2-sweep shim
@@ -134,4 +135,5 @@ The `.agent/` folder contains external expert analyses of the langres project:
 - **`docs/USE_CASES.md`** — use-case taxonomy and roadmap (V1 / V1.1 / out-of-scope; streaming, temporal, collective resolution).
 - **`docs/DX_RESOLVER.md`** — before/after of the M0 `Resolver`: the manual lambda pipeline vs. the declarative `from_schema` + `save`/`load` path.
 - **`docs/EXPERIMENTS.md`** — experimentation DX getting-started: the `run_methods` full-pipeline race vs. `evaluate_judge_on_candidates` (judged-once) for compiled/paid judges; `derive_threshold` to kill magic constants; the `SpendMonitor` budget seam.
+- **`docs/HUGGING_FACE.md`** — validated local/Hub artifact lifecycle, immutable revision pinning, model-card facts, and claim levels.
 - **`CHANGELOG.md`** (repo root) — release history (0.3.0 / 0.2.0); pre-0.2.0 POC milestone history is preserved in git history and `docs/research/`.

--- a/docs/HUGGING_FACE.md
+++ b/docs/HUGGING_FACE.md
@@ -1,0 +1,113 @@
+# Hugging Face model sharing
+
+langres publishes a complete entity-resolution architecture as a validated
+bundle around its existing `resolver.json` artifact. The model topology,
+selection thresholds, resource references, and registered operation specs stay
+in `resolver.json`; `langres-artifact.json` adds the exact file allowlist,
+checksums, compatibility facts, model references, claim level, and optional
+measurement summary.
+
+Install the Hub client only when you need remote download or upload:
+
+```bash
+pip install "langres[hub]"
+```
+
+Local save/load does not require that extra:
+
+```python
+model.save_pretrained(
+    "artifacts/acme-er",
+    measurement_summary={
+        "protocol_id": "official-v1",
+        "evaluation_id": "amazon-google-v1",
+        "dataset_ids": ("amazon-google:test",),
+        "quality": {"pair_f1": 0.91},
+        "tokens": {"input_tokens": 123_456, "output_tokens": 7_890},
+        "cost": {"usd": 2.34},
+        "performance": {"p95_latency_ms": 84.2},
+        "hardware": {"accelerator": "NVIDIA L4"},
+    },
+)
+
+reloaded = langres.ERModel.from_pretrained("artifacts/acme-er")
+```
+
+Prompt-bearing configuration is excluded by default. If the model contains a
+custom/default serialized prompt, inspect `model.config_dict()` and opt in
+explicitly:
+
+```python
+model.save_pretrained(
+    "artifacts/prompted-er",
+    allow_sensitive_config=True,
+)
+```
+
+The outer manifest and generated card then state that prompt-bearing
+configuration is included.
+
+Remote operations use the same journey:
+
+```python
+result = model.push_to_hub(
+    "acme/entity-resolver",
+    private=True,
+    revision="main",
+    commit_message="Publish official-v1 result",
+)
+
+reloaded = langres.ERModel.from_pretrained(
+    "acme/entity-resolver",
+    revision=result.commit_oid,
+)
+print(reloaded.pretrained_source_.resolved_revision)
+```
+
+`from_pretrained` first resolves a branch or tag to an immutable repository
+commit, downloads only `langres-artifact.json`, validates its bounded schema
+against repository metadata, then downloads the exact allowlist at that commit.
+It rejects traversal, symlinks, missing allowlisted files, unknown sizes, checksum
+mismatches, unknown component/operation types, and malformed layouts before
+`ERModel.load()` constructs a component. Files not named by the manifest are
+ignored and never downloaded, which keeps repeated repository updates usable
+without weakening the exact download allowlist. Artifacts never supply Python
+module paths and never enable remote code.
+
+Bundles are deliberately state-free in this first release: only
+`resolver.json`, the generated model card, and an optional aggregate measurement
+summary are eligible. `save_pretrained` rejects Resolver sidecars because
+existing sidecar formats may contain corpus rows, compiled prompts, NumPy data,
+or native FAISS binaries. Publish a fresh configuration-only model; sharing
+trusted learned state requires a future explicit per-component safe-publication
+contract.
+
+An artifact is accepted only by the same langres minor release that created it
+(patch releases remain compatible). In-place directory overwrite is
+intentionally unsupported; publish to a new directory and switch the reference
+after validation.
+
+## Claim levels
+
+- `reference-only` (default): the bundle contains topology and pinned or
+  unpinned resource references, not copied model weights.
+- `benchmark-reproducible`: requires named protocol/evaluation/datasets, at
+  least one quality metric, plus full `organization/repository` Hub ids and
+  immutable 40-character commit SHAs for every Hugging Face base and adapter.
+  API, endpoint, local, shorthand, branch, and tag references are not eligible
+  for this claim. It still references immutable Hub weights rather than copying
+  them.
+- `frozen-weights`: deliberately rejected for now. Local trained resource paths
+  are not yet copied and rebased into the bundle, so claiming frozen weights
+  would be misleading.
+
+The model card and optional `measurement-summary.json` contain only explicitly
+selected aggregate facts. Dataset rows, generations, judgement logs, local
+caches, and tracker credentials are never included. Prompt-bearing resolver
+configuration is included only with `allow_sensitive_config=True` and is
+declared in both manifest and card. Tokens are forwarded to the Hub client for
+the requested operation and are never written to the bundle or model card.
+
+Hub artifact revision provenance is separate from resource `ModelRef`
+revisions: `pretrained_source_.resolved_revision` identifies the bundle commit,
+while each resource revision identifies the actual embedder, reranker, or LLM.

--- a/docs/HUGGING_FACE.md
+++ b/docs/HUGGING_FACE.md
@@ -47,6 +47,11 @@ model.save_pretrained(
 The outer manifest and generated card then state that prompt-bearing
 configuration is included.
 
+Credentials are never publishable, even with `allow_sensitive_config=True`.
+Keep API keys, authorization headers, tokens, and similar secrets out of
+serialized LiteLLM `provider` / `extra_body` options; inject them through the
+runtime client or environment instead.
+
 Remote operations use the same journey:
 
 ```python
@@ -107,6 +112,8 @@ caches, and tracker credentials are never included. Prompt-bearing resolver
 configuration is included only with `allow_sensitive_config=True` and is
 declared in both manifest and card. Tokens are forwarded to the Hub client for
 the requested operation and are never written to the bundle or model card.
+The outer manifest also records the install extras needed by optional
+components, including `[trained]` for calibrators and random-forest matchers.
 
 Hub artifact revision provenance is separate from resource `ModelRef`
 revisions: `pretrained_source_.resolved_revision` identifies the bundle commit,

--- a/docs/TECHNICAL_OVERVIEW.md
+++ b/docs/TECHNICAL_OVERVIEW.md
@@ -53,7 +53,8 @@ behind an opt-in extra. Nothing below is auto-orchestrated by a magic
   `core.metrics` / `core.benchmark` stays importable without it. (There is no
   `pytrec_eval` anywhere in the tree.)
 - **`[hub]`** — huggingface-hub: the optional remote transport used by
-  `ERModel.from_pretrained(..., repo_id=...)` and `ERModel.push_to_hub(...)`.
+  `ERModel.from_pretrained("organization/repository", ...)` and
+  `ERModel.push_to_hub(...)`.
   Local `save_pretrained` / `from_pretrained` stays available without this
   extra.
 

--- a/docs/TECHNICAL_OVERVIEW.md
+++ b/docs/TECHNICAL_OVERVIEW.md
@@ -52,6 +52,10 @@ behind an opt-in extra. Nothing below is auto-orchestrated by a magic
   `core.metrics.evaluate_blocking_with_ranking`, imported lazily so the rest of
   `core.metrics` / `core.benchmark` stays importable without it. (There is no
   `pytrec_eval` anywhere in the tree.)
+- **`[hub]`** — huggingface-hub: the optional remote transport used by
+  `ERModel.from_pretrained(..., repo_id=...)` and `ERModel.push_to_hub(...)`.
+  Local `save_pretrained` / `from_pretrained` stays available without this
+  extra.
 
 Hyperparameter search is opt-in too: `langres.autoresearch.blocker_optimizer.BlockerOptimizer` (Optuna)
 tunes *blocker* parameters — see §5. A general `Optimizer` over full pipelines is
@@ -1248,7 +1252,31 @@ nothing; read a trail back with `RunStore(path).read()` (each `RunRecord`'s
 `metrics["accepted"]` is `1.0`/`0.0`, so the incumbent timeline is reconstructable
 from the store alone). `RunStore` is local-only by design; a durable off-laptop
 dashboard is available via `tracker="trackio"` (local-first; an HF Space/Dataset
-sync is a `space_id`/`HF_TOKEN` opt-in) -- models-on-Hub is not built. Still deferred: an Optuna/LLAMBO proposer and the matching vertical
+sync is a `space_id`/`HF_TOKEN` opt-in). A model's state-free configuration and
+bounded result summary can separately be shared through the pretrained Hub
+lifecycle below. Still deferred: an Optuna/LLAMBO proposer and the matching vertical
 (`log_loss` / AUC-PR steering) + fine-tuning. See
 [EXPERIMENTS.md](EXPERIMENTS.md#self-tuning-the-autoresearch-loop-langresoptimize)
 for the worked amazon_google proof and `examples/research/blocking_recall_autoresearch.py`.
+## Pretrained artifact lifecycle
+
+`ERModel.save_pretrained`, `ERModel.from_pretrained`, and
+`ERModel.push_to_hub` delegate lazily to `langres.hub`. They wrap the unchanged
+local `resolver.json` in a strict `langres-artifact.json` envelope containing an
+exact regular-file allowlist, sizes, SHA-256 checksums, resource `ModelRef`
+facts, compatibility metadata, and an optional bounded measurement summary.
+The first artifact version is deliberately state-free: it rejects Resolver
+sidecars because current sidecars can contain corpus rows, compiled prompts, or
+native binary state. In-place overwrite is also refused; publish a new validated
+directory or Hub commit and then switch the reference.
+Prompt-bearing JSON configuration is also excluded by default. Publishing it
+requires an explicit `allow_sensitive_config=True`, after which the manifest and
+model card disclose that prompts are included.
+
+Remote loading resolves the requested Hub revision to an immutable commit SHA
+before downloading the exact manifest-derived allowlist. The snapshot is fully
+validated and its registered component/operation types are preflighted before
+`ERModel.load` reconstructs anything. The loader accepts the same langres minor
+release (patches may differ), ignores repository files outside the manifest
+without downloading them, and never serializes Hub tokens or raw experiment
+data. See `docs/HUGGING_FACE.md`.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -99,6 +99,7 @@ nav:
   - Tutorial - Your Own CSV: TUTORIAL_YOUR_OWN_CSV.md
   - Technical Overview: TECHNICAL_OVERVIEW.md
   - Experiments: EXPERIMENTS.md
+  - Hugging Face: HUGGING_FACE.md
   - Benchmarks: BENCHMARKS.md
   - Adding a Method: ADDING_A_METHOD.md
   - Use Cases: USE_CASES.md

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -124,6 +124,12 @@ wandb = [
 trackio = [
     "trackio>=0.20,<1",
 ]
+# Direct Hub lifecycle dependency. Do not rely on Trackio or the semantic stack
+# to install this transitively: local save/load remains client-free, while
+# remote from_pretrained/push_to_hub imports it lazily.
+hub = [
+    "huggingface-hub>=0.34,<2",
+]
 
 [build-system]
 requires = ["hatchling"]

--- a/src/langres/_pretrained_artifact.py
+++ b/src/langres/_pretrained_artifact.py
@@ -68,6 +68,10 @@ _RESOURCE_COMPONENTS: dict[str, tuple[str, str]] = {
     "dspy_judge": ("model", "llm"),
     "select_judge": ("model", "llm"),
 }
+_OPTIONAL_COMPONENT_EXTRAS: dict[str, str] = {
+    "calibrator": "trained",
+    "random_forest": "trained",
+}
 _HF_MODEL_NAME_COMPONENTS = frozenset(
     {
         "fastembed_sparse_embedder",
@@ -76,6 +80,12 @@ _HF_MODEL_NAME_COMPONENTS = frozenset(
 )
 _INPROCESS_LLM_COMPONENTS = frozenset({"llm_judge", "resource_transformers_llm"})
 _HF_REPO_ID = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._-]{0,95}/[A-Za-z0-9][A-Za-z0-9._-]{0,95}$")
+_CREDENTIAL_KEY = re.compile(
+    r"(?:^|_)(?:api_key|access_token|auth|authorization|bearer|credential|"
+    r"credentials|authentication|cookie|openai_key|password|private_key|secret|"
+    r"set_cookie|signature|sig|subscription_key|token)(?:$|_)",
+    re.IGNORECASE,
+)
 
 
 class PretrainedArtifactError(ValueError):
@@ -408,6 +418,12 @@ def validate_bundle(root: Path) -> PretrainedManifest:
     resolver_manifest = ArtifactManifest.model_validate_json(
         (root / manifest.resolver_path).read_bytes()
     )
+    credential_paths = credential_config_paths(resolver_manifest)
+    if credential_paths:
+        raise PretrainedArtifactError(
+            "resolver.json contains credential-bearing transport configuration that cannot "
+            "be loaded from a pretrained artifact. Fields: " + ", ".join(credential_paths[:10])
+        )
     actual_refs, actual_extras = resource_facts(resolver_manifest)
     if actual_refs != manifest.model_refs or actual_extras != manifest.required_extras:
         raise PretrainedArtifactError("outer resource identity does not match resolver.json")
@@ -477,6 +493,35 @@ def sensitive_config_paths(resolver_manifest: ArtifactManifest) -> tuple[str, ..
     return tuple(sorted(set(found)))
 
 
+def credential_config_paths(resolver_manifest: ArtifactManifest) -> tuple[str, ...]:
+    """Find credentials embedded in serialized LiteLLM transport options."""
+    found: list[str] = []
+
+    def visit(value: object, path: str) -> None:
+        if isinstance(value, Mapping):
+            for key, nested in value.items():
+                key_text = str(key)
+                child = f"{path}.{key_text}"
+                normalized_key = re.sub(r"[^a-z0-9]+", "_", key_text.lower()).strip("_")
+                if (
+                    _CREDENTIAL_KEY.search(normalized_key) is not None
+                    and nested is not None
+                    and nested != ""
+                ):
+                    found.append(child)
+                visit(nested, child)
+        elif isinstance(value, (list, tuple)):
+            for index, nested in enumerate(value):
+                visit(nested, f"{path}[{index}]")
+
+    for index, spec in enumerate(component_specs(resolver_manifest)):
+        for field in ("provider", "extra_body"):
+            value = spec.config.get(field)
+            if value is not None:
+                visit(value, f"component[{index}].{spec.type_name}.{field}")
+    return tuple(sorted(set(found)))
+
+
 def resource_facts(
     resolver_manifest: ArtifactManifest,
 ) -> tuple[tuple[ModelRef, ...], tuple[str, ...]]:
@@ -486,6 +531,9 @@ def resource_facts(
     refs: list[ModelRef] = []
     extras: set[str] = set()
     for spec in expanded:
+        optional_extra = _OPTIONAL_COMPONENT_EXTRAS.get(spec.type_name)
+        if optional_extra is not None:
+            extras.add(optional_extra)
         metadata = _RESOURCE_COMPONENTS.get(spec.type_name)
         if metadata is None:
             if spec.type_name.startswith("resource_") or {
@@ -531,6 +579,13 @@ def build_manifest(
 ) -> PretrainedManifest:
     resolver = ArtifactManifest.model_validate_json((root / RESOLVER_MANIFEST).read_text())
     model_refs, extras = resource_facts(resolver)
+    credential_paths = credential_config_paths(resolver)
+    if credential_paths:
+        raise ArtifactEligibilityError(
+            "resolver.json contains credential-bearing transport configuration that cannot "
+            "be published. Remove these fields and inject credentials at runtime instead. "
+            "Fields: " + ", ".join(credential_paths[:10])
+        )
     sensitive_paths = sensitive_config_paths(resolver)
     if sensitive_paths and not allow_sensitive_config:
         raise ArtifactEligibilityError(

--- a/src/langres/_pretrained_artifact.py
+++ b/src/langres/_pretrained_artifact.py
@@ -661,10 +661,33 @@ def validate_remote_inventory(
             raise PretrainedArtifactError(f"remote metadata has unknown size for {item.path!r}")
         if remote_size != item.size:
             raise PretrainedArtifactError(f"remote metadata size mismatch for {item.path!r}")
+    metadata_limits = {
+        manifest.resolver_path: MAX_RESOLVER_BYTES,
+        manifest.model_card_path: MAX_CARD_BYTES,
+    }
+    if manifest.measurement_summary_path is not None:
+        metadata_limits[manifest.measurement_summary_path] = MAX_SUMMARY_BYTES
+    for relative, limit in metadata_limits.items():
+        remote_size = inventory[relative]
+        if remote_size is not None and remote_size > limit:
+            raise PretrainedArtifactError(
+                f"remote metadata file {relative!r} exceeds {limit} bytes"
+            )
     manifest_size = inventory[BUNDLE_MANIFEST]
     if manifest_size is None or manifest_size > MAX_MANIFEST_BYTES:
         raise PretrainedArtifactError("remote bundle manifest size is unknown or oversized")
     return tuple(sorted(expected))
+
+
+def validate_remote_manifest_inventory(inventory: Mapping[str, int | None]) -> None:
+    """Bound the bootstrap manifest before asking a Hub client to download it."""
+    if BUNDLE_MANIFEST not in inventory:
+        raise PretrainedArtifactError(
+            f"remote artifact inventory mismatch: missing={[BUNDLE_MANIFEST]}"
+        )
+    manifest_size = inventory[BUNDLE_MANIFEST]
+    if manifest_size is None or manifest_size > MAX_MANIFEST_BYTES:
+        raise PretrainedArtifactError("remote bundle manifest size is unknown or oversized")
 
 
 def copy_allowlisted_files(

--- a/src/langres/_pretrained_artifact.py
+++ b/src/langres/_pretrained_artifact.py
@@ -242,11 +242,17 @@ def _validate_benchmark_claim(
 
 
 def _version_minor(version: str) -> tuple[int, int]:
-    core = version.split("+", 1)[0].split("-", 1)[0]
-    parts = core.split(".")
-    if len(parts) != 3 or any(not part.isdigit() for part in parts):
+    parsed = re.fullmatch(
+        r"(?:\d+!)?"
+        r"(?P<major>0|[1-9]\d*)\.(?P<minor>0|[1-9]\d*)\.(?:0|[1-9]\d*)"
+        r"(?:(?:a|b|rc)\d+)?(?:\.post\d+)?(?:\.dev\d+)?"
+        r"(?:\+[A-Za-z0-9]+(?:[._-][A-Za-z0-9]+)*)?",
+        version,
+        flags=re.IGNORECASE,
+    )
+    if parsed is None:
         raise ValueError(f"unsupported langres version format {version!r}")
-    return int(parts[0]), int(parts[1])
+    return int(parsed["major"]), int(parsed["minor"])
 
 
 def _compatibility_for(version: str) -> str:
@@ -466,6 +472,8 @@ def sensitive_config_paths(resolver_manifest: ArtifactManifest) -> tuple[str, ..
 
     for index, spec in enumerate(component_specs(resolver_manifest)):
         visit(spec.config, f"component[{index}].{spec.type_name}")
+    for index, op_spec in enumerate(resolver_manifest.ops or ()):
+        visit(op_spec.params, f"op[{index}].{op_spec.role}")
     return tuple(sorted(set(found)))
 
 
@@ -482,6 +490,7 @@ def resource_facts(
         if metadata is None:
             if spec.type_name.startswith("resource_") or {
                 "model",
+                "model_name",
                 "model_ref",
             }.intersection(spec.config):
                 raise PretrainedArtifactError(

--- a/src/langres/_pretrained_artifact.py
+++ b/src/langres/_pretrained_artifact.py
@@ -1,0 +1,690 @@
+"""Pure contracts and validation helpers for shareable langres artifacts.
+
+The existing ``resolver.json`` remains the source of truth for model topology.
+This module adds a strict outer bundle envelope without changing those frozen
+local-persistence bytes.  It intentionally imports no Hub client.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import math
+import re
+from collections.abc import Iterable, Mapping
+from pathlib import Path, PurePosixPath
+from typing import Annotated, Literal
+
+from pydantic import (
+    BaseModel,
+    ConfigDict,
+    Field,
+    StringConstraints,
+    field_validator,
+    model_validator,
+)
+
+from langres._version import __version__ as LANGRES_VERSION
+from langres.core.model_ref import IN_PROCESS_KINDS, ModelRef, normalize_model_ref, to_config
+from langres.core.serialization import ArtifactManifest, ArtifactSource, ComponentSpec
+
+BUNDLE_VERSION = "1"
+BUNDLE_MANIFEST = "langres-artifact.json"
+MODEL_CARD = "README.md"
+MEASUREMENT_SUMMARY = "measurement-summary.json"
+RESOLVER_MANIFEST = "resolver.json"
+
+MAX_MANIFEST_BYTES = 1_000_000
+MAX_RESOLVER_BYTES = 10_000_000
+MAX_SUMMARY_BYTES = 1_000_000
+MAX_CARD_BYTES = 100_000
+MAX_FILES = 256
+MAX_FILE_BYTES = 2_000_000_000
+MAX_TOTAL_BYTES = 10_000_000_000
+MAX_CARD_TEXT = 20_000
+MAX_SUMMARY_ITEMS = 256
+
+Sha256 = Annotated[str, StringConstraints(pattern=r"^[0-9a-f]{64}$")]
+ClaimLevel = Literal["reference-only", "frozen-weights", "benchmark-reproducible"]
+JsonFact = str | int | float | bool | None
+
+_FIXED_ROOTS = frozenset(
+    {
+        RESOLVER_MANIFEST,
+        BUNDLE_MANIFEST,
+        MODEL_CARD,
+        MEASUREMENT_SUMMARY,
+    }
+)
+_RESOURCE_COMPONENTS: dict[str, tuple[str, str]] = {
+    "resource_sentence_transformer": ("model", "semantic"),
+    "resource_cross_encoder_reranker": ("model", "semantic"),
+    "resource_litellm": ("model", "llm"),
+    "resource_transformers_llm": ("model", "semantic"),
+    "sentence_transformer_embedder": ("model_ref", "semantic"),
+    "fastembed_sparse_embedder": ("model_name", "semantic"),
+    "fastembed_late_interaction_embedder": ("model_name", "semantic"),
+    "llm_judge": ("model", "llm"),
+    "dspy_judge": ("model", "llm"),
+    "select_judge": ("model", "llm"),
+}
+_HF_MODEL_NAME_COMPONENTS = frozenset(
+    {
+        "fastembed_sparse_embedder",
+        "fastembed_late_interaction_embedder",
+    }
+)
+_INPROCESS_LLM_COMPONENTS = frozenset({"llm_judge", "resource_transformers_llm"})
+_HF_REPO_ID = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._-]{0,95}/[A-Za-z0-9][A-Za-z0-9._-]{0,95}$")
+
+
+class PretrainedArtifactError(ValueError):
+    """A bundle is unsafe, malformed, incompatible, or incomplete."""
+
+
+class ArtifactEligibilityError(PretrainedArtifactError):
+    """The requested sharing claim is not supported by the supplied facts."""
+
+
+def safe_relative_path(value: str) -> str:
+    """Validate and normalize one manifest-owned POSIX relative path."""
+    if "\\" in value or "\x00" in value:
+        raise ValueError("artifact paths must be normalized POSIX paths")
+    path = PurePosixPath(value)
+    if not value or path.is_absolute() or any(part in {"", ".", ".."} for part in path.parts):
+        raise ValueError(f"unsafe artifact path {value!r}")
+    root = path.parts[0]
+    if root not in _FIXED_ROOTS:
+        raise ValueError(f"artifact path {value!r} is outside the state-free pretrained allowlist")
+    if (
+        root
+        in {
+            RESOLVER_MANIFEST,
+            BUNDLE_MANIFEST,
+            MODEL_CARD,
+            MEASUREMENT_SUMMARY,
+        }
+        and len(path.parts) != 1
+    ):
+        raise ValueError(f"artifact root file {root!r} cannot contain child paths")
+    return path.as_posix()
+
+
+class ArtifactFile(BaseModel):
+    """One exact regular file in the validated bundle."""
+
+    model_config = ConfigDict(frozen=True, extra="forbid", strict=True)
+
+    path: str
+    size: int = Field(ge=0, le=MAX_FILE_BYTES)
+    sha256: Sha256
+
+    @field_validator("path")
+    @classmethod
+    def _safe_path(cls, value: str) -> str:
+        return safe_relative_path(value)
+
+
+class ModelCardSpec(BaseModel):
+    """Human-authored facts required for a useful, honest model card."""
+
+    model_config = ConfigDict(frozen=True, extra="forbid", strict=True)
+
+    intended_use: str = "Research and evaluation of entity-resolution architectures with langres."
+    limitations: tuple[str, ...] = (
+        "Quality and latency depend on the dataset, thresholds, hardware, and serving setup.",
+    )
+
+    @field_validator("intended_use")
+    @classmethod
+    def _bounded_use(cls, value: str) -> str:
+        value = value.strip()
+        if not value or len(value) > 2_000:
+            raise ValueError("intended_use must contain 1..2000 characters")
+        return value
+
+    @field_validator("limitations")
+    @classmethod
+    def _bounded_limitations(cls, value: tuple[str, ...]) -> tuple[str, ...]:
+        if not value or len(value) > 32:
+            raise ValueError("limitations must contain 1..32 entries")
+        normalized = tuple(item.strip() for item in value)
+        if any(not item or len(item) > 1_000 for item in normalized):
+            raise ValueError("each limitation must contain 1..1000 characters")
+        return normalized
+
+
+class MeasurementSummary(BaseModel):
+    """Bounded publication facts; never raw records, prompts, or generations."""
+
+    model_config = ConfigDict(frozen=True, extra="forbid", strict=True, allow_inf_nan=False)
+
+    protocol_id: str | None = None
+    evaluation_id: str | None = None
+    dataset_ids: tuple[str, ...] = ()
+    quality: dict[str, JsonFact] = Field(default_factory=dict)
+    cost: dict[str, JsonFact] = Field(default_factory=dict)
+    tokens: dict[str, JsonFact] = Field(default_factory=dict)
+    performance: dict[str, JsonFact] = Field(default_factory=dict)
+    hardware: dict[str, JsonFact] = Field(default_factory=dict)
+    size: dict[str, JsonFact] = Field(default_factory=dict)
+
+    @model_validator(mode="after")
+    def _bounded(self) -> "MeasurementSummary":
+        mappings = (
+            self.quality,
+            self.cost,
+            self.tokens,
+            self.performance,
+            self.hardware,
+            self.size,
+        )
+        if sum(len(mapping) for mapping in mappings) > MAX_SUMMARY_ITEMS:
+            raise ValueError(f"measurement summary exceeds {MAX_SUMMARY_ITEMS} facts")
+        if len(self.dataset_ids) > 64:
+            raise ValueError("measurement summary exceeds 64 dataset ids")
+        for mapping in mappings:
+            for key, value in mapping.items():
+                if not key or len(key) > 200:
+                    raise ValueError("measurement fact keys must contain 1..200 characters")
+                if isinstance(value, float) and not math.isfinite(value):
+                    raise ValueError("measurement facts must be finite")
+                if isinstance(value, str) and len(value) > 2_000:
+                    raise ValueError("measurement string facts are limited to 2000 characters")
+        return self
+
+
+def _is_immutable_hf_ref(ref: ModelRef) -> bool:
+    if (
+        ref.kind != "hf"
+        or _HF_REPO_ID.fullmatch(ref.base) is None
+        or ref.revision is None
+        or re.fullmatch(r"[0-9a-f]{40}", ref.revision) is None
+    ):
+        return False
+    if ref.adapter is None:
+        return True
+    return (
+        _HF_REPO_ID.fullmatch(ref.adapter) is not None
+        and ref.adapter_revision is not None
+        and re.fullmatch(r"[0-9a-f]{40}", ref.adapter_revision) is not None
+    )
+
+
+def _validate_benchmark_claim(
+    model_refs: Iterable[ModelRef],
+    summary: MeasurementSummary | None,
+) -> None:
+    refs = tuple(model_refs)
+    if summary is None:
+        raise ArtifactEligibilityError("benchmark-reproducible requires a measurement summary")
+    if (
+        not summary.protocol_id
+        or not summary.evaluation_id
+        or not summary.dataset_ids
+        or not summary.quality
+    ):
+        raise ArtifactEligibilityError(
+            "benchmark-reproducible requires protocol_id, evaluation_id, dataset_ids, "
+            "and at least one quality metric"
+        )
+    if any(ref.kind != "hf" for ref in refs):
+        raise ArtifactEligibilityError(
+            "benchmark-reproducible supports only immutable Hugging Face resources; "
+            "API, endpoint, and local references must use claim_level='reference-only'"
+        )
+    if any(not _is_immutable_hf_ref(ref) for ref in refs):
+        raise ArtifactEligibilityError(
+            "benchmark-reproducible requires every base and adapter to be a full "
+            "'organization/repository' Hugging Face id pinned to an immutable "
+            "40-character commit SHA"
+        )
+
+
+def _version_minor(version: str) -> tuple[int, int]:
+    core = version.split("+", 1)[0].split("-", 1)[0]
+    parts = core.split(".")
+    if len(parts) != 3 or any(not part.isdigit() for part in parts):
+        raise ValueError(f"unsupported langres version format {version!r}")
+    return int(parts[0]), int(parts[1])
+
+
+def _compatibility_for(version: str) -> str:
+    major, minor = _version_minor(version)
+    return f">={major}.{minor}.0,<{major}.{minor + 1}.0"
+
+
+class PretrainedManifest(BaseModel):
+    """Strict outer envelope for one unchanged Resolver artifact."""
+
+    model_config = ConfigDict(frozen=True, extra="forbid", strict=True)
+
+    bundle_version: Literal["1"] = "1"
+    langres_version: str = LANGRES_VERSION
+    langres_compatibility: str
+    resolver_path: Literal["resolver.json"] = "resolver.json"
+    claim_level: ClaimLevel = "reference-only"
+    required_extras: tuple[str, ...] = ()
+    model_refs: tuple[ModelRef, ...] = ()
+    sensitive_config_included: bool = False
+    measurement_summary_path: Literal["measurement-summary.json"] | None = None
+    model_card_path: Literal["README.md"] = "README.md"
+    files: tuple[ArtifactFile, ...]
+
+    @model_validator(mode="after")
+    def _coherent(self) -> "PretrainedManifest":
+        expected_compatibility = _compatibility_for(self.langres_version)
+        if self.langres_compatibility != expected_compatibility:
+            raise ValueError(
+                "langres_compatibility must be the conservative minor-version interval "
+                f"{expected_compatibility!r}"
+            )
+        if _version_minor(LANGRES_VERSION) != _version_minor(self.langres_version):
+            raise PretrainedArtifactError(
+                f"artifact requires langres {self.langres_compatibility}; "
+                f"installed version is {LANGRES_VERSION}"
+            )
+        paths = [item.path for item in self.files]
+        if len(paths) != len(set(paths)):
+            raise ValueError("artifact manifest contains duplicate file paths")
+        required = {self.resolver_path, self.model_card_path}
+        if self.measurement_summary_path is not None:
+            required.add(self.measurement_summary_path)
+        missing = required.difference(paths)
+        if missing:
+            raise ValueError(f"artifact manifest is missing required files: {sorted(missing)}")
+        if len(self.files) > MAX_FILES:
+            raise ValueError(f"artifact exceeds {MAX_FILES} files")
+        if sum(item.size for item in self.files) > MAX_TOTAL_BYTES:
+            raise ValueError(f"artifact exceeds {MAX_TOTAL_BYTES} total bytes")
+        if self.claim_level == "frozen-weights":
+            raise ArtifactEligibilityError(
+                "frozen-weights is not supported yet: local resource paths are not copied "
+                "and rebased into the bundle. Use claim_level='reference-only'."
+            )
+        if self.claim_level == "benchmark-reproducible":
+            if self.measurement_summary_path is None:
+                raise ArtifactEligibilityError(
+                    "benchmark-reproducible requires a measurement summary"
+                )
+            mutable = [ref for ref in self.model_refs if ref.kind != "hf"]
+            if mutable:
+                raise ArtifactEligibilityError(
+                    "benchmark-reproducible supports only immutable Hugging Face resources; "
+                    "API, endpoint, and local references must use claim_level='reference-only'"
+                )
+            if any(not _is_immutable_hf_ref(ref) for ref in self.model_refs):
+                raise ArtifactEligibilityError(
+                    "benchmark-reproducible requires every base and adapter to be a full "
+                    "'organization/repository' Hugging Face id pinned to an immutable "
+                    "40-character commit SHA"
+                )
+        return self
+
+
+def sha256_file(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as handle:
+        for chunk in iter(lambda: handle.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def _iter_regular_files(root: Path, *, exclude_manifest: bool = True) -> list[ArtifactFile]:
+    files: list[ArtifactFile] = []
+    for candidate in sorted(root.rglob("*")):
+        relative = candidate.relative_to(root).as_posix()
+        if exclude_manifest and relative == BUNDLE_MANIFEST:
+            continue
+        if candidate.is_symlink():
+            raise PretrainedArtifactError(f"artifact contains a symlink: {relative}")
+        if candidate.is_dir():
+            continue
+        if not candidate.is_file():
+            raise PretrainedArtifactError(f"artifact contains a non-regular file: {relative}")
+        safe_relative_path(relative)
+        stat = candidate.stat()
+        if stat.st_size > MAX_FILE_BYTES:
+            raise PretrainedArtifactError(
+                f"artifact file {relative!r} exceeds {MAX_FILE_BYTES} bytes"
+            )
+        files.append(ArtifactFile(path=relative, size=stat.st_size, sha256=sha256_file(candidate)))
+    if len(files) > MAX_FILES:
+        raise PretrainedArtifactError(f"artifact exceeds {MAX_FILES} files")
+    if sum(item.size for item in files) > MAX_TOTAL_BYTES:
+        raise PretrainedArtifactError(f"artifact exceeds {MAX_TOTAL_BYTES} total bytes")
+    return files
+
+
+def read_manifest(path: Path) -> PretrainedManifest:
+    data = path.read_bytes()
+    if len(data) > MAX_MANIFEST_BYTES:
+        raise PretrainedArtifactError(f"{BUNDLE_MANIFEST} exceeds {MAX_MANIFEST_BYTES} bytes")
+    try:
+        return PretrainedManifest.model_validate_json(data)
+    except Exception as exc:
+        if isinstance(exc, ArtifactEligibilityError):
+            raise
+        raise PretrainedArtifactError(f"invalid {BUNDLE_MANIFEST}: {exc}") from None
+
+
+def validate_bundle(root: Path) -> PretrainedManifest:
+    """Validate the full tree and checksums before component reconstruction."""
+    if root.is_symlink() or not root.is_dir():
+        raise PretrainedArtifactError(f"artifact root must be a regular directory: {root}")
+    manifest_path = root / BUNDLE_MANIFEST
+    if manifest_path.is_symlink() or not manifest_path.is_file():
+        raise PretrainedArtifactError(f"artifact is missing regular {BUNDLE_MANIFEST}")
+    manifest = read_manifest(manifest_path)
+    actual = {item.path: item for item in _iter_regular_files(root)}
+    expected = {item.path: item for item in manifest.files}
+    if actual.keys() != expected.keys():
+        raise PretrainedArtifactError(
+            "artifact file allowlist mismatch: "
+            f"missing={sorted(expected.keys() - actual.keys())}, "
+            f"unexpected={sorted(actual.keys() - expected.keys())}"
+        )
+    for relative, expected_file in expected.items():
+        actual_file = actual[relative]
+        if actual_file.size != expected_file.size or actual_file.sha256 != expected_file.sha256:
+            raise PretrainedArtifactError(f"artifact checksum/size mismatch for {relative!r}")
+    bounded_metadata = {
+        manifest.resolver_path: MAX_RESOLVER_BYTES,
+        manifest.model_card_path: MAX_CARD_BYTES,
+    }
+    if manifest.measurement_summary_path is not None:
+        bounded_metadata[manifest.measurement_summary_path] = MAX_SUMMARY_BYTES
+    for relative, limit in bounded_metadata.items():
+        if expected[relative].size > limit:
+            raise PretrainedArtifactError(
+                f"artifact metadata file {relative!r} exceeds {limit} bytes"
+            )
+    resolver_manifest = ArtifactManifest.model_validate_json(
+        (root / manifest.resolver_path).read_bytes()
+    )
+    actual_refs, actual_extras = resource_facts(resolver_manifest)
+    if actual_refs != manifest.model_refs or actual_extras != manifest.required_extras:
+        raise PretrainedArtifactError("outer resource identity does not match resolver.json")
+    actual_sensitive = bool(sensitive_config_paths(resolver_manifest))
+    if actual_sensitive != manifest.sensitive_config_included:
+        raise PretrainedArtifactError(
+            "outer sensitive-config declaration does not match resolver.json"
+        )
+    summary: MeasurementSummary | None = None
+    if manifest.measurement_summary_path is not None:
+        try:
+            summary = MeasurementSummary.model_validate_json(
+                (root / manifest.measurement_summary_path).read_bytes()
+            )
+        except Exception as exc:
+            raise PretrainedArtifactError(f"invalid measurement summary: {exc}") from None
+    if manifest.claim_level == "benchmark-reproducible":
+        _validate_benchmark_claim(manifest.model_refs, summary)
+    return manifest
+
+
+def component_specs(resolver_manifest: ArtifactManifest) -> tuple[ComponentSpec, ...]:
+    """Return top-level and recursively nested component specs."""
+    specs = list(resolver_manifest.components)
+    if resolver_manifest.ops is not None:
+        specs.extend(spec.component for spec in resolver_manifest.ops if spec.component is not None)
+
+    def nested_specs(value: object) -> Iterable[ComponentSpec]:
+        if isinstance(value, Mapping):
+            if isinstance(value.get("type_name"), str) and isinstance(value.get("config"), Mapping):
+                nested = ComponentSpec.model_validate(value)
+                yield nested
+                yield from nested_specs(nested.config)
+                return
+            for nested_value in value.values():
+                yield from nested_specs(nested_value)
+        elif isinstance(value, (list, tuple)):
+            for nested_value in value:
+                yield from nested_specs(nested_value)
+
+    expanded: list[ComponentSpec] = []
+    for spec in specs:
+        expanded.append(spec)
+        expanded.extend(nested_specs(spec.config))
+    return tuple(expanded)
+
+
+def sensitive_config_paths(resolver_manifest: ArtifactManifest) -> tuple[str, ...]:
+    """Find serialized prompt-bearing fields that require explicit publication consent."""
+    found: list[str] = []
+
+    def visit(value: object, path: str) -> None:
+        if isinstance(value, Mapping):
+            for key, nested in value.items():
+                child = f"{path}.{key}" if path else str(key)
+                if "prompt" in str(key).lower() and nested is not None and nested != "":
+                    found.append(child)
+                visit(nested, child)
+        elif isinstance(value, (list, tuple)):
+            for index, nested in enumerate(value):
+                visit(nested, f"{path}[{index}]")
+
+    for index, spec in enumerate(component_specs(resolver_manifest)):
+        visit(spec.config, f"component[{index}].{spec.type_name}")
+    return tuple(sorted(set(found)))
+
+
+def resource_facts(
+    resolver_manifest: ArtifactManifest,
+) -> tuple[tuple[ModelRef, ...], tuple[str, ...]]:
+    """Extract model refs and install extras from every nested component."""
+    expanded = component_specs(resolver_manifest)
+
+    refs: list[ModelRef] = []
+    extras: set[str] = set()
+    for spec in expanded:
+        metadata = _RESOURCE_COMPONENTS.get(spec.type_name)
+        if metadata is None:
+            if spec.type_name.startswith("resource_") or {
+                "model",
+                "model_ref",
+            }.intersection(spec.config):
+                raise PretrainedArtifactError(
+                    f"model-bearing component {spec.type_name!r} has no explicit "
+                    "pretrained resource metadata; refusing to omit its identity"
+                )
+            continue
+        field, extra = metadata
+        raw = spec.config.get(field)
+        if spec.type_name == "sentence_transformer_embedder" and raw is None:
+            raw = {
+                "base": spec.config.get("model_name"),
+                "kind": "hf",
+            }
+        if spec.type_name in _HF_MODEL_NAME_COMPONENTS and isinstance(raw, str):
+            raw = {"base": raw, "kind": "hf"}
+        if raw is None:
+            raise PretrainedArtifactError(
+                f"resource component {spec.type_name!r} has no model identity"
+            )
+        ref = normalize_model_ref(raw)  # type: ignore[arg-type]
+        refs.append(ref)
+        extras.add(extra)
+        if spec.type_name in _INPROCESS_LLM_COMPONENTS and ref.kind in IN_PROCESS_KINDS:
+            extras.add("semantic")
+            if ref.adapter is not None:
+                extras.add("finetune")
+    unique = {json.dumps(to_config(ref), sort_keys=True): ref for ref in refs}
+    return tuple(unique[key] for key in sorted(unique)), tuple(sorted(extras))
+
+
+def build_manifest(
+    root: Path,
+    *,
+    claim_level: ClaimLevel,
+    measurement_summary: MeasurementSummary | None,
+    allow_sensitive_config: bool,
+) -> PretrainedManifest:
+    resolver = ArtifactManifest.model_validate_json((root / RESOLVER_MANIFEST).read_text())
+    model_refs, extras = resource_facts(resolver)
+    sensitive_paths = sensitive_config_paths(resolver)
+    if sensitive_paths and not allow_sensitive_config:
+        raise ArtifactEligibilityError(
+            "resolver.json contains prompt-bearing configuration that is excluded from upload "
+            "by default. Inspect it, then pass allow_sensitive_config=True to publish it. "
+            "Fields: " + ", ".join(sensitive_paths[:10])
+        )
+    if claim_level == "frozen-weights":
+        raise ArtifactEligibilityError(
+            "frozen-weights is not supported yet: local resource paths are not copied "
+            "and rebased into the bundle. Use claim_level='reference-only'."
+        )
+    if claim_level == "benchmark-reproducible":
+        _validate_benchmark_claim(model_refs, measurement_summary)
+    summary_path: Literal["measurement-summary.json"] | None = (
+        "measurement-summary.json" if measurement_summary is not None else None
+    )
+    return PretrainedManifest(
+        langres_compatibility=_compatibility_for(LANGRES_VERSION),
+        claim_level=claim_level,
+        required_extras=extras,
+        model_refs=model_refs,
+        sensitive_config_included=bool(sensitive_paths),
+        measurement_summary_path=summary_path,
+        files=tuple(_iter_regular_files(root)),
+    )
+
+
+def render_model_card(
+    manifest: PretrainedManifest,
+    card: ModelCardSpec,
+    summary: MeasurementSummary | None,
+) -> str:
+    """Render deterministic, bounded Markdown from explicitly selected facts."""
+    refs = (
+        "\n".join(
+            f"- `{ref.base}` ({ref.kind}, revision={ref.revision or 'unpinned'})"
+            for ref in manifest.model_refs
+        )
+        or "- No typed model resources recorded."
+    )
+    limitations = "\n".join(f"- {item}" for item in card.limitations)
+    metrics = ""
+    if summary is not None:
+        identity = (
+            f"- Protocol: `{summary.protocol_id or 'unspecified'}`\n"
+            f"- Evaluation: `{summary.evaluation_id or 'unspecified'}`\n"
+            "- Datasets: "
+            + (
+                ", ".join(f"`{dataset}`" for dataset in summary.dataset_ids)
+                if summary.dataset_ids
+                else "unspecified"
+            )
+        )
+        facts: list[str] = []
+        for section in ("quality", "cost", "tokens", "performance", "hardware", "size"):
+            values = getattr(summary, section)
+            if values:
+                facts.append(
+                    f"### {section.title()}\n\n"
+                    + "\n".join(f"- `{key}`: {values[key]}" for key in sorted(values))
+                )
+        metrics = (
+            "\n\n## Measurement summary\n\n"
+            + identity
+            + "\n\n"
+            + ("\n\n".join(facts) if facts else "No numeric facts supplied.")
+        )
+    text = (
+        "# langres entity-resolution artifact\n\n"
+        f"**Claim level:** `{manifest.claim_level}`\n\n"
+        f"**Prompt-bearing configuration included:** "
+        f"`{str(manifest.sensitive_config_included).lower()}`\n\n"
+        "## Intended use\n\n"
+        f"{card.intended_use}\n\n"
+        "## Model resources\n\n"
+        f"{refs}\n\n"
+        "## Limitations\n\n"
+        f"{limitations}"
+        f"{metrics}\n"
+    )
+    if len(text) > MAX_CARD_TEXT:
+        raise PretrainedArtifactError(f"generated model card exceeds {MAX_CARD_TEXT} characters")
+    return text
+
+
+def dump_summary(path: Path, summary: MeasurementSummary) -> None:
+    path.write_text(summary.model_dump_json(indent=2) + "\n")
+
+
+def preflight_resolver_manifest(path: Path) -> None:
+    """Resolve every registered type before ERModel.load constructs anything."""
+    from langres.core.registry import (
+        get_component,
+        get_model,
+        get_op_serializer,
+    )
+
+    manifest = ArtifactManifest.model_validate_json(path.read_bytes())
+    try:
+        if manifest.model_class is not None:
+            get_model(manifest.model_class)
+        for spec in component_specs(manifest):
+            get_component(spec.type_name)
+        for op in manifest.ops or ():
+            get_op_serializer(op.role)
+    except Exception as exc:
+        raise PretrainedArtifactError(
+            "artifact references an unavailable registered type. Install the package/extra "
+            f"that owns it and register it before loading. Cause: {exc}"
+        ) from None
+
+
+def validate_remote_inventory(
+    manifest: PretrainedManifest,
+    inventory: Mapping[str, int | None],
+) -> tuple[str, ...]:
+    """Validate Hub metadata before downloading the full snapshot."""
+    expected = {BUNDLE_MANIFEST, *(item.path for item in manifest.files)}
+    missing = expected.difference(inventory)
+    if missing:
+        raise PretrainedArtifactError(
+            f"remote artifact inventory mismatch: missing={sorted(missing)}"
+        )
+    for item in manifest.files:
+        remote_size = inventory[item.path]
+        if remote_size is None:
+            raise PretrainedArtifactError(f"remote metadata has unknown size for {item.path!r}")
+        if remote_size != item.size:
+            raise PretrainedArtifactError(f"remote metadata size mismatch for {item.path!r}")
+    manifest_size = inventory[BUNDLE_MANIFEST]
+    if manifest_size is None or manifest_size > MAX_MANIFEST_BYTES:
+        raise PretrainedArtifactError("remote bundle manifest size is unknown or oversized")
+    return tuple(sorted(expected))
+
+
+def copy_allowlisted_files(
+    source: Path,
+    destination: Path,
+    paths: Iterable[str],
+) -> None:
+    """Copy exact validated paths out of a client download directory."""
+    import shutil
+
+    if source.is_symlink() or not source.is_dir():
+        raise PretrainedArtifactError("download root must be a regular directory")
+    destination.mkdir(parents=True, exist_ok=False)
+    for relative in paths:
+        safe_relative_path(relative)
+        src = source.joinpath(*PurePosixPath(relative).parts)
+        relative_path = src.relative_to(source)
+        ancestors = [
+            source.joinpath(*relative_path.parts[:index])
+            for index in range(1, len(relative_path.parts))
+        ]
+        if (
+            any(parent.is_symlink() for parent in ancestors)
+            or src.is_symlink()
+            or not src.is_file()
+        ):
+            raise PretrainedArtifactError(
+                f"downloaded artifact path {relative!r} is missing, a symlink, or non-regular"
+            )
+        dest = destination.joinpath(*PurePosixPath(relative).parts)
+        dest.parent.mkdir(parents=True, exist_ok=True)
+        shutil.copyfile(src, dest)

--- a/src/langres/core/_model_persist.py
+++ b/src/langres/core/_model_persist.py
@@ -91,8 +91,9 @@ class ModelPersistence(ModelState):
         transport: object | None = None,
     ) -> Any:
         """Load a local or immutable Hub bundle through the safe outer manifest."""
-        from_pretrained = _hub_callable("from_pretrained")
+        from_pretrained = _hub_callable("_from_pretrained_as")
         model = from_pretrained(
+            cls,
             repo_or_path,
             revision=revision,
             token=token,

--- a/src/langres/core/_model_persist.py
+++ b/src/langres/core/_model_persist.py
@@ -12,9 +12,10 @@ no pickle**: every slot is rebuilt from the component registry by its
 ``type_name``.
 """
 
+import importlib
 import logging
 from pathlib import Path
-from typing import Any
+from typing import Any, Callable, cast
 
 from langres._version import __version__ as LANGRES_VERSION
 from langres.core._artifacts import (
@@ -40,8 +41,77 @@ logger = logging.getLogger(__name__)
 _MANIFEST_FILENAME = "resolver.json"
 
 
+def _hub_callable(name: str) -> Callable[..., Any]:
+    """Resolve one outer Hub adapter function without a core -> Hub import edge."""
+    function = getattr(importlib.import_module("langres.hub"), name, None)
+    if not callable(function):
+        raise RuntimeError(f"langres.hub does not provide callable {name!r}")
+    return cast(Callable[..., Any], function)
+
+
 class ModelPersistence(ModelState):
     """``save`` / ``load`` / ``config_dict`` for an ``ERModel``."""
+
+    def save_pretrained(
+        self,
+        path: str | Path,
+        *,
+        measurement_summary: object | None = None,
+        model_card: object | None = None,
+        claim_level: str = "reference-only",
+        allow_sensitive_config: bool = False,
+        overwrite: bool = False,
+    ) -> Path:
+        """Write a validated shareable bundle using the optional Hub lifecycle.
+
+        Dispatch is resolved only when called, so local Resolver construction
+        and ``import langres`` never import the Hub adapter or optional client.
+        """
+        save_pretrained = _hub_callable("save_pretrained")
+        return cast(
+            Path,
+            save_pretrained(
+                self,
+                path,
+                measurement_summary=measurement_summary,
+                model_card=model_card,
+                claim_level=claim_level,
+                allow_sensitive_config=allow_sensitive_config,
+                overwrite=overwrite,
+            ),
+        )
+
+    @classmethod
+    def from_pretrained(
+        cls,
+        repo_or_path: str | Path,
+        *,
+        revision: str | None = None,
+        token: str | None = None,
+        transport: object | None = None,
+    ) -> Any:
+        """Load a local or immutable Hub bundle through the safe outer manifest."""
+        from_pretrained = _hub_callable("from_pretrained")
+        model = from_pretrained(
+            repo_or_path,
+            revision=revision,
+            token=token,
+            transport=transport,
+        )
+        if not isinstance(model, cls):
+            raise TypeError(
+                f"artifact reconstructed {type(model).__name__}, not requested {cls.__name__}"
+            )
+        return model
+
+    def push_to_hub(
+        self,
+        repo_id: str,
+        **kwargs: object,
+    ) -> Any:
+        """Build and upload a fresh validated bundle through a lazy Hub transport."""
+        push_to_hub = _hub_callable("push_to_hub")
+        return push_to_hub(self, repo_id, **kwargs)
 
     def _slots(self) -> list[tuple[str, object]]:
         """Ordered (slot_name, component) pairs, skipping absent optional slots.

--- a/src/langres/core/_model_state.py
+++ b/src/langres/core/_model_state.py
@@ -41,6 +41,7 @@ from langres.core.op import (
 )
 from langres.core.spend import SpendMonitor
 from langres.core.spend_cap import SpendCappedMatcher, effective_budget
+from langres.core.serialization import ArtifactSource
 
 logger = logging.getLogger(__name__)
 
@@ -157,6 +158,10 @@ class ModelState:
         # Set by fit(); the sklearn trailing-underscore "produced by fit" digest.
         # None until fit() runs (never serialized -- it is a fit-time artifact).
         self.fit_report_: FitReport | None = None
+        # Runtime provenance for models loaded through langres.hub. Kept out of
+        # resolver.json/config identity: the artifact's repository revision is
+        # provenance, while resource ModelRef revisions remain model identity.
+        self.pretrained_source_: ArtifactSource | None = None
         # Slots start empty so a named architecture can defer binding until it
         # knows the schema (see _topology). The base __init__ fills them at once.
         #

--- a/src/langres/core/serialization.py
+++ b/src/langres/core/serialization.py
@@ -21,10 +21,11 @@ adapters (``op_spec`` / ``rebuild_op``, which reach into those modules) live in
 data contract stays a dependency-free leaf.
 """
 
+import re
 from pathlib import Path
-from typing import Protocol, runtime_checkable
+from typing import Literal, Protocol, runtime_checkable
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, ConfigDict, Field, model_validator
 
 #: The **classic four-slot** on-disk layout, frozen at ``"1"``. A classic
 #: (``self._ops is None``) save always stamps this, so its bytes — and the
@@ -38,6 +39,33 @@ CLASSIC_ARTIFACT_VERSION = "1"
 #: (#193, persist v2). The reader accepts any layout in ``[1, ARTIFACT_VERSION]``;
 #: only an explicit-chain (``self._ops is not None``) save stamps ``"2"``.
 ARTIFACT_VERSION = "2"
+
+
+class ArtifactSource(BaseModel):
+    """Runtime provenance for a locally or remotely loaded model artifact.
+
+    This is pure data, not a Hub transport contract. Keeping it beside the
+    existing artifact manifests lets core expose typed provenance without a
+    dependency on ``langres.hub`` or its optional client.
+    """
+
+    model_config = ConfigDict(frozen=True, extra="forbid", strict=True)
+
+    kind: Literal["local", "hub"]
+    location: str
+    requested_revision: str | None = None
+    resolved_revision: str | None = None
+
+    @model_validator(mode="after")
+    def _hub_is_pinned(self) -> "ArtifactSource":
+        if not self.location.strip():
+            raise ValueError("artifact source location must be non-empty")
+        if self.kind == "hub" and (
+            self.resolved_revision is None
+            or re.fullmatch(r"[0-9a-f]{40}", self.resolved_revision) is None
+        ):
+            raise ValueError("Hub artifact sources require an immutable 40-character commit SHA")
+        return self
 
 
 @runtime_checkable

--- a/src/langres/hub.py
+++ b/src/langres/hub.py
@@ -32,6 +32,7 @@ from langres._pretrained_artifact import (
     read_manifest,
     render_model_card,
     validate_bundle,
+    validate_remote_manifest_inventory,
     validate_remote_inventory,
 )
 from langres.core.resolver import ERModel
@@ -427,6 +428,7 @@ def _remote_from_pretrained(
     inventory = {item.path: item.size for item in remote.files}
     if len(inventory) != len(remote.files):
         raise PretrainedArtifactError("remote repository metadata contains duplicate paths")
+    validate_remote_manifest_inventory(inventory)
     with tempfile.TemporaryDirectory(prefix="langres-hub-") as temp:
         temp_root = Path(temp)
         bootstrap = temp_root / "bootstrap"

--- a/src/langres/hub.py
+++ b/src/langres/hub.py
@@ -7,6 +7,7 @@ The Hub client is an optional transport. Local ``save_pretrained`` and
 
 from __future__ import annotations
 
+import re
 import shutil
 import tempfile
 from collections.abc import Sequence
@@ -479,6 +480,11 @@ def from_pretrained(
             source=ArtifactSource(kind="local", location=str(candidate.absolute())),
         )
     if isinstance(repo_or_path, Path):
+        raise FileNotFoundError(f"local pretrained artifact does not exist: {candidate}")
+    if (
+        str(repo_or_path).startswith((".", "~", "/", "\\"))
+        or re.match(r"^[A-Za-z]:[\\/]", str(repo_or_path)) is not None
+    ):
         raise FileNotFoundError(f"local pretrained artifact does not exist: {candidate}")
     resolved_transport = transport or HuggingFaceHubTransport()
     return _remote_from_pretrained(

--- a/src/langres/hub.py
+++ b/src/langres/hub.py
@@ -1,0 +1,554 @@
+"""Safe local and Hugging Face lifecycle for langres pretrained artifacts.
+
+The Hub client is an optional transport. Local ``save_pretrained`` and
+``from_pretrained`` use only stdlib/Pydantic and the existing Resolver loader;
+``huggingface_hub`` is imported only when a remote operation is requested.
+"""
+
+from __future__ import annotations
+
+import shutil
+import tempfile
+from collections.abc import Sequence
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Protocol, runtime_checkable
+
+from langres._pretrained_artifact import (
+    BUNDLE_MANIFEST,
+    MODEL_CARD,
+    RESOLVER_MANIFEST,
+    ArtifactEligibilityError,
+    ClaimLevel,
+    MeasurementSummary,
+    ModelCardSpec,
+    PretrainedArtifactError,
+    PretrainedManifest,
+    build_manifest,
+    copy_allowlisted_files,
+    dump_summary,
+    preflight_resolver_manifest,
+    read_manifest,
+    render_model_card,
+    validate_bundle,
+    validate_remote_inventory,
+)
+from langres.core.resolver import ERModel
+from langres.core.serialization import ArtifactSource
+
+
+def _missing_hub_extra() -> PretrainedArtifactError:
+    return PretrainedArtifactError(
+        "Remote Hugging Face operations require the optional Hub client. "
+        "Install it with: pip install 'langres[hub]'"
+    )
+
+
+def _provider_error(
+    action: str,
+    repo_id: str,
+    *,
+    revision: str | None,
+    cause: Exception,
+) -> PretrainedArtifactError:
+    detail = f" at revision {revision!r}" if revision is not None else ""
+    return PretrainedArtifactError(
+        f"Hugging Face {action} failed for repository {repo_id!r}{detail} ({type(cause).__name__})"
+    )
+
+
+@dataclass(frozen=True)
+class RemoteFile:
+    """One path/size fact returned by remote repository metadata."""
+
+    path: str
+    size: int | None
+
+
+@dataclass(frozen=True)
+class RemoteRepository:
+    """Resolved immutable repository metadata."""
+
+    repo_id: str
+    requested_revision: str | None
+    resolved_revision: str
+    files: tuple[RemoteFile, ...]
+
+
+@dataclass(frozen=True)
+class UploadResult:
+    """Transport-neutral result of one atomic Hub commit."""
+
+    repo_id: str
+    revision: str
+    commit_oid: str
+    url: str
+
+
+@runtime_checkable
+class HubTransport(Protocol):
+    """Minimal injected seam used by the real client and zero-network fakes."""
+
+    def resolve(
+        self,
+        repo_id: str,
+        *,
+        revision: str | None,
+        token: str | None,
+    ) -> RemoteRepository:
+        """Resolve a moving revision to an immutable commit and file inventory."""
+        ...
+
+    def snapshot_download(
+        self,
+        repo_id: str,
+        *,
+        revision: str,
+        local_dir: Path,
+        allow_patterns: Sequence[str],
+        token: str | None,
+    ) -> Path:
+        """Download only the exact allowlisted paths at one immutable commit."""
+        ...
+
+    def create_repo(
+        self,
+        repo_id: str,
+        *,
+        private: bool,
+        token: str | None,
+    ) -> str:
+        """Create or locate one model repository and return its canonical id."""
+        ...
+
+    def upload_folder(
+        self,
+        repo_id: str,
+        *,
+        folder_path: Path,
+        revision: str,
+        allow_patterns: Sequence[str],
+        commit_message: str,
+        commit_description: str | None,
+        parent_commit: str | None,
+        token: str | None,
+    ) -> UploadResult:
+        """Commit an exact validated bundle."""
+        ...
+
+
+class HuggingFaceHubTransport:
+    """Lazy adapter over the official ``huggingface_hub`` Python client."""
+
+    def resolve(
+        self,
+        repo_id: str,
+        *,
+        revision: str | None,
+        token: str | None,
+    ) -> RemoteRepository:
+        try:
+            from huggingface_hub import HfApi
+        except ModuleNotFoundError as exc:
+            raise _missing_hub_extra() from exc
+
+        try:
+            info = HfApi().model_info(
+                repo_id,
+                revision=revision,
+                files_metadata=True,
+                token=token,
+            )
+        except Exception as exc:
+            raise _provider_error(
+                "revision resolution",
+                repo_id,
+                revision=revision,
+                cause=exc,
+            ) from exc
+        if not info.sha:
+            raise PretrainedArtifactError(
+                f"Hugging Face did not return an immutable SHA for {repo_id!r}"
+            )
+        siblings = info.siblings or ()
+        return RemoteRepository(
+            repo_id=repo_id,
+            requested_revision=revision,
+            resolved_revision=info.sha,
+            files=tuple(RemoteFile(path=item.rfilename, size=item.size) for item in siblings),
+        )
+
+    def snapshot_download(
+        self,
+        repo_id: str,
+        *,
+        revision: str,
+        local_dir: Path,
+        allow_patterns: Sequence[str],
+        token: str | None,
+    ) -> Path:
+        try:
+            from huggingface_hub import snapshot_download
+        except ModuleNotFoundError as exc:
+            raise _missing_hub_extra() from exc
+
+        try:
+            result = snapshot_download(
+                repo_id,
+                repo_type="model",
+                revision=revision,
+                local_dir=local_dir,
+                allow_patterns=list(allow_patterns),
+                token=token,
+            )
+        except Exception as exc:
+            raise _provider_error(
+                "snapshot download",
+                repo_id,
+                revision=revision,
+                cause=exc,
+            ) from exc
+        return Path(result)
+
+    def create_repo(
+        self,
+        repo_id: str,
+        *,
+        private: bool,
+        token: str | None,
+    ) -> str:
+        try:
+            from huggingface_hub import HfApi
+        except ModuleNotFoundError as exc:
+            raise _missing_hub_extra() from exc
+
+        try:
+            result = HfApi().create_repo(
+                repo_id=repo_id,
+                repo_type="model",
+                private=private,
+                exist_ok=True,
+                token=token,
+            )
+        except Exception as exc:
+            raise _provider_error(
+                "repository creation",
+                repo_id,
+                revision=None,
+                cause=exc,
+            ) from exc
+        return str(getattr(result, "repo_id", repo_id))
+
+    def upload_folder(
+        self,
+        repo_id: str,
+        *,
+        folder_path: Path,
+        revision: str,
+        allow_patterns: Sequence[str],
+        commit_message: str,
+        commit_description: str | None,
+        parent_commit: str | None,
+        token: str | None,
+    ) -> UploadResult:
+        try:
+            from huggingface_hub import HfApi
+        except ModuleNotFoundError as exc:
+            raise _missing_hub_extra() from exc
+
+        try:
+            commit = HfApi().upload_folder(
+                repo_id=repo_id,
+                repo_type="model",
+                folder_path=folder_path,
+                revision=revision,
+                allow_patterns=list(allow_patterns),
+                commit_message=commit_message,
+                commit_description=commit_description,
+                parent_commit=parent_commit,
+                token=token,
+            )
+        except Exception as exc:
+            raise _provider_error(
+                "upload",
+                repo_id,
+                revision=revision,
+                cause=exc,
+            ) from exc
+        oid = getattr(commit, "oid", None)
+        if not isinstance(oid, str) or not oid:
+            raise PretrainedArtifactError("Hugging Face upload returned no commit OID")
+        return UploadResult(
+            repo_id=repo_id,
+            revision=revision,
+            commit_oid=oid,
+            url=str(commit),
+        )
+
+
+def _coerce_summary(
+    value: MeasurementSummary | dict[str, object] | None,
+) -> MeasurementSummary | None:
+    if value is None or isinstance(value, MeasurementSummary):
+        return value
+    return MeasurementSummary.model_validate(value)
+
+
+def _coerce_card(value: ModelCardSpec | dict[str, object] | None) -> ModelCardSpec:
+    if value is None:
+        return ModelCardSpec()
+    if isinstance(value, ModelCardSpec):
+        return value
+    return ModelCardSpec.model_validate(value)
+
+
+def _write_bundle(
+    model: ERModel,
+    root: Path,
+    *,
+    measurement_summary: MeasurementSummary | None,
+    model_card: ModelCardSpec,
+    claim_level: ClaimLevel,
+    allow_sensitive_config: bool,
+) -> PretrainedManifest:
+    model.save(root)
+    state_files = [
+        item.relative_to(root).as_posix()
+        for item in root.rglob("*")
+        if item.is_file() and item.name != RESOLVER_MANIFEST
+    ]
+    if state_files:
+        raise ArtifactEligibilityError(
+            "pretrained bundles are state-free and cannot publish Resolver sidecars, "
+            "because they may contain records, prompts, or native binary state. "
+            "Publish a fresh configuration-only model. Found: "
+            + ", ".join(sorted(state_files)[:10])
+        )
+    if measurement_summary is not None:
+        dump_summary(root / "measurement-summary.json", measurement_summary)
+
+    # Build once to derive resource identities for the card, then rebuild after
+    # writing the card so README is included in the exact file allowlist.
+    placeholder = root / MODEL_CARD
+    placeholder.write_text("")
+    manifest = build_manifest(
+        root,
+        claim_level=claim_level,
+        measurement_summary=measurement_summary,
+        allow_sensitive_config=allow_sensitive_config,
+    )
+    placeholder.write_text(render_model_card(manifest, model_card, measurement_summary))
+    manifest = build_manifest(
+        root,
+        claim_level=claim_level,
+        measurement_summary=measurement_summary,
+        allow_sensitive_config=allow_sensitive_config,
+    )
+    (root / BUNDLE_MANIFEST).write_text(manifest.model_dump_json(indent=2) + "\n")
+    validate_bundle(root)
+    preflight_resolver_manifest(root / RESOLVER_MANIFEST)
+    return manifest
+
+
+def _promote_directory(stage: Path, destination: Path, *, overwrite: bool) -> None:
+    destination.parent.mkdir(parents=True, exist_ok=True)
+    if not destination.exists():
+        stage.replace(destination)
+        return
+    suffix = (
+        " In-place overwrite is intentionally unsupported; publish to a new directory "
+        "and switch references after validation."
+        if overwrite
+        else ""
+    )
+    raise FileExistsError(f"{destination} already exists.{suffix}")
+
+
+def save_pretrained(
+    model: ERModel,
+    path: str | Path,
+    *,
+    measurement_summary: MeasurementSummary | dict[str, object] | None = None,
+    model_card: ModelCardSpec | dict[str, object] | None = None,
+    claim_level: ClaimLevel = "reference-only",
+    allow_sensitive_config: bool = False,
+    overwrite: bool = False,
+) -> Path:
+    """Write an atomic, validated bundle around the model's Resolver artifact."""
+    destination = Path(path).expanduser()
+    if destination.is_symlink():
+        raise PretrainedArtifactError(f"artifact destination cannot be a symlink: {destination}")
+    destination = destination.absolute()
+    summary = _coerce_summary(measurement_summary)
+    card = _coerce_card(model_card)
+    destination.parent.mkdir(parents=True, exist_ok=True)
+    stage = Path(tempfile.mkdtemp(prefix=f".{destination.name}.stage-", dir=destination.parent))
+    promoted = False
+    try:
+        _write_bundle(
+            model,
+            stage,
+            measurement_summary=summary,
+            model_card=card,
+            claim_level=claim_level,
+            allow_sensitive_config=allow_sensitive_config,
+        )
+        _promote_directory(stage, destination, overwrite=overwrite)
+        promoted = True
+    finally:
+        if not promoted and stage.exists():
+            shutil.rmtree(stage)
+    return destination
+
+
+def _load_local(path: Path, *, source: ArtifactSource) -> ERModel:
+    manifest = validate_bundle(path)
+    preflight_resolver_manifest(path / manifest.resolver_path)
+    model = ERModel.load(path)
+    model.pretrained_source_ = source
+    return model
+
+
+def _remote_from_pretrained(
+    repo_id: str,
+    *,
+    revision: str | None,
+    token: str | None,
+    transport: HubTransport,
+) -> ERModel:
+    remote = transport.resolve(repo_id, revision=revision, token=token)
+    source = ArtifactSource(
+        kind="hub",
+        location=repo_id,
+        requested_revision=revision,
+        resolved_revision=remote.resolved_revision,
+    )
+    inventory = {item.path: item.size for item in remote.files}
+    if len(inventory) != len(remote.files):
+        raise PretrainedArtifactError("remote repository metadata contains duplicate paths")
+    with tempfile.TemporaryDirectory(prefix="langres-hub-") as temp:
+        temp_root = Path(temp)
+        bootstrap = temp_root / "bootstrap"
+        downloaded = transport.snapshot_download(
+            repo_id,
+            revision=remote.resolved_revision,
+            local_dir=bootstrap,
+            allow_patterns=(BUNDLE_MANIFEST,),
+            token=token,
+        )
+        bootstrap_manifest = downloaded / BUNDLE_MANIFEST
+        if bootstrap_manifest.is_symlink() or not bootstrap_manifest.is_file():
+            raise PretrainedArtifactError(
+                f"bootstrap download did not return a regular {BUNDLE_MANIFEST}"
+            )
+        manifest = read_manifest(bootstrap_manifest)
+        allowlist = validate_remote_inventory(manifest, inventory)
+
+        snapshot = temp_root / "snapshot"
+        downloaded = transport.snapshot_download(
+            repo_id,
+            revision=remote.resolved_revision,
+            local_dir=snapshot,
+            allow_patterns=allowlist,
+            token=token,
+        )
+        clean = temp_root / "validated"
+        copy_allowlisted_files(downloaded, clean, allowlist)
+        return _load_local(
+            clean,
+            source=source,
+        )
+
+
+def from_pretrained(
+    repo_or_path: str | Path,
+    *,
+    revision: str | None = None,
+    token: str | None = None,
+    transport: HubTransport | None = None,
+) -> ERModel:
+    """Load a validated local bundle or an immutable allowlisted Hub snapshot."""
+    candidate = Path(repo_or_path).expanduser()
+    if candidate.exists():
+        if candidate.is_symlink():
+            raise PretrainedArtifactError(f"artifact root cannot be a symlink: {candidate}")
+        if revision is not None:
+            raise ValueError("revision is only valid for a Hub repo id, not a local path")
+        return _load_local(
+            candidate.absolute(),
+            source=ArtifactSource(kind="local", location=str(candidate.absolute())),
+        )
+    if isinstance(repo_or_path, Path):
+        raise FileNotFoundError(f"local pretrained artifact does not exist: {candidate}")
+    resolved_transport = transport or HuggingFaceHubTransport()
+    return _remote_from_pretrained(
+        str(repo_or_path),
+        revision=revision,
+        token=token,
+        transport=resolved_transport,
+    )
+
+
+def push_to_hub(
+    model: ERModel,
+    repo_id: str,
+    *,
+    private: bool = False,
+    revision: str = "main",
+    commit_message: str = "Upload langres pretrained artifact",
+    commit_description: str | None = None,
+    parent_commit: str | None = None,
+    token: str | None = None,
+    measurement_summary: MeasurementSummary | dict[str, object] | None = None,
+    model_card: ModelCardSpec | dict[str, object] | None = None,
+    claim_level: ClaimLevel = "reference-only",
+    allow_sensitive_config: bool = False,
+    transport: HubTransport | None = None,
+) -> UploadResult:
+    """Build a fresh validated bundle and upload only its exact allowlist."""
+    resolved_transport = transport or HuggingFaceHubTransport()
+    with tempfile.TemporaryDirectory(prefix="langres-push-") as temp:
+        bundle = Path(temp) / "artifact"
+        save_pretrained(
+            model,
+            bundle,
+            measurement_summary=measurement_summary,
+            model_card=model_card,
+            claim_level=claim_level,
+            allow_sensitive_config=allow_sensitive_config,
+        )
+        manifest = validate_bundle(bundle)
+        allowlist = tuple(sorted({BUNDLE_MANIFEST, *(item.path for item in manifest.files)}))
+        canonical_repo = resolved_transport.create_repo(
+            repo_id,
+            private=private,
+            token=token,
+        )
+        return resolved_transport.upload_folder(
+            canonical_repo,
+            folder_path=bundle,
+            revision=revision,
+            allow_patterns=allowlist,
+            commit_message=commit_message,
+            commit_description=commit_description,
+            parent_commit=parent_commit,
+            token=token,
+        )
+
+
+__all__ = [
+    "ArtifactEligibilityError",
+    "ArtifactSource",
+    "ClaimLevel",
+    "HubTransport",
+    "HuggingFaceHubTransport",
+    "MeasurementSummary",
+    "ModelCardSpec",
+    "PretrainedArtifactError",
+    "RemoteFile",
+    "RemoteRepository",
+    "UploadResult",
+    "from_pretrained",
+    "push_to_hub",
+    "save_pretrained",
+]

--- a/src/langres/hub.py
+++ b/src/langres/hub.py
@@ -403,10 +403,15 @@ def save_pretrained(
     return destination
 
 
-def _load_local(path: Path, *, source: ArtifactSource) -> ERModel:
+def _load_local(
+    path: Path,
+    *,
+    source: ArtifactSource,
+    model_cls: type[ERModel],
+) -> ERModel:
     manifest = validate_bundle(path)
     preflight_resolver_manifest(path / manifest.resolver_path)
-    model = ERModel.load(path)
+    model = model_cls.load(path)
     model.pretrained_source_ = source
     return model
 
@@ -417,6 +422,7 @@ def _remote_from_pretrained(
     revision: str | None,
     token: str | None,
     transport: HubTransport,
+    model_cls: type[ERModel],
 ) -> ERModel:
     remote = transport.resolve(repo_id, revision=revision, token=token)
     source = ArtifactSource(
@@ -460,17 +466,19 @@ def _remote_from_pretrained(
         return _load_local(
             clean,
             source=source,
+            model_cls=model_cls,
         )
 
 
-def from_pretrained(
+def _from_pretrained_as(
+    model_cls: type[ERModel],
     repo_or_path: str | Path,
     *,
     revision: str | None = None,
     token: str | None = None,
     transport: HubTransport | None = None,
 ) -> ERModel:
-    """Load a validated local bundle or an immutable allowlisted Hub snapshot."""
+    """Load a bundle through the class that owns the persistence method."""
     candidate = Path(repo_or_path).expanduser()
     if candidate.exists():
         if candidate.is_symlink():
@@ -480,6 +488,7 @@ def from_pretrained(
         return _load_local(
             candidate.absolute(),
             source=ArtifactSource(kind="local", location=str(candidate.absolute())),
+            model_cls=model_cls,
         )
     if isinstance(repo_or_path, Path):
         raise FileNotFoundError(f"local pretrained artifact does not exist: {candidate}")
@@ -494,6 +503,24 @@ def from_pretrained(
         revision=revision,
         token=token,
         transport=resolved_transport,
+        model_cls=model_cls,
+    )
+
+
+def from_pretrained(
+    repo_or_path: str | Path,
+    *,
+    revision: str | None = None,
+    token: str | None = None,
+    transport: HubTransport | None = None,
+) -> ERModel:
+    """Load a validated local bundle or an immutable allowlisted Hub snapshot."""
+    return _from_pretrained_as(
+        ERModel,
+        repo_or_path,
+        revision=revision,
+        token=token,
+        transport=transport,
     )
 
 

--- a/tests/hub/__init__.py
+++ b/tests/hub/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for the safe pretrained artifact lifecycle."""

--- a/tests/hub/conftest.py
+++ b/tests/hub/conftest.py
@@ -1,0 +1,122 @@
+from __future__ import annotations
+
+import shutil
+from collections.abc import Sequence
+from pathlib import Path
+
+import pytest
+from pydantic import BaseModel
+
+from langres.core.resolver import ERModel
+from langres.hub import RemoteFile, RemoteRepository, UploadResult
+
+
+class Entity(BaseModel):
+    id: str
+    name: str
+
+
+@pytest.fixture
+def model() -> ERModel:
+    return ERModel.from_schema(Entity)
+
+
+class FakeHubTransport:
+    """Filesystem-backed zero-network Hub transport."""
+
+    def __init__(self, root: Path, *, sha: str = "a" * 40) -> None:
+        self.root = root
+        self.sha = sha
+        self.repo_id: str | None = None
+        self.resolve_calls: list[tuple[str, str | None]] = []
+        self.download_calls: list[tuple[str, str, tuple[str, ...]]] = []
+        self.create_calls: list[tuple[str, bool]] = []
+        self.upload_calls: list[dict[str, object]] = []
+
+    def resolve(
+        self,
+        repo_id: str,
+        *,
+        revision: str | None,
+        token: str | None,
+    ) -> RemoteRepository:
+        del token
+        self.resolve_calls.append((repo_id, revision))
+        files = tuple(
+            RemoteFile(path=item.relative_to(self.root).as_posix(), size=item.stat().st_size)
+            for item in sorted(self.root.rglob("*"))
+            if item.is_file()
+        )
+        return RemoteRepository(
+            repo_id=repo_id,
+            requested_revision=revision,
+            resolved_revision=self.sha,
+            files=files,
+        )
+
+    def snapshot_download(
+        self,
+        repo_id: str,
+        *,
+        revision: str,
+        local_dir: Path,
+        allow_patterns: Sequence[str],
+        token: str | None,
+    ) -> Path:
+        del token
+        self.download_calls.append((repo_id, revision, tuple(allow_patterns)))
+        local_dir.mkdir(parents=True, exist_ok=True)
+        for relative in allow_patterns:
+            source = self.root / relative
+            destination = local_dir / relative
+            destination.parent.mkdir(parents=True, exist_ok=True)
+            shutil.copyfile(source, destination)
+        return local_dir
+
+    def create_repo(
+        self,
+        repo_id: str,
+        *,
+        private: bool,
+        token: str | None,
+    ) -> str:
+        del token
+        self.repo_id = repo_id
+        self.create_calls.append((repo_id, private))
+        self.root.mkdir(parents=True, exist_ok=True)
+        return repo_id
+
+    def upload_folder(
+        self,
+        repo_id: str,
+        *,
+        folder_path: Path,
+        revision: str,
+        allow_patterns: Sequence[str],
+        commit_message: str,
+        commit_description: str | None,
+        parent_commit: str | None,
+        token: str | None,
+    ) -> UploadResult:
+        del token
+        self.upload_calls.append(
+            {
+                "repo_id": repo_id,
+                "revision": revision,
+                "allow_patterns": tuple(allow_patterns),
+                "commit_message": commit_message,
+                "commit_description": commit_description,
+                "parent_commit": parent_commit,
+            }
+        )
+        for relative in allow_patterns:
+            source = folder_path / relative
+            destination = self.root / relative
+            destination.parent.mkdir(parents=True, exist_ok=True)
+            shutil.copyfile(source, destination)
+        return UploadResult(
+            repo_id=repo_id,
+            revision=revision,
+            commit_oid=self.sha,
+            url=f"https://huggingface.co/{repo_id}/commit/{self.sha}",
+        )

--- a/tests/hub/test_fake_lifecycle.py
+++ b/tests/hub/test_fake_lifecycle.py
@@ -1,0 +1,79 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from langres._pretrained_artifact import BUNDLE_MANIFEST
+from langres.core.resolver import ERModel
+from langres.hub import from_pretrained, push_to_hub
+
+from .conftest import FakeHubTransport
+
+
+def test_push_then_load_pins_revision_and_uses_exact_allowlist(
+    model: ERModel, tmp_path: Path
+) -> None:
+    remote = tmp_path / "remote"
+    transport = FakeHubTransport(remote)
+
+    result = push_to_hub(
+        model,
+        "acme/entity-resolver",
+        private=True,
+        revision="research",
+        commit_message="publish result",
+        commit_description="reproduction bundle",
+        parent_commit="b" * 40,
+        token="hf_secret",
+        transport=transport,
+    )
+    assert result.commit_oid == "a" * 40
+    assert transport.create_calls == [("acme/entity-resolver", True)]
+    upload = transport.upload_calls[0]
+    assert upload["revision"] == "research"
+    assert upload["parent_commit"] == "b" * 40
+    assert BUNDLE_MANIFEST in upload["allow_patterns"]
+    assert "hf_secret" not in repr(transport.__dict__)
+
+    loaded = from_pretrained(
+        "acme/entity-resolver",
+        revision="release-1",
+        token="hf_secret",
+        transport=transport,
+    )
+    assert loaded.config_dict() == model.config_dict()
+    assert loaded.pretrained_source_ is not None
+    assert loaded.pretrained_source_.requested_revision == "release-1"
+    assert loaded.pretrained_source_.resolved_revision == "a" * 40
+    assert transport.resolve_calls == [("acme/entity-resolver", "release-1")]
+    assert len(transport.download_calls) == 2
+    assert transport.download_calls[0][1] == "a" * 40
+    assert transport.download_calls[0][2] == (BUNDLE_MANIFEST,)
+    assert transport.download_calls[1][1] == "a" * 40
+    assert set(transport.download_calls[1][2]) == {
+        item.relative_to(remote).as_posix() for item in remote.rglob("*") if item.is_file()
+    }
+
+
+def test_model_method_push_uses_same_transport(model: ERModel, tmp_path: Path) -> None:
+    transport = FakeHubTransport(tmp_path / "remote")
+    result = model.push_to_hub("acme/method", transport=transport)
+    assert result.repo_id == "acme/method"
+
+
+def test_repeated_push_ignores_stale_files_outside_new_manifest(
+    model: ERModel, tmp_path: Path
+) -> None:
+    transport = FakeHubTransport(tmp_path / "remote")
+    push_to_hub(
+        model,
+        "acme/repeated",
+        measurement_summary={"quality": {"pair_f1": 0.9}},
+        transport=transport,
+    )
+    assert (transport.root / "measurement-summary.json").is_file()
+
+    push_to_hub(model, "acme/repeated", transport=transport)
+    loaded = from_pretrained("acme/repeated", transport=transport)
+
+    assert loaded.config_dict() == model.config_dict()
+    assert "measurement-summary.json" not in transport.download_calls[-1][2]

--- a/tests/hub/test_local.py
+++ b/tests/hub/test_local.py
@@ -23,7 +23,7 @@ from langres.core.resolver import ERModel
 from langres.hub import from_pretrained, save_pretrained
 from langres.resources import Generate, Parse, TransformersLLM
 
-from .conftest import Entity
+from .conftest import Entity, FakeHubTransport
 
 
 def test_save_pretrained_preserves_resolver_bytes_and_loads(model: ERModel, tmp_path: Path) -> None:
@@ -48,6 +48,25 @@ def test_save_pretrained_preserves_resolver_bytes_and_loads(model: ERModel, tmp_
 def test_method_shims_match_free_functions(model: ERModel, tmp_path: Path) -> None:
     bundle = model.save_pretrained(tmp_path / "bundle")
     loaded = ERModel.from_pretrained(bundle)
+    assert loaded.config_dict() == model.config_dict()
+
+
+def test_unregistered_subclass_from_pretrained_preserves_requested_class(
+    tmp_path: Path,
+) -> None:
+    class ResearchResolver(ERModel):
+        pass
+
+    model = ResearchResolver.from_schema(Entity)
+    transport = FakeHubTransport(tmp_path / "remote")
+    model.push_to_hub("acme/research-resolver", transport=transport)
+
+    loaded = ResearchResolver.from_pretrained(
+        "acme/research-resolver",
+        transport=transport,
+    )
+
+    assert type(loaded) is ResearchResolver
     assert loaded.config_dict() == model.config_dict()
 
 

--- a/tests/hub/test_local.py
+++ b/tests/hub/test_local.py
@@ -10,6 +10,7 @@ from langres._pretrained_artifact import (
     ArtifactEligibilityError,
     MeasurementSummary,
     PretrainedArtifactError,
+    _version_minor,
     validate_bundle,
 )
 from langres.architectures import VectorLLMCascade
@@ -120,6 +121,27 @@ def test_missing_path_object_is_not_mistaken_for_hub_repo(tmp_path: Path) -> Non
     missing = tmp_path / "missing"
     with pytest.raises(FileNotFoundError, match="does not exist"):
         from_pretrained(missing)
+
+
+@pytest.mark.parametrize("missing", ("./missing", "/tmp/langres-missing", "~/langres-missing"))
+def test_missing_path_like_string_is_not_mistaken_for_hub_repo(missing: str) -> None:
+    with pytest.raises(FileNotFoundError, match="does not exist"):
+        from_pretrained(missing)
+
+
+@pytest.mark.parametrize(
+    ("version", "expected"),
+    (
+        ("0.0.0.dev0", (0, 0)),
+        ("0.3.0rc1", (0, 3)),
+        ("0.3.0.post1", (0, 3)),
+        ("1.2.3+local.1", (1, 2)),
+    ),
+)
+def test_version_compatibility_accepts_pep440_versions(
+    version: str, expected: tuple[int, int]
+) -> None:
+    assert _version_minor(version) == expected
 
 
 def _transformer_topology(

--- a/tests/hub/test_local.py
+++ b/tests/hub/test_local.py
@@ -1,0 +1,350 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from langres._pretrained_artifact import (
+    BUNDLE_MANIFEST,
+    ArtifactEligibilityError,
+    MeasurementSummary,
+    PretrainedArtifactError,
+    validate_bundle,
+)
+from langres.architectures import VectorLLMCascade
+from langres.core.blockers.all_pairs import AllPairsBlocker
+from langres.core.clusterer import Clusterer
+from langres.core.model_ref import ModelRef
+from langres.core.op import ThresholdSelect
+from langres.core.op_adapters import BlockerSource, ClustererStage
+from langres.core.resolver import ERModel
+from langres.hub import from_pretrained, save_pretrained
+from langres.resources import Generate, Parse, TransformersLLM
+
+from .conftest import Entity
+
+
+def test_save_pretrained_preserves_resolver_bytes_and_loads(model: ERModel, tmp_path: Path) -> None:
+    raw = tmp_path / "raw"
+    model.save(raw)
+    bundle = save_pretrained(model, tmp_path / "bundle")
+
+    assert (bundle / "resolver.json").read_bytes() == (raw / "resolver.json").read_bytes()
+    assert (bundle / BUNDLE_MANIFEST).is_file()
+    assert (bundle / "README.md").is_file()
+    manifest = validate_bundle(bundle)
+    assert manifest.claim_level == "reference-only"
+
+    loaded = from_pretrained(bundle)
+    assert isinstance(loaded, ERModel)
+    assert loaded.config_dict() == model.config_dict()
+    assert loaded.pretrained_source_ is not None
+    assert loaded.pretrained_source_.kind == "local"
+    assert loaded.pretrained_source_.location == str(bundle.resolve())
+
+
+def test_method_shims_match_free_functions(model: ERModel, tmp_path: Path) -> None:
+    bundle = model.save_pretrained(tmp_path / "bundle")
+    loaded = ERModel.from_pretrained(bundle)
+    assert loaded.config_dict() == model.config_dict()
+
+
+def test_measurement_summary_is_bounded_and_published(model: ERModel, tmp_path: Path) -> None:
+    summary = MeasurementSummary(
+        protocol_id="official-v1",
+        evaluation_id="eval-1",
+        dataset_ids=("amazon-google:test",),
+        quality={"pair_f1": 0.91},
+        tokens={"input_tokens": 123, "output_tokens": 45},
+        cost={"usd": None},
+        hardware={"accelerator": "cpu"},
+    )
+    bundle = save_pretrained(
+        model,
+        tmp_path / "bundle",
+        measurement_summary=summary,
+    )
+    payload = json.loads((bundle / "measurement-summary.json").read_text())
+    card = (bundle / "README.md").read_text()
+    assert payload["tokens"]["input_tokens"] == 123
+    assert "pair_f1" in card
+    assert "input_tokens" in card
+
+
+def test_frozen_weights_claim_fails_before_promotion(model: ERModel, tmp_path: Path) -> None:
+    destination = tmp_path / "bundle"
+    with pytest.raises(ArtifactEligibilityError, match="frozen-weights"):
+        save_pretrained(model, destination, claim_level="frozen-weights")
+    assert not destination.exists()
+
+
+def test_existing_destination_requires_explicit_overwrite(model: ERModel, tmp_path: Path) -> None:
+    destination = save_pretrained(model, tmp_path / "bundle")
+    marker = destination / "old-marker.txt"
+    marker.write_text("old")
+    with pytest.raises(FileExistsError):
+        save_pretrained(model, destination)
+    assert marker.read_text() == "old"
+
+    with pytest.raises(FileExistsError, match="intentionally unsupported"):
+        save_pretrained(model, destination, overwrite=True)
+    assert marker.read_text() == "old"
+
+
+def test_checksum_failure_happens_before_resolver_load(
+    model: ERModel, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    bundle = save_pretrained(model, tmp_path / "bundle")
+    (bundle / "resolver.json").write_text("{}")
+    called = False
+
+    def _load(_cls, _path):
+        nonlocal called
+        called = True
+        raise AssertionError("must not construct components")
+
+    monkeypatch.setattr(ERModel, "load", classmethod(_load))
+    with pytest.raises(PretrainedArtifactError, match="checksum/size mismatch"):
+        from_pretrained(bundle)
+    assert called is False
+
+
+def test_local_revision_is_rejected(model: ERModel, tmp_path: Path) -> None:
+    bundle = save_pretrained(model, tmp_path / "bundle")
+    with pytest.raises(ValueError, match="only valid for a Hub repo"):
+        from_pretrained(bundle, revision="main")
+
+
+def test_missing_path_object_is_not_mistaken_for_hub_repo(tmp_path: Path) -> None:
+    missing = tmp_path / "missing"
+    with pytest.raises(FileNotFoundError, match="does not exist"):
+        from_pretrained(missing)
+
+
+def _transformer_topology(
+    *,
+    revision: str | None,
+    adapter: str | None = None,
+    adapter_revision: str | None = None,
+) -> ERModel:
+    return ERModel.from_topology(
+        ops=[
+            BlockerSource(AllPairsBlocker(schema=Entity)),
+            Generate(
+                TransformersLLM(
+                    ModelRef(
+                        base="acme/local-matcher",
+                        kind="hf",
+                        revision=revision,
+                        adapter=adapter,
+                        adapter_revision=adapter_revision,
+                    )
+                )
+            ),
+            Parse(),
+            ThresholdSelect(0.5),
+            ClustererStage(Clusterer(threshold=0.5)),
+        ]
+    )
+
+
+def test_benchmark_claim_requires_pinned_hf_resources_and_summary(
+    tmp_path: Path,
+) -> None:
+    summary = MeasurementSummary(
+        protocol_id="protocol-v1",
+        evaluation_id="evaluation-v1",
+        dataset_ids=("fixture:test",),
+        quality={"pair_f1": 0.9},
+    )
+    bundle = save_pretrained(
+        _transformer_topology(revision="a" * 40),
+        tmp_path / "pinned",
+        measurement_summary=summary,
+        claim_level="benchmark-reproducible",
+    )
+    manifest = validate_bundle(bundle)
+    assert manifest.claim_level == "benchmark-reproducible"
+    assert manifest.model_refs[0].revision == "a" * 40
+    assert manifest.required_extras == ("semantic",)
+
+    with pytest.raises(ArtifactEligibilityError, match="commit SHA"):
+        save_pretrained(
+            _transformer_topology(revision=None),
+            tmp_path / "unpinned",
+            measurement_summary=summary,
+            claim_level="benchmark-reproducible",
+        )
+
+
+def test_benchmark_claim_requires_identified_nonempty_measurement(
+    model: ERModel, tmp_path: Path
+) -> None:
+    with pytest.raises(ArtifactEligibilityError, match="protocol_id"):
+        save_pretrained(
+            model,
+            tmp_path / "empty-summary",
+            measurement_summary=MeasurementSummary(),
+            claim_level="benchmark-reproducible",
+        )
+
+
+def test_benchmark_claim_requires_adapter_revision(tmp_path: Path) -> None:
+    summary = MeasurementSummary(
+        protocol_id="protocol-v1",
+        evaluation_id="evaluation-v1",
+        dataset_ids=("fixture:test",),
+        quality={"pair_f1": 0.9},
+    )
+    model = _transformer_topology(
+        revision="b" * 40,
+        adapter="acme/adapter",
+    )
+    with pytest.raises(ArtifactEligibilityError, match="commit SHA"):
+        save_pretrained(
+            model,
+            tmp_path / "unpinned-adapter",
+            measurement_summary=summary,
+            claim_level="benchmark-reproducible",
+        )
+
+
+def test_benchmark_claim_rejects_local_adapter_even_with_sha_like_revision(
+    tmp_path: Path,
+) -> None:
+    summary = MeasurementSummary(
+        protocol_id="protocol-v1",
+        evaluation_id="evaluation-v1",
+        dataset_ids=("fixture:test",),
+        quality={"pair_f1": 0.9},
+    )
+    model = _transformer_topology(
+        revision="a" * 40,
+        adapter="./private-local-adapter",
+        adapter_revision="b" * 40,
+    )
+    with pytest.raises(ArtifactEligibilityError, match="organization/repository"):
+        save_pretrained(
+            model,
+            tmp_path / "local-adapter",
+            measurement_summary=summary,
+            claim_level="benchmark-reproducible",
+        )
+
+
+def test_nested_legacy_architecture_resources_are_published(tmp_path: Path) -> None:
+    pytest.importorskip("faiss")
+    pytest.importorskip("litellm")
+    model = VectorLLMCascade(
+        schema=Entity,
+        embedder=ModelRef(
+            base="sentence-transformers/all-MiniLM-L6-v2",
+            kind="hf",
+            revision="e" * 40,
+        ),
+        llm=ModelRef(base="openai/gpt-5-mini", kind="api"),
+    )
+    manifest = validate_bundle(
+        save_pretrained(
+            model,
+            tmp_path / "nested",
+            allow_sensitive_config=True,
+        )
+    )
+
+    assert {ref.base for ref in manifest.model_refs} == {
+        "sentence-transformers/all-MiniLM-L6-v2",
+        "openai/gpt-5-mini",
+    }
+    assert manifest.required_extras == ("llm", "semantic")
+    assert manifest.sensitive_config_included is True
+
+
+@pytest.mark.parametrize(
+    ("model_ref", "expected_extras"),
+    [
+        (ModelRef(base="openai/gpt-5-mini", kind="api"), ("llm",)),
+        (
+            ModelRef(base="acme/local-llm", kind="hf", revision="a" * 40),
+            ("llm", "semantic"),
+        ),
+        (ModelRef(base="./local-llm", kind="local"), ("llm", "semantic")),
+        (
+            ModelRef(
+                base="acme/base",
+                kind="hf",
+                revision="a" * 40,
+                adapter="acme/adapter",
+                adapter_revision="b" * 40,
+            ),
+            ("finetune", "llm", "semantic"),
+        ),
+    ],
+)
+def test_legacy_llm_extras_follow_runtime_route_and_adapter(
+    model_ref: ModelRef,
+    expected_extras: tuple[str, ...],
+    tmp_path: Path,
+) -> None:
+    pytest.importorskip("litellm")
+    from langres.core.matchers.llm_judge import LLMMatcher
+
+    model = ERModel.from_schema(Entity, matcher=LLMMatcher(model=model_ref))
+    manifest = validate_bundle(
+        save_pretrained(
+            model,
+            tmp_path / model_ref.kind,
+            allow_sensitive_config=True,
+        )
+    )
+    assert manifest.required_extras == expected_extras
+
+
+def test_transformers_resource_adapter_requires_finetune_extra(tmp_path: Path) -> None:
+    model = _transformer_topology(
+        revision="a" * 40,
+        adapter="acme/adapter",
+        adapter_revision="b" * 40,
+    )
+    manifest = validate_bundle(save_pretrained(model, tmp_path / "adapter"))
+    assert manifest.required_extras == ("finetune", "semantic")
+
+
+def test_benchmark_claim_rejects_moving_hf_revisions(tmp_path: Path) -> None:
+    summary = MeasurementSummary(
+        protocol_id="protocol-v1",
+        evaluation_id="evaluation-v1",
+        dataset_ids=("fixture:test",),
+        quality={"pair_f1": 0.9},
+    )
+    with pytest.raises(ArtifactEligibilityError, match="commit SHA"):
+        save_pretrained(
+            _transformer_topology(revision="main"),
+            tmp_path / "moving",
+            measurement_summary=summary,
+            claim_level="benchmark-reproducible",
+        )
+
+
+def test_incompatible_minor_version_is_rejected(model: ERModel, tmp_path: Path) -> None:
+    bundle = save_pretrained(model, tmp_path / "bundle")
+    manifest_path = bundle / BUNDLE_MANIFEST
+    payload = json.loads(manifest_path.read_text())
+    payload["langres_version"] = "99.0.0"
+    payload["langres_compatibility"] = ">=99.0.0,<99.1.0"
+    manifest_path.write_text(json.dumps(payload))
+
+    with pytest.raises(PretrainedArtifactError, match="installed version"):
+        from_pretrained(bundle)
+
+
+def test_malformed_compatibility_is_rejected(model: ERModel, tmp_path: Path) -> None:
+    bundle = save_pretrained(model, tmp_path / "bundle")
+    manifest_path = bundle / BUNDLE_MANIFEST
+    payload = json.loads(manifest_path.read_text())
+    payload["langres_compatibility"] = "*"
+    manifest_path.write_text(json.dumps(payload))
+
+    with pytest.raises(PretrainedArtifactError, match="langres_compatibility"):
+        from_pretrained(bundle)

--- a/tests/hub/test_security.py
+++ b/tests/hub/test_security.py
@@ -14,7 +14,10 @@ from langres._pretrained_artifact import (
     MAX_MANIFEST_BYTES,
     MAX_RESOLVER_BYTES,
     PretrainedArtifactError,
+    resource_facts,
+    sensitive_config_paths,
 )
+from langres.core.serialization import ArtifactManifest, ComponentSpec, OpSpec
 from langres.core.resolver import ERModel
 from langres.hub import from_pretrained, push_to_hub, save_pretrained
 
@@ -77,6 +80,37 @@ def test_prompt_bearing_config_requires_explicit_publication_consent(
     assert prompt in resolver
     assert system in resolver
     assert json.loads((bundle / BUNDLE_MANIFEST).read_text())["sensitive_config_included"]
+
+
+def test_prompt_bearing_op_params_require_publication_consent() -> None:
+    manifest = ArtifactManifest(
+        artifact_version="2",
+        langres_version="0.3.0",
+        ops=(
+            OpSpec(
+                role="custom_prompt_op",
+                params={"prompt_template": "PRIVATE {left} {right}"},
+            ),
+        ),
+    )
+
+    assert sensitive_config_paths(manifest) == ("op[0].custom_prompt_op.prompt_template",)
+
+
+def test_unknown_model_name_component_fails_closed() -> None:
+    manifest = ArtifactManifest(
+        artifact_version="1",
+        langres_version="0.3.0",
+        components=(
+            ComponentSpec(
+                type_name="unknown_model_component",
+                config={"model_name": "organization/repository"},
+            ),
+        ),
+    )
+
+    with pytest.raises(PretrainedArtifactError, match="model-bearing component"):
+        resource_facts(manifest)
 
 
 def test_symlink_in_local_bundle_is_rejected(model: ERModel, tmp_path: Path) -> None:

--- a/tests/hub/test_security.py
+++ b/tests/hub/test_security.py
@@ -18,8 +18,13 @@ from langres._pretrained_artifact import (
     sensitive_config_paths,
 )
 from langres.core.serialization import ArtifactManifest, ComponentSpec, OpSpec
+from langres.core.blockers.all_pairs import AllPairsBlocker
+from langres.core.clusterer import Clusterer
+from langres.core.op import ThresholdSelect
+from langres.core.op_adapters import BlockerSource, ClustererStage
 from langres.core.resolver import ERModel
 from langres.hub import from_pretrained, push_to_hub, save_pretrained
+from langres.resources import Generate, LiteLLM, Parse
 
 from .conftest import Entity, FakeHubTransport
 
@@ -95,6 +100,87 @@ def test_prompt_bearing_op_params_require_publication_consent() -> None:
     )
 
     assert sensitive_config_paths(manifest) == ("op[0].custom_prompt_op.prompt_template",)
+
+
+@pytest.mark.parametrize(
+    "transport_options",
+    (
+        {"provider": {"api_key": "sk-private"}},
+        {"extra_body": {"headers": {"Authorization": "Bearer private"}}},
+    ),
+)
+def test_credential_bearing_transport_config_is_never_publishable(
+    transport_options: dict[str, object],
+    tmp_path: Path,
+) -> None:
+    model = ERModel.from_topology(
+        ops=[
+            BlockerSource(AllPairsBlocker(schema=Entity)),
+            Generate(
+                LiteLLM(
+                    {"base": "openai/gpt-5-mini", "kind": "api"},
+                    **transport_options,
+                )
+            ),
+            Parse(),
+            ThresholdSelect(0.5),
+            ClustererStage(Clusterer(threshold=0.5)),
+        ]
+    )
+    destination = tmp_path / "credential-bearing"
+
+    with pytest.raises(ArtifactEligibilityError, match="credential-bearing"):
+        save_pretrained(
+            model,
+            destination,
+            allow_sensitive_config=True,
+        )
+    assert not destination.exists()
+
+
+def test_credential_bearing_transport_config_is_rejected_when_loading(
+    tmp_path: Path,
+) -> None:
+    model = ERModel.from_topology(
+        ops=[
+            BlockerSource(AllPairsBlocker(schema=Entity)),
+            Generate(LiteLLM({"base": "openai/gpt-5-mini", "kind": "api"})),
+            Parse(),
+            ThresholdSelect(0.5),
+            ClustererStage(Clusterer(threshold=0.5)),
+        ]
+    )
+    bundle = save_pretrained(model, tmp_path / "bundle")
+    resolver = json.loads((bundle / "resolver.json").read_text())
+    generate = next(op for op in resolver["ops"] if op["role"] == "generate")
+    generate["component"]["config"]["extra_body"] = {"headers": {"Authorization": "Bearer private"}}
+    (bundle / "resolver.json").write_text(json.dumps(resolver))
+
+    manifest = json.loads((bundle / BUNDLE_MANIFEST).read_text())
+    import hashlib
+
+    content = (bundle / "resolver.json").read_bytes()
+    for item in manifest["files"]:
+        if item["path"] == "resolver.json":
+            item["size"] = len(content)
+            item["sha256"] = hashlib.sha256(content).hexdigest()
+    (bundle / BUNDLE_MANIFEST).write_text(json.dumps(manifest))
+
+    with pytest.raises(PretrainedArtifactError, match="credential-bearing"):
+        from_pretrained(bundle)
+
+
+def test_trained_components_declare_the_trained_extra() -> None:
+    manifest = ArtifactManifest(
+        artifact_version="1",
+        langres_version="0.3.0",
+        components=(
+            ComponentSpec(type_name="calibrator", config={}),
+            ComponentSpec(type_name="random_forest", config={}),
+        ),
+    )
+
+    assert resource_facts(manifest) == ((), ("trained",))
 
 
 def test_unknown_model_name_component_fails_closed() -> None:

--- a/tests/hub/test_security.py
+++ b/tests/hub/test_security.py
@@ -1,0 +1,274 @@
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+from langres._pretrained_artifact import (
+    BUNDLE_MANIFEST,
+    ArtifactEligibilityError,
+    MAX_MANIFEST_BYTES,
+    MAX_RESOLVER_BYTES,
+    PretrainedArtifactError,
+)
+from langres.core.resolver import ERModel
+from langres.hub import from_pretrained, push_to_hub, save_pretrained
+
+from .conftest import Entity, FakeHubTransport
+
+
+def test_unexpected_remote_file_is_never_downloaded(model: ERModel, tmp_path: Path) -> None:
+    remote = tmp_path / "remote"
+    transport = FakeHubTransport(remote)
+    push_to_hub(model, "acme/model", transport=transport)
+    (remote / "records.jsonl").write_text('{"secret": true}\n')
+
+    loaded = from_pretrained("acme/model", transport=transport)
+    assert loaded.config_dict() == model.config_dict()
+    assert len(transport.download_calls) == 2
+    assert transport.download_calls[0][2] == (BUNDLE_MANIFEST,)
+    assert "records.jsonl" not in transport.download_calls[1][2]
+
+
+def test_state_sidecars_are_never_published(
+    model: ERModel, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    original_save = model.save
+
+    def save_with_sensitive_state(path: str | Path) -> None:
+        original_save(path)
+        state = Path(path) / "module"
+        state.mkdir()
+        (state / "program.json").write_text('{"prompt": "private"}')
+
+    monkeypatch.setattr(model, "save", save_with_sensitive_state)
+    destination = tmp_path / "bundle"
+    with pytest.raises(ArtifactEligibilityError, match="state-free"):
+        save_pretrained(model, destination)
+    assert not destination.exists()
+
+
+def test_prompt_bearing_config_requires_explicit_publication_consent(
+    tmp_path: Path,
+) -> None:
+    pytest.importorskip("litellm")
+    prompt = "PRIVATE PROMPT {left} versus {right}"
+    system = "PRIVATE SYSTEM INSTRUCTION"
+    model = ERModel.from_schema(
+        Entity,
+        matcher="prompt_llm",
+        model="openai/gpt-5-mini",
+        prompt_template=prompt,
+        system_prompt=system,
+    )
+
+    with pytest.raises(ArtifactEligibilityError, match="allow_sensitive_config=True"):
+        save_pretrained(model, tmp_path / "rejected")
+    bundle = save_pretrained(
+        model,
+        tmp_path / "consented",
+        allow_sensitive_config=True,
+    )
+    resolver = (bundle / "resolver.json").read_text()
+    assert prompt in resolver
+    assert system in resolver
+    assert json.loads((bundle / BUNDLE_MANIFEST).read_text())["sensitive_config_included"]
+
+
+def test_symlink_in_local_bundle_is_rejected(model: ERModel, tmp_path: Path) -> None:
+    bundle = save_pretrained(model, tmp_path / "bundle")
+    target = tmp_path / "outside"
+    target.write_text("secret")
+    link = bundle / "module"
+    try:
+        os.symlink(target, link)
+    except OSError:
+        pytest.skip("symlinks unavailable")
+    with pytest.raises(PretrainedArtifactError, match="symlink"):
+        from_pretrained(bundle)
+
+
+def test_symlink_destination_is_rejected(model: ERModel, tmp_path: Path) -> None:
+    target = tmp_path / "target"
+    target.mkdir()
+    link = tmp_path / "bundle"
+    try:
+        os.symlink(target, link)
+    except OSError:
+        pytest.skip("symlinks unavailable")
+    with pytest.raises(PretrainedArtifactError, match="destination cannot be a symlink"):
+        save_pretrained(model, link, overwrite=True)
+    assert not (target / BUNDLE_MANIFEST).exists()
+
+
+def test_manifest_traversal_is_rejected(model: ERModel, tmp_path: Path) -> None:
+    bundle = save_pretrained(model, tmp_path / "bundle")
+    payload = json.loads((bundle / BUNDLE_MANIFEST).read_text())
+    payload["files"][0]["path"] = "../resolver.json"
+    (bundle / BUNDLE_MANIFEST).write_text(json.dumps(payload))
+    with pytest.raises(PretrainedArtifactError, match="unsafe artifact path"):
+        from_pretrained(bundle)
+
+
+def test_oversized_manifest_is_rejected(model: ERModel, tmp_path: Path) -> None:
+    bundle = save_pretrained(model, tmp_path / "bundle")
+    (bundle / BUNDLE_MANIFEST).write_bytes(b" " * (MAX_MANIFEST_BYTES + 1))
+    with pytest.raises(PretrainedArtifactError, match="exceeds"):
+        from_pretrained(bundle)
+
+
+def test_oversized_resolver_is_rejected_before_parsing(model: ERModel, tmp_path: Path) -> None:
+    bundle = save_pretrained(model, tmp_path / "bundle")
+    content = b" " * (MAX_RESOLVER_BYTES + 1)
+    (bundle / "resolver.json").write_bytes(content)
+    manifest = json.loads((bundle / BUNDLE_MANIFEST).read_text())
+    import hashlib
+
+    for item in manifest["files"]:
+        if item["path"] == "resolver.json":
+            item["size"] = len(content)
+            item["sha256"] = hashlib.sha256(content).hexdigest()
+    (bundle / BUNDLE_MANIFEST).write_text(json.dumps(manifest))
+
+    with pytest.raises(PretrainedArtifactError, match="metadata file.*exceeds"):
+        from_pretrained(bundle)
+
+
+def test_unknown_component_fails_preflight_before_model_load(
+    model: ERModel, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    bundle = save_pretrained(model, tmp_path / "bundle")
+    resolver = json.loads((bundle / "resolver.json").read_text())
+    resolver["components"][0]["type_name"] = "attacker_component"
+    (bundle / "resolver.json").write_text(json.dumps(resolver))
+
+    # Refresh the outer checksum so this reaches registry preflight rather than
+    # being rejected earlier as ordinary corruption.
+    manifest = json.loads((bundle / BUNDLE_MANIFEST).read_text())
+    import hashlib
+
+    content = (bundle / "resolver.json").read_bytes()
+    for item in manifest["files"]:
+        if item["path"] == "resolver.json":
+            item["size"] = len(content)
+            item["sha256"] = hashlib.sha256(content).hexdigest()
+    (bundle / BUNDLE_MANIFEST).write_text(json.dumps(manifest))
+
+    called = False
+
+    def _load(_cls, _path):
+        nonlocal called
+        called = True
+        raise AssertionError("must not reconstruct")
+
+    monkeypatch.setattr(ERModel, "load", classmethod(_load))
+    with pytest.raises(PretrainedArtifactError, match="unavailable registered type"):
+        from_pretrained(bundle)
+    assert called is False
+
+
+def test_unknown_nested_component_fails_preflight_before_model_load(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    pytest.importorskip("faiss")
+    pytest.importorskip("litellm")
+    from langres.architectures import VectorLLMCascade
+    from langres.core.model_ref import ModelRef
+
+    model = VectorLLMCascade(
+        schema=Entity,
+        embedder=ModelRef(
+            base="sentence-transformers/all-MiniLM-L6-v2",
+            kind="hf",
+            revision="e" * 40,
+        ),
+        llm=ModelRef(base="openai/gpt-5-mini", kind="api"),
+    )
+    bundle = save_pretrained(
+        model,
+        tmp_path / "bundle",
+        allow_sensitive_config=True,
+    )
+    resolver = json.loads((bundle / "resolver.json").read_text())
+    cascade = next(item for item in resolver["components"] if item["type_name"] == "cascade_judge")
+    cascade["config"]["student"] = {"type_name": "attacker_nested", "config": {}}
+    (bundle / "resolver.json").write_text(json.dumps(resolver))
+
+    manifest = json.loads((bundle / BUNDLE_MANIFEST).read_text())
+    import hashlib
+
+    content = (bundle / "resolver.json").read_bytes()
+    for item in manifest["files"]:
+        if item["path"] == "resolver.json":
+            item["size"] = len(content)
+            item["sha256"] = hashlib.sha256(content).hexdigest()
+    (bundle / BUNDLE_MANIFEST).write_text(json.dumps(manifest))
+
+    called = False
+
+    def _load(_cls, _path):
+        nonlocal called
+        called = True
+        raise AssertionError("must not reconstruct")
+
+    monkeypatch.setattr(ERModel, "load", classmethod(_load))
+    with pytest.raises(PretrainedArtifactError, match="unavailable registered type"):
+        from_pretrained(bundle)
+    assert called is False
+
+
+def test_outer_resource_identity_cannot_disagree_with_resolver(
+    model: ERModel, tmp_path: Path
+) -> None:
+    bundle = save_pretrained(model, tmp_path / "bundle")
+    manifest = json.loads((bundle / BUNDLE_MANIFEST).read_text())
+    manifest["required_extras"] = ["attacker-extra"]
+    (bundle / BUNDLE_MANIFEST).write_text(json.dumps(manifest))
+    with pytest.raises(PretrainedArtifactError, match="outer resource identity"):
+        from_pretrained(bundle)
+
+
+def test_importing_hub_adapter_keeps_optional_client_lazy() -> None:
+    script = (
+        "import sys; import langres.hub; "
+        "assert 'huggingface_hub' not in sys.modules; "
+        "assert 'torch' not in sys.modules; "
+        "assert 'litellm' not in sys.modules"
+    )
+    result = subprocess.run(
+        [sys.executable, "-c", script],
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode == 0, result.stderr
+
+
+def test_missing_hub_extra_has_install_remedy() -> None:
+    script = """
+import builtins
+from langres.hub import HuggingFaceHubTransport, PretrainedArtifactError
+
+original = builtins.__import__
+def blocked(name, *args, **kwargs):
+    if name == "huggingface_hub":
+        raise ModuleNotFoundError("No module named 'huggingface_hub'")
+    return original(name, *args, **kwargs)
+builtins.__import__ = blocked
+
+try:
+    HuggingFaceHubTransport().resolve("acme/model", revision=None, token=None)
+except PretrainedArtifactError as exc:
+    assert "pip install 'langres[hub]'" in str(exc)
+else:
+    raise AssertionError("missing optional dependency was not translated")
+"""
+    result = subprocess.run(
+        [sys.executable, "-c", script],
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode == 0, result.stderr

--- a/tests/hub/test_security.py
+++ b/tests/hub/test_security.py
@@ -155,6 +155,19 @@ def test_oversized_manifest_is_rejected(model: ERModel, tmp_path: Path) -> None:
         from_pretrained(bundle)
 
 
+def test_oversized_remote_manifest_is_rejected_before_download(
+    model: ERModel, tmp_path: Path
+) -> None:
+    remote = tmp_path / "remote"
+    transport = FakeHubTransport(remote)
+    push_to_hub(model, "acme/model", transport=transport)
+    (remote / BUNDLE_MANIFEST).write_bytes(b" " * (MAX_MANIFEST_BYTES + 1))
+
+    with pytest.raises(PretrainedArtifactError, match="manifest size"):
+        from_pretrained("acme/model", transport=transport)
+    assert transport.download_calls == []
+
+
 def test_oversized_resolver_is_rejected_before_parsing(model: ERModel, tmp_path: Path) -> None:
     bundle = save_pretrained(model, tmp_path / "bundle")
     content = b" " * (MAX_RESOLVER_BYTES + 1)
@@ -170,6 +183,29 @@ def test_oversized_resolver_is_rejected_before_parsing(model: ERModel, tmp_path:
 
     with pytest.raises(PretrainedArtifactError, match="metadata file.*exceeds"):
         from_pretrained(bundle)
+
+
+def test_oversized_remote_metadata_is_rejected_before_full_download(
+    model: ERModel, tmp_path: Path
+) -> None:
+    remote = tmp_path / "remote"
+    transport = FakeHubTransport(remote)
+    push_to_hub(model, "acme/model", transport=transport)
+    content = b" " * (MAX_RESOLVER_BYTES + 1)
+    (remote / "resolver.json").write_bytes(content)
+    manifest = json.loads((remote / BUNDLE_MANIFEST).read_text())
+    import hashlib
+
+    for item in manifest["files"]:
+        if item["path"] == "resolver.json":
+            item["size"] = len(content)
+            item["sha256"] = hashlib.sha256(content).hexdigest()
+    (remote / BUNDLE_MANIFEST).write_text(json.dumps(manifest))
+
+    with pytest.raises(PretrainedArtifactError, match="resolver.json.*exceeds"):
+        from_pretrained("acme/model", transport=transport)
+    assert len(transport.download_calls) == 1
+    assert transport.download_calls[0][2] == (BUNDLE_MANIFEST,)
 
 
 def test_unknown_component_fails_preflight_before_model_load(

--- a/tests/hub/test_transport.py
+++ b/tests/hub/test_transport.py
@@ -1,0 +1,99 @@
+from __future__ import annotations
+
+from pathlib import Path
+from types import SimpleNamespace
+
+import huggingface_hub
+import pytest
+
+from langres.hub import HuggingFaceHubTransport, PretrainedArtifactError
+
+
+class _Commit:
+    oid = "c" * 40
+
+    def __str__(self) -> str:
+        return "https://huggingface.co/acme/model/commit/" + self.oid
+
+
+class _Api:
+    calls: list[tuple[str, dict[str, object]]] = []
+
+    def model_info(self, repo_id: str, **kwargs: object) -> object:
+        self.calls.append(("model_info", {"repo_id": repo_id, **kwargs}))
+        return SimpleNamespace(
+            sha="a" * 40,
+            siblings=[SimpleNamespace(rfilename="resolver.json", size=12)],
+        )
+
+    def create_repo(self, **kwargs: object) -> object:
+        self.calls.append(("create_repo", dict(kwargs)))
+        return SimpleNamespace(repo_id=kwargs["repo_id"])
+
+    def upload_folder(self, **kwargs: object) -> object:
+        self.calls.append(("upload_folder", dict(kwargs)))
+        return _Commit()
+
+
+def test_real_transport_forwards_pins_allowlists_and_commit_metadata(
+    monkeypatch, tmp_path: Path
+) -> None:
+    _Api.calls = []
+    snapshot_calls: list[dict[str, object]] = []
+
+    def _snapshot_download(repo_id: str, **kwargs: object) -> str:
+        snapshot_calls.append({"repo_id": repo_id, **kwargs})
+        return str(kwargs["local_dir"])
+
+    monkeypatch.setattr(huggingface_hub, "HfApi", _Api)
+    monkeypatch.setattr(huggingface_hub, "snapshot_download", _snapshot_download)
+    transport = HuggingFaceHubTransport()
+
+    info = transport.resolve("acme/model", revision="tag", token="secret")
+    assert info.resolved_revision == "a" * 40
+    assert info.files[0].size == 12
+
+    transport.snapshot_download(
+        "acme/model",
+        revision=info.resolved_revision,
+        local_dir=tmp_path,
+        allow_patterns=("resolver.json",),
+        token="secret",
+    )
+    assert snapshot_calls[0]["revision"] == "a" * 40
+    assert snapshot_calls[0]["allow_patterns"] == ["resolver.json"]
+
+    assert transport.create_repo("acme/model", private=True, token="secret") == "acme/model"
+    result = transport.upload_folder(
+        "acme/model",
+        folder_path=tmp_path,
+        revision="main",
+        allow_patterns=("resolver.json",),
+        commit_message="publish",
+        commit_description="facts",
+        parent_commit="b" * 40,
+        token="secret",
+    )
+    assert result.commit_oid == "c" * 40
+    upload = next(kwargs for name, kwargs in _Api.calls if name == "upload_folder")
+    assert upload["parent_commit"] == "b" * 40
+    assert upload["allow_patterns"] == ["resolver.json"]
+
+
+def test_provider_errors_are_sanitized_with_repository_context(monkeypatch) -> None:
+    class FailingApi:
+        def model_info(self, *args: object, **kwargs: object) -> object:
+            del args, kwargs
+            raise RuntimeError("secret provider detail")
+
+    monkeypatch.setattr(huggingface_hub, "HfApi", FailingApi)
+    with pytest.raises(
+        PretrainedArtifactError,
+        match=r"revision resolution failed.*acme/model.*release.*RuntimeError",
+    ) as error:
+        HuggingFaceHubTransport().resolve(
+            "acme/model",
+            revision="release",
+            token="secret",
+        )
+    assert "secret provider detail" not in str(error.value)

--- a/tools/refactor_target_packages.json
+++ b/tools/refactor_target_packages.json
@@ -104,6 +104,11 @@
     "statistics, and report contracts; core never imports it. The package therefore maps",
     "to its own 'experiments' target rather than being folded into benchmarks or tracking.",
     "",
+    "The Hugging Face lifecycle is an outer adapter: langres.hub and its pure bundle",
+    "validator map to 'hub' and depend inward on unchanged core persistence. Core never",
+    "imports the Hub transport or huggingface_hub; ArtifactSource is pure artifact data in",
+    "core.serialization.",
+    "",
     "'exact' wins over 'prefix'; among prefixes the longest match wins."
   ],
   "prefix": {
@@ -134,8 +139,10 @@
   "exact": {
     "langres": "root",
     "langres._method_names": "architectures",
+    "langres._pretrained_artifact": "hub",
     "langres._version": "core",
     "langres.cli": "root",
+    "langres.hub": "hub",
     "langres.optimize": "optimize",
     "langres.tracking": "tracking",
     "langres.tracking.factories": "tracking",


### PR DESCRIPTION
## Summary
- add configuration-only save_pretrained/from_pretrained/push_to_hub lifecycle around unchanged resolver.json
- validate exact checksummed manifests, immutable Hub revisions, compatibility, nested resource identities, and bounded publication metrics
- reject Resolver sidecars and in-place overwrites so corpus text, prompts, and native binary state are never published or remotely deserialized
- keep huggingface_hub optional and lazy behind the [hub] extra

## Verification
- 151 passed, 1 skipped across Hub, persistence, import-budget, import-graph, and topology suites
- ruff check .
- mypy src/langres

Stacked on #193 integration branch codex/research-execution-foundation.