### PR TITLE
fix(hub): close credential and semantic metadata gaps

### DIFF
--- a/docs/HUGGING_FACE.md
+++ b/docs/HUGGING_FACE.md
@@ -50,7 +50,8 @@ configuration is included.
 Credentials are never publishable, even with `allow_sensitive_config=True`.
 Keep API keys, authorization headers, tokens, and similar secrets out of
 serialized LiteLLM `provider` / `extra_body` options; inject them through the
-runtime client or environment instead.
+runtime client or environment instead. Endpoint `api_base` URLs must likewise
+exclude userinfo and credential-bearing query parameters.
 
 Remote operations use the same journey:
 
@@ -114,6 +115,8 @@ declared in both manifest and card. Tokens are forwarded to the Hub client for
 the requested operation and are never written to the bundle or model card.
 The outer manifest also records the install extras needed by optional
 components, including `[trained]` for calibrators and random-forest matchers.
+Vector blockers and FAISS indexes declare `[semantic]` even when their embedder
+does not carry a model reference.
 
 Hub artifact revision provenance is separate from resource `ModelRef`
 revisions: `pretrained_source_.resolved_revision` identifies the bundle commit,

--- a/src/langres/_pretrained_artifact.py
+++ b/src/langres/_pretrained_artifact.py
@@ -75,6 +75,7 @@ _COMPONENT_EXTRAS: dict[str, str] = {
     "random_forest": "trained",
     "vector_blocker": "semantic",
 }
+_LEGACY_MISSING_EXTRA_COMPONENTS = frozenset({"faiss_index", "vector_blocker"})
 _HF_MODEL_NAME_COMPONENTS = frozenset(
     {
         "fastembed_sparse_embedder",
@@ -454,7 +455,7 @@ def validate_bundle(root: Path) -> PretrainedManifest:
     legacy_compatible_missing = {
         _COMPONENT_EXTRAS[spec.type_name]
         for spec in component_specs(resolver_manifest)
-        if spec.type_name in _COMPONENT_EXTRAS
+        if spec.type_name in _LEGACY_MISSING_EXTRA_COMPONENTS
     }
     extras_without_compatible_omissions = tuple(
         extra for extra in actual_extras if extra not in missing_extras

--- a/src/langres/_pretrained_artifact.py
+++ b/src/langres/_pretrained_artifact.py
@@ -14,6 +14,7 @@ import re
 from collections.abc import Iterable, Mapping
 from pathlib import Path, PurePosixPath
 from typing import Annotated, Literal
+from urllib.parse import parse_qsl, urlsplit
 
 from pydantic import (
     BaseModel,
@@ -68,9 +69,11 @@ _RESOURCE_COMPONENTS: dict[str, tuple[str, str]] = {
     "dspy_judge": ("model", "llm"),
     "select_judge": ("model", "llm"),
 }
-_OPTIONAL_COMPONENT_EXTRAS: dict[str, str] = {
+_COMPONENT_EXTRAS: dict[str, str] = {
     "calibrator": "trained",
+    "faiss_index": "semantic",
     "random_forest": "trained",
+    "vector_blocker": "semantic",
 }
 _HF_MODEL_NAME_COMPONENTS = frozenset(
     {
@@ -494,31 +497,59 @@ def sensitive_config_paths(resolver_manifest: ArtifactManifest) -> tuple[str, ..
 
 
 def credential_config_paths(resolver_manifest: ArtifactManifest) -> tuple[str, ...]:
-    """Find credentials embedded in serialized LiteLLM transport options."""
+    """Find credentials embedded in serialized transport configuration."""
     found: list[str] = []
+
+    def credential_key(value: object) -> bool:
+        normalized = re.sub(r"[^a-z0-9]+", "_", str(value).lower()).strip("_")
+        return _CREDENTIAL_KEY.search(normalized) is not None
 
     def visit(value: object, path: str) -> None:
         if isinstance(value, Mapping):
             for key, nested in value.items():
                 key_text = str(key)
                 child = f"{path}.{key_text}"
-                normalized_key = re.sub(r"[^a-z0-9]+", "_", key_text.lower()).strip("_")
-                if (
-                    _CREDENTIAL_KEY.search(normalized_key) is not None
-                    and nested is not None
-                    and nested != ""
-                ):
+                if credential_key(key_text) and nested is not None and nested != "":
                     found.append(child)
                 visit(nested, child)
         elif isinstance(value, (list, tuple)):
             for index, nested in enumerate(value):
                 visit(nested, f"{path}[{index}]")
 
+    def credential_bearing_url(value: str) -> bool:
+        try:
+            parsed = urlsplit(value)
+            if parsed.username is not None or parsed.password is not None:
+                return True
+            return any(credential_key(key) for key, _ in parse_qsl(parsed.query))
+        except ValueError:
+            # A malformed authority may still contain serialized userinfo. Fail
+            # closed on that recognizable credential shape.
+            return "@" in value.partition("://")[2].partition("/")[0]
+
+    def visit_api_bases(value: object, path: str) -> None:
+        if isinstance(value, Mapping):
+            for key, nested in value.items():
+                key_text = str(key)
+                child = f"{path}.{key_text}"
+                if (
+                    key_text.lower() == "api_base"
+                    and isinstance(nested, str)
+                    and credential_bearing_url(nested)
+                ):
+                    found.append(child)
+                visit_api_bases(nested, child)
+        elif isinstance(value, (list, tuple)):
+            for index, nested in enumerate(value):
+                visit_api_bases(nested, f"{path}[{index}]")
+
     for index, spec in enumerate(component_specs(resolver_manifest)):
+        component_path = f"component[{index}].{spec.type_name}"
         for field in ("provider", "extra_body"):
             value = spec.config.get(field)
             if value is not None:
-                visit(value, f"component[{index}].{spec.type_name}.{field}")
+                visit(value, f"{component_path}.{field}")
+        visit_api_bases(spec.config, component_path)
     return tuple(sorted(set(found)))
 
 
@@ -531,9 +562,9 @@ def resource_facts(
     refs: list[ModelRef] = []
     extras: set[str] = set()
     for spec in expanded:
-        optional_extra = _OPTIONAL_COMPONENT_EXTRAS.get(spec.type_name)
-        if optional_extra is not None:
-            extras.add(optional_extra)
+        component_extra = _COMPONENT_EXTRAS.get(spec.type_name)
+        if component_extra is not None:
+            extras.add(component_extra)
         metadata = _RESOURCE_COMPONENTS.get(spec.type_name)
         if metadata is None:
             if spec.type_name.startswith("resource_") or {

--- a/src/langres/_pretrained_artifact.py
+++ b/src/langres/_pretrained_artifact.py
@@ -89,6 +89,27 @@ _CREDENTIAL_KEY = re.compile(
     r"set_cookie|signature|sig|subscription_key|token)(?:$|_)",
     re.IGNORECASE,
 )
+_COMPACT_CREDENTIAL_KEYS = frozenset(
+    {
+        "accesstoken",
+        "apikey",
+        "authentication",
+        "authorization",
+        "authtoken",
+        "bearer",
+        "cookie",
+        "credential",
+        "credentials",
+        "openaikey",
+        "password",
+        "privatekey",
+        "secret",
+        "setcookie",
+        "signature",
+        "subscriptionkey",
+        "token",
+    }
+)
 
 
 class PretrainedArtifactError(ValueError):
@@ -428,7 +449,21 @@ def validate_bundle(root: Path) -> PretrainedManifest:
             "be loaded from a pretrained artifact. Fields: " + ", ".join(credential_paths[:10])
         )
     actual_refs, actual_extras = resource_facts(resolver_manifest)
-    if actual_refs != manifest.model_refs or actual_extras != manifest.required_extras:
+    declared_extras = manifest.required_extras
+    missing_extras = set(actual_extras).difference(declared_extras)
+    legacy_compatible_missing = {
+        _COMPONENT_EXTRAS[spec.type_name]
+        for spec in component_specs(resolver_manifest)
+        if spec.type_name in _COMPONENT_EXTRAS
+    }
+    extras_without_compatible_omissions = tuple(
+        extra for extra in actual_extras if extra not in missing_extras
+    )
+    if (
+        actual_refs != manifest.model_refs
+        or not missing_extras.issubset(legacy_compatible_missing)
+        or extras_without_compatible_omissions != declared_extras
+    ):
         raise PretrainedArtifactError("outer resource identity does not match resolver.json")
     actual_sensitive = bool(sensitive_config_paths(resolver_manifest))
     if actual_sensitive != manifest.sensitive_config_included:
@@ -501,8 +536,10 @@ def credential_config_paths(resolver_manifest: ArtifactManifest) -> tuple[str, .
     found: list[str] = []
 
     def credential_key(value: object) -> bool:
-        normalized = re.sub(r"[^a-z0-9]+", "_", str(value).lower()).strip("_")
-        return _CREDENTIAL_KEY.search(normalized) is not None
+        key_text = re.sub(r"(?<=[a-z0-9])(?=[A-Z])", "_", str(value))
+        normalized = re.sub(r"[^a-z0-9]+", "_", key_text.lower()).strip("_")
+        compact = re.sub(r"[^a-z0-9]+", "", key_text.lower())
+        return _CREDENTIAL_KEY.search(normalized) is not None or compact in _COMPACT_CREDENTIAL_KEYS
 
     def visit(value: object, path: str) -> None:
         if isinstance(value, Mapping):

--- a/tests/hub/test_security.py
+++ b/tests/hub/test_security.py
@@ -170,6 +170,41 @@ def test_credential_bearing_transport_config_is_rejected_when_loading(
         from_pretrained(bundle)
 
 
+@pytest.mark.parametrize(
+    "api_base",
+    (
+        "https://user:token@host.example/v1",
+        "https://host.example/v1?api_key=private",
+    ),
+)
+def test_credential_bearing_endpoint_url_is_never_publishable(
+    api_base: str,
+    tmp_path: Path,
+) -> None:
+    model = ERModel.from_topology(
+        ops=[
+            BlockerSource(AllPairsBlocker(schema=Entity)),
+            Generate(
+                LiteLLM(
+                    {
+                        "base": "served-model",
+                        "kind": "endpoint",
+                        "api_base": api_base,
+                    }
+                )
+            ),
+            Parse(),
+            ThresholdSelect(0.5),
+            ClustererStage(Clusterer(threshold=0.5)),
+        ]
+    )
+    destination = tmp_path / "credential-bearing-endpoint"
+
+    with pytest.raises(ArtifactEligibilityError, match="credential-bearing"):
+        save_pretrained(model, destination)
+    assert not destination.exists()
+
+
 def test_trained_components_declare_the_trained_extra() -> None:
     manifest = ArtifactManifest(
         artifact_version="1",
@@ -181,6 +216,19 @@ def test_trained_components_declare_the_trained_extra() -> None:
     )
 
     assert resource_facts(manifest) == ((), ("trained",))
+
+
+def test_vector_components_declare_the_semantic_extra() -> None:
+    manifest = ArtifactManifest(
+        artifact_version="1",
+        langres_version="0.3.0",
+        components=(
+            ComponentSpec(type_name="vector_blocker", config={}),
+            ComponentSpec(type_name="faiss_index", config={}),
+        ),
+    )
+
+    assert resource_facts(manifest) == ((), ("semantic",))
 
 
 def test_unknown_model_name_component_fails_closed() -> None:

--- a/tests/hub/test_security.py
+++ b/tests/hub/test_security.py
@@ -256,6 +256,29 @@ def test_legacy_vector_bundle_without_semantic_extra_remains_valid(
     assert validate_bundle(bundle).required_extras == ()
 
 
+def test_missing_trained_extra_is_not_legacy_compatible(
+    model: ERModel,
+    tmp_path: Path,
+) -> None:
+    bundle = save_pretrained(model, tmp_path / "missing-trained")
+    resolver = json.loads((bundle / "resolver.json").read_text())
+    resolver["components"][0]["type_name"] = "calibrator"
+    (bundle / "resolver.json").write_text(json.dumps(resolver))
+
+    manifest = json.loads((bundle / BUNDLE_MANIFEST).read_text())
+    import hashlib
+
+    content = (bundle / "resolver.json").read_bytes()
+    for item in manifest["files"]:
+        if item["path"] == "resolver.json":
+            item["size"] = len(content)
+            item["sha256"] = hashlib.sha256(content).hexdigest()
+    (bundle / BUNDLE_MANIFEST).write_text(json.dumps(manifest))
+
+    with pytest.raises(PretrainedArtifactError, match="outer resource identity"):
+        validate_bundle(bundle)
+
+
 def test_unknown_model_name_component_fails_closed() -> None:
     manifest = ArtifactManifest(
         artifact_version="1",

--- a/tests/hub/test_security.py
+++ b/tests/hub/test_security.py
@@ -16,6 +16,7 @@ from langres._pretrained_artifact import (
     PretrainedArtifactError,
     resource_facts,
     sensitive_config_paths,
+    validate_bundle,
 )
 from langres.core.serialization import ArtifactManifest, ComponentSpec, OpSpec
 from langres.core.blockers.all_pairs import AllPairsBlocker
@@ -175,6 +176,8 @@ def test_credential_bearing_transport_config_is_rejected_when_loading(
     (
         "https://user:token@host.example/v1",
         "https://host.example/v1?api_key=private",
+        "https://host.example/v1?apiKey=private",
+        "https://host.example/v1?accessToken=private",
     ),
 )
 def test_credential_bearing_endpoint_url_is_never_publishable(
@@ -229,6 +232,28 @@ def test_vector_components_declare_the_semantic_extra() -> None:
     )
 
     assert resource_facts(manifest) == ((), ("semantic",))
+
+
+def test_legacy_vector_bundle_without_semantic_extra_remains_valid(
+    model: ERModel,
+    tmp_path: Path,
+) -> None:
+    bundle = save_pretrained(model, tmp_path / "legacy-vector")
+    resolver = json.loads((bundle / "resolver.json").read_text())
+    resolver["components"][0]["type_name"] = "vector_blocker"
+    (bundle / "resolver.json").write_text(json.dumps(resolver))
+
+    manifest = json.loads((bundle / BUNDLE_MANIFEST).read_text())
+    import hashlib
+
+    content = (bundle / "resolver.json").read_bytes()
+    for item in manifest["files"]:
+        if item["path"] == "resolver.json":
+            item["size"] = len(content)
+            item["sha256"] = hashlib.sha256(content).hexdigest()
+    (bundle / BUNDLE_MANIFEST).write_text(json.dumps(manifest))
+
+    assert validate_bundle(bundle).required_extras == ()
 
 
 def test_unknown_model_name_component_fails_closed() -> None:


### PR DESCRIPTION
## Summary

Follow-up to #224 for the exact-head Codex review findings:

- reject credentials embedded in endpoint `api_base` userinfo or secret query parameters
- declare `[semantic]` for `vector_blocker` and `faiss_index`, even with model-free/custom embedders
- document both publication contracts

## Verification

- `PYTHONPATH=src pytest tests/hub --no-cov -q` — 58 passed
- `ruff check` and `ruff format --check` — passed
- strict `mypy src/langres/_pretrained_artifact.py` — passed
- `git diff --check` — passed