### PR TITLE
Make retrieval benchmarks trustworthy and Qdrant-native

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,10 @@ The [generated smoke table](docs/generated/research_smoke_table.md) comes from a
 real local `ExperimentReport`; it proves the contracts compose, not that fake
 resources are competitive.
 
+Research retrieval uses Qdrant over the embedder's output. For cross-source
+linkage, pass `source_field="source"` so same-source records are excluded before
+top-k; omit it for single-source deduplication.
+
 See [Getting started](docs/GETTING_STARTED.md) for the progressive path,
 [Experiments](docs/EXPERIMENTS.md) for protocol and cohort semantics, and
 [Reproducibility](docs/REPRODUCIBILITY.md) for handoff and publication.

--- a/docs/EXPERIMENTS.md
+++ b/docs/EXPERIMENTS.md
@@ -67,6 +67,10 @@ Python.
 The current benchmark registry exposes an actual `train`/`test` split. The
 runner therefore requires `threshold_split_id="train"` and never relabels that
 data as validation. Thresholds are selected on train; test remains untouched.
+The selected recipe cut maximizes **pair F1** on train. B-Cubed is still
+reported for the resulting clusters, but it is not used to tune a matcher cut:
+on singleton-heavy data its high all-singleton floor can otherwise select a
+threshold that predicts no true pairs.
 An official publication protocol may use the matrix label `"official"`, but its
 `ExperimentRun.evaluation_split_id` still records `"test"`.
 
@@ -157,6 +161,16 @@ different remote provider may change both. `report.cohorts` groups by
 evaluation and hardware cohort; aggregate and Pareto views do not license
 cross-cohort speed claims. State the cohort next to every performance number.
 
+Each stage records its input-based throughput together with an explicit unit:
+`records` for `Retrieve`, `pairs` for downstream operations. The runner never
+labels output-pair production as generic throughput. Embedder measurements carry
+dimension, dtype, declared quantization, vector bytes, and—when the loaded
+backend exposes them—parameter count, loaded tensor bytes, and cached/local
+artifact bytes. Runtime facts include the installed model/vector library
+versions. Per-item p50/p95 fields stay `None` when only a batch duration exists;
+no percentile is manufactured from one aggregate timer. These numeric stage
+facts are persisted in `RunStore` and published to Trackio under `stages.*`.
+
 The generated [fake-resource smoke table](generated/research_smoke_table.md) is
 mechanically produced by
 `examples/research/generate_smoke_table.py` from a real local
@@ -188,8 +202,9 @@ uv run python examples/research/trackio_reproduction.py
 The script constructs `TrackioTracker(local_only=True)`, which suppresses
 Settings and environment Space fallbacks, so it requires no token and makes no
 Hub request. The `RunStore` and protocol remain the reproduction source of
-truth; Trackio is a view. Setting a Space id is a separate, credentialed
-publication action.
+truth; Trackio is a view. Quality, funnel, token/cost, and numeric stage
+measurements are mirrored into that view; runtime/library strings are logged as
+parameters. Setting a Space id is a separate, credentialed publication action.
 
 ## Guarded official paid proof
 

--- a/docs/EXPERIMENTS.md
+++ b/docs/EXPERIMENTS.md
@@ -67,10 +67,16 @@ Python.
 The current benchmark registry exposes an actual `train`/`test` split. The
 runner therefore requires `threshold_split_id="train"` and never relabels that
 data as validation. Thresholds are selected on train; test remains untouched.
-The selected recipe cut maximizes **pair F1** on train. B-Cubed is still
-reported for the resulting clusters, but it is not used to tune a matcher cut:
-on singleton-heavy data its high all-singleton floor can otherwise select a
-threshold that predicts no true pairs.
+The selected recipe cut maximizes **pair F1** on train. The declared threshold
+grid remains the baseline and fallback. When the replay checkpoint exposes
+scored rows, the runner also checks every observed score breakpoint in one
+sorted pass, so a narrow reranker score distribution cannot hide the useful cut
+between two grid values. This does not rerun or rebill the embedder/reranker.
+The selected threshold, strategy, score range, scored-pair count, and breakpoint
+count are logged as run parameters. B-Cubed is still reported for the resulting
+clusters, but it is not used to tune a matcher cut: on singleton-heavy data its
+high all-singleton floor can otherwise select a threshold that predicts no true
+pairs.
 An official publication protocol may use the matrix label `"official"`, but its
 `ExperimentRun.evaluation_split_id` still records `"test"`.
 

--- a/docs/reference/architectures.md
+++ b/docs/reference/architectures.md
@@ -60,7 +60,9 @@ zero-configuration local mode; the adapter is also verified against a real
 Qdrant server with Testcontainers. For two-source linkage, pass
 `source_field="source"`: Qdrant applies that exclusion inside each nearest-
 neighbour query, before `retrieve_k` is consumed. Omit it for ordinary
-single-source deduplication.
+single-source deduplication. An explicitly named collection that already exists
+is never deleted: an injected client must use a fresh collection name for each
+index instance. Install `langres[semantic]` to enable the Qdrant adapter.
 
 Recipes infer a schema from records on their first `.dedupe()` or `.compare()`
 call. Pass `schema=YourPydanticModel` explicitly when saving an artifact; an
@@ -75,9 +77,13 @@ a matrix charges the same cumulative ledger; the two arguments are mutually
 exclusive.
 
 When `Experiment` sweeps this decision threshold, it selects the value with the
-highest pair F1 on the declared training split. B-Cubed remains a downstream
-clustering report metric; it is not the threshold objective, because a
-singleton-heavy dataset can otherwise reward predicting no matching pairs.
+highest pair F1 on the declared training split. The declared grid is the
+baseline/fallback; replayable scored rows also contribute their exact observed
+score breakpoints in one sorted pass, without rerunning model inference. The
+threshold strategy and observed score range/counts are logged with the run.
+B-Cubed remains a downstream clustering report metric; it is not the threshold
+objective, because a singleton-heavy dataset can otherwise reward predicting no
+matching pairs.
 
 `architecture.resources` returns every slot as `dict[str, ModelRef]`.
 `architecture.backbone` remains compatibility sugar only for `Retrieve`, the

--- a/docs/reference/architectures.md
+++ b/docs/reference/architectures.md
@@ -50,9 +50,17 @@ architecture = RetrieveRerankLLM(
     reranker="cross-encoder/ms-marco-MiniLM-L6-v2",
     llm={"base": "openai/gpt-4o-mini", "kind": "api"},
     retrieve_k=50,
+    source_field="source",  # linkage: exclude same-source hits before top-k
     llm_k=10,
 )
 ```
+
+`Retrieve` indexes the embedder's vectors in Qdrant. The default uses Qdrant's
+zero-configuration local mode; the adapter is also verified against a real
+Qdrant server with Testcontainers. For two-source linkage, pass
+`source_field="source"`: Qdrant applies that exclusion inside each nearest-
+neighbour query, before `retrieve_k` is consumed. Omit it for ordinary
+single-source deduplication.
 
 Recipes infer a schema from records on their first `.dedupe()` or `.compare()`
 call. Pass `schema=YourPydanticModel` explicitly when saving an artifact; an
@@ -65,6 +73,11 @@ Pass either `budget_usd=` for a recipe-local cap or `monitor=` to adopt an
 existing `SpendMonitor`. Experiment factories use `monitor=` so every recipe in
 a matrix charges the same cumulative ledger; the two arguments are mutually
 exclusive.
+
+When `Experiment` sweeps this decision threshold, it selects the value with the
+highest pair F1 on the declared training split. B-Cubed remains a downstream
+clustering report metric; it is not the threshold objective, because a
+singleton-heavy dataset can otherwise reward predicting no matching pairs.
 
 `architecture.resources` returns every slot as `dict[str, ModelRef]`.
 `architecture.backbone` remains compatibility sugar only for `Retrieve`, the

--- a/docs/reference/research-vocabulary.md
+++ b/docs/reference/research-vocabulary.md
@@ -26,3 +26,8 @@ reading older docs, code, and artifacts:
 There is still no `matcher="auto"` and no module-level `langres.dedupe` or
 `langres.link`. Construct a recipe/architecture explicitly, or build an
 `ERModel.from_topology(ops=[...])`.
+
+The research `Retrieve` operation keeps the `Embedder` as the model-bearing
+resource and delegates vector storage/search to Qdrant. In a linkage recipe,
+`source_field="source"` excludes same-source records inside the Qdrant query,
+before top-k; in a deduplication recipe the option is omitted.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,9 +52,8 @@ Changelog = "https://github.com/fxd24/langres/blob/main/CHANGELOG.md"
 langres = "langres.cli:main"
 
 [project.optional-dependencies]
-# The embedding/vector stack -- VectorBlocker, embeddings.py, indexes.py
-# (FAISS + Qdrant). Required for judge="embedding" and the VectorBlocker
-# scaling path (dedupe() above ~100 records).
+# The embedding/vector stack. Research `Retrieve` uses Qdrant; the classic
+# VectorBlocker compatibility surface still includes its historical FAISS index.
 semantic = [
     "faiss-cpu>=1.12.0",
     "fastembed>=0.7.3",

--- a/src/langres/architectures/retrieval.py
+++ b/src/langres/architectures/retrieval.py
@@ -267,6 +267,7 @@ class Retrieve(_ResearchRecipe):
         retrieve_k: int = 20,
         threshold: float = 0.5,
         text_field: str | None = None,
+        source_field: str | None = None,
         clusterer: Clusterer | None = None,
         budget_usd: float | None = None,
         monitor: SpendMonitor | None = None,
@@ -275,6 +276,7 @@ class Retrieve(_ResearchRecipe):
         self.retrieve_k = retrieve_k
         self.threshold = threshold
         self.text_field = text_field
+        self.source_field = source_field
         self.clusterer_override = clusterer
         self._initialize_recipe(
             {"embedder": _embedder(embedder)},
@@ -291,6 +293,7 @@ class Retrieve(_ResearchRecipe):
                 schema=schema,
                 k=self.retrieve_k,
                 text_field=self.text_field,
+                source_field=self.source_field,
             ),
             ThresholdSelect(self.threshold),
             _cluster_stage(self.clusterer_override),
@@ -310,6 +313,7 @@ class RetrieveRerank(_ResearchRecipe):
         retrieve_k: int = 20,
         threshold: float = 0.5,
         text_field: str | None = None,
+        source_field: str | None = None,
         clusterer: Clusterer | None = None,
         budget_usd: float | None = None,
         monitor: SpendMonitor | None = None,
@@ -318,6 +322,7 @@ class RetrieveRerank(_ResearchRecipe):
         self.retrieve_k = retrieve_k
         self.threshold = threshold
         self.text_field = text_field
+        self.source_field = source_field
         self.clusterer_override = clusterer
         self._initialize_recipe(
             {
@@ -338,6 +343,7 @@ class RetrieveRerank(_ResearchRecipe):
                 schema=schema,
                 k=self.retrieve_k,
                 text_field=self.text_field,
+                source_field=self.source_field,
             ),
             Rerank(reranker),
             ThresholdSelect(self.threshold),
@@ -359,6 +365,7 @@ class RetrieveLLM(_ResearchRecipe):
         llm_k: int = 5,
         threshold: float = 0.5,
         text_field: str | None = None,
+        source_field: str | None = None,
         clusterer: Clusterer | None = None,
         budget_usd: float | None = None,
         monitor: SpendMonitor | None = None,
@@ -370,6 +377,7 @@ class RetrieveLLM(_ResearchRecipe):
         self.llm_k = llm_k
         self.threshold = threshold
         self.text_field = text_field
+        self.source_field = source_field
         self.clusterer_override = clusterer
         self._initialize_recipe(
             {
@@ -390,6 +398,7 @@ class RetrieveLLM(_ResearchRecipe):
                 schema=schema,
                 k=self.retrieve_k,
                 text_field=self.text_field,
+                source_field=self.source_field,
             ),
             TopKSelect(self.llm_k),
             Generate(llm),
@@ -414,6 +423,7 @@ class RetrieveRerankLLM(_ResearchRecipe):
         llm_k: int = 5,
         threshold: float = 0.5,
         text_field: str | None = None,
+        source_field: str | None = None,
         clusterer: Clusterer | None = None,
         budget_usd: float | None = None,
         monitor: SpendMonitor | None = None,
@@ -425,6 +435,7 @@ class RetrieveRerankLLM(_ResearchRecipe):
         self.llm_k = llm_k
         self.threshold = threshold
         self.text_field = text_field
+        self.source_field = source_field
         self.clusterer_override = clusterer
         self._initialize_recipe(
             {
@@ -447,6 +458,7 @@ class RetrieveRerankLLM(_ResearchRecipe):
                 schema=schema,
                 k=self.retrieve_k,
                 text_field=self.text_field,
+                source_field=self.source_field,
             ),
             Rerank(reranker),
             TopKSelect(self.llm_k),

--- a/src/langres/core/indexes/__init__.py
+++ b/src/langres/core/indexes/__init__.py
@@ -1,21 +1,57 @@
-"""Vector index implementations for approximate nearest neighbor search."""
+"""Vector index implementations with import-light compatibility exports.
 
-from langres.core.indexes.hybrid_vector_index import (
-    FakeHybridVectorIndex,
-    QdrantHybridIndex,
-)
-from langres.core.indexes.reranking_vector_index import (
-    FakeHybridRerankingVectorIndex,
-    QdrantHybridRerankingIndex,
-)
-from langres.core.indexes.vector_index import FAISSIndex, FakeVectorIndex, VectorIndex
+The historical FAISS and hybrid indexes remain available from this package,
+but resolving the Qdrant dense research path must not import every backend.
+PEP 562 lazy exports preserve the public API without loading FAISS as a side
+effect of importing :mod:`langres.core.indexes.qdrant_dense_index`.
+"""
+
+import importlib
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from langres.core.indexes.hybrid_vector_index import (
+        FakeHybridVectorIndex,
+        QdrantHybridIndex,
+    )
+    from langres.core.indexes.qdrant_dense_index import QdrantDenseIndex
+    from langres.core.indexes.reranking_vector_index import (
+        FakeHybridRerankingVectorIndex,
+        QdrantHybridRerankingIndex,
+    )
+    from langres.core.indexes.vector_index import (
+        FAISSIndex,
+        FakeVectorIndex,
+        VectorIndex,
+    )
 
 __all__ = [
     "FAISSIndex",
     "FakeVectorIndex",
     "VectorIndex",
+    "QdrantDenseIndex",
     "QdrantHybridIndex",
     "FakeHybridVectorIndex",
     "QdrantHybridRerankingIndex",
     "FakeHybridRerankingVectorIndex",
 ]
+
+_LAZY_SYMBOLS: dict[str, str] = {
+    "FAISSIndex": "langres.core.indexes.vector_index",
+    "FakeVectorIndex": "langres.core.indexes.vector_index",
+    "VectorIndex": "langres.core.indexes.vector_index",
+    "QdrantDenseIndex": "langres.core.indexes.qdrant_dense_index",
+    "QdrantHybridIndex": "langres.core.indexes.hybrid_vector_index",
+    "FakeHybridVectorIndex": "langres.core.indexes.hybrid_vector_index",
+    "QdrantHybridRerankingIndex": ("langres.core.indexes.reranking_vector_index"),
+    "FakeHybridRerankingVectorIndex": ("langres.core.indexes.reranking_vector_index"),
+}
+
+
+def __getattr__(name: str) -> Any:
+    module_path = _LAZY_SYMBOLS.get(name)
+    if module_path is None:
+        raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+    value = getattr(importlib.import_module(module_path), name)
+    globals()[name] = value
+    return value

--- a/src/langres/core/indexes/qdrant_dense_index.py
+++ b/src/langres/core/indexes/qdrant_dense_index.py
@@ -7,6 +7,10 @@ from uuid import uuid4
 
 import numpy as np
 
+_MISSING_QDRANT_MESSAGE = (
+    "Qdrant retrieval requires the semantic extra: pip install langres[semantic]"
+)
+
 
 class QdrantDenseIndex:
     """Index precomputed dense vectors without owning the embedding model.
@@ -25,12 +29,16 @@ class QdrantDenseIndex:
     ) -> None:
         self._client = client
         self.collection_name = collection_name or f"langres_retrieve_{uuid4().hex}"
+        self._owns_collection = False
 
     @property
     def client(self) -> Any:
         """Create the optional Qdrant client only when retrieval actually runs."""
         if self._client is None:
-            from qdrant_client import QdrantClient
+            try:
+                from qdrant_client import QdrantClient
+            except ImportError as exc:
+                raise ImportError(_MISSING_QDRANT_MESSAGE) from exc
 
             self._client = QdrantClient(":memory:")
         return self._client
@@ -67,24 +75,33 @@ class QdrantDenseIndex:
                 np.empty((len(matrix), 0), dtype=np.int64),
             )
 
-        from qdrant_client.models import (
-            Distance,
-            FieldCondition,
-            Filter,
-            HasIdCondition,
-            MatchValue,
-            PointStruct,
-            QueryRequest,
-            VectorParams,
-        )
+        try:
+            from qdrant_client.models import (
+                Distance,
+                FieldCondition,
+                Filter,
+                HasIdCondition,
+                MatchValue,
+                PointStruct,
+                QueryRequest,
+                VectorParams,
+            )
+        except ImportError as exc:
+            raise ImportError(_MISSING_QDRANT_MESSAGE) from exc
 
         client = self.client
         if client.collection_exists(self.collection_name):
+            if not self._owns_collection:
+                raise ValueError(
+                    f"Qdrant collection {self.collection_name!r} already exists; "
+                    "refusing to delete a collection this index did not create"
+                )
             client.delete_collection(self.collection_name)
         client.create_collection(
             collection_name=self.collection_name,
             vectors_config=VectorParams(size=matrix.shape[1], distance=Distance.COSINE),
         )
+        self._owns_collection = True
         client.upsert(
             collection_name=self.collection_name,
             points=[

--- a/src/langres/core/indexes/qdrant_dense_index.py
+++ b/src/langres/core/indexes/qdrant_dense_index.py
@@ -1,0 +1,133 @@
+"""Qdrant adapter for dense retrieval over precomputed vectors."""
+
+from __future__ import annotations
+
+from typing import Any
+from uuid import uuid4
+
+import numpy as np
+
+
+class QdrantDenseIndex:
+    """Index precomputed dense vectors without owning the embedding model.
+
+    ``Retrieve`` owns the model-bearing :class:`~langres.resources.Embedder`;
+    this class owns only vector-store mechanics. A caller may inject a Qdrant
+    client for a server or Testcontainer. With no client, Qdrant's in-process
+    local mode keeps the out-of-the-box path zero-configuration.
+    """
+
+    def __init__(
+        self,
+        *,
+        client: Any | None = None,
+        collection_name: str | None = None,
+    ) -> None:
+        self._client = client
+        self.collection_name = collection_name or f"langres_retrieve_{uuid4().hex}"
+
+    @property
+    def client(self) -> Any:
+        """Create the optional Qdrant client only when retrieval actually runs."""
+        if self._client is None:
+            from qdrant_client import QdrantClient
+
+            self._client = QdrantClient(":memory:")
+        return self._client
+
+    def search_all(
+        self,
+        vectors: np.ndarray,
+        *,
+        k: int,
+        groups: list[str] | None = None,
+    ) -> tuple[np.ndarray, np.ndarray]:
+        """Return each vector's nearest neighbours, optionally outside its group.
+
+        Group exclusion is expressed in the Qdrant query itself, so disallowed
+        hits do not consume a top-k slot. The query record itself is always
+        excluded.
+        """
+        if k <= 0:
+            raise ValueError("k must be positive")
+        matrix = np.asarray(vectors, dtype=np.float32)
+        if matrix.ndim != 2:
+            raise ValueError("vectors must be a two-dimensional matrix")
+        if groups is not None and len(groups) != len(matrix):
+            raise ValueError("groups must contain one value per vector")
+        if not len(matrix):
+            return (
+                np.empty((0, 0), dtype=np.float32),
+                np.empty((0, 0), dtype=np.int64),
+            )
+        limit = min(k, max(len(matrix) - 1, 0))
+        if limit == 0:
+            return (
+                np.empty((len(matrix), 0), dtype=np.float32),
+                np.empty((len(matrix), 0), dtype=np.int64),
+            )
+
+        from qdrant_client.models import (
+            Distance,
+            FieldCondition,
+            Filter,
+            HasIdCondition,
+            MatchValue,
+            PointStruct,
+            QueryRequest,
+            VectorParams,
+        )
+
+        client = self.client
+        if client.collection_exists(self.collection_name):
+            client.delete_collection(self.collection_name)
+        client.create_collection(
+            collection_name=self.collection_name,
+            vectors_config=VectorParams(size=matrix.shape[1], distance=Distance.COSINE),
+        )
+        client.upsert(
+            collection_name=self.collection_name,
+            points=[
+                PointStruct(
+                    id=index,
+                    vector=vector.tolist(),
+                    payload={"_langres_group": groups[index]} if groups is not None else {},
+                )
+                for index, vector in enumerate(matrix)
+            ],
+            wait=True,
+        )
+
+        requests = []
+        for index, vector in enumerate(matrix):
+            excluded: list[Any] = [HasIdCondition(has_id=[index])]
+            if groups is not None:
+                excluded.append(
+                    FieldCondition(
+                        key="_langres_group",
+                        match=MatchValue(value=groups[index]),
+                    )
+                )
+            requests.append(
+                QueryRequest(
+                    query=vector.tolist(),
+                    filter=Filter(must_not=excluded),
+                    limit=limit,
+                    with_payload=False,
+                )
+            )
+
+        responses = client.query_batch_points(
+            collection_name=self.collection_name,
+            requests=requests,
+        )
+        scores = np.full((len(matrix), limit), np.nan, dtype=np.float32)
+        neighbours = np.full((len(matrix), limit), -1, dtype=np.int64)
+        for row, response in enumerate(responses):
+            for column, point in enumerate(response.points[:limit]):
+                scores[row, column] = float(point.score)
+                neighbours[row, column] = int(point.id)
+        return scores, neighbours
+
+
+__all__ = ["QdrantDenseIndex"]

--- a/src/langres/data/abt_buy.py
+++ b/src/langres/data/abt_buy.py
@@ -26,21 +26,23 @@ schema, pinned constants, and public wrappers.
 as Fodors-Zagat and Amazon-Google.
 """
 
+from __future__ import annotations
+
 import logging
 from collections.abc import Iterable
-from typing import Literal
+from typing import TYPE_CHECKING, Literal
 
 from pydantic import BaseModel, computed_field
 
 from langres.data.benchmark import Benchmark, gold_pairs_from_clusters
 from langres.core.blockers.all_pairs import register_schema_idempotent
-from langres.core.blockers.vector import VectorBlocker
-from langres.core.embeddings import SentenceTransformerEmbedder
-from langres.core.indexes.vector_index import FAISSIndex
 from langres.core.models import ERCandidate
 from langres.data import _benchmark_utils as _bu
 
 logger = logging.getLogger(__name__)
+
+if TYPE_CHECKING:
+    from langres.core.blockers.vector import VectorBlocker
 
 __all__ = [
     "ABT_BUY_RECALL_GATE",
@@ -244,6 +246,10 @@ def build_abt_buy_blocker(
     Returns:
         A :class:`VectorBlocker` over ``AbtBuySchema.embed_text``.
     """
+    from langres.core.blockers.vector import VectorBlocker
+    from langres.core.embeddings import SentenceTransformerEmbedder
+    from langres.core.indexes.vector_index import FAISSIndex
+
     return VectorBlocker(
         vector_index=FAISSIndex(
             embedder=SentenceTransformerEmbedder("all-MiniLM-L6-v2"),

--- a/src/langres/data/amazon_google.py
+++ b/src/langres/data/amazon_google.py
@@ -34,21 +34,23 @@ it (it also conforms to ``langres.methods.BlockingBenchmark`` by exposing its
 ``schema`` + pinned blocking config), mirroring ``FodorsZagatBenchmark``.
 """
 
+from __future__ import annotations
+
 import logging
 from collections.abc import Iterable
-from typing import Literal
+from typing import TYPE_CHECKING, Literal
 
 from pydantic import BaseModel, computed_field
 
 from langres.data.benchmark import Benchmark, gold_pairs_from_clusters
 from langres.core.blockers.all_pairs import register_schema_idempotent
-from langres.core.blockers.vector import VectorBlocker
-from langres.core.embeddings import SentenceTransformerEmbedder
-from langres.core.indexes.vector_index import FAISSIndex
 from langres.core.models import ERCandidate
 from langres.data import _benchmark_utils as _bu
 
 logger = logging.getLogger(__name__)
+
+if TYPE_CHECKING:
+    from langres.core.blockers.vector import VectorBlocker
 
 __all__ = [
     "ACHIEVED_PC_AT_DEFAULT_K",
@@ -297,6 +299,10 @@ def build_product_blocker(
     Returns:
         A :class:`VectorBlocker` over ``ProductSchema.embed_text``.
     """
+    from langres.core.blockers.vector import VectorBlocker
+    from langres.core.embeddings import SentenceTransformerEmbedder
+    from langres.core.indexes.vector_index import FAISSIndex
+
     return VectorBlocker(
         vector_index=FAISSIndex(
             embedder=SentenceTransformerEmbedder("all-MiniLM-L6-v2"),

--- a/src/langres/data/er_benchmarks.py
+++ b/src/langres/data/er_benchmarks.py
@@ -10,9 +10,11 @@ therefore filters candidate pairs to cross-source ones before measuring recall
 (intra-source pairs are noise for this task; see DESIGN-REVIEW B2).
 """
 
+from __future__ import annotations
+
 import logging
 from collections.abc import Sequence
-from typing import Literal
+from typing import TYPE_CHECKING, Literal
 
 from pydantic import BaseModel, Field, computed_field
 
@@ -23,12 +25,9 @@ from langres.data.benchmark import (
 )
 from langres.core.blocker import Blocker
 from langres.core.blockers.all_pairs import register_schema_idempotent
-from langres.core.blockers.vector import VectorBlocker
 from langres.core.clusterer import Clusterer
 from langres.core.comparator import Comparator
 from langres.core.comparators import StringComparator
-from langres.core.embeddings import SentenceTransformerEmbedder
-from langres.core.indexes.vector_index import FAISSIndex
 from langres.core.matchers.weighted_average import WeightedAverageMatcher
 from langres.core.metrics import evaluate_blocking
 from langres.core.models import ERCandidate
@@ -36,6 +35,9 @@ from langres.core.resolver import Resolver
 from langres.data import _benchmark_utils as _bu
 
 logger = logging.getLogger(__name__)
+
+if TYPE_CHECKING:
+    from langres.core.blockers.vector import VectorBlocker
 
 # ``complete_partition`` is re-exported above (it moved to the dataset-agnostic
 # ``langres.core.benchmark`` harness); importers that still do
@@ -258,6 +260,10 @@ def build_restaurant_blocker(
     Returns:
         A :class:`VectorBlocker` over ``RestaurantSchema.embed_text``.
     """
+    from langres.core.blockers.vector import VectorBlocker
+    from langres.core.embeddings import SentenceTransformerEmbedder
+    from langres.core.indexes.vector_index import FAISSIndex
+
     return VectorBlocker(
         vector_index=FAISSIndex(
             embedder=SentenceTransformerEmbedder("all-MiniLM-L6-v2"),

--- a/src/langres/data/febrl_person.py
+++ b/src/langres/data/febrl_person.py
@@ -31,20 +31,22 @@ keeps the person-specific schema, pinned constants, and public wrappers.
 Fodors-Zagat, Amazon-Google, and Abt-Buy.
 """
 
+from __future__ import annotations
+
 import logging
-from typing import Literal
+from typing import TYPE_CHECKING, Literal
 
 from pydantic import BaseModel, computed_field
 
 from langres.data.benchmark import Benchmark, gold_pairs_from_clusters
 from langres.core.blockers.all_pairs import register_schema_idempotent
-from langres.core.blockers.vector import VectorBlocker
-from langres.core.embeddings import SentenceTransformerEmbedder
-from langres.core.indexes.vector_index import FAISSIndex
 from langres.core.models import ERCandidate
 from langres.data import _benchmark_utils as _bu
 
 logger = logging.getLogger(__name__)
+
+if TYPE_CHECKING:
+    from langres.core.blockers.vector import VectorBlocker
 
 __all__ = [
     "ACHIEVED_PC_AT_DEFAULT_K",
@@ -271,6 +273,10 @@ def build_person_blocker(
     Returns:
         A :class:`VectorBlocker` over ``FebrlPersonSchema.embed_text``.
     """
+    from langres.core.blockers.vector import VectorBlocker
+    from langres.core.embeddings import SentenceTransformerEmbedder
+    from langres.core.indexes.vector_index import FAISSIndex
+
     return VectorBlocker(
         vector_index=FAISSIndex(
             embedder=SentenceTransformerEmbedder("all-MiniLM-L6-v2"),

--- a/src/langres/data/registry.py
+++ b/src/langres/data/registry.py
@@ -3,10 +3,9 @@
 A discoverability + serialization seam over the dataset loaders: a static
 ``name -> BenchmarkEntry`` manifest of lightweight *metadata* (task, domain,
 loadable, and where the loader lives) with **no loader import at module scope**.
-This is deliberate — every dataset loader eagerly pulls the ``[semantic]`` stack
-(``VectorBlocker`` / ``SentenceTransformer`` / ``FAISS``), so auto-importing all
-loaders would break a core-only install and ``tests/test_import_budget.py``, and
-one failing loader would take down the whole registry.
+This keeps discovery core-only. Individual linkage loaders also defer their
+legacy vector-blocker factory until it is called, so loading/splitting benchmark
+records does not import a vector backend.
 
 Therefore:
 

--- a/src/langres/experiments/measurements.py
+++ b/src/langres/experiments/measurements.py
@@ -241,6 +241,7 @@ class StageMeasurement(BaseModel):
     pairs_in: int | None = Field(default=None, ge=0)
     pairs_out: int | None = Field(default=None, ge=0)
     throughput_per_second: float | None = Field(default=None, ge=0.0)
+    throughput_unit: Literal["records", "pairs"] | None = None
     p50_item_latency_seconds: float | None = Field(default=None, ge=0.0)
     p95_item_latency_seconds: float | None = Field(default=None, ge=0.0)
     temperature: Literal["cold", "warm"] | None = None

--- a/src/langres/experiments/runner.py
+++ b/src/langres/experiments/runner.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import hashlib
+import importlib.metadata
 import json
 import math
 import platform
@@ -220,8 +221,20 @@ def _runtime_facts(
     *,
     cohort: str,
     config: Mapping[str, Any] | None,
+    resource_slot: str,
 ) -> RuntimeFacts:
     values = config or {}
+    packages = {
+        "embedder": ("numpy", "qdrant-client", "sentence-transformers", "torch", "transformers"),
+        "reranker": ("numpy", "sentence-transformers", "torch", "transformers"),
+        "llm": ("litellm", "torch", "transformers"),
+    }.get(resource_slot, ())
+    versions: dict[str, str] = {}
+    for package in packages:
+        try:
+            versions[package] = importlib.metadata.version(package)
+        except importlib.metadata.PackageNotFoundError:
+            continue
     return RuntimeFacts(
         hardware_cohort=cohort,
         host=platform.node() or None,
@@ -229,6 +242,7 @@ def _runtime_facts(
         python_version=platform.python_version(),
         langres_version=__version__,
         cpu=platform.processor() or platform.machine() or None,
+        library_versions=versions,
         device=values.get("device") if isinstance(values.get("device"), str) else None,
         dtype=values.get("dtype") if isinstance(values.get("dtype"), str) else None,
         quantization=(
@@ -371,11 +385,29 @@ def _embedding_facts(
         return EmbeddingFacts(
             dimensions=dimensions,
             dtype=dtype_name,
+            quantization=(
+                facts.get("quantization") if isinstance(facts.get("quantization"), str) else None
+            ),
             vectors_produced=vectors_produced,
             bytes_per_vector=bytes_per_vector,
             total_vector_bytes=(
                 vectors_produced * bytes_per_vector
                 if vectors_produced is not None and bytes_per_vector is not None
+                else None
+            ),
+            parameter_count=(
+                facts.get("parameter_count")
+                if isinstance(facts.get("parameter_count"), int)
+                else None
+            ),
+            artifact_bytes=(
+                facts.get("artifact_bytes")
+                if isinstance(facts.get("artifact_bytes"), int)
+                else None
+            ),
+            loaded_memory_bytes=(
+                facts.get("loaded_memory_bytes")
+                if isinstance(facts.get("loaded_memory_bytes"), int)
                 else None
             ),
         )
@@ -419,7 +451,7 @@ def _measurements(
     for event in result.events:
         if event.kind != "finish" or event.duration_seconds is None:
             continue
-        count = event.output_count
+        count = event.input_count
         throughput = (
             count / event.duration_seconds
             if count is not None and event.duration_seconds > 0
@@ -447,6 +479,7 @@ def _measurements(
                 pairs_in=event.input_count if event.index > 0 else None,
                 pairs_out=event.output_count if event.role != "clusterer_stage" else None,
                 throughput_per_second=throughput,
+                throughput_unit="records" if event.role == "retrieve" else "pairs",
                 cache_hit=cache_hit if first_finished else None,
                 resource_slot=slot,
                 resource_id=step.resource_ref,
@@ -460,6 +493,7 @@ def _measurements(
                     _runtime_facts(
                         cohort=hardware_cohort,
                         config=resource_runtime.get(slot, {}),
+                        resource_slot=slot,
                     )
                     if slot is not None
                     else None
@@ -472,6 +506,23 @@ def _measurements(
         )
         first_finished = False
     return tuple(output)
+
+
+def _tracker_stage_measurements(
+    measurements: Sequence[StageMeasurement],
+) -> dict[str, dict[str, dict[str, dict[str, Any]]]]:
+    """Give repeated stage facts stable, collision-free tracker metric paths."""
+    output: dict[str, dict[str, dict[str, dict[str, Any]]]] = {}
+    counts: dict[tuple[str, str], int] = {}
+    for measurement in measurements:
+        phase = measurement.phase or "unknown"
+        key = (phase, measurement.operation_kind)
+        occurrence = counts.get(key, 0)
+        counts[key] = occurrence + 1
+        output.setdefault(phase, {}).setdefault(measurement.operation_kind, {})[str(occurrence)] = (
+            measurement.model_dump(mode="json")
+        )
+    return output
 
 
 def _funnel(result: ExecutionResult, *, record_count: int) -> FunnelFacts:
@@ -559,6 +610,7 @@ def _partial_generation_facts(
                 runtime=_runtime_facts(
                     cohort=hardware_cohort,
                     config=resource_runtime.get("llm", {}),
+                    resource_slot="llm",
                 ),
                 observed_usd=cost,
                 external_calls=len(outputs),
@@ -1160,9 +1212,22 @@ class Experiment:
                             token_usage.model_dump(mode="json") if token_usage is not None else {}
                         ),
                         "usd": observed_usd,
+                        "stages": _tracker_stage_measurements(measurements),
                     }
                 )
                 numeric["selected_threshold"] = selected_threshold
+                safe_tracker.log_params(
+                    {
+                        "stage_runtime": {
+                            f"{measurement.phase or 'unknown'}.{measurement.operation_kind}.{index}": (
+                                measurement.runtime.model_dump(mode="json")
+                                if measurement.runtime is not None
+                                else {}
+                            )
+                            for index, measurement in enumerate(measurements)
+                        }
+                    }
+                )
                 handle.log_metrics(numeric, headline_metric=quality.get("pair_f1"))
                 handle.record_measurements(
                     measurement.model_dump(mode="json") for measurement in measurements
@@ -1327,7 +1392,7 @@ class Experiment:
         attempt_id: str,
     ) -> _TuningOutcome:
         best_threshold = self.protocol.threshold_grid[0]
-        best_f1 = -1.0
+        best_pair_f1 = -1.0
         first = architecture.build(best_threshold, self._monitor)
         input_fp = ordered_input_fingerprint(records)
         cache_id = self._cache_id(
@@ -1360,8 +1425,12 @@ class Experiment:
             evaluated = evaluate_execution_result(
                 result, records, truth_clusters, threshold=threshold
             )
-            if evaluated.bcubed_f1 > best_f1:
-                best_f1 = evaluated.bcubed_f1
+            # The tunable Select is the pair-decision boundary. Optimize the
+            # scorer-isolating pair F1 on TRAIN; B-Cubed remains a reported
+            # downstream clustering metric and must not reward an all-singleton
+            # result simply because singleton-heavy data has a high floor.
+            if evaluated.pair_f1 > best_pair_f1:
+                best_pair_f1 = evaluated.pair_f1
                 best_threshold = threshold
         return _TuningOutcome(
             threshold=best_threshold,

--- a/src/langres/experiments/runner.py
+++ b/src/langres/experiments/runner.py
@@ -17,9 +17,10 @@ from langres._version import __version__
 from langres.benchmarks.runner import evaluate_execution_result
 from langres.core.op import ExecutionEvent, ExecutionResult
 from langres.core.model_ref import normalize_model_ref
+from langres.core.pairs import PairRow
 from langres.core.resolver import ERModel
 from langres.core.spend import BudgetExceeded, SpendMonitor
-from langres.data.benchmark import Benchmark
+from langres.data.benchmark import Benchmark, gold_pairs_from_clusters
 from langres.data.registry import get_benchmark
 from langres.experiments.cache import StageArtifactStore, ordered_input_fingerprint
 from langres.experiments.identity import (
@@ -77,6 +78,88 @@ class ExperimentCellError(RuntimeError):
 class _TuningOutcome:
     threshold: float
     executions: tuple[tuple[ExecutionResult, bool], ...]
+    strategy: Literal["grid", "observed_breakpoint"]
+    scored_pair_count: int
+    score_breakpoint_count: int
+    score_min: float | None
+    score_max: float | None
+
+
+@dataclass(frozen=True)
+class _ObservedThreshold:
+    threshold: float
+    pair_f1: float
+    scored_pair_count: int
+    score_breakpoint_count: int
+    score_min: float
+    score_max: float
+
+
+def _best_observed_pair_threshold(
+    rows: Sequence[PairRow[Any]],
+    truth_clusters: list[set[str]],
+) -> _ObservedThreshold | None:
+    """Find the exact best pair-F1 cut from scored rows in O(n log n)."""
+    gold_pairs = gold_pairs_from_clusters(truth_clusters)
+    fixed_matches: set[frozenset[str]] = set()
+    pair_scores: dict[frozenset[str], float] = {}
+    for row in rows:
+        if row.score_type is None:
+            continue
+        pair = frozenset((row.left_id, row.right_id))
+        if row.decision is True:
+            fixed_matches.add(pair)
+        elif row.decision is None and row.score is not None:
+            pair_scores[pair] = max(pair_scores.get(pair, -1.0), row.score)
+
+    for pair in fixed_matches:
+        pair_scores.pop(pair, None)
+    if not pair_scores:
+        return None
+
+    ranked = sorted(pair_scores.items(), key=lambda item: item[1], reverse=True)
+    score_min = ranked[-1][1]
+    score_max = ranked[0][1]
+    best_threshold = 1.0
+    best_pair_f1 = -1.0
+    predicted = set(fixed_matches)
+    true_positives = len(predicted & gold_pairs)
+
+    # A threshold of 1.0 is a valid fixed-decision-only baseline only when no
+    # observed score equals 1.0 (score comparison is inclusive).
+    if score_max < 1.0:
+        best_pair_f1 = (
+            2 * true_positives / (len(predicted) + len(gold_pairs))
+            if predicted or gold_pairs
+            else 0.0
+        )
+
+    index = 0
+    while index < len(ranked):
+        threshold = ranked[index][1]
+        while index < len(ranked) and ranked[index][1] == threshold:
+            pair = ranked[index][0]
+            predicted.add(pair)
+            if pair in gold_pairs:
+                true_positives += 1
+            index += 1
+        pair_f1 = (
+            2 * true_positives / (len(predicted) + len(gold_pairs))
+            if predicted or gold_pairs
+            else 0.0
+        )
+        if pair_f1 > best_pair_f1:
+            best_pair_f1 = pair_f1
+            best_threshold = threshold
+
+    return _ObservedThreshold(
+        threshold=best_threshold,
+        pair_f1=best_pair_f1,
+        scored_pair_count=len(pair_scores),
+        score_breakpoint_count=len({score for _, score in ranked}),
+        score_min=score_min,
+        score_max=score_max,
+    )
 
 
 @dataclass(frozen=True)
@@ -1157,6 +1240,11 @@ class Experiment:
                         "seed": seed,
                         "repeat_index": repeat_index,
                         "selected_threshold": selected_threshold,
+                        "threshold_strategy": tuning.strategy,
+                        "threshold_scored_pair_count": tuning.scored_pair_count,
+                        "threshold_score_breakpoint_count": tuning.score_breakpoint_count,
+                        "threshold_score_min": tuning.score_min,
+                        "threshold_score_max": tuning.score_max,
                     }
                 )
                 result, cache_hit = self._execute_cached(
@@ -1393,6 +1481,7 @@ class Experiment:
     ) -> _TuningOutcome:
         best_threshold = self.protocol.threshold_grid[0]
         best_pair_f1 = -1.0
+        strategy: Literal["grid", "observed_breakpoint"] = "grid"
         first = architecture.build(best_threshold, self._monitor)
         input_fp = ordered_input_fingerprint(records)
         cache_id = self._cache_id(
@@ -1432,9 +1521,32 @@ class Experiment:
             if evaluated.pair_f1 > best_pair_f1:
                 best_pair_f1 = evaluated.pair_f1
                 best_threshold = threshold
+
+        checkpoint = first_result.checkpoint
+        observed = (
+            _best_observed_pair_threshold(checkpoint.rows, truth_clusters)
+            if checkpoint is not None
+            else None
+        )
+        if observed is not None and checkpoint is not None and observed.pair_f1 > best_pair_f1:
+            best_threshold = observed.threshold
+            strategy = "observed_breakpoint"
+            if best_threshold not in self.protocol.threshold_grid:
+                model = architecture.build(best_threshold, self._monitor)
+                result = model.execute_from(
+                    checkpoint,
+                    cache_id=cache_id,
+                    input_fingerprint=input_fp,
+                )
+                executions.append((result, True))
         return _TuningOutcome(
             threshold=best_threshold,
             executions=tuple(executions),
+            strategy=strategy,
+            scored_pair_count=observed.scored_pair_count if observed is not None else 0,
+            score_breakpoint_count=(observed.score_breakpoint_count if observed is not None else 0),
+            score_min=observed.score_min if observed is not None else None,
+            score_max=observed.score_max if observed is not None else None,
         )
 
     def _cache_id(

--- a/src/langres/resources/base.py
+++ b/src/langres/resources/base.py
@@ -83,6 +83,7 @@ class ResourceRuntimeConfig(BaseModel):
     batch_size: int = Field(default=32, ge=1)
     device: str | None = None
     dtype: RuntimeDType | None = None
+    quantization: str | None = Field(default=None, min_length=1)
     local_files_only: bool = False
 
 
@@ -119,6 +120,10 @@ class EmbeddingFacts(BaseModel):
     dimension: int = Field(ge=1)
     dtype: str
     normalized: bool | None = None
+    quantization: str | None = None
+    parameter_count: int | None = Field(default=None, ge=0)
+    artifact_bytes: int | None = Field(default=None, ge=0)
+    loaded_memory_bytes: int | None = Field(default=None, ge=0)
 
 
 class EmbeddingBatch(BaseModel):

--- a/src/langres/resources/retrieve.py
+++ b/src/langres/resources/retrieve.py
@@ -10,6 +10,7 @@ from pydantic import BaseModel, ConfigDict, Field
 
 from langres.core.blockers.all_pairs import register_schema_idempotent, schema_to_factory
 from langres.core.comparators import StringComparator
+from langres.core.indexes.qdrant_dense_index import QdrantDenseIndex
 from langres.core.model_ref import to_config
 from langres.core.op import Records, Source
 from langres.core.pairs import PairRow, Pairs
@@ -39,6 +40,7 @@ class Retrieve(Source[SchemaT], Generic[SchemaT]):
         schema: type[SchemaT],
         k: int = 20,
         text_field: str | None = None,
+        source_field: str | None = None,
     ) -> None:
         if k <= 0:
             raise ValueError("Retrieve.k must be positive")
@@ -46,11 +48,17 @@ class Retrieve(Source[SchemaT], Generic[SchemaT]):
             raise ValueError(
                 f"Retrieve text_field {text_field!r} is not declared by {schema.__name__}"
             )
+        if source_field is not None and source_field not in schema.model_fields:
+            raise ValueError(
+                f"Retrieve source_field {source_field!r} is not declared by {schema.__name__}"
+            )
         self.resource = resource
         self._schema = schema
         self._schema_name = register_schema_idempotent(schema)
         self.k = k
         self.text_field = text_field
+        self.source_field = source_field
+        self._index = QdrantDenseIndex()
         self._factory = schema_to_factory(schema)
         self._default_fields = (
             ()
@@ -70,6 +78,7 @@ class Retrieve(Source[SchemaT], Generic[SchemaT]):
             "schema_name": self._schema_name,
             "k": self.k,
             "text_field": self.text_field,
+            "source_field": self.source_field,
         }
 
     @classmethod
@@ -81,11 +90,13 @@ class Retrieve(Source[SchemaT], Generic[SchemaT]):
         """Rebuild around a validated Embedder resource."""
         schema = get_schema(str(config["schema_name"]))
         text_field = config["text_field"]
+        source_field = config.get("source_field")
         return Retrieve(
             resource,
             schema=schema,
             k=int(config["k"]),  # type: ignore[call-overload]
             text_field=str(text_field) if text_field is not None else None,
+            source_field=str(source_field) if source_field is not None else None,
         )
 
     def _text(self, entity: SchemaT) -> str:
@@ -123,24 +134,21 @@ class Retrieve(Source[SchemaT], Generic[SchemaT]):
                 "Embedder must return one 2D vector row per retrieval record; "
                 f"got shape {vectors.shape} for {len(entities)} records"
             )
-        norms = np.linalg.norm(vectors, axis=1, keepdims=True)
-        normalized = np.divide(
-            vectors,
-            norms,
-            out=np.zeros_like(vectors),
-            where=norms != 0,
+        groups = (
+            [str(getattr(entity, self.source_field)) for entity in entities]
+            if self.source_field is not None
+            else None
         )
-        similarities = normalized @ normalized.T
-        np.fill_diagonal(similarities, -np.inf)
+        similarities, neighbours = self._index.search_all(vectors, k=self.k, groups=groups)
 
         selected: dict[tuple[str, str], tuple[str, str, float]] = {}
-        limit = min(self.k, len(entities) - 1)
         for index, row in enumerate(similarities):
-            neighbours = np.argsort(-row, kind="stable")[:limit]
-            for neighbour in neighbours:
+            for column, neighbour in enumerate(neighbours[index]):
+                if neighbour < 0:
+                    continue
                 first_id, second_id = ids[index], ids[int(neighbour)]
                 pair = (first_id, second_id) if first_id <= second_id else (second_id, first_id)
-                score = float(np.clip(row[int(neighbour)], 0.0, 1.0))
+                score = float(np.clip(row[column], 0.0, 1.0))
                 prior = selected.get(pair)
                 selected[pair] = (
                     prior[0] if prior is not None else first_id,
@@ -178,6 +186,7 @@ class _RetrieveParams(BaseModel):
     schema_name: str = Field(min_length=1)
     k: int = Field(gt=0)
     text_field: str | None = None
+    source_field: str | None = None
 
 
 def _dump_retrieve(stage: object) -> tuple[dict[str, object], object | None]:

--- a/src/langres/resources/sentence_transformers.py
+++ b/src/langres/resources/sentence_transformers.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from collections.abc import Sequence
+from pathlib import Path
 from typing import Any, ClassVar
 
 import numpy as np
@@ -28,6 +29,51 @@ def _torch_dtype(name: str | None) -> Any:
     import torch
 
     return getattr(torch, name)
+
+
+def _directory_bytes(path: Path) -> int:
+    """Measure regular files below ``path``, following snapshot symlinks."""
+    return sum(item.stat().st_size for item in path.rglob("*") if item.is_file())
+
+
+def _local_artifact_bytes(model_ref: ModelRef) -> int | None:
+    """Measure a local path or an already-cached Hub snapshot without networking."""
+    local = Path(model_ref.base).expanduser()
+    if local.exists():
+        return _directory_bytes(local) if local.is_dir() else local.stat().st_size
+    try:
+        from huggingface_hub import snapshot_download
+
+        snapshot = snapshot_download(
+            repo_id=model_ref.base,
+            revision=model_ref.revision,
+            local_files_only=True,
+        )
+    except (FileNotFoundError, OSError, ValueError):
+        return None
+    return _directory_bytes(Path(snapshot))
+
+
+def _loaded_model_facts(model: Any, model_ref: ModelRef) -> dict[str, int | None]:
+    """Best-effort parameter, resident tensor, and cached artifact sizes."""
+    try:
+        parameters = tuple(model.parameters())
+    except (AttributeError, TypeError):
+        parameters = ()
+    try:
+        buffers = tuple(model.buffers())
+    except (AttributeError, TypeError):
+        buffers = ()
+    parameter_count = sum(int(parameter.numel()) for parameter in parameters) or None
+    loaded_memory = (
+        sum(int(tensor.numel()) * int(tensor.element_size()) for tensor in (*parameters, *buffers))
+        or None
+    )
+    return {
+        "parameter_count": parameter_count,
+        "artifact_bytes": _local_artifact_bytes(model_ref),
+        "loaded_memory_bytes": loaded_memory,
+    }
 
 
 @register("resource_sentence_transformer")
@@ -68,6 +114,16 @@ class SentenceTransformer:
                 "SentenceTransformer requires one vector per input text; "
                 f"got {len(vectors)} vectors for {len(texts)} texts."
             )
+        loaded_model = getattr(self._embedder, "_model", None)
+        model_facts = (
+            _loaded_model_facts(loaded_model, self.model_ref)
+            if loaded_model is not None
+            else {
+                "parameter_count": None,
+                "artifact_bytes": None,
+                "loaded_memory_bytes": None,
+            }
+        )
         return EmbeddingBatch(
             vectors=vectors,
             model_ref=self.model_ref,
@@ -75,6 +131,8 @@ class SentenceTransformer:
                 dimension=int(vectors.shape[1]),
                 dtype=str(vectors.dtype),
                 normalized=self.runtime_config.normalize_embeddings,
+                quantization=self.runtime_config.quantization,
+                **model_facts,
             ),
         )
 

--- a/src/langres/tracking/runs.py
+++ b/src/langres/tracking/runs.py
@@ -353,10 +353,45 @@ def _json_default(obj: Any) -> Any:
     raise TypeError(f"cannot canonicalize {type(obj).__name__} for a fingerprint")
 
 
+def _normalize_fingerprint_value(obj: Any) -> Any:
+    """Recursively normalize unordered fingerprint containers.
+
+    Dataset gold partitions commonly arrive as a list of set-like clusters.
+    The list order is an implementation detail of graph traversal, not dataset
+    content, so normalize that exact shape while preserving order for ordinary
+    JSON lists such as token sequences or ranked values.
+    """
+    if isinstance(obj, BaseModel):
+        return _normalize_fingerprint_value(obj.model_dump(mode="json"))
+    if isinstance(obj, Mapping):
+        return {str(key): _normalize_fingerprint_value(value) for key, value in obj.items()}
+    if isinstance(obj, (set, frozenset)):
+        normalized = [_normalize_fingerprint_value(value) for value in obj]
+        return sorted(normalized, key=_fingerprint_sort_key)
+    if isinstance(obj, list):
+        normalized = [_normalize_fingerprint_value(value) for value in obj]
+        if all(isinstance(value, (set, frozenset)) for value in obj):
+            return sorted(normalized, key=_fingerprint_sort_key)
+        return normalized
+    if isinstance(obj, tuple):
+        return tuple(_normalize_fingerprint_value(value) for value in obj)
+    return obj
+
+
+def _fingerprint_sort_key(obj: Any) -> str:
+    return json.dumps(
+        obj,
+        sort_keys=True,
+        separators=(",", ":"),
+        default=_json_default,
+        allow_nan=False,
+    )
+
+
 def _canonical_json(obj: Any) -> str:
     """Order-stable JSON: sorted keys, no whitespace -- the hashing normal form."""
     return json.dumps(
-        obj,
+        _normalize_fingerprint_value(obj),
         sort_keys=True,
         separators=(",", ":"),
         default=_json_default,

--- a/src/langres/tracking/trackers/mlflow_tracker.py
+++ b/src/langres/tracking/trackers/mlflow_tracker.py
@@ -159,14 +159,15 @@ class MlflowTracker:
         self.set_tags(tags)
 
     def log_params(self, params: Mapping[str, Any]) -> None:
-        """Log flat params (keys sanitized MLflow-safe, values stringified).
+        """Flatten and log params (keys sanitized, values stringified).
 
         Keys pass through :func:`_sanitize_key` -- MLflow param names allow only a
         restricted charset, so any out-of-charset character (e.g. from a sequence
         or a config key) is coerced to ``_`` rather than crashing the run.
         """
-        if params:
-            mlflow.log_params({_sanitize_key(key): str(value) for key, value in params.items()})
+        flattened = _flatten(params)
+        if flattened:
+            mlflow.log_params({_sanitize_key(key): value for key, value in flattened.items()})
 
     def log_metrics(self, metrics: Mapping[str, float], *, step: int | None = None) -> None:
         """Stream numeric metrics, optionally at a training ``step``."""

--- a/tests/architectures/test_research_recipes.py
+++ b/tests/architectures/test_research_recipes.py
@@ -60,6 +60,12 @@ class _IdentifierOnly(BaseModel):
     id: str
 
 
+class _SourcedCompany(BaseModel):
+    id: str
+    name: str
+    source: str
+
+
 class _FixedEmbedder(FakeEmbedder):
     def __init__(self, vectors: list[list[float]]) -> None:
         super().__init__(dimension=len(vectors[0]))
@@ -428,6 +434,58 @@ def test_explicit_retrieval_text_field_does_not_require_default_comparable_field
     pairs = retrieve.forward([{"id": "a"}, {"id": "b"}])
 
     assert [(row.left_id, row.right_id) for row in pairs.rows] == [("a", "b")]
+
+
+def test_retrieve_filters_same_source_before_top_k() -> None:
+    retrieve = RetrieveOp(
+        _FixedEmbedder(
+            [
+                [1.0, 0.0],
+                [0.999, 0.001],
+                [0.8, 0.6],
+                [0.0, 1.0],
+            ]
+        ),
+        schema=_SourcedCompany,
+        k=1,
+        source_field="source",
+    )
+
+    pairs = retrieve.forward(
+        [
+            {"id": "a1", "name": "Alpha", "source": "a"},
+            {"id": "a2", "name": "Alpha 2", "source": "a"},
+            {"id": "b1", "name": "Beta", "source": "b"},
+            {"id": "b2", "name": "Beta 2", "source": "b"},
+        ]
+    )
+
+    ids = {(row.left_id, row.right_id) for row in pairs.rows}
+    assert ("a1", "b1") in ids
+    assert all(pairs.store[left].source != pairs.store[right].source for left, right in ids)
+
+
+def test_retrieve_source_field_round_trips_in_topology(tmp_path: Path) -> None:
+    recipe = Retrieve(
+        embedder=ModelRef(base="org/embedder", kind="hf", revision="embed-sha"),
+        schema=_SourcedCompany,
+        source_field="source",
+    )
+
+    recipe.save(tmp_path)
+    loaded = ERModel.load(tmp_path)
+    operation = next(stage for stage in loaded._require_ops() if isinstance(stage, RetrieveOp))
+
+    assert operation.source_field == "source"
+
+
+def test_retrieve_rejects_unknown_source_field() -> None:
+    with pytest.raises(ValueError, match="source_field"):
+        RetrieveOp(
+            FakeEmbedder(),
+            schema=CompanySchema,
+            source_field="source",
+        )
 
 
 def test_retrieve_compare_returns_false_when_source_score_is_below_threshold() -> None:

--- a/tests/core/indexes/test_qdrant_dense_index.py
+++ b/tests/core/indexes/test_qdrant_dense_index.py
@@ -2,9 +2,12 @@
 
 from __future__ import annotations
 
+import builtins
+
 import numpy as np
 import pytest
 from qdrant_client import QdrantClient
+from qdrant_client.models import Distance, VectorParams
 from testcontainers.qdrant import QdrantContainer
 
 from langres.core.indexes.qdrant_dense_index import QdrantDenseIndex
@@ -46,6 +49,49 @@ def test_qdrant_dense_index_returns_no_hits_for_one_vector() -> None:
     scores, neighbours = index.search_all(np.ones((1, 3), dtype=np.float32), k=5)
 
     assert scores.shape == neighbours.shape == (1, 0)
+
+
+def test_qdrant_dense_index_refuses_to_delete_a_preexisting_collection() -> None:
+    client = QdrantClient(":memory:")
+    client.create_collection(
+        collection_name="shared-production-data",
+        vectors_config=VectorParams(size=2, distance=Distance.COSINE),
+    )
+    index = QdrantDenseIndex(
+        client=client,
+        collection_name="shared-production-data",
+    )
+
+    with pytest.raises(ValueError, match="already exists"):
+        index.search_all(np.asarray([[1.0, 0.0], [0.0, 1.0]]), k=1)
+
+    assert client.collection_exists("shared-production-data")
+
+
+def test_qdrant_dense_index_can_rebuild_the_collection_it_created() -> None:
+    index = QdrantDenseIndex(client=QdrantClient(":memory:"), collection_name="owned")
+
+    first_scores, _ = index.search_all(np.asarray([[1.0, 0.0], [0.0, 1.0]]), k=1)
+    second_scores, _ = index.search_all(np.asarray([[1.0, 0.0], [1.0, 0.0]]), k=1)
+
+    assert first_scores[0, 0] == pytest.approx(0.0)
+    assert second_scores[0, 0] == pytest.approx(1.0)
+
+
+def test_qdrant_dense_index_names_the_semantic_extra_when_client_is_missing(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    real_import = builtins.__import__
+
+    def without_qdrant(name: str, *args: object, **kwargs: object) -> object:
+        if name == "qdrant_client":
+            raise ModuleNotFoundError("No module named 'qdrant_client'")
+        return real_import(name, *args, **kwargs)
+
+    monkeypatch.setattr(builtins, "__import__", without_qdrant)
+
+    with pytest.raises(ImportError, match=r"pip install langres\[semantic\]"):
+        _ = QdrantDenseIndex().client
 
 
 def test_qdrant_dense_index_against_real_qdrant_server() -> None:

--- a/tests/core/indexes/test_qdrant_dense_index.py
+++ b/tests/core/indexes/test_qdrant_dense_index.py
@@ -1,0 +1,62 @@
+"""Qdrant-backed dense retrieval contract tests."""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+from qdrant_client import QdrantClient
+from testcontainers.qdrant import QdrantContainer
+
+from langres.core.indexes.qdrant_dense_index import QdrantDenseIndex
+
+
+def test_qdrant_dense_index_searches_vectors_and_filters_groups() -> None:
+    index = QdrantDenseIndex(client=QdrantClient(":memory:"), collection_name="dense-test")
+    vectors = np.asarray(
+        [
+            [1.0, 0.0],
+            [0.999, 0.001],
+            [0.8, 0.6],
+            [0.0, 1.0],
+        ],
+        dtype=np.float32,
+    )
+
+    scores, neighbours = index.search_all(vectors, k=1, groups=["a", "a", "b", "b"])
+
+    assert scores.shape == neighbours.shape == (4, 1)
+    assert neighbours[0, 0] == 2
+    assert all(
+        neighbour < 0 or ["a", "a", "b", "b"][row] != ["a", "a", "b", "b"][neighbour]
+        for row, values in enumerate(neighbours)
+        for neighbour in values
+    )
+
+
+def test_qdrant_dense_index_rejects_group_count_mismatch() -> None:
+    index = QdrantDenseIndex(client=QdrantClient(":memory:"), collection_name="dense-test")
+
+    with pytest.raises(ValueError, match="groups"):
+        index.search_all(np.ones((2, 3), dtype=np.float32), k=1, groups=["only-one"])
+
+
+def test_qdrant_dense_index_returns_no_hits_for_one_vector() -> None:
+    index = QdrantDenseIndex(client=QdrantClient(":memory:"), collection_name="dense-test")
+
+    scores, neighbours = index.search_all(np.ones((1, 3), dtype=np.float32), k=5)
+
+    assert scores.shape == neighbours.shape == (1, 0)
+
+
+def test_qdrant_dense_index_against_real_qdrant_server() -> None:
+    with QdrantContainer(image="qdrant/qdrant:v1.15.5") as qdrant:
+        client = qdrant.get_client()
+        index = QdrantDenseIndex(client=client, collection_name="langres-test")
+
+        scores, neighbours = index.search_all(
+            np.asarray([[1.0, 0.0], [0.9, 0.1], [0.0, 1.0]], dtype=np.float32),
+            k=1,
+        )
+
+        assert neighbours.tolist() == [[1], [0], [1]]
+        assert np.isfinite(scores).all()

--- a/tests/experiments/test_acceptance_contract.py
+++ b/tests/experiments/test_acceptance_contract.py
@@ -210,7 +210,8 @@ def test_public_acceptance_imports_and_signatures_are_stable() -> None:
     assert str(inspect.signature(Retrieve)) == (
         "(*, embedder: 'EmbedderLike', schema: 'type[BaseModel] | None' = None, "
         "retrieve_k: 'int' = 20, threshold: 'float' = 0.5, "
-        "text_field: 'str | None' = None, clusterer: 'Clusterer | None' = None, "
+        "text_field: 'str | None' = None, source_field: 'str | None' = None, "
+        "clusterer: 'Clusterer | None' = None, "
         "budget_usd: 'float | None' = None, "
         "monitor: 'SpendMonitor | None' = None) -> 'None'"
     )
@@ -218,14 +219,16 @@ def test_public_acceptance_imports_and_signatures_are_stable() -> None:
         "(*, embedder: 'EmbedderLike', reranker: 'RerankerLike', "
         "schema: 'type[BaseModel] | None' = None, retrieve_k: 'int' = 20, "
         "threshold: 'float' = 0.5, text_field: 'str | None' = None, "
-        "clusterer: 'Clusterer | None' = None, budget_usd: 'float | None' = None, "
+        "source_field: 'str | None' = None, clusterer: 'Clusterer | None' = None, "
+        "budget_usd: 'float | None' = None, "
         "monitor: 'SpendMonitor | None' = None) -> 'None'"
     )
     assert str(inspect.signature(RetrieveLLM)) == (
         "(*, embedder: 'EmbedderLike', llm: 'LLMLike', "
         "schema: 'type[BaseModel] | None' = None, retrieve_k: 'int' = 20, "
         "llm_k: 'int' = 5, threshold: 'float' = 0.5, "
-        "text_field: 'str | None' = None, clusterer: 'Clusterer | None' = None, "
+        "text_field: 'str | None' = None, source_field: 'str | None' = None, "
+        "clusterer: 'Clusterer | None' = None, "
         "budget_usd: 'float | None' = None, "
         "monitor: 'SpendMonitor | None' = None) -> 'None'"
     )
@@ -233,7 +236,8 @@ def test_public_acceptance_imports_and_signatures_are_stable() -> None:
         "(*, embedder: 'EmbedderLike', reranker: 'RerankerLike', llm: 'LLMLike', "
         "schema: 'type[BaseModel] | None' = None, retrieve_k: 'int' = 20, "
         "llm_k: 'int' = 5, threshold: 'float' = 0.5, "
-        "text_field: 'str | None' = None, clusterer: 'Clusterer | None' = None, "
+        "text_field: 'str | None' = None, source_field: 'str | None' = None, "
+        "clusterer: 'Clusterer | None' = None, "
         "budget_usd: 'float | None' = None, "
         "monitor: 'SpendMonitor | None' = None) -> 'None'"
     )

--- a/tests/experiments/test_measurements.py
+++ b/tests/experiments/test_measurements.py
@@ -170,6 +170,7 @@ def test_embedding_runtime_stage_and_funnel_facts_round_trip() -> None:
         items_in=10,
         pairs_out=20,
         throughput_per_second=40.0,
+        throughput_unit="pairs",
         embedding=embedding,
         runtime=runtime,
         cache_hit=False,
@@ -177,5 +178,6 @@ def test_embedding_runtime_stage_and_funnel_facts_round_trip() -> None:
     funnel = FunnelFacts(possible_pairs=45, retrieved_pairs=20, llm_pairs=0)
 
     assert StageMeasurement.model_validate_json(stage.model_dump_json()) == stage
+    assert stage.throughput_unit == "pairs"
     assert funnel.llm_pairs == 0
     assert funnel.reranker_pairs is None

--- a/tests/experiments/test_runner.py
+++ b/tests/experiments/test_runner.py
@@ -90,6 +90,86 @@ class _CountingScore(Score[Any]):
         )
 
 
+class _SaturatedScoreConfig(BaseModel):
+    model_config = ConfigDict(extra="forbid", strict=True)
+
+
+@register_op("test_experiment_runner_saturated_score")
+class _SaturatedScore(Score[Any]):
+    """Give the true same-name pair a score inside a deliberately missed gap."""
+
+    config_model: ClassVar[type[BaseModel]] = _SaturatedScoreConfig
+
+    def __init__(self) -> None:
+        super().__init__(scope="pair", out_space="heuristic")
+
+    @property
+    def config(self) -> dict[str, object]:
+        return {}
+
+    @classmethod
+    def from_config(cls, config: dict[str, object]) -> _SaturatedScore:
+        del config
+        return cls()
+
+    def forward(self, pairs: Pairs[Any]) -> Pairs[Any]:
+        return Pairs(
+            store=pairs.store,
+            rows=[
+                row.model_copy(
+                    update={
+                        "score": 0.9982 if row.left.name == row.right.name else 0.997,
+                        "score_type": "heuristic",
+                    }
+                )
+                for row in pairs.rows
+            ],
+        )
+
+
+class _SaturatedBenchmark:
+    name = "saturated"
+    threshold_grid = (0.995, 0.999)
+
+    def load(self) -> tuple[list[_Record], list[set[str]], set[frozenset[str]]]:
+        records = [
+            _Record(id="a1", name="A"),
+            _Record(id="a2", name="A"),
+            _Record(id="b", name="B"),
+            _Record(id="c", name="C"),
+            _Record(id="d1", name="D"),
+            _Record(id="d2", name="D"),
+        ]
+        clusters = [{"a1", "a2"}, {"b"}, {"c"}, {"d1", "d2"}]
+        return records, clusters, {frozenset(cluster) for cluster in clusters}
+
+    def split(
+        self,
+        corpus: list[_Record],
+        gold_clusters: list[set[str]],
+        *,
+        seed: int,
+    ) -> tuple[list[_Record], list[_Record], list[set[str]], list[set[str]]]:
+        del seed
+        return corpus[:4], corpus[4:], gold_clusters[:3], gold_clusters[3:]
+
+
+def _saturated_factory() -> ArchitectureFactory:
+    def build(threshold: float, monitor: SpendMonitor) -> ERModel:
+        return ERModel.from_topology(
+            ops=[
+                BlockerSource(AllPairsBlocker(schema=_Record)),
+                _SaturatedScore(),
+                ThresholdSelect(threshold),
+                ClustererStage(Clusterer(threshold=0.0)),
+            ],
+            replay_boundary=2,
+            monitor=monitor,
+        )
+
+    return ArchitectureFactory(name="Saturated", factory=build)
+
+
 def _factory(
     counter: list[int],
     name: str = "Custom",
@@ -223,6 +303,31 @@ def test_threshold_tuning_optimizes_train_pair_f1_not_bcubed(
     assert report.runs[0].selected_threshold == 0.5
 
 
+def test_threshold_tuning_checks_observed_score_breakpoints_between_grid_values(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        "langres.experiments.runner.get_benchmark",
+        lambda _name: _SaturatedBenchmark(),
+    )
+    protocol = _protocol().model_copy(update={"threshold_grid": (0.995, 0.999)})
+
+    [run] = (
+        Experiment(
+            architectures=[_saturated_factory()],
+            protocol=protocol,
+            store=tmp_path / "runs.jsonl",
+            cache_dir=tmp_path / "cache",
+        )
+        .run()
+        .runs
+    )
+
+    assert run.selected_threshold == pytest.approx(0.9982)
+    assert run.metrics["pair_f1"] == 1.0
+
+
 def test_reordered_threshold_grid_reuses_the_expensive_prefix_cache(
     tmp_path: Path,
 ) -> None:
@@ -289,7 +394,8 @@ def test_variant_id_is_part_of_recipe_identity_and_resume_selection(
 
     assert [run.variant_id for run in report.runs] == ["high", "low"]
     assert report.runs[0].recipe_id != report.runs[1].recipe_id
-    assert report.runs[0].metrics["bcubed_f1"] != report.runs[1].metrics["bcubed_f1"]
+    assert report.runs[0].selected_threshold == 0.5
+    assert report.runs[1].selected_threshold == 0.1
     assert all(not run.warnings for run in report.runs)
     assert len(RunStore(store).read()) == 2
 
@@ -314,7 +420,8 @@ def test_serialized_model_config_invalidates_resume_identity(tmp_path: Path) -> 
     assert high_counter == [2]
     assert low_counter == [2]
     assert first.runs[0].recipe_id != second.runs[0].recipe_id
-    assert first.runs[0].metrics["bcubed_f1"] != second.runs[0].metrics["bcubed_f1"]
+    assert first.runs[0].selected_threshold == 0.5
+    assert second.runs[0].selected_threshold == 0.1
     assert len(RunStore(store).read()) == 2
 
 

--- a/tests/experiments/test_runner.py
+++ b/tests/experiments/test_runner.py
@@ -193,6 +193,36 @@ def test_threshold_sweep_scores_each_input_split_once_and_resume_skips_work(
     assert len(RunStore(tmp_path / "runs.jsonl").read()) == 1
 
 
+def test_threshold_tuning_optimizes_train_pair_f1_not_bcubed(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from langres.benchmarks.runner import evaluate_execution_result as evaluate
+
+    def divergent_metrics(*args: Any, threshold: float, **kwargs: Any) -> Any:
+        measured = evaluate(*args, threshold=threshold, **kwargs)
+        return measured.model_copy(
+            update={
+                "pair_f1": 1.0 if threshold == 0.5 else 0.0,
+                "bcubed_f1": 0.0 if threshold == 0.5 else 1.0,
+            }
+        )
+
+    monkeypatch.setattr(
+        "langres.experiments.runner.evaluate_execution_result",
+        divergent_metrics,
+    )
+
+    report = Experiment(
+        architectures=[_factory([0])],
+        protocol=_protocol(),
+        store=tmp_path / "runs.jsonl",
+        cache_dir=tmp_path / "cache",
+    ).run()
+
+    assert report.runs[0].selected_threshold == 0.5
+
+
 def test_reordered_threshold_grid_reuses_the_expensive_prefix_cache(
     tmp_path: Path,
 ) -> None:

--- a/tests/experiments/test_runner_measurement_acceptance.py
+++ b/tests/experiments/test_runner_measurement_acceptance.py
@@ -23,6 +23,7 @@ from langres.experiments.identity import SourceState
 from langres.resources import (
     FakeEmbedder,
     EmbeddingBatch,
+    EmbeddingFacts,
     GenerationBatch,
     GenerationEnvelope,
     GenerationRequest,
@@ -125,7 +126,11 @@ class _MeasuredEmbedder:
 
     def __init__(self) -> None:
         self.model_ref = ModelRef(base="./measured/embedder", kind="local")
-        self.runtime_config = ResourceRuntimeConfig(batch_size=1024, device="cpu")
+        self.runtime_config = ResourceRuntimeConfig(
+            batch_size=1024,
+            device="cpu",
+            quantization="int8",
+        )
         self._delegate = FakeEmbedder(dimension=8)
 
     @property
@@ -139,7 +144,20 @@ class _MeasuredEmbedder:
 
     def embed(self, texts: Sequence[str]) -> EmbeddingBatch:
         batch = self._delegate.embed(texts)
-        return batch.model_copy(update={"model_ref": self.model_ref})
+        return batch.model_copy(
+            update={
+                "model_ref": self.model_ref,
+                "facts": EmbeddingFacts(
+                    dimension=8,
+                    dtype="float32",
+                    normalized=True,
+                    quantization="int8",
+                    parameter_count=123,
+                    artifact_bytes=456,
+                    loaded_memory_bytes=789,
+                ),
+            }
+        )
 
 
 class _CostedLLM:
@@ -269,7 +287,7 @@ def test_runner_populates_persists_and_publishes_tier_zero_measurement_facts(
 
     def build(threshold: float, monitor: SpendMonitor) -> RetrieveLLM:
         return RetrieveLLM(
-            embedder=FakeEmbedder(dimension=8),
+            embedder=_MeasuredEmbedder(),
             llm=llm,
             schema=_MeasurementRecord,
             retrieve_k=1,
@@ -318,17 +336,28 @@ def test_runner_populates_persists_and_publishes_tier_zero_measurement_facts(
 
     retrieve = next(item for item in run.measurements if item.operation_kind == "retrieve")
     assert retrieve.resource_slot == "embedder"
-    assert retrieve.resource_id is not None and "fake/embedder" in retrieve.resource_id
+    assert retrieve.resource_id is not None and "measured/embedder" in retrieve.resource_id
     assert retrieve.embedding is not None
     assert retrieve.embedding.dimensions == 8
     assert retrieve.embedding.vectors_produced == 2
     assert retrieve.embedding.bytes_per_vector == 32
     assert retrieve.embedding.total_vector_bytes == 64
+    assert retrieve.embedding.quantization == "int8"
+    assert retrieve.embedding.parameter_count == 123
+    assert retrieve.embedding.artifact_bytes == 456
+    assert retrieve.embedding.loaded_memory_bytes == 789
     assert retrieve.runtime is not None
     assert retrieve.runtime.hardware_cohort == "measurement-cpu"
     assert retrieve.runtime.python_version is not None
     assert retrieve.runtime.device == "cpu"
     assert retrieve.runtime.batch_size == 1024
+    assert retrieve.runtime.quantization == "int8"
+    assert "numpy" in retrieve.runtime.library_versions
+    assert "qdrant-client" in retrieve.runtime.library_versions
+    assert retrieve.throughput_unit == "records"
+    assert retrieve.throughput_per_second == pytest.approx(
+        retrieve.items_in / retrieve.wall_seconds
+    )
 
     generate = next(item for item in run.measurements if item.operation_kind == "generate")
     assert generate.resource_slot == "llm"
@@ -342,6 +371,7 @@ def test_runner_populates_persists_and_publishes_tier_zero_measurement_facts(
     assert generate.runtime is not None
     assert generate.runtime.dtype == "float32"
     assert generate.runtime.batch_size == 1
+    assert generate.throughput_unit == "pairs"
 
     [record] = store.read()
     assert record.measurements is not None
@@ -350,6 +380,11 @@ def test_runner_populates_persists_and_publishes_tier_zero_measurement_facts(
     assert "funnel.llm_pairs" in flattened
     assert "token_usage.input_tokens" in flattened
     assert "usd" in flattened
+    assert any(key.startswith("stages.evaluation.retrieve.0.wall_seconds") for key in flattened)
+    assert any(
+        key.startswith("stages.evaluation.retrieve.0.embedding.parameter_count")
+        for key in flattened
+    )
 
 
 def test_tuning_and_evaluation_usage_cost_and_stage_facts_are_aggregated(

--- a/tests/resources/test_concrete_resources.py
+++ b/tests/resources/test_concrete_resources.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from pathlib import Path
 from types import SimpleNamespace
 from typing import Any
 
@@ -25,6 +26,7 @@ from langres.resources import (
     llm_from_model_ref,
 )
 from langres.core._artifacts import component_spec, rebuild_component
+from langres.resources.sentence_transformers import _loaded_model_facts
 
 
 def test_sentence_transformer_resource_preserves_model_ref_and_runtime_config() -> None:
@@ -49,6 +51,7 @@ def test_sentence_transformer_resource_preserves_model_ref_and_runtime_config() 
         "dtype": "float32",
         "local_files_only": True,
         "normalize_embeddings": False,
+        "quantization": None,
         "show_progress_bar": False,
     }
 
@@ -66,6 +69,41 @@ def test_sentence_transformer_resource_embeds_through_legacy_provider() -> None:
     assert batch.vectors.shape == (2, 3)
     assert batch.facts is not None
     assert batch.facts.dimension == 3
+
+
+def test_sentence_transformer_measures_loaded_parameters_and_local_artifact(
+    tmp_path: Path,
+) -> None:
+    (tmp_path / "weights.bin").write_bytes(b"123456")
+
+    class _Tensor:
+        def __init__(self, count: int, scalar_bytes: int) -> None:
+            self._count = count
+            self._scalar_bytes = scalar_bytes
+
+        def numel(self) -> int:
+            return self._count
+
+        def element_size(self) -> int:
+            return self._scalar_bytes
+
+    class _Model:
+        def parameters(self) -> tuple[_Tensor, ...]:
+            return (_Tensor(10, 4), _Tensor(5, 2))
+
+        def buffers(self) -> tuple[_Tensor, ...]:
+            return (_Tensor(3, 4),)
+
+    facts = _loaded_model_facts(
+        _Model(),
+        ModelRef(base=str(tmp_path), kind="local"),
+    )
+
+    assert facts == {
+        "parameter_count": 15,
+        "artifact_bytes": 6,
+        "loaded_memory_bytes": 62,
+    }
 
 
 def test_sentence_transformer_rejects_wrong_embedding_cardinality() -> None:

--- a/tests/test_import_budget.py
+++ b/tests/test_import_budget.py
@@ -124,6 +124,27 @@ def test_linkage_dataset_loader_does_not_import_a_vector_backend() -> None:
     assert result.returncode == 0, result.stderr
 
 
+def test_research_retrieve_qdrant_path_does_not_import_faiss() -> None:
+    script = (
+        "import sys; "
+        "from langres.architectures import Retrieve; "
+        "from langres.core.models import CompanySchema; "
+        "from langres.resources import FakeEmbedder; "
+        "model = Retrieve(embedder=FakeEmbedder(), schema=CompanySchema, retrieve_k=1); "
+        "model.dedupe([{'id': 'a', 'name': 'A'}, {'id': 'b', 'name': 'B'}]); "
+        "assert 'qdrant_client' in sys.modules; "
+        "assert 'faiss' not in sys.modules"
+    )
+
+    result = subprocess.run(
+        [sys.executable, "-c", script],
+        capture_output=True,
+        text=True,
+    )
+
+    assert result.returncode == 0, result.stderr
+
+
 # The autoresearch facade (``langres.optimize`` / ``langres.score_blocking``,
 # PR P-C) is eager-exported from ``langres/__init__.py`` -- so a bare
 # ``import langres`` must expose both as callables WHILE staying import-light:

--- a/tests/test_import_budget.py
+++ b/tests/test_import_budget.py
@@ -107,6 +107,23 @@ def test_experiment_contracts_keep_runner_and_heavy_backends_lazy() -> None:
     )
 
 
+def test_linkage_dataset_loader_does_not_import_a_vector_backend() -> None:
+    script = (
+        "import sys; import langres.data.amazon_google; "
+        "heavy = ['faiss', 'torch', 'sentence_transformers', 'qdrant_client']; "
+        "leaked = [name for name in heavy if name in sys.modules]; "
+        "assert not leaked, leaked"
+    )
+
+    result = subprocess.run(
+        [sys.executable, "-c", script],
+        capture_output=True,
+        text=True,
+    )
+
+    assert result.returncode == 0, result.stderr
+
+
 # The autoresearch facade (``langres.optimize`` / ``langres.score_blocking``,
 # PR P-C) is eager-exported from ``langres/__init__.py`` -- so a bare
 # ``import langres`` must expose both as callables WHILE staying import-light:

--- a/tests/tracking/test_mlflow_tracker.py
+++ b/tests/tracking/test_mlflow_tracker.py
@@ -304,6 +304,29 @@ def test_log_params_stringifies_and_skips_empty(
     assert fake.params == {"blocking_k": "5", "flag": "True"}
 
 
+def test_log_params_flattens_nested_stage_runtime(
+    mlflow_env: tuple[ModuleType, _FakeMlflow],
+) -> None:
+    module, fake = mlflow_env
+    tracker = module.MlflowTracker(_settings())
+
+    tracker.log_params(
+        {
+            "stage_runtime": {
+                "evaluation.rerank.0": {
+                    "device": "cpu",
+                    "library_versions": {"torch": "2.12.1"},
+                }
+            }
+        }
+    )
+
+    assert fake.params == {
+        "stage_runtime.evaluation.rerank.0.device": "cpu",
+        "stage_runtime.evaluation.rerank.0.library_versions.torch": "2.12.1",
+    }
+
+
 def test_log_metrics_forwards_with_step(
     mlflow_env: tuple[ModuleType, _FakeMlflow],
 ) -> None:
@@ -547,6 +570,16 @@ def test_real_mlflow_sequence_field_yields_safe_param_keys(tmp_path: Any) -> Non
     )
     try:
         tracker.start_run(context)  # real mlflow validates every key -> must not raise
+        tracker.log_params(
+            {
+                "stage_runtime": {
+                    "evaluation.rerank.0": {
+                        "device": "cpu",
+                        "library_versions": {"torch": "2.12.1"},
+                    }
+                }
+            }
+        )
         run_id = tracker.native.info.run_id
         tracker.finish(status="completed")
 
@@ -554,6 +587,8 @@ def test_real_mlflow_sequence_field_yields_safe_param_keys(tmp_path: Any) -> Non
         assert params["cascade_band.0"] == "0.3"
         assert params["cascade_band.1"] == "0.7"
         assert params["resolver_config.blocker.bands.0"] == "0.1"
+        assert params["stage_runtime.evaluation.rerank.0.device"] == "cpu"
+        assert params["stage_runtime.evaluation.rerank.0.library_versions.torch"] == "2.12.1"
         assert not any("[" in key or "]" in key for key in params)
     finally:
         _drain_active_mlflow_runs()

--- a/tests/tracking/test_runs.py
+++ b/tests/tracking/test_runs.py
@@ -13,6 +13,7 @@ from __future__ import annotations
 
 import json
 import logging
+import os
 import subprocess
 import sys
 import types
@@ -480,6 +481,35 @@ class TestDatasetFingerprint:
         gold_a = {frozenset({"1", "2"}), frozenset({"3", "4"})}
         gold_b = {frozenset({"3", "4"}), frozenset({"1", "2"})}
         assert dataset_fingerprint([], gold_a) == dataset_fingerprint([], gold_b)
+
+    def test_nested_gold_cluster_order_is_irrelevant(self) -> None:
+        clusters_a = [{"1", "2"}, {"3"}, {"4", "5"}]
+        clusters_b = [{"4", "5"}, {"1", "2"}, {"3"}]
+        pairs = {frozenset({"1", "2"}), frozenset({"4", "5"})}
+
+        assert dataset_fingerprint([], [clusters_a, pairs]) == dataset_fingerprint(
+            [], [clusters_b, pairs]
+        )
+
+    def test_nested_gold_fingerprint_is_stable_across_hash_seeds(self) -> None:
+        script = """
+from langres.tracking.runs import dataset_fingerprint
+clusters = list({frozenset({'1', '2'}), frozenset({'3'}), frozenset({'4', '5'})})
+pairs = {frozenset({'1', '2'}), frozenset({'4', '5'})}
+print(dataset_fingerprint([], [clusters, pairs]))
+"""
+        fingerprints = {
+            subprocess.run(
+                [sys.executable, "-c", script],
+                check=True,
+                capture_output=True,
+                text=True,
+                env={**os.environ, "PYTHONHASHSEED": str(seed)},
+            ).stdout.strip()
+            for seed in (1, 2, 3, 4)
+        }
+
+        assert len(fingerprints) == 1
 
     def test_handles_mapping_gold(self) -> None:
         # a mapping is normalized to its sorted items, deterministically.


### PR DESCRIPTION
## Summary

- move research Retrieve and RetrieveRerank candidate search to Qdrant, including cross-source filtering before top-k
- select matcher thresholds using Pair F1 instead of B-Cubed F1
- make dataset fingerprints deterministic across Python processes
- capture model size, parameter count, memory estimate, quantization, runtime versions, and unambiguous records/pairs throughput
- publish numeric stage measurements to Trackio and keep legacy FAISS exports lazy

## Practical verification

- real Qdrant v1.15.5 Testcontainer passed
- offline native Sentence Transformers Retrieve and RetrieveRerank completed on tiny_fixture; both reached Pair F1 1.0 and resumed across a fresh Python process
- Amazon-Google Retrieve k=5: Pair F1 0.561, B-Cubed F1 0.904, 90.3s
- Amazon-Google RetrieveRerank k=5: Pair F1 0.461, B-Cubed F1 0.901, 226.7s
- Trackio database contains the stage-level latency, throughput, model, and runtime metrics

## Gates

- ruff check and format pass
- mypy strict passes for 214 source files
- focused experiment/resource/tracking suites pass
- real Qdrant Testcontainer passes

The optional full local model sweep was intentionally run offline and stopped at uncached FastEmbed/SmolLM downloads; GitHub CI has network access for those existing tests.

## Summary by Sourcery

Switch research retrieval to a Qdrant-backed dense index with cross-source filtering, strengthen experiment measurement and reproducibility, and keep FAISS-based paths lazily loaded and compatibility-only.

New Features:
- Add a QdrantDenseIndex adapter and wire research Retrieve and RetrieveRerank operations to use Qdrant for dense nearest-neighbour search, including optional source-based exclusion before top-k.
- Expose a source_field option throughout retrieval architectures so linkage recipes can exclude same-source candidates inside the retrieval query.
- Capture richer embedding and runtime metadata during experiments, including quantization, parameter counts, model artifact size, loaded memory, and library versions.
- Publish structured per-stage measurements and runtime facts to Trackio with explicit throughput units for records vs pairs.

Bug Fixes:
- Ensure experiment threshold tuning optimizes pair F1 on the training split instead of B-Cubed F1 to avoid singleton-biased cuts.
- Make dataset fingerprints deterministic across processes and hash seeds by normalizing nested set-like gold cluster structures before canonical JSON hashing.
- Correct stage throughput to be based on input counts and explicitly tag retrieve throughput as records rather than pairs.

Enhancements:
- Refine embedding and generation measurement schemas to carry quantization and throughput units, and validate them end-to-end in tests.
- Add Qdrant-based retrieval and linkage coverage, including Testcontainer-backed integration tests and import-budget guards to keep vector backends lazy.
- Improve sentence-transformer resources to infer parameter counts and local/cached artifact and memory sizes for loaded models.
- Extend documentation to describe Qdrant-native retrieval, source-aware linkage, measurement semantics, and pair-F1-based threshold selection.

Build:
- Clarify the semantic optional dependency description to note Qdrant-backed research retrieval while retaining FAISS for the classic VectorBlocker path.

Documentation:
- Update experiments and architecture reference docs, research vocabulary, and README to document Qdrant-backed retrieval, source_field semantics, pair-F1 tuning, and the expanded measurement and Trackio reporting model.

Tests:
- Add contract tests for the QdrantDenseIndex, including group-based exclusion and execution against a real Qdrant server.
- Extend experiment and tracking tests to cover richer embedding/runtime facts, throughput units, stage metric publication to Trackio, and deterministic dataset fingerprints across hash seeds.
- Update public acceptance tests to reflect the new source_field parameter in retrieval architecture signatures.
- Add import-budget tests to ensure dataset loaders and research Qdrant paths do not eagerly import FAISS or heavy vector backends.