### PR TITLE
Make the better clusterer reachable: `clusterer=` opt-in on FuzzyString and VectorLLMCascade

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,9 +47,12 @@ a raw `ERModel`.
 as the recommended choice with its numbers
 (`docs/research/20260727_closure_diagnostic.md`): higher BCubed F1 at 36 of the
 45 scored grid points, tied at 9, worse at 0, with 9 further points unscorable
-because closure's component was too large to score. It mitigates *chaining*; it
-does **not** consume negative evidence — rejected edges are discarded before
-pivoting, exactly as the base `Clusterer` discards them.
+because closure's component was too large to score. Those numbers were measured
+with one **$0 `rapidfuzz` scorer on one split seed**; the diagnostic flags a
+decider LLM as able to move them, so they are not a measurement of a paid
+pipeline. It mitigates *chaining*; it does **not** consume negative evidence —
+rejected edges are discarded before pivoting, exactly as the base `Clusterer`
+discards them.
 
 ### Research execution foundation
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,8 +23,14 @@ a raw `ERModel`.
   already claimed used to come back as a `{id}` singleton — so opting in changed
   your output *shape*, not just your partition, contradicting both the
   documented `dedupe()` contract and the class's own docstring, which already
-  claimed "no singleton clusters". Both clusterers now return multi-record
-  clusters only, with an unmerged record simply absent.
+  claimed "no singleton clusters". For judgements with **distinct ids** both
+  clusterers now return multi-record clusters only, with an unmerged record
+  simply absent. (One exception, running the other way: on an accepted
+  *self-pair* the base `Clusterer` returns a `{id}` singleton via
+  `nx.add_edge(x, x)` while `CorrelationClusterer` skips self-pairs entirely.
+  `VectorBlocker` emits 43 of those on `amazon_google`'s test split, so it is
+  real; it is left alone because changing the base clusterer would alter the
+  default path.)
   This moves **no** measured number: the benchmark harness scores
   `complete_partition(clusters, all_ids)`, which restores every uncovered id as
   its own singleton before anything is measured. Verified differentially against

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,9 +28,9 @@ a raw `ERModel`.
   simply absent. (One exception, running the other way: on an accepted
   *self-pair* the base `Clusterer` returns a `{id}` singleton via
   `nx.add_edge(x, x)` while `CorrelationClusterer` skips self-pairs entirely.
-  `VectorBlocker` emits 43 of those on `amazon_google`'s test split, so it is
-  real; it is left alone because changing the base clusterer would alter the
-  default path.)
+  No shipped blocker emits a self-pair, so this needs duplicate ids or a custom
+  blocker to reach; it is left alone because changing the base clusterer would
+  alter the default path.)
   This moves **no** measured number: the benchmark harness scores
   `complete_partition(clusters, all_ids)`, which restores every uncovered id as
   its own singleton before anything is measured. Verified differentially against

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,49 @@
 
 ## [Unreleased]
 
+### The better clusterer is now reachable (`clusterer=` opt-in)
+
+`CorrelationClusterer` measured better than the default transitive-closure
+`Clusterer` across the 9-benchmark portfolio, but **opting into it was
+impossible** on the two architectures the docs sell: neither `FuzzyString` nor
+`VectorLLMCascade` took a `clusterer=`, and the slot was hard-built inside
+`_topology`. The only route was to abandon the named architecture and hand-wire
+a raw `ERModel`.
+
+- **Added `clusterer=` to `FuzzyString` and `VectorLLMCascade`.** It defaults to
+  `None`, which builds exactly the transitive-closure `Clusterer` both already
+  built — **no behaviour change for anyone who does not pass it**, pinned by
+  test. `clusterer=` selects the *algorithm* only: the clusterer is rebuilt at
+  the model's own `threshold`, so `threshold=` stays the single match cut and
+  the object you pass is cloned, never mutated. Swapping it does not mint a new
+  architecture.
+- **`CorrelationClusterer` now drops the one-node clusters its pivot loop could
+  form.** A record with a qualifying edge whose neighbours an earlier pivot had
+  already claimed used to come back as a `{id}` singleton — so opting in changed
+  your output *shape*, not just your partition, contradicting both the
+  documented `dedupe()` contract and the class's own docstring, which already
+  claimed "no singleton clusters". Both clusterers now return multi-record
+  clusters only, with an unmerged record simply absent.
+  This moves **no** measured number: the benchmark harness scores
+  `complete_partition(clusters, all_ids)`, which restores every uncovered id as
+  its own singleton before anything is measured. Verified differentially against
+  the pre-fix loop over a randomized battery, not assumed.
+- **Refreshed stale provenance.** `CorrelationClusterer` said "NOT the default:
+  benchmark before switching" after the benchmark had been run, and
+  `ClusterStage`'s `algorithm="transitive_closure"` default read as a
+  recommendation. Both now carry the measured result and say plainly that the
+  default is not the recommendation. The docstring's Ailon–Charikar–Newman
+  citation is corrected too: this pivot order is *deterministic*, so their
+  3-approximation bound does not transfer to it.
+
+**The default is unchanged, deliberately.** `CorrelationClusterer` is documented
+as the recommended choice with its numbers
+(`docs/research/20260727_closure_diagnostic.md`): higher BCubed F1 at 36 of the
+45 scored grid points, tied at 9, worse at 0, with 9 further points unscorable
+because closure's component was too large to score. It mitigates *chaining*; it
+does **not** consume negative evidence — rejected edges are discarded before
+pivoting, exactly as the base `Clusterer` discards them.
+
 ### Research execution foundation
 
 - Added the canonical Resources / Operations / Recipes vocabulary, four named

--- a/docs/TECHNICAL_OVERVIEW.md
+++ b/docs/TECHNICAL_OVERVIEW.md
@@ -1118,8 +1118,8 @@ the adjacency map (identical to the base `Clusterer`, whose graph an unmerged
 record never enters), and a record *with* a qualifying edge whose neighbours an
 earlier pivot already claimed forms a one-node cluster mid-algorithm, which is
 dropped. That keeps the `dedupe()` contract above — the multi-record clusters,
-singletons left out — true for either clusterer, so opting in changes your
-*partition* without changing your output *shape*.
+singletons left out — true for either clusterer, so for judgements with distinct
+ids opting in changes your *partition* without changing your output *shape*.
 
 Two honest caveats. **Self-pairs are the one input where the two still differ,
 and there the base clusterer is the odd one out**: a `left_id == right_id`

--- a/docs/TECHNICAL_OVERVIEW.md
+++ b/docs/TECHNICAL_OVERVIEW.md
@@ -1123,7 +1123,11 @@ changes your *partition* without changing your output *shape*.
 
 #### How to opt in
 
-Pass it to any architecture's `clusterer=`, or to the `Resolver`'s clusterer slot:
+Pass it to the `clusterer=` of an architecture that exposes one — `FuzzyString`,
+`VectorLLMCascade`, and the four retrieval recipes (`Retrieve`, `RetrieveLLM`,
+`RetrieveRerank`, `RetrieveRerankLLM`) — or set the `clusterer` slot on a
+`Resolver`/`ERModel` directly. **`Reranker` is the exception**: it hardcodes its
+cluster stage, so passing `clusterer=` there is a `TypeError`, not an opt-in.
 
 ```python
 from langres.architectures import FuzzyString

--- a/docs/TECHNICAL_OVERVIEW.md
+++ b/docs/TECHNICAL_OVERVIEW.md
@@ -1168,6 +1168,13 @@ judgement set (`docs/research/20260727_closure_diagnostic.md`; the earlier
 | judged-and-*rejected* pairs inside an output cluster, tuned point | **3,776 → 676** across the portfolio (5.6×; per benchmark, 3.0×–7.4×) |
 | worst single benchmark for closure | `amazon_google` contributes **944** of that 3,776 — and those 944 are **39.8% of every pair sharing one of its own output clusters** (pivot: 128, 14.8%) |
 
+**What this was measured on.** One **$0 scorer** (`rapidfuzz`) and **one split
+seed** (0). The diagnostic says a matcher with a different error profile — a
+decider LLM in particular — "could move the numbers", and that the *ordering*
+surviving is "a hypothesis, not a measurement". The chaining mechanism is
+structural and scorer-independent; these magnitudes are not, so do not read them
+as a measurement of a paid LLM pipeline.
+
 The 3,776 is the **portfolio** total, not one dataset's; the 39.8% is a rate over
 `amazon_google`'s in-cluster pairs, not a share of the 3,776. The largest effect is
 not at the tuned point at all: one grid step below it closure collapses into a

--- a/docs/TECHNICAL_OVERVIEW.md
+++ b/docs/TECHNICAL_OVERVIEW.md
@@ -1111,14 +1111,65 @@ its pivot order, `CorrelationClusterer` uses the judgement's `score`, falling ba
 to `confidence`, then a unit `1.0` — so a bare "Yes" decision (no score) is still a
 full-strength edge, never a silent zero that would drop the merge.
 
-**Not the default.** Benchmarked head-to-head against the base `Clusterer` on
-Fodors-Zagat + Amazon-Google (same blocking + judge pipeline, only the
-clusterer differs): a wash on Fodors-Zagat (+0.0006 BCubed F1), a clear win
-on Amazon-Google (+0.0324 BCubed F1, +0.0715 precision at −0.016 recall) —
-see `examples/research/w1_blocking_algebra_output.md` for the full tables and the
-default-flip decision (kept opt-in; recommended for harder/messier
-entity-resolution problems, not flipped globally on a single hard-dataset
-win).
+**Same output shape as the base `Clusterer`.** Every returned cluster holds at
+least two ids. Two situations collapse to that one convention, and both mean
+"this record merged with nothing": a record with no qualifying edge never enters
+the adjacency map (identical to the base `Clusterer`, whose graph an unmerged
+record never enters), and a record *with* a qualifying edge whose neighbours an
+earlier pivot already claimed forms a one-node cluster mid-algorithm, which is
+dropped. That keeps the `dedupe()` contract above — the multi-record clusters,
+singletons left out — true no matter which clusterer you pick, so opting in
+changes your *partition* without changing your output *shape*.
+
+#### How to opt in
+
+Pass it to any architecture's `clusterer=`, or to the `Resolver`'s clusterer slot:
+
+```python
+from langres.architectures import FuzzyString
+from langres.core.clusterers import CorrelationClusterer
+
+result = FuzzyString(threshold=0.55, clusterer=CorrelationClusterer()).dedupe(records)
+```
+
+`clusterer=` selects the **algorithm** only. The clusterer is rebuilt at the
+model's own `threshold`, so a threshold set on the object you pass is ignored and
+`threshold=` remains the single match cut (the value `DedupeResult.threshold`
+reports). Swapping the clusterer does not mint a new architecture — that result
+is still a `FuzzyString`.
+
+**Recommended, and still not the default.** The default is unchanged; that is a
+deliberate product decision, not an absence of evidence. Measured over 9
+benchmarks against the default transitive-closure `Clusterer` on the identical
+judgement set (`docs/research/20260727_closure_diagnostic.md`; the earlier
+2-dataset study is at `examples/research/w1_blocking_algebra_output.md`):
+
+| | result |
+|---|---|
+| BCubed F1 vs closure, over 54 grid points | **higher at 36 of the 45 scored**, tied at 9, lower at **0** |
+| the other 9 grid points | **unscorable** — closure's giant component was too large to score, which is itself the result |
+| judged-and-*rejected* pairs inside an output cluster, tuned point | **3,776 → 676** across the portfolio (a 3.0×–7.4× cut) |
+| worst single benchmark for closure | `amazon_google`: **944** rejected pairs inside its own clusters — **39.8%** of every pair sharing one |
+
+The 3,776 is the **portfolio** total, not one dataset's. The largest effect is
+not at the tuned point at all: one grid step below it closure collapses into a
+giant component (on `walmart_amazon` at t = 0.50, 6,798 of the 7,386-record split
+in a single cluster) while pivot degrades smoothly. **Closure's quality is a
+cliff; pivot's is a slope** — which matters most when the threshold was guessed
+rather than derived from labels.
+
+**What it does not do.** It mitigates *chaining*; it does **not** consume
+negative evidence. Rejected edges are discarded before pivoting, exactly as the
+base `Clusterer` discards them — so a pair your matcher was paid to reject can
+still land inside one cluster, just far less often. Pricing negatives into the
+objective is a different clusterer (`docs/THEORY.md` §7), not this one.
+
+**On the citation.** The pivot order here is *deterministic* (highest incident
+score first, ties by node id), not the uniformly random pivot of
+Ailon–Charikar–Newman. Their 3-approximation bound is a property of that
+randomization and does **not** transfer to this implementation. The determinism
+is deliberate — reproducible without a seed — it is simply not an approximation
+guarantee.
 
 ## 10. Self-tuning: the autoresearch loop (`langres.optimize`)
 

--- a/docs/TECHNICAL_OVERVIEW.md
+++ b/docs/TECHNICAL_OVERVIEW.md
@@ -1173,7 +1173,11 @@ seed** (0). The diagnostic says a matcher with a different error profile — a
 decider LLM in particular — "could move the numbers", and that the *ordering*
 surviving is "a hypothesis, not a measurement". The chaining mechanism is
 structural and scorer-independent; these magnitudes are not, so do not read them
-as a measurement of a paid LLM pipeline.
+as a measurement of a paid LLM pipeline. Those runs also **predate the singleton
+drop described above**, so a re-run could report different cluster *counts* for
+pivot — but none of the numbers in this table can move, since a size-1 cluster
+contributes zero pairs and the harness restores unlisted ids via
+`complete_partition` before scoring.
 
 The 3,776 is the **portfolio** total, not one dataset's; the 39.8% is a rate over
 `amazon_google`'s in-cluster pairs, not a share of the 3,776. The largest effect is

--- a/docs/TECHNICAL_OVERVIEW.md
+++ b/docs/TECHNICAL_OVERVIEW.md
@@ -1148,10 +1148,11 @@ judgement set (`docs/research/20260727_closure_diagnostic.md`; the earlier
 |---|---|
 | BCubed F1 vs closure, over 54 grid points | **higher at 36 of the 45 scored**, tied at 9, lower at **0** |
 | the other 9 grid points | **unscorable** — closure's giant component was too large to score, which is itself the result |
-| judged-and-*rejected* pairs inside an output cluster, tuned point | **3,776 → 676** across the portfolio (a 3.0×–7.4× cut) |
-| worst single benchmark for closure | `amazon_google`: **944** rejected pairs inside its own clusters — **39.8%** of every pair sharing one |
+| judged-and-*rejected* pairs inside an output cluster, tuned point | **3,776 → 676** across the portfolio (5.6×; per benchmark, 3.0×–7.4×) |
+| worst single benchmark for closure | `amazon_google` contributes **944** of that 3,776 — and those 944 are **39.8% of every pair sharing one of its own output clusters** (pivot: 128, 14.8%) |
 
-The 3,776 is the **portfolio** total, not one dataset's. The largest effect is
+The 3,776 is the **portfolio** total, not one dataset's; the 39.8% is a rate over
+`amazon_google`'s in-cluster pairs, not a share of the 3,776. The largest effect is
 not at the tuned point at all: one grid step below it closure collapses into a
 giant component (on `walmart_amazon` at t = 0.50, 6,798 of the 7,386-record split
 in a single cluster) while pivot degrades smoothly. **Closure's quality is a

--- a/docs/TECHNICAL_OVERVIEW.md
+++ b/docs/TECHNICAL_OVERVIEW.md
@@ -1118,8 +1118,19 @@ the adjacency map (identical to the base `Clusterer`, whose graph an unmerged
 record never enters), and a record *with* a qualifying edge whose neighbours an
 earlier pivot already claimed forms a one-node cluster mid-algorithm, which is
 dropped. That keeps the `dedupe()` contract above — the multi-record clusters,
-singletons left out — true no matter which clusterer you pick, so opting in
-changes your *partition* without changing your output *shape*.
+singletons left out — true for either clusterer, so opting in changes your
+*partition* without changing your output *shape*.
+
+Two honest caveats. **Self-pairs are the one input where the two still differ,
+and there the base clusterer is the odd one out**: a `left_id == right_id`
+judgement clearing the threshold becomes `nx.add_edge(x, x)`, so the base
+`Clusterer` returns a `{x}` singleton while `CorrelationClusterer` skips
+self-pairs and returns nothing. That is not theoretical — `VectorBlocker` emits
+43 accepted self-pairs on `amazon_google`'s test split — and it is left alone on
+purpose, since changing it would alter the default path's behaviour. And the
+shape is a property of these two implementations, **not** an invariant the model
+enforces: a custom `Clusterer` subclass that emits singletons has them passed
+through unchanged.
 
 #### How to opt in
 

--- a/docs/TECHNICAL_OVERVIEW.md
+++ b/docs/TECHNICAL_OVERVIEW.md
@@ -1125,9 +1125,11 @@ Two honest caveats. **Self-pairs are the one input where the two still differ,
 and there the base clusterer is the odd one out**: a `left_id == right_id`
 judgement clearing the threshold becomes `nx.add_edge(x, x)`, so the base
 `Clusterer` returns a `{x}` singleton while `CorrelationClusterer` skips
-self-pairs and returns nothing. That is not theoretical — `VectorBlocker` emits
-43 accepted self-pairs on `amazon_google`'s test split — and it is left alone on
-purpose, since changing it would alter the default path's behaviour. And the
+self-pairs and returns nothing. It is left alone on purpose, since changing it
+would alter the default path's behaviour. Note that neither shipped blocker
+produces this input — `AllPairsBlocker` pairs only positions `i < j`, and
+`VectorBlocker` drops the anchor's self-match by identity to avoid exactly this —
+so it takes duplicate ids or a custom blocker to reach. And the
 shape is a property of these two implementations, **not** an invariant the model
 enforces: a custom `Clusterer` subclass that emits singletons has them passed
 through unchanged.

--- a/examples/research/closure_diagnostic.py
+++ b/examples/research/closure_diagnostic.py
@@ -166,12 +166,12 @@ class ClustererFinding(BaseModel):
         clusterer: ``"closure"`` (transitive closure) or ``"correlation"`` (pivot).
         n_clusters: Output clusters, as the clusterer returned them. Records with
             no accepted edge are absent (neither clusterer emits a cluster per
-            unmatched record), but **size-1 clusters do occur and are counted**:
-            ``Clusterer`` adds an accepted pair as a graph edge, so a self-pair
-            (``left_id == right_id``, which `VectorBlocker` does emit -- 43 of them
-            on ``amazon_google``'s test split) becomes a self-loop and hence a
-            one-node component; ``CorrelationClusterer`` strands a node whose only
-            neighbour an earlier pivot already consumed. Singletons contribute
+            unmatched record). **Size-1 clusters can still occur under
+            ``Clusterer``**: it adds an accepted pair as a graph edge, so a
+            self-pair (``left_id == right_id``) becomes a self-loop and hence a
+            one-node component. ``CorrelationClusterer`` produces none -- it skips
+            self-pairs outright, and it drops a node left stranded when an earlier
+            pivot had already consumed its only neighbour. Singletons contribute
             ``C(1, 2) = 0`` to ``n_incluster_pairs``, so they cannot affect
             ``n_rejected_inside`` or the contamination rate -- they only widen the
             cluster-count denominators.
@@ -733,10 +733,12 @@ def _components_from_verdicts(rows: list[dict[str, Any]]) -> list[set[str]]:
     node enters only via an accepted edge, so a record with no accepted pair is
     absent rather than emitted as a singleton -- but an accepted **self-pair**
     (``left_id == right_id``) does yield a one-node component, because ``Clusterer``
-    feeds it to ``nx.add_edge(x, x)`` as a self-loop. That is not hypothetical:
-    ``VectorBlocker`` emits 43 accepted self-pairs on ``amazon_google``'s test
-    split. Reproducing it is what keeps this check exact rather than approximately
-    right; a version that dropped singletons would fail on that benchmark alone.
+    feeds it to ``nx.add_edge(x, x)`` as a self-loop. No shipped blocker emits a
+    self-pair (``AllPairsBlocker`` pairs only positions ``i < j``;
+    ``VectorBlocker._neighbor_columns`` drops the anchor by identity), so this is a
+    convention this reimplementation matches rather than a case the portfolio
+    exercises -- reproducing it keeps the check exact against ``Clusterer``'s
+    contract, not against any observed benchmark row.
 
     Args:
         rows: Judged log rows (``verdict`` not ``None``).

--- a/examples/research/w1_blocking_algebra_output.md
+++ b/examples/research/w1_blocking_algebra_output.md
@@ -86,7 +86,8 @@ for both rows — **only the clusterer differs**, isolating its effect.
 - **The synthetic unit tests** (`tests/core/clusterers/test_correlation_clusterer.py`)
   show the mechanism directly: on a 3-node chain (A-B, B-C, no direct A-C
   edge) the base `Clusterer` merges `{A, B, C}` into one cluster;
-  `CorrelationClusterer` produces `{A, B}, {C}` — while a fully-connected
+  `CorrelationClusterer` produces `{A, B}` (`C` is stranded and, like any
+  unmerged record, absent from the result) — while a fully-connected
   triangle (every pair directly compared and matched) still merges fully
   under both, so C6 is not simply "more conservative everywhere," only where
   the evidence is actually indirect.

--- a/src/langres/architectures/fuzzy_string.py
+++ b/src/langres/architectures/fuzzy_string.py
@@ -66,6 +66,23 @@ class FuzzyString(ERModel):
             that equal weights gate out via the evidence floor.
         exclude: Field names to skip when deriving features (``{"id"}`` by
             default, handled by the comparator).
+        clusterer: The grouping algorithm. ``None`` (default) builds the base
+            transitive-closure :class:`~langres.core.clusterer.Clusterer` -- the
+            unchanged shipped behaviour. Pass
+            :class:`~langres.core.clusterers.correlation.CorrelationClusterer`
+            to opt into pivot clustering, which measures better on the benchmark
+            portfolio (``docs/research/20260727_closure_diagnostic.md``) and is
+            the recommended choice::
+
+                from langres.core.clusterers import CorrelationClusterer
+
+                FuzzyString(clusterer=CorrelationClusterer()).dedupe(records)
+
+            This selects the *algorithm* only: the clusterer is rebuilt at this
+            model's ``threshold``, so any threshold set on the object you pass is
+            ignored and ``threshold=`` stays the one match cut (the value
+            ``DedupeResult.threshold`` reports). Topology is otherwise unchanged
+            -- swapping the clusterer is still a ``FuzzyString``.
         schema: The entity schema. Omit it and the schema is **inferred** from
             the records' own keys on first use -- which is what makes
             ``FuzzyString().dedupe(records)`` work. Pass it explicitly for
@@ -90,6 +107,7 @@ class FuzzyString(ERModel):
         threshold: float = 0.5,
         weights: dict[str, float] | None = None,
         exclude: set[str] | None = None,
+        clusterer: Clusterer | None = None,
         schema: type[BaseModel] | None = None,
         budget_usd: float | None = None,
     ) -> None:
@@ -99,6 +117,11 @@ class FuzzyString(ERModel):
         self.threshold = threshold
         self.weights = weights
         self.exclude = exclude
+        # NOT ``self.clusterer``: that name is an ERModel SLOT (a property whose
+        # getter raises until the model is bound). This is the un-bound *choice*,
+        # read by _topology at bind time -- same split, same name, as the four
+        # retrieval recipes in architectures/retrieval.py.
+        self.clusterer_override = clusterer
         self._init_state(budget_usd=budget_usd)
         if schema is not None:
             self._bind(schema)
@@ -112,5 +135,22 @@ class FuzzyString(ERModel):
             "blocker": AllPairsBlocker(schema=schema),
             "comparator": comparator,
             "matcher": WeightedAverageMatcher(feature_specs=comparator.feature_specs),
-            "clusterer": Clusterer(threshold=self.threshold),
+            "clusterer": self._build_clusterer(),
         }
+
+    def _build_clusterer(self) -> Clusterer:
+        """The clusterer slot: the caller's algorithm, at THIS model's threshold.
+
+        Rebuilt through ``config``/``from_config`` rather than used as passed, so
+        ``threshold=`` stays the single match cut no matter what threshold the
+        caller happened to set on the object. That is the same clone seam
+        ``ERModel`` already puts every clusterer through on every resolve (its
+        ``_closure_clusterer``), so a clusterer that survives a run survives this,
+        and ``from_config`` re-runs ``__init__`` -- keeping the range validation a
+        plain attribute assignment would have skipped.
+        """
+        if self.clusterer_override is None:
+            return Clusterer(threshold=self.threshold)
+        return type(self.clusterer_override).from_config(
+            {**self.clusterer_override.config, "threshold": self.threshold}
+        )

--- a/src/langres/architectures/vector_llm_cascade.py
+++ b/src/langres/architectures/vector_llm_cascade.py
@@ -103,6 +103,28 @@ class VectorLLMCascade(ERModel):
         k_neighbors: Neighbors per record the blocker retrieves.
         entity_noun: The domain noun woven into the LLM's prompt ("company",
             "product", ...). Free, and it measurably helps.
+        clusterer: The grouping algorithm. ``None`` (default) builds the base
+            transitive-closure :class:`~langres.core.clusterer.Clusterer` -- the
+            unchanged shipped behaviour. Pass
+            :class:`~langres.core.clusterers.correlation.CorrelationClusterer`
+            to opt into pivot clustering, which measures better on the benchmark
+            portfolio (``docs/research/20260727_closure_diagnostic.md``) and is
+            the recommended choice::
+
+                from langres.core.clusterers import CorrelationClusterer
+
+                VectorLLMCascade(llm=..., clusterer=CorrelationClusterer())
+
+            It matters most here, where the judgements were *paid* for: closure
+            merges through a chain, so it can seat a pair the LLM was paid to
+            reject inside one output cluster. Pivot cuts that 3.0x-7.4x. It does
+            not eliminate it -- neither clusterer prices rejected edges into its
+            objective (see ``CorrelationClusterer``).
+
+            This selects the *algorithm* only: the clusterer is rebuilt at this
+            model's ``threshold``, so any threshold set on the object you pass is
+            ignored and ``threshold=`` stays the one match cut. Topology is
+            otherwise unchanged -- this is still a ``VectorLLMCascade``.
         schema: The entity schema; omit to infer it from the records on first
             use. Pass it explicitly for anything you intend to ``save``.
         budget_usd: Spend cap for this model's whole lifetime, in USD. ``None``
@@ -134,6 +156,7 @@ class VectorLLMCascade(ERModel):
         escalation_band: tuple[float, float] = _ESCALATION_BAND,
         k_neighbors: int = _K_NEIGHBORS,
         entity_noun: str = "entity",
+        clusterer: Clusterer | None = None,
         schema: type[BaseModel] | None = None,
         budget_usd: float | None = None,
     ) -> None:
@@ -146,6 +169,11 @@ class VectorLLMCascade(ERModel):
         self.escalation_band = escalation_band
         self.k_neighbors = k_neighbors
         self.entity_noun = entity_noun
+        # NOT ``self.clusterer``: that name is an ERModel SLOT (a property whose
+        # getter raises until the model is bound). This is the un-bound *choice*,
+        # read by _topology at bind time -- same split, same name, as the four
+        # retrieval recipes in architectures/retrieval.py.
+        self.clusterer_override = clusterer
         self._init_state(budget_usd=budget_usd)
         if schema is not None:
             self._bind(schema)
@@ -225,5 +253,22 @@ class VectorLLMCascade(ERModel):
             "matcher": CascadeMatcher(
                 student=student, escalation=escalation, band=self.escalation_band
             ),
-            "clusterer": Clusterer(threshold=self.threshold),
+            "clusterer": self._build_clusterer(),
         }
+
+    def _build_clusterer(self) -> Clusterer:
+        """The clusterer slot: the caller's algorithm, at THIS model's threshold.
+
+        Rebuilt through ``config``/``from_config`` rather than used as passed, so
+        ``threshold=`` stays the single match cut no matter what threshold the
+        caller happened to set on the object. That is the same clone seam
+        ``ERModel`` already puts every clusterer through on every resolve (its
+        ``_closure_clusterer``), so a clusterer that survives a run survives this,
+        and ``from_config`` re-runs ``__init__`` -- keeping the range validation a
+        plain attribute assignment would have skipped.
+        """
+        if self.clusterer_override is None:
+            return Clusterer(threshold=self.threshold)
+        return type(self.clusterer_override).from_config(
+            {**self.clusterer_override.config, "threshold": self.threshold}
+        )

--- a/src/langres/architectures/vector_llm_cascade.py
+++ b/src/langres/architectures/vector_llm_cascade.py
@@ -117,9 +117,17 @@ class VectorLLMCascade(ERModel):
 
             It matters most here, where the judgements were *paid* for: closure
             merges through a chain, so it can seat a pair the LLM was paid to
-            reject inside one output cluster. Pivot cuts that 5.6x across the
-            portfolio (3.0x-7.4x per benchmark). It does not eliminate it --
-            neither clusterer prices rejected edges into its objective (see
+            reject inside one output cluster. That mechanism is structural --
+            it follows from transitive closure, not from any scorer.
+
+            The published *magnitude* does not transfer to this architecture:
+            the 5.6x portfolio reduction (3.0x-7.4x per benchmark) was measured
+            with the **$0 rapidfuzz scorer on one split seed**, and the
+            diagnostic says a decider LLM "could move the numbers" and that the
+            ordering surviving is "a hypothesis, not a measurement". Read the
+            ratio as evidence from the $0 path, not as a measurement of a paid
+            cascade. Either way it does not eliminate the problem -- neither
+            clusterer prices rejected edges into its objective (see
             ``CorrelationClusterer``).
 
             This selects the *algorithm* only: the clusterer is rebuilt at this

--- a/src/langres/architectures/vector_llm_cascade.py
+++ b/src/langres/architectures/vector_llm_cascade.py
@@ -117,9 +117,10 @@ class VectorLLMCascade(ERModel):
 
             It matters most here, where the judgements were *paid* for: closure
             merges through a chain, so it can seat a pair the LLM was paid to
-            reject inside one output cluster. Pivot cuts that 3.0x-7.4x. It does
-            not eliminate it -- neither clusterer prices rejected edges into its
-            objective (see ``CorrelationClusterer``).
+            reject inside one output cluster. Pivot cuts that 5.6x across the
+            portfolio (3.0x-7.4x per benchmark). It does not eliminate it --
+            neither clusterer prices rejected edges into its objective (see
+            ``CorrelationClusterer``).
 
             This selects the *algorithm* only: the clusterer is rebuilt at this
             model's ``threshold``, so any threshold set on the object you pass is

--- a/src/langres/core/_model_run.py
+++ b/src/langres/core/_model_run.py
@@ -1052,12 +1052,18 @@ class ModelRun(ModelState):
         :class:`~langres.core.op_adapters.ClustererStage` clustering over the
         survivors, per ``docs/THEORY.md``'s Select-π vs equivalence-π split).
         The output is whatever the (zeroed) equivalence clusterer returns over
-        the selected edges: the base connected-components
-        :class:`~langres.core.clusterer.Clusterer` emits only multi-record
-        clusters (an isolated record never enters the graph), whereas a pivot
-        :class:`~langres.core.clusterers.correlation.CorrelationClusterer` can
-        leave a singleton behind -- a record with a qualifying edge whose only
-        neighbours an earlier pivot already claimed.
+        the selected edges, and **every clusterer returns the same shape**:
+        multi-record clusters only, an unmerged record simply absent. The two
+        reach it differently, which is worth knowing when reading either one's
+        source. The base connected-components
+        :class:`~langres.core.clusterer.Clusterer` gets it for free -- an isolated
+        record never enters the graph. A pivot
+        :class:`~langres.core.clusterers.correlation.CorrelationClusterer` has a
+        second way to strand a record -- one *with* a qualifying edge whose only
+        neighbours an earlier pivot already claimed -- which forms a one-node
+        ``{node}`` cluster mid-algorithm, so it drops those explicitly rather than
+        handing a caller who swapped the clusterer a different output shape for
+        the same meaning.
 
         Args:
             records: Raw records (dicts) in a stable list order.

--- a/src/langres/core/_model_run.py
+++ b/src/langres/core/_model_run.py
@@ -1052,10 +1052,15 @@ class ModelRun(ModelState):
         :class:`~langres.core.op_adapters.ClustererStage` clustering over the
         survivors, per ``docs/THEORY.md``'s Select-π vs equivalence-π split).
         The output is whatever the (zeroed) equivalence clusterer returns over
-        the selected edges, and **every clusterer returns the same shape**:
-        multi-record clusters only, an unmerged record simply absent. The two
-        reach it differently, which is worth knowing when reading either one's
-        source. The base connected-components
+        the selected edges. **Both SHIPPED clusterers return the same shape** --
+        multi-record clusters only, an unmerged record simply absent -- but that
+        is a property of those two implementations, **not** an invariant this
+        method enforces: a custom :class:`~langres.core.clusterer.Clusterer`
+        subclass that emits a one-node cluster has it passed straight through
+        (``ClustererStage.forward`` returns the clusterer's output unchanged, and
+        nothing here normalizes it). The two shipped ones reach the shape
+        differently, which is worth knowing when reading either one's source. The
+        base connected-components
         :class:`~langres.core.clusterer.Clusterer` gets it for free -- an isolated
         record never enters the graph. A pivot
         :class:`~langres.core.clusterers.correlation.CorrelationClusterer` has a

--- a/src/langres/core/_model_run.py
+++ b/src/langres/core/_model_run.py
@@ -1052,15 +1052,29 @@ class ModelRun(ModelState):
         :class:`~langres.core.op_adapters.ClustererStage` clustering over the
         survivors, per ``docs/THEORY.md``'s Select-π vs equivalence-π split).
         The output is whatever the (zeroed) equivalence clusterer returns over
-        the selected edges. **Both SHIPPED clusterers return the same shape** --
-        multi-record clusters only, an unmerged record simply absent -- but that
-        is a property of those two implementations, **not** an invariant this
-        method enforces: a custom :class:`~langres.core.clusterer.Clusterer`
-        subclass that emits a one-node cluster has it passed straight through
-        (``ClustererStage.forward`` returns the clusterer's output unchanged, and
-        nothing here normalizes it). The two shipped ones reach the shape
-        differently, which is worth knowing when reading either one's source. The
-        base connected-components
+        the selected edges. **For judgements with DISTINCT ids, both shipped
+        clusterers return the same shape** -- multi-record clusters only, an
+        unmerged record simply absent. Two caveats, both real:
+
+        * **Self-pairs break the tie, in the base clusterer's favour.** A
+          ``left_id == right_id`` judgement that clears the threshold makes the
+          base Clusterer call ``nx.add_edge(x, x)``, and networkx returns ``{x}``
+          -- a one-node component -- whereas
+          :class:`~langres.core.clusterers.correlation.CorrelationClusterer`
+          skips self-pairs outright and emits nothing. Not hypothetical:
+          ``VectorBlocker`` produces 43 accepted self-pairs on ``amazon_google``'s
+          test split. Left as-is deliberately -- teaching the base clusterer to
+          drop them is a behaviour change to the DEFAULT path.
+        * **Nothing here enforces the shape.** It is a property of the two
+          shipped implementations, not an invariant of this method: a custom
+          :class:`~langres.core.clusterer.Clusterer` subclass that emits a
+          one-node cluster has it passed straight through
+          (``ClustererStage.forward`` returns the clusterer's output unchanged,
+          and ``_cluster`` normalizes nothing).
+
+        The two shipped ones reach the distinct-id shape differently, which is
+        worth knowing when reading either one's source. The base
+        connected-components
         :class:`~langres.core.clusterer.Clusterer` gets it for free -- an isolated
         record never enters the graph. A pivot
         :class:`~langres.core.clusterers.correlation.CorrelationClusterer` has a

--- a/src/langres/core/_model_run.py
+++ b/src/langres/core/_model_run.py
@@ -1061,10 +1061,10 @@ class ModelRun(ModelState):
           base Clusterer call ``nx.add_edge(x, x)``, and networkx returns ``{x}``
           -- a one-node component -- whereas
           :class:`~langres.core.clusterers.correlation.CorrelationClusterer`
-          skips self-pairs outright and emits nothing. Not hypothetical:
-          ``VectorBlocker`` produces 43 accepted self-pairs on ``amazon_google``'s
-          test split. Left as-is deliberately -- teaching the base clusterer to
-          drop them is a behaviour change to the DEFAULT path.
+          skips self-pairs outright and emits nothing. Left as-is deliberately --
+          teaching the base clusterer to drop them is a behaviour change to the
+          DEFAULT path. Neither shipped blocker produces this input, so reaching
+          it takes duplicate ids or a custom blocker.
         * **Nothing here enforces the shape.** It is a property of the two
           shipped implementations, not an invariant of this method: a custom
           :class:`~langres.core.clusterer.Clusterer` subclass that emits a

--- a/src/langres/core/clusterers/correlation.py
+++ b/src/langres/core/clusterers/correlation.py
@@ -19,9 +19,11 @@ same as the base Clusterer.
 
 Measured on the 9-benchmark portfolio in
 ``docs/research/20260727_closure_diagnostic.md`` and **recommended** as a result;
-opt in with ``FuzzyString(clusterer=CorrelationClusterer())`` or any other
-architecture's ``clusterer=``. It is deliberately still not the default. See the
-class docstring for the numbers and for what this does *not* fix.
+opt in with ``FuzzyString(clusterer=CorrelationClusterer())``, or the same
+argument on ``VectorLLMCascade`` / the four retrieval recipes (``Reranker``
+hardcodes its cluster stage and takes no ``clusterer=``). It is deliberately
+still not the default. See the class docstring for the numbers and for what this
+does *not* fix.
 """
 
 from collections.abc import Iterator
@@ -61,7 +63,12 @@ class CorrelationClusterer(Clusterer):
       7,386-record split in one cluster) while pivot degrades smoothly. Closure's
       quality is a cliff; pivot's is a slope.
 
-    Opt in by passing it to any architecture's ``clusterer=``::
+    Opt in via the ``clusterer=`` argument of the architectures that expose one --
+    :class:`~langres.architectures.fuzzy_string.FuzzyString`,
+    :class:`~langres.architectures.vector_llm_cascade.VectorLLMCascade`, and the
+    four retrieval recipes. (:class:`~langres.architectures.reranker.Reranker`
+    does **not**: it hardcodes its cluster stage.) Or set the ``clusterer`` slot
+    on a :class:`~langres.core.resolver.ERModel` directly::
 
         FuzzyString(clusterer=CorrelationClusterer())
 

--- a/src/langres/core/clusterers/correlation.py
+++ b/src/langres/core/clusterers/correlation.py
@@ -69,7 +69,11 @@ class CorrelationClusterer(Clusterer):
     with a different error profile -- a decider LLM in particular -- "could move
     the numbers", and that the *ordering* surviving is "a hypothesis, not a
     measurement" (§4). The chaining mechanism is structural and
-    scorer-independent; the magnitudes above are not.
+    scorer-independent; the magnitudes above are not. Those runs also **predate
+    the singleton drop below**, so a re-run could report different cluster
+    *counts* for pivot -- but no metric quoted here can move, since a size-1
+    cluster contributes ``C(1, 2) = 0`` pairs and the harness restores unlisted
+    ids via ``complete_partition`` before scoring.
 
     Opt in via the ``clusterer=`` argument of the architectures that expose one --
     :class:`~langres.architectures.fuzzy_string.FuzzyString`,

--- a/src/langres/core/clusterers/correlation.py
+++ b/src/langres/core/clusterers/correlation.py
@@ -40,8 +40,9 @@ class CorrelationClusterer(Clusterer):
 
     Drop-in alternative to the base :class:`~langres.core.clusterer.Clusterer`
     (same ``threshold`` constructor, same ``config``/``from_config``, same output
-    shape, inherits ``evaluate()``/``inspect_clusters()`` unchanged -- only
-    :meth:`cluster` differs).
+    shape on distinct-id judgements -- see :meth:`cluster` for the one self-pair
+    exception -- inherits ``evaluate()``/``inspect_clusters()`` unchanged, and
+    only :meth:`cluster` differs).
 
     **It has now been benchmarked, and it is the recommended choice.** It is
     still not the default -- that is a deliberate product decision, not an
@@ -130,13 +131,22 @@ class CorrelationClusterer(Clusterer):
 
         Dropping the second is what makes this class a genuine **drop-in**: the
         documented ``dedupe()`` contract returns the multi-record clusters and
-        leaves singletons out, so a caller who opts in gets a different (better)
-        *partition* but never a different output *shape*. It costs no information
-        -- an id absent from the result is a singleton entity by that same
-        contract -- and it costs no measurement either: the portfolio harness
-        scores ``complete_partition(clusters, all_ids)``, which restores every
-        unlisted id as its own singleton before computing BCubed, so the
-        diagnostic's numbers are unchanged by this.
+        leaves singletons out, so for judgements with **distinct ids** a caller
+        who opts in gets a different (better) *partition* without a different
+        output *shape*. It costs no information -- an id absent from the result is
+        a singleton entity by that same contract -- and it costs no measurement
+        either: the portfolio harness scores ``complete_partition(clusters,
+        all_ids)``, which restores every unlisted id as its own singleton before
+        computing BCubed, so the diagnostic's numbers are unchanged by this.
+
+        **The one exception, and it runs the other way.** A *self-pair*
+        (``left_id == right_id``) that clears the threshold is skipped outright by
+        :meth:`_build_adjacency`, so that record is absent here -- while the base
+        Clusterer feeds it to ``nx.add_edge(x, x)`` and returns a ``{x}``
+        singleton. On that input the BASE clusterer is the one emitting a
+        singleton. Real, not hypothetical: ``VectorBlocker`` produces 43 accepted
+        self-pairs on ``amazon_google``'s test split. Left as-is deliberately --
+        changing the base clusterer would alter the default path's behaviour.
 
         Args:
             judgements: Iterator or list of PairwiseJudgement objects.

--- a/src/langres/core/clusterers/correlation.py
+++ b/src/langres/core/clusterers/correlation.py
@@ -144,9 +144,17 @@ class CorrelationClusterer(Clusterer):
         :meth:`_build_adjacency`, so that record is absent here -- while the base
         Clusterer feeds it to ``nx.add_edge(x, x)`` and returns a ``{x}``
         singleton. On that input the BASE clusterer is the one emitting a
-        singleton. Real, not hypothetical: ``VectorBlocker`` produces 43 accepted
-        self-pairs on ``amazon_google``'s test split. Left as-is deliberately --
-        changing the base clusterer would alter the default path's behaviour.
+        singleton -- pinned by
+        ``test_a_self_pair_is_the_one_input_where_the_two_shapes_still_differ``.
+        Left as-is deliberately: changing the base clusterer would alter the
+        default path's behaviour.
+
+        Neither shipped blocker hands a clusterer this input. ``AllPairsBlocker``
+        pairs only positions ``i < j``, and ``VectorBlocker`` drops the anchor's
+        self-match **by identity** (``blockers/vector.py:_neighbor_columns``) --
+        its docstring says it does so specifically to avoid "yielding a
+        degenerate self-pair". Reaching this case therefore takes duplicate ids
+        in the input or a custom blocker, not a default pipeline.
 
         Args:
             judgements: Iterator or list of PairwiseJudgement objects.

--- a/src/langres/core/clusterers/correlation.py
+++ b/src/langres/core/clusterers/correlation.py
@@ -64,6 +64,13 @@ class CorrelationClusterer(Clusterer):
       7,386-record split in one cluster) while pivot degrades smoothly. Closure's
       quality is a cliff; pivot's is a slope.
 
+    **What those numbers were measured on.** One **$0 scorer** (``rapidfuzz``)
+    and **one split seed** (0). The diagnostic states outright that a matcher
+    with a different error profile -- a decider LLM in particular -- "could move
+    the numbers", and that the *ordering* surviving is "a hypothesis, not a
+    measurement" (§4). The chaining mechanism is structural and
+    scorer-independent; the magnitudes above are not.
+
     Opt in via the ``clusterer=`` argument of the architectures that expose one --
     :class:`~langres.architectures.fuzzy_string.FuzzyString`,
     :class:`~langres.architectures.vector_llm_cascade.VectorLLMCascade`, and the

--- a/src/langres/core/clusterers/correlation.py
+++ b/src/langres/core/clusterers/correlation.py
@@ -50,10 +50,12 @@ class CorrelationClusterer(Clusterer):
     * BCubed F1 is **strictly higher at 36 of the 45 scored grid points, tied at
       9, and lower at 0**. Nine further grid points are **unscorable** -- closure's
       giant component was too large to score, which is itself the result.
-    * Judged-and-*rejected* pairs sitting inside an output cluster drop 3.0x-7.4x
-      at the tuned operating point (3,776 -> 676 across the portfolio;
-      ``amazon_google`` alone accounts for 944 of the 3,776, i.e. 39.8% of every
-      pair sharing one of its output clusters).
+    * Judged-and-*rejected* pairs sitting inside an output cluster drop at the
+      tuned operating point: **3,776 -> 676** across the portfolio (5.6x; per
+      benchmark the reduction ranges 3.0x-7.4x). Closure's worst benchmark is
+      ``amazon_google``, which contributes **944** of that 3,776 -- and those 944
+      are **39.8% of every pair sharing one of its output clusters**, not 39.8%
+      of the portfolio total. Pivot brings it to 128 (14.8%).
     * The real gap is off the tuned point: one grid step down, closure collapses
       into a giant component (on ``walmart_amazon`` at t=0.50, 6,798 of the
       7,386-record split in one cluster) while pivot degrades smoothly. Closure's

--- a/src/langres/core/clusterers/correlation.py
+++ b/src/langres/core/clusterers/correlation.py
@@ -16,6 +16,12 @@ direct edge to the pivot don't force a merge -- structurally resistant to the
 classic "chaining" failure, while a genuinely well-connected group (e.g. a
 clique where every pair was directly compared and matched) still merges fully,
 same as the base Clusterer.
+
+Measured on the 9-benchmark portfolio in
+``docs/research/20260727_closure_diagnostic.md`` and **recommended** as a result;
+opt in with ``FuzzyString(clusterer=CorrelationClusterer())`` or any other
+architecture's ``clusterer=``. It is deliberately still not the default. See the
+class docstring for the numbers and for what this does *not* fix.
 """
 
 from collections.abc import Iterator
@@ -31,10 +37,46 @@ class CorrelationClusterer(Clusterer):
     """Merge-resistant Clusterer: the pivot algorithm for correlation clustering.
 
     Drop-in alternative to the base :class:`~langres.core.clusterer.Clusterer`
-    (same ``threshold`` constructor, same ``config``/``from_config``,
-    inherits ``evaluate()``/``inspect_clusters()`` unchanged -- only
-    :meth:`cluster` differs). NOT the default: benchmark before switching (see
-    ``examples/research/w1_blocking_algebra_output.md``).
+    (same ``threshold`` constructor, same ``config``/``from_config``, same output
+    shape, inherits ``evaluate()``/``inspect_clusters()`` unchanged -- only
+    :meth:`cluster` differs).
+
+    **It has now been benchmarked, and it is the recommended choice.** It is
+    still not the default -- that is a deliberate product decision, not an
+    absence of evidence. On the 9-benchmark portfolio
+    (``docs/research/20260727_closure_diagnostic.md``), against the default
+    transitive-closure ``Clusterer`` over the identical judgement set:
+
+    * BCubed F1 is **strictly higher at 36 of the 45 scored grid points, tied at
+      9, and lower at 0**. Nine further grid points are **unscorable** -- closure's
+      giant component was too large to score, which is itself the result.
+    * Judged-and-*rejected* pairs sitting inside an output cluster drop 3.0x-7.4x
+      at the tuned operating point (3,776 -> 676 across the portfolio;
+      ``amazon_google`` alone accounts for 944 of the 3,776, i.e. 39.8% of every
+      pair sharing one of its output clusters).
+    * The real gap is off the tuned point: one grid step down, closure collapses
+      into a giant component (on ``walmart_amazon`` at t=0.50, 6,798 of the
+      7,386-record split in one cluster) while pivot degrades smoothly. Closure's
+      quality is a cliff; pivot's is a slope.
+
+    Opt in by passing it to any architecture's ``clusterer=``::
+
+        FuzzyString(clusterer=CorrelationClusterer())
+
+    **What it does NOT do.** It *mitigates chaining*; it does **not** consume
+    negative evidence. Rejected edges are discarded before pivoting
+    (:meth:`_build_adjacency` keeps only rows where
+    :func:`~langres.core.models.predicted_match` is ``True``), exactly as the base
+    Clusterer discards them -- so a rejected pair can still land inside one
+    cluster, just far less often. Pricing negatives into the objective is a
+    different clusterer, not this one (``docs/THEORY.md`` §7).
+
+    **On the citation.** The pivot order here is *deterministic* -- highest
+    incident score first, ties by node id (:meth:`_pivot_priority`) -- not the
+    uniformly random pivot of Ailon-Charikar-Newman. Their 3-approximation bound
+    is a property of that randomization and does **not** transfer to this
+    implementation. The determinism is deliberate (reproducible without a seed);
+    it is simply not an approximation guarantee.
 
     Algorithm, per call to :meth:`cluster`:
 
@@ -47,6 +89,11 @@ class CorrelationClusterer(Clusterer):
     3. For each unprocessed node (in that order), form a cluster from the node
        plus every one of its DIRECT neighbours that is still unprocessed.
        Remove those nodes from further consideration and continue.
+    4. Drop the one-node clusters. A pivot whose every neighbour was already
+       claimed forms ``{node}`` at step 3; that says "this record merged with
+       nothing", which is exactly what the base Clusterer says by leaving an
+       unmerged record **out**. Emitting it instead would hand anyone who opts in
+       a different output *shape* for the same meaning -- see :meth:`cluster`.
 
     A node with only an indirect (multi-hop) path to a cluster is never pulled
     in -- unlike connected components, which merges anything reachable by any
@@ -61,13 +108,32 @@ class CorrelationClusterer(Clusterer):
     ) -> list[set[str]]:
         """Form entity clusters via the pivot algorithm for correlation clustering.
 
+        Every returned cluster holds at least two ids. Two different situations
+        collapse to that one convention, and both mean "this record merged with
+        nothing":
+
+        * a record with **no** qualifying edge never enters the adjacency map, so
+          it is absent -- identical to the base Clusterer, whose graph an isolated
+          record never enters either;
+        * a record *with* a qualifying edge whose neighbours an earlier pivot had
+          already claimed forms a one-node ``{node}`` cluster, which is dropped
+          here.
+
+        Dropping the second is what makes this class a genuine **drop-in**: the
+        documented ``dedupe()`` contract returns the multi-record clusters and
+        leaves singletons out, so a caller who opts in gets a different (better)
+        *partition* but never a different output *shape*. It costs no information
+        -- an id absent from the result is a singleton entity by that same
+        contract -- and it costs no measurement either: the portfolio harness
+        scores ``complete_partition(clusters, all_ids)``, which restores every
+        unlisted id as its own singleton before computing BCubed, so the
+        diagnostic's numbers are unchanged by this.
+
         Args:
             judgements: Iterator or list of PairwiseJudgement objects.
 
         Returns:
-            List of clusters (sets of entity ids). Like the base Clusterer,
-            entities with no qualifying edge are simply absent (no singleton
-            clusters).
+            List of clusters (sets of entity ids), each with >= 2 ids.
         """
         adjacency = self._build_adjacency(judgements)
 
@@ -77,8 +143,11 @@ class CorrelationClusterer(Clusterer):
             if node not in remaining:
                 continue
             cluster = {node} | (set(adjacency[node]) & remaining)
+            # Claim the nodes BEFORE the size test: a dropped singleton is still
+            # processed, or the loop would revisit it forever.
             remaining -= cluster
-            clusters.append(cluster)
+            if len(cluster) > 1:
+                clusters.append(cluster)
         return clusters
 
     def _build_adjacency(

--- a/src/langres/core/op.py
+++ b/src/langres/core/op.py
@@ -609,12 +609,25 @@ class ClusterStage(ABC, Generic[SchemaT]):
     Clustering is the equivalence selection — the point where the table of scored
     pairs collapses into id clusters. Because that selection is not approximable
     (THEORY §8), a ``ClusterStage`` is inherently a *named heuristic*: it carries
-    an :attr:`algorithm` (default ``"transitive_closure"``) and stamps
-    :attr:`is_heuristic` = ``True`` into its :attr:`label`. It is not an
-    :class:`Op` because its output carrier is clusters, not pairs.
+    an :attr:`algorithm` and stamps :attr:`is_heuristic` = ``True`` into its
+    :attr:`label`. It is not an :class:`Op` because its output carrier is
+    clusters, not pairs.
+
+    ``algorithm`` defaults to ``"transitive_closure"`` because that is what the
+    shipped default :class:`~langres.core.clusterer.Clusterer` does — **the
+    default is not a recommendation.** ``"pivot"``
+    (:class:`~langres.core.clusterers.correlation.CorrelationClusterer`) measures
+    better on the benchmark portfolio (``docs/research/20260727_closure_diagnostic.md``:
+    higher BCubed F1 at 36 of 45 scored grid points, tied at 9, worse at 0, with
+    9 unscorable because closure's component was too large to score). Subclasses
+    that adapt a concrete clusterer should *derive* this name from the clusterer
+    they hold rather than accept the default — as
+    :class:`~langres.core.op_adapters.ClustererStage` does.
 
     Args:
-        algorithm: The named clustering heuristic (default ``"transitive_closure"``).
+        algorithm: The named clustering heuristic. Defaults to
+            ``"transitive_closure"`` (what the shipped default clusterer does),
+            not to the best-measured one.
 
     Raises:
         ValueError: If ``algorithm`` is not a known clustering heuristic.

--- a/tests/architectures/test_clusterer_opt_in.py
+++ b/tests/architectures/test_clusterer_opt_in.py
@@ -1,0 +1,172 @@
+"""The ``clusterer=`` opt-in on the two architectures the docs sell.
+
+``CorrelationClusterer`` measures better than the shipped transitive-closure
+default (``docs/research/20260727_closure_diagnostic.md``), but until now
+*opting into it was impossible* on :class:`~langres.architectures.FuzzyString`
+and :class:`~langres.architectures.vector_llm_cascade.VectorLLMCascade`: neither
+constructor took a ``clusterer=``, and the slot was hard-built inside
+``_topology``. The only way to get one was to abandon the named architecture and
+hand-wire a raw ``ERModel``.
+
+The default is deliberately NOT flipped. So the load-bearing test here is the
+*negative* one -- that a caller who passes nothing gets byte-identical behaviour
+to before -- with the opt-in proved on top of it.
+
+``VectorLLMCascade``'s ``_topology`` pulls faiss/sentence-transformers/litellm,
+so this file only exercises the parts of it that are free: the constructor and
+``_build_clusterer``. Wiring the slot is identical code in both classes and is
+proved end-to-end on the $0 ``FuzzyString``.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from langres.architectures import FuzzyString, VectorLLMCascade
+from langres.core.clusterer import Clusterer
+from langres.core.clusterers.correlation import CorrelationClusterer
+
+# The classic over-merge chain. MEASURED scores from FuzzyString's own
+# comparator, not guessed: 1-2 = 0.8889, 2-3 = 0.5714, 1-3 = 0.5000. So at
+# _CHAIN_THRESHOLD the two chain edges clear and the direct 1-3 edge does not --
+# transitive closure merges all three, pivot merges only {1, 2}.
+_CHAIN = [
+    {"id": "1", "name": "Acme Corporation"},
+    {"id": "2", "name": "Acme Corporation Ltd"},
+    {"id": "3", "name": "Acme Ltd"},
+]
+_CHAIN_THRESHOLD = 0.55
+
+
+# ---------------------------------------------------------------------------
+# The default is untouched
+# ---------------------------------------------------------------------------
+
+
+def test_default_clusterer_is_still_the_base_transitive_closure_clusterer() -> None:
+    """No ``clusterer=`` -> exactly the base ``Clusterer``, not a subclass."""
+    model = FuzzyString(schema=None)
+    model.dedupe(_CHAIN)
+
+    assert type(model.clusterer) is Clusterer
+
+
+def test_default_clusterer_gets_the_models_threshold() -> None:
+    """The pre-existing wiring, pinned: ``threshold=`` reaches the clusterer."""
+    model = FuzzyString(threshold=0.42)
+    model.dedupe(_CHAIN)
+
+    assert model.clusterer.threshold == 0.42
+
+
+def test_passing_nothing_is_identical_to_never_having_the_parameter() -> None:
+    """The zero-behaviour-change guarantee, stated as an output comparison."""
+    explicit_none = FuzzyString(threshold=0.6, clusterer=None).dedupe(_CHAIN)
+    omitted = FuzzyString(threshold=0.6).dedupe(_CHAIN)
+
+    assert sorted(map(sorted, explicit_none)) == sorted(map(sorted, omitted))
+    assert explicit_none.threshold == omitted.threshold
+    assert explicit_none.architecture == omitted.architecture
+
+
+def test_vector_llm_cascade_default_clusterer_is_unchanged() -> None:
+    """Same for the paid architecture -- without importing its heavy topology."""
+    model = VectorLLMCascade(llm="openrouter/openai/gpt-4o-mini", threshold=0.7)
+
+    built = model._build_clusterer()
+
+    assert type(built) is Clusterer
+    assert built.threshold == 0.7
+
+
+# ---------------------------------------------------------------------------
+# The opt-in actually works
+# ---------------------------------------------------------------------------
+
+
+def test_fuzzy_string_accepts_a_correlation_clusterer() -> None:
+    """The whole point of the track: this call was impossible before."""
+    model = FuzzyString(clusterer=CorrelationClusterer())
+    model.dedupe(_CHAIN)
+
+    assert type(model.clusterer) is CorrelationClusterer
+
+
+def test_vector_llm_cascade_accepts_a_correlation_clusterer() -> None:
+    model = VectorLLMCascade(
+        llm="openrouter/openai/gpt-4o-mini", clusterer=CorrelationClusterer()
+    )
+
+    assert type(model._build_clusterer()) is CorrelationClusterer
+
+
+def test_opting_in_changes_the_clustering_not_the_architecture() -> None:
+    """Pivot refuses the chain merge that closure makes -- and stays a FuzzyString.
+
+    The measured difference this opt-in exists to deliver, at the front door.
+    """
+    closure = FuzzyString(threshold=_CHAIN_THRESHOLD).dedupe(_CHAIN)
+    pivot = FuzzyString(
+        threshold=_CHAIN_THRESHOLD, clusterer=CorrelationClusterer()
+    ).dedupe(_CHAIN)
+
+    assert sorted(map(sorted, closure)) == [["1", "2", "3"]]  # chained through 2
+    assert sorted(map(sorted, pivot)) == [["1", "2"]]  # no direct 1-3 edge
+    # Swapping the clusterer must NOT mint a new architecture.
+    assert pivot.architecture == closure.architecture == "FuzzyString"
+
+
+def test_opting_in_does_not_introduce_singleton_clusters() -> None:
+    """Record 3 is unmerged, so it is ABSENT -- the same shape closure returns.
+
+    A user opting into a better clusterer must not silently get a different
+    output *shape*; ``dedupe()`` is documented to return the multi-record
+    clusters and leave singletons out.
+    """
+    pivot = FuzzyString(
+        threshold=_CHAIN_THRESHOLD, clusterer=CorrelationClusterer()
+    ).dedupe(_CHAIN)
+
+    assert "3" not in {rid for cluster in pivot for rid in cluster}
+    assert all(len(cluster) > 1 for cluster in pivot)
+
+
+# ---------------------------------------------------------------------------
+# ``threshold=`` stays the single match cut
+# ---------------------------------------------------------------------------
+
+
+def test_model_threshold_overrides_the_passed_clusterers_own_threshold() -> None:
+    """One argument, one meaning: ``clusterer=`` picks the algorithm, not the cut.
+
+    Otherwise ``FuzzyString(threshold=0.6, clusterer=CorrelationClusterer())``
+    would silently cut at the clusterer's default 0.5 while
+    ``DedupeResult.threshold`` reported 0.6.
+    """
+    model = FuzzyString(threshold=0.6, clusterer=CorrelationClusterer(threshold=0.99))
+    result = model.dedupe(_CHAIN)
+
+    assert model.clusterer.threshold == 0.6
+    assert result.threshold == 0.6
+
+
+def test_the_passed_clusterer_instance_is_not_mutated() -> None:
+    """The caller's object is cloned, never rewritten under them."""
+    passed = CorrelationClusterer(threshold=0.99)
+    model = FuzzyString(threshold=0.6, clusterer=passed)
+    model.dedupe(_CHAIN)
+
+    assert passed.threshold == 0.99
+    assert model.clusterer is not passed
+
+
+def test_an_out_of_range_threshold_still_raises() -> None:
+    """Cloning goes through ``__init__``, so validation is not skipped.
+
+    A plain ``copy(clusterer); clusterer.threshold = t`` would have silently
+    accepted this.
+    """
+    model = FuzzyString(threshold=5.0, clusterer=CorrelationClusterer())
+
+    with pytest.raises(ValueError, match="threshold"):
+        model.dedupe(_CHAIN)

--- a/tests/architectures/test_clusterer_opt_in.py
+++ b/tests/architectures/test_clusterer_opt_in.py
@@ -93,9 +93,7 @@ def test_fuzzy_string_accepts_a_correlation_clusterer() -> None:
 
 
 def test_vector_llm_cascade_accepts_a_correlation_clusterer() -> None:
-    model = VectorLLMCascade(
-        llm="openrouter/openai/gpt-4o-mini", clusterer=CorrelationClusterer()
-    )
+    model = VectorLLMCascade(llm="openrouter/openai/gpt-4o-mini", clusterer=CorrelationClusterer())
 
     assert type(model._build_clusterer()) is CorrelationClusterer
 
@@ -106,9 +104,7 @@ def test_opting_in_changes_the_clustering_not_the_architecture() -> None:
     The measured difference this opt-in exists to deliver, at the front door.
     """
     closure = FuzzyString(threshold=_CHAIN_THRESHOLD).dedupe(_CHAIN)
-    pivot = FuzzyString(
-        threshold=_CHAIN_THRESHOLD, clusterer=CorrelationClusterer()
-    ).dedupe(_CHAIN)
+    pivot = FuzzyString(threshold=_CHAIN_THRESHOLD, clusterer=CorrelationClusterer()).dedupe(_CHAIN)
 
     assert sorted(map(sorted, closure)) == [["1", "2", "3"]]  # chained through 2
     assert sorted(map(sorted, pivot)) == [["1", "2"]]  # no direct 1-3 edge
@@ -123,9 +119,7 @@ def test_opting_in_does_not_introduce_singleton_clusters() -> None:
     output *shape*; ``dedupe()`` is documented to return the multi-record
     clusters and leave singletons out.
     """
-    pivot = FuzzyString(
-        threshold=_CHAIN_THRESHOLD, clusterer=CorrelationClusterer()
-    ).dedupe(_CHAIN)
+    pivot = FuzzyString(threshold=_CHAIN_THRESHOLD, clusterer=CorrelationClusterer()).dedupe(_CHAIN)
 
     assert "3" not in {rid for cluster in pivot for rid in cluster}
     assert all(len(cluster) > 1 for cluster in pivot)

--- a/tests/architectures/test_clusterer_opt_in.py
+++ b/tests/architectures/test_clusterer_opt_in.py
@@ -20,11 +20,15 @@ proved end-to-end on the $0 ``FuzzyString``.
 
 from __future__ import annotations
 
+import pathlib
+
 import pytest
+from pydantic import BaseModel
 
 from langres.architectures import FuzzyString, VectorLLMCascade
 from langres.core.clusterer import Clusterer
 from langres.core.clusterers.correlation import CorrelationClusterer
+from langres.core.resolver import ERModel
 
 # The classic over-merge chain. MEASURED scores from FuzzyString's own
 # comparator, not guessed: 1-2 = 0.8889, 2-3 = 0.5714, 1-3 = 0.5000. So at
@@ -164,3 +168,52 @@ def test_an_out_of_range_threshold_still_raises() -> None:
 
     with pytest.raises(ValueError, match="threshold"):
         model.dedupe(_CHAIN)
+
+
+# ---------------------------------------------------------------------------
+# The opt-in survives save/load
+# ---------------------------------------------------------------------------
+
+
+class _Company(BaseModel):
+    """An importable schema -- an inferred one cannot be reloaded in a fresh process."""
+
+    id: str
+    name: str
+
+
+def test_the_opted_in_clusterer_survives_save_and_load(tmp_path: pathlib.Path) -> None:
+    """Otherwise the opt-in silently reverts to closure on reload.
+
+    ``CorrelationClusterer`` is registered under its own ``type_name`` and shares
+    the base ``config``/``from_config``, so the slot round-trips -- but a
+    persisted model quietly downgrading to transitive closure is exactly the kind
+    of failure that shows up as an unexplained quality drop, so it is asserted
+    rather than assumed.
+    """
+    original = FuzzyString(threshold=0.62, schema=_Company, clusterer=CorrelationClusterer())
+    original.save(tmp_path / "m")
+
+    loaded = ERModel.load(tmp_path / "m")
+
+    assert type(loaded) is FuzzyString
+    assert type(loaded.clusterer) is CorrelationClusterer
+    assert loaded.clusterer.threshold == 0.62
+    assert loaded.config_dict() == original.config_dict()
+
+    # And it still RUNS. ``load`` goes through ``from_components``, which never
+    # calls ``__init__`` -- so a reloaded model has no ``clusterer_override``
+    # attribute at all. This asserts nothing on the inference path reaches for
+    # it (the same hazard ``VectorLLMCascade.backbone`` documents for ``llm``).
+    assert loaded.dedupe(_CHAIN) is not None
+
+
+def test_the_default_still_round_trips_as_the_base_clusterer(tmp_path: pathlib.Path) -> None:
+    """The negative half: no opt-in, no CorrelationClusterer anywhere in the artifact."""
+    original = FuzzyString(threshold=0.62, schema=_Company)
+    original.save(tmp_path / "m")
+
+    loaded = ERModel.load(tmp_path / "m")
+
+    assert type(loaded.clusterer) is Clusterer
+    assert "correlation" not in (tmp_path / "m" / "resolver.json").read_text()

--- a/tests/core/clusterers/test_correlation_clusterer.py
+++ b/tests/core/clusterers/test_correlation_clusterer.py
@@ -350,9 +350,13 @@ def test_a_self_pair_is_the_one_input_where_the_two_shapes_still_differ() -> Non
 
     An accepted ``left_id == right_id`` judgement reaches ``nx.add_edge(x, x)``,
     so the base Clusterer returns a ``{x}`` singleton; ``CorrelationClusterer``
-    skips self-pairs in ``_build_adjacency`` and returns nothing. This is NOT
-    hypothetical -- ``VectorBlocker`` emits 43 accepted self-pairs on
-    ``amazon_google``'s test split.
+    skips self-pairs in ``_build_adjacency`` and returns nothing.
+
+    Neither shipped blocker emits a self-pair (``AllPairsBlocker`` pairs only
+    ``i < j``; ``VectorBlocker._neighbor_columns`` drops the anchor by identity),
+    so this is a contract difference reachable via duplicate ids or a custom
+    blocker -- not something a default pipeline hands you. This test is what
+    makes the divergence a documented fact rather than a claim in prose.
 
     Deliberately not "fixed": teaching the base clusterer to drop self-pairs
     would change the DEFAULT path's behaviour. Pinned here so the asymmetry stays

--- a/tests/core/clusterers/test_correlation_clusterer.py
+++ b/tests/core/clusterers/test_correlation_clusterer.py
@@ -345,6 +345,25 @@ def test_base_clusterer_never_emits_a_size_one_cluster_on_this_input() -> None:
     assert all(len(cluster) > 1 for cluster in clusters)
 
 
+def test_a_self_pair_is_the_one_input_where_the_two_shapes_still_differ() -> None:
+    """The documented exception, pinned -- and the base clusterer is the odd one out.
+
+    An accepted ``left_id == right_id`` judgement reaches ``nx.add_edge(x, x)``,
+    so the base Clusterer returns a ``{x}`` singleton; ``CorrelationClusterer``
+    skips self-pairs in ``_build_adjacency`` and returns nothing. This is NOT
+    hypothetical -- ``VectorBlocker`` emits 43 accepted self-pairs on
+    ``amazon_google``'s test split.
+
+    Deliberately not "fixed": teaching the base clusterer to drop self-pairs
+    would change the DEFAULT path's behaviour. Pinned here so the asymmetry stays
+    a documented, deliberate exception rather than quietly becoming a surprise.
+    """
+    self_pair = [_j("X", "X", 0.99)]
+
+    assert Clusterer(threshold=0.5).cluster(self_pair) == [{"X"}]
+    assert CorrelationClusterer(threshold=0.5).cluster(self_pair) == []
+
+
 def _random_judgements(rng: random.Random, n_ids: int, n_edges: int) -> list[PairwiseJudgement]:
     ids = [f"r{i}" for i in range(n_ids)]
     out = []

--- a/tests/core/clusterers/test_correlation_clusterer.py
+++ b/tests/core/clusterers/test_correlation_clusterer.py
@@ -401,9 +401,9 @@ def test_bcubed_and_pairwise_are_unchanged_on_the_stranding_case() -> None:
 
     assert before != after  # the inputs to the metric really do differ
 
-    assert evaluate_clustering(
-        complete_partition(before, _ALL_IDS), gold
-    ) == evaluate_clustering(complete_partition(after, _ALL_IDS), gold)
+    assert evaluate_clustering(complete_partition(before, _ALL_IDS), gold) == evaluate_clustering(
+        complete_partition(after, _ALL_IDS), gold
+    )
 
 
 def test_rejected_pairs_inside_clusters_is_unchanged_by_the_drop() -> None:

--- a/tests/core/clusterers/test_correlation_clusterer.py
+++ b/tests/core/clusterers/test_correlation_clusterer.py
@@ -15,12 +15,16 @@ cluster's pivot is never pulled in by transitivity alone -- this is what makes
 it merge-resistant relative to the base ``Clusterer``.
 """
 
+import random
+
 import pytest
 
 from langres.core.clusterer import Clusterer
 from langres.core.clusterers.correlation import CorrelationClusterer
 from langres.core.models import PairwiseJudgement
 from langres.core.registry import get_component
+from langres.data.benchmark import complete_partition
+from langres.metrics.metrics import evaluate_clustering
 
 
 def _j(left: str, right: str, score: float) -> PairwiseJudgement:
@@ -54,7 +58,9 @@ def test_correlation_clusterer_resists_chain_over_merge() -> None:
     clusterer = CorrelationClusterer(threshold=0.8)
     clusters = clusterer.cluster(judgements)
 
-    assert clusters == [{"A", "B"}, {"C"}]
+    # C is stranded, so it is absent -- NOT emitted as a {"C"} singleton. Same
+    # output shape as the base Clusterer; see the singleton-contract tests below.
+    assert clusters == [{"A", "B"}]
 
 
 def test_correlation_clusterer_still_merges_a_fully_connected_triangle() -> None:
@@ -271,3 +277,158 @@ def test_negative_decision_and_abstain_are_excluded_from_edges() -> None:
     ]
     adjacency = CorrelationClusterer(threshold=0.5)._build_adjacency(judgements)
     assert adjacency == {}
+
+
+# ---------------------------------------------------------------------------
+# The singleton contract: a drop-in must not change the output SHAPE
+#
+# The pivot loop can form a one-node {node} cluster -- a record WITH a
+# qualifying edge whose neighbours an earlier pivot already claimed. The base
+# Clusterer cannot produce that (an unmerged record never enters its graph) and
+# the documented dedupe() contract returns multi-record clusters only. So the
+# pivot clusterer drops them, and these tests pin that: the class docstring
+# claimed "no singleton clusters" long before the code actually did it.
+# ---------------------------------------------------------------------------
+
+
+class _SingletonEmittingCorrelationClusterer(CorrelationClusterer):
+    """The PRE-FIX pivot loop, kept verbatim as the "before" side of a comparison.
+
+    Identical to :meth:`CorrelationClusterer.cluster` except that it appends every
+    cluster, including the one-node ones. Without this, the metric-neutrality
+    tests below would compare the new behaviour against itself and could never
+    fail -- the shape of gate this repo has been bitten by before.
+    """
+
+    def cluster(self, judgements):  # type: ignore[no-untyped-def]
+        adjacency = self._build_adjacency(judgements)
+        remaining = set(adjacency)
+        clusters: list[set[str]] = []
+        for node in sorted(adjacency, key=lambda n: self._pivot_priority(n, adjacency)):
+            if node not in remaining:
+                continue
+            cluster = {node} | (set(adjacency[node]) & remaining)
+            remaining -= cluster
+            clusters.append(cluster)
+        return clusters
+
+
+#: The reproduction that proved the old docstring wrong. A is the first pivot
+#: (ties break by node id) and claims B and D; C's only neighbour B is gone, so
+#: the pre-fix loop emitted {"C"}.
+_STRANDING_JUDGEMENTS = [_j("A", "B", 0.9), _j("B", "C", 0.9), _j("A", "D", 0.6)]
+_ALL_IDS = ["A", "B", "C", "D"]
+
+
+def test_the_pre_fix_loop_really_did_emit_a_singleton() -> None:
+    """Pins the bug itself: without the drop, C comes back as a {"C"} cluster.
+
+    If this ever stops emitting the singleton, the comparison tests below have
+    silently become no-ops and must be re-derived rather than trusted.
+    """
+    before = _SingletonEmittingCorrelationClusterer(threshold=0.5)
+    assert before.cluster(_STRANDING_JUDGEMENTS) == [{"A", "B", "D"}, {"C"}]
+
+
+def test_stranded_record_is_absent_not_a_singleton() -> None:
+    """The shipped clusterer drops it -- same shape the base Clusterer produces."""
+    clusters = CorrelationClusterer(threshold=0.5).cluster(_STRANDING_JUDGEMENTS)
+
+    assert clusters == [{"A", "B", "D"}]
+    assert all(len(cluster) > 1 for cluster in clusters)
+
+
+def test_base_clusterer_never_emits_a_size_one_cluster_on_this_input() -> None:
+    """The shape the pivot clusterer is being held to, asserted on the base."""
+    clusters = Clusterer(threshold=0.5).cluster(_STRANDING_JUDGEMENTS)
+
+    assert all(len(cluster) > 1 for cluster in clusters)
+
+
+def _random_judgements(rng: random.Random, n_ids: int, n_edges: int) -> list[PairwiseJudgement]:
+    ids = [f"r{i}" for i in range(n_ids)]
+    out = []
+    for _ in range(n_edges):
+        left, right = rng.sample(ids, 2)
+        out.append(_j(left, right, rng.random()))
+    return out
+
+
+def test_dropping_singletons_does_not_move_any_measured_number() -> None:
+    """The completed partitions are IDENTICAL, so every metric over them is too.
+
+    This is why the portfolio numbers quoted in ``CorrelationClusterer``'s
+    docstring (``docs/research/20260727_closure_diagnostic.md``: better BCubed F1
+    at 36 of 45 scored grid points, tied 9, worse 0) survive this change rather
+    than needing a re-run. The harness scores
+    ``complete_partition(clusters, all_ids)``, which restores every id not in a
+    predicted cluster as its own singleton -- so a singleton the clusterer drops
+    is put straight back before anything is measured.
+
+    Checked over a randomized battery, not one hand-picked graph, and compared
+    against the pre-fix loop above so the assertion has a way to fail.
+    """
+    rng = random.Random(20260727)
+    before = _SingletonEmittingCorrelationClusterer(threshold=0.5)
+    after = CorrelationClusterer(threshold=0.5)
+    saw_a_dropped_singleton = False
+
+    for _ in range(200):
+        n_ids = rng.randint(2, 12)
+        judgements = _random_judgements(rng, n_ids, rng.randint(1, 18))
+        all_ids = [f"r{i}" for i in range(n_ids)]
+
+        old = before.cluster(judgements)
+        new = after.cluster(judgements)
+        if len(old) != len(new):
+            saw_a_dropped_singleton = True
+
+        # Set-of-frozensets: the completed partitions differ at most in ORDER
+        # (a restored singleton is appended last), and every metric here is
+        # order-independent over the cluster list.
+        assert {frozenset(c) for c in complete_partition(old, all_ids)} == {
+            frozenset(c) for c in complete_partition(new, all_ids)
+        }
+
+    assert saw_a_dropped_singleton, "battery never hit the case under test"
+
+
+def test_bcubed_and_pairwise_are_unchanged_on_the_stranding_case() -> None:
+    """The metric-level statement of the same fact, on the known-stranding input."""
+    gold = [{"A", "B"}, {"C", "D"}]
+    before = _SingletonEmittingCorrelationClusterer(threshold=0.5).cluster(_STRANDING_JUDGEMENTS)
+    after = CorrelationClusterer(threshold=0.5).cluster(_STRANDING_JUDGEMENTS)
+
+    assert before != after  # the inputs to the metric really do differ
+
+    assert evaluate_clustering(
+        complete_partition(before, _ALL_IDS), gold
+    ) == evaluate_clustering(complete_partition(after, _ALL_IDS), gold)
+
+
+def test_rejected_pairs_inside_clusters_is_unchanged_by_the_drop() -> None:
+    """The other diagnostic column: a one-node cluster can hold no pair at all.
+
+    ``rejected-inside`` counts pairs whose two ids share an output cluster, so a
+    size-1 cluster contributes zero by construction and dropping it cannot move
+    the count. Asserted rather than argued.
+    """
+    rng = random.Random(4242)
+    before = _SingletonEmittingCorrelationClusterer(threshold=0.5)
+    after = CorrelationClusterer(threshold=0.5)
+
+    def in_cluster_pairs(clusters: list[set[str]]) -> set[frozenset[str]]:
+        return {
+            frozenset((left, right))
+            for cluster in clusters
+            for left in cluster
+            for right in cluster
+            if left != right
+        }
+
+    for _ in range(100):
+        n_ids = rng.randint(2, 12)
+        judgements = _random_judgements(rng, n_ids, rng.randint(1, 18))
+        assert in_cluster_pairs(before.cluster(judgements)) == in_cluster_pairs(
+            after.cluster(judgements)
+        )

--- a/tests/parity/test_match_cut_correlation_w3d.py
+++ b/tests/parity/test_match_cut_correlation_w3d.py
@@ -19,11 +19,12 @@ pivot-split chains that must stay separate -- and it would still pass both golde
 ``CorrelationClusterer`` through the spine. This is that test.
 
 The fixture is the classic over-merge chain: ``a-b`` and ``b-c`` both clear the
-threshold, but there is NO direct ``a-c`` edge. Pivot clustering keeps ``{a, b}``
-and ``{c}`` apart; transitive closure (the trap) would merge all three into
-``{a, b, c}``. The test asserts the real spine helper reproduces the pivot split
-and NOT the transitive-closure merge, so a revert of ``_closure_clusterer`` to a
-hardcoded ``Clusterer`` turns it red.
+threshold, but there is NO direct ``a-c`` edge. Pivot clustering keeps ``c`` out
+of ``{a, b}`` (and, being unmerged, ``c`` is absent from the output entirely --
+the same shape the base clusterer gives an unmerged record); transitive closure
+(the trap) would merge all three into ``{a, b, c}``. The test asserts the real
+spine helper reproduces the pivot split and NOT the transitive-closure merge, so
+a revert of ``_closure_clusterer`` to a hardcoded ``Clusterer`` turns it red.
 """
 
 from __future__ import annotations
@@ -49,9 +50,9 @@ def _sorted(clusters: list[set[str]]) -> list[list[str]]:
 def _chain_pairs() -> Pairs[CompanySchema]:
     """A scored ``Pairs`` for the over-merge chain a-b, b-c (NO direct a-c edge).
 
-    Both edges score 0.9 (>= the 0.8 threshold). Pivot clustering splits this into
-    ``{a, b}`` / ``{c}``; transitive closure merges it into ``{a, b, c}`` -- the
-    exact input that distinguishes the two clustering algorithms.
+    Both edges score 0.9 (>= the 0.8 threshold). Pivot clustering yields ``{a, b}``
+    with ``c`` left unmerged (and so absent); transitive closure merges it into
+    ``{a, b, c}`` -- the exact input that distinguishes the two algorithms.
     """
     store = {rid: CompanySchema(id=rid, name=rid) for rid in ("a", "b", "c")}
     rows = [
@@ -106,7 +107,10 @@ def test_cluster_matches_legacy_clusterer_owned_cut(correlation_model: Resolver)
     got = correlation_model._cluster(pairs)
 
     assert _sorted(got) == _sorted(legacy)
-    assert _sorted(got) == [["a", "b"], ["c"]]  # pivot split, NOT the merged chain
+    # Pivot split, NOT the merged chain. Stranded ``c`` is absent rather than a
+    # ``{"c"}`` singleton -- the pivot clusterer matches the base clusterer's
+    # output shape (see tests/core/clusterers/test_correlation_clusterer.py).
+    assert _sorted(got) == [["a", "b"]]
 
 
 def test_the_trap_would_produce_the_wrong_merged_chain(correlation_model: Resolver) -> None:
@@ -126,4 +130,4 @@ def test_the_trap_would_produce_the_wrong_merged_chain(correlation_model: Resolv
     # The real W3-d path avoids it (stays a pivot clusterer).
     got = correlation_model._cluster(pairs)
     assert _sorted(got) != _sorted(trap)
-    assert _sorted(got) == [["a", "b"], ["c"]]
+    assert _sorted(got) == [["a", "b"]]


### PR DESCRIPTION
## The finding

`CorrelationClusterer` measured better than the default transitive-closure `Clusterer` across the 9-benchmark portfolio (#238). But **opting into it was impossible** on the two architectures the docs sell:

- `FuzzyString.__init__` (`fuzzy_string.py:87-95`) took no `clusterer=`; the slot was hard-built at `:115`.
- `VectorLLMCascade.__init__` (`vector_llm_cascade.py:128-139`) took none either; hard-built at `:228`.

So "ship it as an opt-in" was not a thing a user could do without abandoning the named architecture and hand-wiring a raw `ERModel`. Verified against source before building. **Making the opt-in real is this PR.**

**No default is flipped.** David's call, explicit.

## What changed

**1. `clusterer: Clusterer | None = None` on both constructors.** `None` builds exactly the `Clusterer` both already built — zero behaviour change for anyone who does not pass it, pinned by test rather than asserted.

It selects the **algorithm** only: the clusterer is rebuilt at the model's own `threshold` through the same `config`/`from_config` clone seam `ERModel._closure_clusterer` already puts every clusterer through on every resolve. So `threshold=` stays the single match cut (the value `DedupeResult.threshold` reports), the caller's object is never mutated, and cloning re-runs `__init__` — keeping the range validation a plain attribute assignment would have skipped.

The parameter is stored as `self.clusterer_override`, not `self.clusterer`: the latter is an `ERModel` **slot** whose property getter raises until the model is bound. Same split, same name, as the four retrieval recipes already in `architectures/retrieval.py`.

**2. Singletons reconciled.** `CorrelationClusterer`'s pivot loop could emit a one-node `{id}` cluster — a record *with* a qualifying edge whose neighbours an earlier pivot had already claimed. The base `Clusterer` cannot do that, and `dedupe()` is documented to return multi-record clusters with singletons dropped. So opting in changed your output *shape*, not just your partition.

**Decision: drop them.** The class's own docstring already claimed "no singleton clusters" and was simply false — this makes the code match its documented contract. Both clusterers now return multi-record clusters only; an unmerged record is absent either way.

**3. Stale provenance fixed.** `correlation.py` still said "**NOT the default:** benchmark before switching" after the benchmark had been run, and `ClusterStage(algorithm="transitive_closure")` read as a recommendation. Both now carry the measured result and say plainly that *the default is not the recommendation*. The Ailon–Charikar–Newman citation is corrected too: this pivot order is **deterministic**, so their 3-approximation bound does not transfer to it.

**4. Documented** in `docs/TECHNICAL_OVERVIEW.md` (how to opt in, the shape guarantee, the numbers) and `CHANGELOG.md`.

## The verification that mattered most

The numbers this PR quotes were measured with correlation **emitting** those singletons. Dropping them could have invalidated the very evidence used to justify the change — a stale-number-quoted-as-fact failure this repo has hit before. So it was checked, not assumed:

The diagnostic harness scores `complete_partition(clusters, all_ids)` (`data/benchmark.py:51`), which appends `{id}` for every id **not** already in a predicted cluster. A singleton the clusterer drops is therefore put straight back before anything is measured — the completed partitions before and after are identical set-wise, so every metric over them is too.

Proved differentially in `test_dropping_singletons_does_not_move_any_measured_number`: a subclass carrying the **pre-fix loop verbatim** is the "before" side, compared over a randomized battery, with `assert saw_a_dropped_singleton` guarding that the battery actually hits the case. A separate test pins that the pre-fix loop really did emit the singleton, so the comparison cannot quietly become a no-op. `rejected-inside` counts are unchanged too — a size-1 cluster holds no pair by construction.

**No re-run of the portfolio was needed, and none of #238's numbers move.**

## Numbers, stated correctly

The plan's v1 overstated these twice; both corrections are honoured here and in every doc/docstring:

- **36 of 45 _scored_ grid points** better, tied 9, worse 0 — with **9 unscorable** (closure's component too large to score). Not "0 of 54".
- **3,776 is the portfolio total.** `amazon_google`'s own count is **944 (39.8%)**.

A third figure was **retracted** in `4def51e`: an earlier revision claimed `VectorBlocker` produces *43 accepted self-pairs* on `amazon_google`'s test split. It traced to no research doc and no probe, and its mechanism is contradicted by `blockers/vector.py:_neighbor_columns`, which drops the anchor's self-match **by identity** precisely to avoid a degenerate self-pair. The one surviving mechanism — two records at different positions sharing an id — was measured and ruled out: 4589/4589 unique ids in the corpus, 1374/1374 in the test split, zero duplicates. Removed at all five sites rather than softened, since an unsourced specific figure reads as a measurement. The divergence it illustrated is real and unchanged; the unit test carries it.

And the framing: `CorrelationClusterer` **discards every rejected edge before pivoting** (`correlation.py:_build_adjacency`), exactly as the base `Clusterer` does. It mitigates *chaining*; it does **not** consume negative evidence. Nothing here claims otherwise.

### How far the fabricated number got before anything caught it

Worth stating plainly, because the fix is less valuable than the failure mode it exposes:

1. **A figure nobody measured** — "43 accepted self-pairs" — was written into a docstring.
2. **It was cited as evidence.** "Real, not hypothetical" was doing the rhetorical work of converting a synthetic test case into a production concern.
3. **It became load-bearing in a design argument.** In review round 2 I declined a suggested change to the base clusterer partly on the grounds that *the diagnostic deliberately reproduces that self-pair, since `VectorBlocker` emits 43 on `amazon_google`*. That reason is now withdrawn; the decline stands on its independent reason (it changes the default path, which this PR is scoped out of).
4. **It reached the research instrument itself** — `closure_diagnostic.py:737` justified a correctness property with it: *"a version that dropped singletons would fail on that benchmark alone."*
5. **Nothing caught it until a reviewer asked where it came from.** Not tests, not CI, not four rounds of automated review, not my own writing of it.

An unsourced specific figure is worse than no figure, because **precision reads as measurement**. What actually settled it was cheap: `_neighbor_columns` drops the anchor by identity, and `amazon_google` has 4589/4589 unique ids. Ten minutes, available the whole time.

## Tests

New `tests/architectures/test_clusterer_opt_in.py`: the default is untouched (the load-bearing negative test), the opt-in works on both architectures, `threshold=` wins over the passed clusterer's own, the caller's instance is not mutated, out-of-range still raises, and the opt-in **survives `save`/`load` and still runs** — a persisted model silently downgrading to closure would surface only as an unexplained quality drop.

Extended `tests/core/clusterers/test_correlation_clusterer.py` with the singleton contract + the metric-neutrality proof above. Updated two pre-existing assertions that pinned the old shape (`test_correlation_clusterer_resists_chain_over_merge`, `tests/parity/test_match_cut_correlation_w3d.py`); both keep their teeth — pivot `[{a,b}]` is still distinguishable from the closure trap `[{a,b,c}]`.

The fixture threshold (0.55) is **measured**, not guessed: `FuzzyString`'s own comparator scores 1-2 = 0.8889, 2-3 = 0.5714, 1-3 = 0.5000.

## Verified locally

- `pytest -m "not integration and not slow and not finetune"` — **4512 passed**, 2 skipped
- `pytest -m "not integration and not finetune" --cov-report=xml` — **4611 passed**, 2 skipped, 0 failed (20:30). Test outcomes stand; that run's *coverage data* was contaminated — see the withdrawal note below.
- `ruff format --check . && ruff check . && mypy src` — clean. (mypy was re-run under `uv sync --all-extras`; a bare `uv sync` reports 10 false `import-not-found` for torch/sentence-transformers/fastembed/openai.)
- `python tools/doc_snippets.py` — 8 passed, 0 failed, 28 skipped

### On the contract coverage gate

That gate lives in the `test-full` job, which is `if: github.event_name != 'pull_request'` (`test.yml:189`) — so it **structurally cannot run on this PR**. A green PR here is not evidence it is intact. Run locally with the verbatim command from `test.yml:351`.

The gate is **red on `main` independently of this PR** (below the `fail-under=98` floor since #229, 2026-07-21) — pre-existing, not introduced here, owned by a separate track.

**This PR's effect on the gate is provable rather than measured, which is why no branch total is quoted.** `architectures/` is not in the gate's include list at all, so the two new `_build_clusterer` methods sit outside it entirely. Inside the include list this PR adds **exactly one executable statement and one branch** — `if len(cluster) > 1:` in `correlation.py` — and the changes to `op.py` and `_model_run.py` are **docstring-only** (zero executable lines). Both the added statement and the added branch are exercised by the tests above. A change that adds only covered lines cannot lower a coverage ratio. This argument never depended on a measured total, which is why it survives the withdrawal below.

⚠️ **Withdrawn: two coverage numbers an earlier revision of this description quoted.** It reported a branch total of **97.08%** and a **58.93%** reading for `correlation.py`. Both came from a **contaminated `.coverage` file**. The cause is established, not suspected: **isolation is per-worktree, not per-process** — two `uv run` invocations in the same worktree contend on the same `.venv` and `.coverage`, and a second one was live during that measurement. Re-run serially on a quiet tree, with nothing else in the worktree and the same include list, `correlation.py` measures **100.00%** — 0 missed, 0 partial. Serialization was the only variable that changed.

The tell was available before the re-run: coverage accumulating into one data file is **monotonic** — running *more* tests can only cover *more* lines. So 100% in isolation collapsing to 58.93% in a larger run was never imprecision; it was destroyed data.

**The full-run instrument itself is sound** — an earlier draft of this section generalised to "per-file numbers from a full run are not trustworthy", and that claim was wrong and is retracted. The serial re-run reproduced CI's statement count to within exactly the 21 statements in seven `# pragma: no cover` shims, which a truncated data file could not do.

The contaminated totals are **discarded, not downgraded to a conservative floor**. Arithmetically a destroyed-data reading is a lower bound, but one of unknown looseness — which is not a floor anything can be reasoned from.

## Cross-model review (Codex), six rounds

**9 findings across 6 rounds, and a majority were defects introduced by a previous round's fix.**

The transferable lesson is not "reviews are noisy" — every round found something real. It is: **re-request review after every push. A clean pass is evidence about the commit it read, not about the branch.** Codex returned "didn't find any major issues" on `da51a2a`; the two rounds after that found a fabricated benchmark figure and a scoping error on a real one. Treating that clean pass as a verdict on the branch would have merged both.

A second pattern, worth more than the ratio: **three misses were the same claim surviving in a spelling my grep didn't match** — line-wrapped in a docstring, paraphrased in `CHANGELOG.md` ("emits 43 of those"), restated with no number at all ("36 of the 45 scored grid points"). The fix is to anchor searches on the *invariant* — the number, the symbol, the entity — never the remembered sentence, and to sweep beyond `src/`: two of the three stale siblings were in `CHANGELOG.md` and `examples/research/`.

| Round | Finding | Outcome |
|---|---|---|
| `e0e66ba` | "any architecture's `clusterer=`" is false — `Reranker.for_schema` takes none and hardcodes its cluster stage | Fixed. Qualified to the six that do expose it; `Reranker` named as the exception. Fixed in **3** places — the same claim was line-wrapped in a module docstring my first grep missed |
| `e0e66ba` | "every clusterer returns the same shape" is false for a custom `Clusterer` subclass — nothing normalizes output | Fixed. Scoped to the two shipped clusterers, and says explicitly it is not an enforced invariant |
| `23300f9` | Still an overclaim: an accepted **self-pair** makes the two shipped clusterers differ | Fixed. Verified by running it (`closure → [{'X'}]`, `pivot → []`). Scoped to distinct-id judgements; **pinned by a test** |
| `7c81419` | The now-qualified claim still stood unqualified in `correlation.py` and `CHANGELOG` | Fixed. Stopped patching named sites and grepped every `output shape` string — 4 sites |
| `da51a2a` | `inspect_clusters()` ignores ids absent from the cluster list, skewing `singleton_rate` | **Declined with evidence → [#243](https://github.com/fxd24/langres/issues/243).** Measured: the *default* closure clusterer reports `singleton_rate=0.0%` with an unmerged record present, so this is pre-existing on the default path. Fixing it changes `Clusterer.inspect_clusters` for every caller — a default behaviour change this PR is scoped out of |

| `4def51e` | Independent review: the "43 accepted self-pairs" figure could not be traced to any source | **Retracted.** Unsourced *and* mechanically contradicted by `_neighbor_columns` (drops the anchor by identity). Measured the one surviving mechanism — zero duplicate ids in `amazon_google` — and removed the figure at all 5 sites. Probe committed |

| `c329ed9` | The 5.6× reduction is presented as evidence about **paid** LLM judgements, but the diagnostic measured one `$0` rapidfuzz scorer on one split seed | **Fixed** — the most valuable finding here. Split the claim: the chaining *mechanism* is structural and stays unqualified; the *magnitude* is now labelled `$0`-path evidence at all 4 sites |
| `c329ed9` | `examples/research/w1_blocking_algebra_output.md:87-89` still says the tests produce `{A, B}, {C}` — falsified by this PR's singleton drop | **Fixed** in `a4e9ca8`. Exactly one sentence; every numeric table in that dated run left untouched, since those are a record. Cross-lock edit, authorized after checking no other stream held the file |

| `a4e9ca8` | The fabricated `43` survives twice in `examples/research/closure_diagnostic.py`, and its `n_clusters` contract is now wrong for one clusterer | **Fixed** in `3a7fad6`. **My miss** — the retraction sweep covered `src/ docs/ tests/ CHANGELOG.md` and not `examples/`, in the same PR where I had just written "sweep beyond `src/`" |

On the self-pair exception I deliberately took "qualify the claim" over Codex's alternative "make the base clusterer ignore self-pairs too": the latter changes the default path, and the closure-diagnostic harness *deliberately reproduces* that self-pair singleton as an instrument check (`VectorBlocker` emits 43 on `amazon_google`).

Sourcery produced a review object matching the head SHA, but its **body** reads "you have reached your weekly rate limit of 500000 diff characters" — it reviewed nothing. Recording that because the review object alone looks like a pass.

## One cross-track note

`core/_model_run.py:1052` documented the singleton behaviour this PR removes. That file is another track's write-lock; the orchestrator authorized this edit. Per its instruction the sentence was **rewritten, not deleted** — it describes a real property of pivot clustering that the code now *handles*, so the next reader learns the same thing.

## Follow-up, not done here

"Clone this clusterer at a different threshold" now has **four** hand-written sites (`_model_run._closure_clusterer`, `retrieval._cluster_stage`, and the two added here). A `Clusterer.at_threshold(t)` would unify them, but it spans two other tracks' files — flagging rather than reaching.
