### PR TITLE
feat(fit): fit() derives the match threshold from labels -- and races it against the incumbent

### DIFF
--- a/docs/EXPERIMENTS.md
+++ b/docs/EXPERIMENTS.md
@@ -426,6 +426,55 @@ threshold = derive_threshold(scores, labels, method="youden")   # or "percentile
 band and report on **held-out test** so the threshold isn't tuned on the pairs it's
 measured on — see `examples/research/m4_calibration.py` for the honest held-out version.
 
+### …or let `fit()` do it: `fit(derive_threshold=True)`
+
+The snippet above is the primitive. If your labels are id-keyed, the model can
+derive and apply the cut itself, holding out for you:
+
+```python
+resolver.fit(records, pairs=labeled_pairs, split=0.3, seed=0, derive_threshold=True)
+
+print(resolver.fit_report_.to_markdown())
+# - Threshold: 0.8824 (derived from 0.5000 by youden on 18 labeled pairs,
+#                      held-out, applied to the clusterer)
+```
+
+It is **opt-in**: the default leaves the constructed threshold alone, which is the
+right no-data fallback. What it changes is that a user who *does* have labels no
+longer resolves at a constant nobody measured.
+
+Four things worth knowing:
+
+- **It needs `pairs=`, not `labels=`.** `pairs=` is what carries the
+  entity-disjoint `split=`. With a split, the cut is derived on `train` and the
+  report's P/R/F1 grade it on `valid`, which the cut never saw. Without one the
+  cut is still derived — and the report says `IN-SAMPLE`, and computes no
+  metrics at all, because an in-sample number here would only flatter the cut.
+- **It fits matchers that have no fit hook.** `WeightedAverageMatcher`,
+  `RapidfuzzMatcher` and the LLM judges have nothing to train, so
+  `fit(pairs=...)` refuses them — but their *threshold* is a real fittable
+  parameter, and those are exactly the pipelines with nothing else to fit.
+- **It knows where your model keeps its cut.** A classic four-slot model writes
+  `clusterer.threshold`; a research recipe / `from_topology` chain has no
+  clusterer at all and writes its terminal `ThresholdSelect`.
+  `fit_report_.threshold_fit.applied_to` says which.
+- **Youden's J is symmetric in cost; ER usually is not.** It maximizes
+  `tpr - fpr`, weighting a false merge exactly as badly as a false split. In
+  entity resolution a false merge propagates through transitive closure and can
+  poison a whole cluster, while a false split leaves two records that can still
+  be merged later. If that asymmetry matters to you, treat the derived cut as a
+  starting point and move it **up**, or call `derive_threshold` yourself with
+  `method="percentile"`.
+
+Needs the `[trained]` extra (scikit-learn). On a core-only install it raises a
+directed `ImportError` rather than quietly keeping the default — identical code
+must not produce a different threshold depending on which extras are installed.
+
+The derived threshold survives `save`/`load`; its **provenance does not**
+(`fit_report_` is a fit-time artifact and is never serialized). Keep
+`fit_report_.model_dump_json()` beside the artifact if you need to show where the
+number came from.
+
 ## Budget monitoring (`SpendMonitor`, ≤ $5)
 
 ```python

--- a/docs/EXPERIMENTS.md
+++ b/docs/EXPERIMENTS.md
@@ -436,14 +436,43 @@ resolver.fit(records, pairs=labeled_pairs, split=0.3, seed=0, derive_threshold=T
 
 print(resolver.fit_report_.to_markdown())
 # - Threshold: 0.8824 (derived from 0.5000 by youden on 18 labeled pairs,
-#                      held-out, applied to the clusterer)
+#                      chosen on train, held-out, applied to the clusterer)
+#
+# ## Threshold selection (chosen on train)
+# - incumbent 0.5000: selection F1 0.5217, held-out F1 0.5714
+# - derived 0.8824 — KEPT: selection F1 1.0000, held-out F1 1.0000
 ```
 
 It is **opt-in**: the default leaves the constructed threshold alone, which is the
 right no-data fallback. What it changes is that a user who *does* have labels no
 longer resolves at a constant nobody measured.
 
-Four things worth knowing:
+**It derives, then races — it does not just apply.** A derived cut is not
+automatically a better cut. Youden's J maximizes `tpr - fpr`, which is flat
+across a wide separating gap, so on cleanly-separated data it happily returns a
+cut that ties on `train` and is *worse* on unseen pairs. We measured exactly
+that: held-out pair-F1 **1.0000 → 0.8000** on a fixture where `0.5` was already
+optimal. So the candidate has to beat the incumbent's pair-F1 to be applied; a
+tie keeps the incumbent, and `fit_report_.threshold_fit.source` reads
+`"declined"` with the rejected candidate still reported:
+
+```
+# - Threshold: 0.5000 (kept: the cut derived from 16 labeled pairs 0.8824
+#                      did not beat it on train)
+```
+
+**The race runs on `train`, never on `valid`.** Picking the winner on the
+held-out split would make that split a selection set and silently downgrade the
+reported P/R/F1 from a held-out estimate to an optimistic one. `train` was
+already spent deriving the candidate, so selecting there costs no further
+honesty — and both `held_out_f1` values in the report stay clean. The residual
+gap, stated rather than hidden: a cut chosen on `train` can still fail to
+generalise; selecting there bounds the risk, it does not remove it. A three-way
+derive/select/report split would close it, and is deliberately left as follow-on
+work — at the label counts this targets (a handful of corrections out of a review
+loop) three splits would make every number noise.
+
+Five more things worth knowing:
 
 - **It needs `pairs=`, not `labels=`.** `pairs=` is what carries the
   entity-disjoint `split=`. With a split, the cut is derived on `train` and the
@@ -464,7 +493,13 @@ Four things worth knowing:
   poison a whole cluster, while a false split leaves two records that can still
   be merged later. If that asymmetry matters to you, treat the derived cut as a
   starting point and move it **up**, or call `derive_threshold` yourself with
-  `method="percentile"`.
+  `method="percentile"`. (The race uses pair-F1, which inherits the same
+  symmetry.)
+- **On an explicit `_ops` chain, deriving costs a full pass over `data`.** A
+  chain's Source owns retrieval, so — unlike a classic model, which scores only
+  the labeled candidates — it must run the whole chain over every record. Cheap
+  for a local scorer; with a paid `Score` in a large chain, size `budget_usd`
+  for it.
 
 Needs the `[trained]` extra (scikit-learn). On a core-only install it raises a
 directed `ImportError` rather than quietly keeping the default — identical code

--- a/docs/EXPERIMENTS.md
+++ b/docs/EXPERIMENTS.md
@@ -480,9 +480,15 @@ Five more things worth knowing:
   cut is still derived — and the report says `IN-SAMPLE`, and computes no
   metrics at all, because an in-sample number here would only flatter the cut.
 - **It fits matchers that have no fit hook.** `WeightedAverageMatcher`,
-  `RapidfuzzMatcher` and the LLM judges have nothing to train, so
+  `RapidfuzzMatcher` and the **score-only** LLM judges have nothing to train, so
   `fit(pairs=...)` refuses them — but their *threshold* is a real fittable
   parameter, and those are exactly the pipelines with nothing else to fit.
+  A *decision-based* judge is the exception and is refused: an
+  `LLMMatcher(response_parser="binary_yes_no")` emits an explicit `decision`, and
+  `predicted_match` gives that precedence over the score, so no cut you fit could
+  change what `resolve()` does. Note the refusal happens after the labeled pairs
+  are scored on the classic path, so on a paid judge it costs those calls before
+  it fails.
 - **It knows where your model keeps its cut.** A classic four-slot model writes
   `clusterer.threshold`; a research recipe / `from_topology` chain has no
   clusterer at all and writes its terminal `ThresholdSelect`.
@@ -497,9 +503,13 @@ Five more things worth knowing:
   symmetry.)
 - **On an explicit `_ops` chain, deriving costs a full pass over `data`.** A
   chain's Source owns retrieval, so — unlike a classic model, which scores only
-  the labeled candidates — it must run the whole chain over every record. Cheap
-  for a local scorer; with a paid `Score` in a large chain, size `budget_usd`
-  for it.
+  the labeled candidates — it must run over every record. It runs the *prefix*
+  ending at the fitted `ThresholdSelect`, not the whole chain: anything
+  downstream of the cut (a reranker `Score`, say) is skipped, both because it
+  cannot influence a threshold applied before it and because its scores would
+  overwrite the ones the cut actually reads. So budget for every `Score` *above*
+  the fitted cut, and none below it. Cheap for a local scorer; with a paid
+  `Score` in that prefix, size `budget_usd` for it.
 
 Needs the `[trained]` extra (scikit-learn). On a core-only install it raises a
 directed `ImportError` rather than quietly keeping the default — identical code

--- a/docs/TECHNICAL_OVERVIEW.md
+++ b/docs/TECHNICAL_OVERVIEW.md
@@ -927,9 +927,9 @@ signature:
   `langres.training.calibration` implements it, consumed by
   `Resolver.fit(method=Platt()/Isotonic())` — see the `method=` seam below.
 
-`Resolver.fit(data, labels=None, *, pairs=None, split=None, seed=0)` consumes the
-**matcher** mixins, detected with `isinstance(module, SupervisedFitMixin)` /
-`isinstance(module, UnsupervisedFitMixin)`:
+`Resolver.fit(data, labels=None, *, pairs=None, split=None, seed=0, method=None,
+derive_threshold=False)` consumes the **matcher** mixins, detected with
+`isinstance(module, SupervisedFitMixin)` / `isinstance(module, UnsupervisedFitMixin)`:
 
 - Matcher implements `SupervisedFitMixin`: supervision comes from either
   pre-aligned `labels` **or** id-keyed `pairs` (see below); passing neither
@@ -940,7 +940,21 @@ signature:
 - Matcher implements **neither** hook (e.g. `WeightedAverageMatcher`): `fit()`
   is a no-op returning `self` — the original sklearn-style symmetry is
   preserved for non-learnable pipelines — unless `labels`/`pairs` was passed,
-  which raises rather than silently discarding them.
+  which raises rather than silently discarding them. The one exception is
+  `derive_threshold=True` (below): a fixed scorer has no matcher to train but its
+  *threshold* is fittable, so `fit(pairs=..., derive_threshold=True)` is accepted.
+
+`derive_threshold=True` (opt-in; default `False` leaves the constructed threshold
+alone) derives a candidate cut from the labeled `train` pairs via
+`curation.harvest.derive_threshold_from_pairs`, **races it against the incumbent
+on `train`**, and applies it only if it strictly wins — a derived cut is not
+automatically a better one. It writes to whichever seam the model keeps its cut
+in: `clusterer.threshold` for a classic four-slot model, the terminal
+`ThresholdSelect` for an explicit `from_topology` chain (which has no clusterer
+slot). Requires `pairs=` (it carries the entity-disjoint `split`), needs the
+`[trained]` extra, and records provenance in `fit_report_.threshold_fit`
+(`ThresholdFit`: derived / declined / default, both candidates, and which split
+selected). Full walkthrough in `docs/EXPERIMENTS.md`.
 
 Every non-raising path sets `resolver.fit_report_` (an sklearn
 trailing-underscore digest, `langres.training.fit_report.FitReport`) and returns

--- a/docs/TECHNICAL_OVERVIEW.md
+++ b/docs/TECHNICAL_OVERVIEW.md
@@ -953,7 +953,7 @@ in: `clusterer.threshold` for a classic four-slot model, the terminal
 `ThresholdSelect` for an explicit `from_topology` chain (which has no clusterer
 slot). Requires `pairs=` (it carries the entity-disjoint `split`), needs the
 `[trained]` extra, and records provenance in `fit_report_.threshold_fit`
-(`ThresholdFit`: derived / declined / default, both candidates, and which split
+(`ThresholdFit`: derived / declined / not_fitted, both candidates, and which split
 selected). Full walkthrough in `docs/EXPERIMENTS.md`.
 
 Every non-raising path sets `resolver.fit_report_` (an sklearn

--- a/src/langres/core/_model_run.py
+++ b/src/langres/core/_model_run.py
@@ -518,11 +518,21 @@ class ModelRun(ModelState):
         below today's threshold, so the "derived" cut could only ever recover the
         cut that produced the sample.
 
-        It runs Source + body with the terminal
+        It runs Source + body **truncated at** the terminal
         :class:`~langres.core.op.ThresholdSelect` (the one
-        :meth:`_chain_threshold_select` names, and the one a fit writes to)
-        omitted -- every other Op, including an upstream ``TopKSelect``, still
-        runs, so the rows are exactly what the cut would have been handed.
+        :meth:`_chain_threshold_select` names, and the one a fit writes to):
+        every Op *before* it -- including an upstream ``TopKSelect`` or ``Score``
+        -- runs, and nothing after it does. The rows are then exactly what that
+        cut would have been handed.
+
+        Truncating rather than *removing* the select is load-bearing. A ``Score``
+        after a ``Select`` is supported topology (that is what a reranker is:
+        ``Source -> ScoreA -> ThresholdSelect -> ScoreB -> ClusterStage``). If the
+        select were merely filtered out and the rest still ran, ``ScoreB`` would
+        overwrite the score column, and the fit would derive a cut from ``ScoreB``
+        values and write it into a select that thresholds ``ScoreA`` values -- a
+        silent scale mismatch. Consequently this measures the chain *up to* the
+        fitted cut; ops downstream of it are not exercised by the fit.
 
         **Explicit ``_ops`` chains only**, which is why there is no classic
         branch here: a four-slot model's cut lives on the clusterer and is
@@ -531,13 +541,19 @@ class ModelRun(ModelState):
         scores only the *labeled* candidates rather than the whole corpus.
         :meth:`_chain_source` raises if this is called without a chain.
 
+        ``records`` are normalized first, exactly as :meth:`_dedupe_explicit` and
+        :meth:`execute` do -- a chain Source is handed typed entities, never the
+        raw dicts a caller passed to ``fit``.
+
         No ``log=``: this is a fit-time measurement pass, not a user-facing
         resolve, so its judgements are not flywheel signal. Scoring still runs
         through the same spend-capped seam as inference.
         """
         fitted_select = self._chain_threshold_select()
-        body = [op for op in self._explicit_body() if op is not fitted_select]
-        return _run_stages(records, [self._chain_source(), *body])
+        body = self._explicit_body()
+        upto = next((i for i, op in enumerate(body) if op is fitted_select), len(body))
+        _schema, normalized = normalize_records(records, self._chain_source_schema())
+        return _run_stages(normalized, [self._chain_source(), *body[:upto]])
 
     def _judgements(
         self, records: list[Any], *, log: JudgementLog | None = None

--- a/src/langres/core/_model_run.py
+++ b/src/langres/core/_model_run.py
@@ -508,6 +508,35 @@ class ModelRun(ModelState):
             return _run_stages(records, [self._chain_source(), *self._explicit_body(log=log)])
         return _run_stages(records, self._stages(log=log))
 
+    def _prethreshold_pairs(self, records: list[Any]) -> Pairs[Any]:
+        """Scored rows as this model's match cut *sees* them -- that cut not applied.
+
+        What a threshold fit has to score against: every row the cut will judge,
+        **including the ones the current cut rejects**. Deriving from
+        :meth:`_scored_pairs` instead would be a subtle, self-confirming bug on an
+        explicit chain -- its ``ThresholdSelect`` has already deleted every row
+        below today's threshold, so the "derived" cut could only ever recover the
+        cut that produced the sample.
+
+        Classic four-slot models need no special handling: their cut lives on the
+        clusterer and is applied at :meth:`_cluster`, never inside the scoring
+        chain, so this *is* :meth:`_scored_pairs`. An explicit ``_ops`` chain runs
+        Source + body with the terminal
+        :class:`~langres.core.op.ThresholdSelect` (the one
+        :meth:`_chain_threshold_select` names, and the one a fit writes to)
+        omitted -- every other Op, including an upstream ``TopKSelect``, still
+        runs, so the rows are exactly what the cut would have been handed.
+
+        No ``log=``: this is a fit-time measurement pass, not a user-facing
+        resolve, so its judgements are not flywheel signal. Scoring still runs
+        through the same spend-capped seam as inference.
+        """
+        if self._ops is None:
+            return self._scored_pairs(records)
+        fitted_select = self._chain_threshold_select()
+        body = [op for op in self._explicit_body() if op is not fitted_select]
+        return _run_stages(records, [self._chain_source(), *body])
+
     def _judgements(
         self, records: list[Any], *, log: JudgementLog | None = None
     ) -> Iterator[PairwiseJudgement]:

--- a/src/langres/core/_model_run.py
+++ b/src/langres/core/_model_run.py
@@ -518,21 +518,23 @@ class ModelRun(ModelState):
         below today's threshold, so the "derived" cut could only ever recover the
         cut that produced the sample.
 
-        Classic four-slot models need no special handling: their cut lives on the
-        clusterer and is applied at :meth:`_cluster`, never inside the scoring
-        chain, so this *is* :meth:`_scored_pairs`. An explicit ``_ops`` chain runs
-        Source + body with the terminal
+        It runs Source + body with the terminal
         :class:`~langres.core.op.ThresholdSelect` (the one
         :meth:`_chain_threshold_select` names, and the one a fit writes to)
         omitted -- every other Op, including an upstream ``TopKSelect``, still
         runs, so the rows are exactly what the cut would have been handed.
 
+        **Explicit ``_ops`` chains only**, which is why there is no classic
+        branch here: a four-slot model's cut lives on the clusterer and is
+        applied at :meth:`_cluster`, never inside the scoring chain, so it has no
+        pre-threshold/post-threshold distinction to draw -- and its fit path
+        scores only the *labeled* candidates rather than the whole corpus.
+        :meth:`_chain_source` raises if this is called without a chain.
+
         No ``log=``: this is a fit-time measurement pass, not a user-facing
         resolve, so its judgements are not flywheel signal. Scoring still runs
         through the same spend-capped seam as inference.
         """
-        if self._ops is None:
-            return self._scored_pairs(records)
         fitted_select = self._chain_threshold_select()
         body = [op for op in self._explicit_body() if op is not fitted_select]
         return _run_stages(records, [self._chain_source(), *body])

--- a/src/langres/core/_model_state.py
+++ b/src/langres/core/_model_state.py
@@ -16,7 +16,7 @@ property that actually implements it.
 
 import logging
 from collections.abc import Sequence
-from typing import Any, ClassVar, Self, cast
+from typing import Any, ClassVar, Literal, Self, cast
 
 from pydantic import BaseModel
 
@@ -159,6 +159,15 @@ class ModelState:
         self.calibrator: CalibratorFitMixin | None = None
         # Set by fit(); the sklearn trailing-underscore "produced by fit" digest.
         # None until fit() runs (never serialized -- it is a fit-time artifact).
+        #
+        # That has a consequence worth naming, because fit() can now DERIVE the
+        # match threshold from labels: the threshold VALUE survives save/load (it
+        # lives on the clusterer / the chain's ThresholdSelect, both of which
+        # serialize), but its PROVENANCE -- derived vs defaulted, from how many
+        # pairs, held-out or in-sample -- does not. A reloaded model therefore
+        # carries a measured cut with no record that it was measured. Persist
+        # ``fit_report_.model_dump_json()`` beside the artifact if that matters.
+        # (See FitReport.threshold_fit / ThresholdFit.)
         self.fit_report_: FitReport | None = None
         # Runtime provenance for models loaded through langres.hub. Kept out of
         # resolver.json/config identity: the artifact's repository revision is
@@ -665,11 +674,22 @@ class ModelState:
     def _chain_threshold(self) -> float | None:
         """The terminal :class:`~langres.core.op.ThresholdSelect`'s threshold -- the chain's
         match cut -- or ``None`` if the chain has no ThresholdSelect. The LAST one wins."""
-        threshold: float | None = None
+        select = self._chain_threshold_select()
+        return None if select is None else select.threshold
+
+    def _chain_threshold_select(self) -> ThresholdSelect[Any] | None:
+        """The chain's *terminal* :class:`~langres.core.op.ThresholdSelect` object itself.
+
+        The object behind :meth:`_chain_threshold`'s number, and the seam a
+        threshold fit writes through. Same LAST-one-wins rule, from one scan, so
+        the reader and the writer can never disagree about which Select owns the
+        chain's match cut.
+        """
+        select: ThresholdSelect[Any] | None = None
         for op in self._chain_body():
             if isinstance(op, ThresholdSelect):
-                threshold = op.threshold
-        return threshold
+                select = op
+        return select
 
     def _chain_scoring_matcher(self) -> Matcher[Any] | None:
         """The chain's last matcher-``Score``'s matcher, unwrapped past its spend cap.
@@ -689,6 +709,61 @@ class ModelState:
         if isinstance(matcher, SpendCappedMatcher):
             return matcher._module  # peel the cap; the wrapped matcher owns ``model``
         return matcher
+
+    # ------------------------------------------------------------------
+    # The match cut, read and written topology-neutrally.
+    #
+    # A model's decision threshold lives in exactly one of two places and the
+    # two are NOT interchangeable: a classic four-slot model keeps it on
+    # ``self.clusterer.threshold``; an explicit ``_ops`` chain keeps it in a
+    # :class:`~langres.core.op.ThresholdSelect` and has no clusterer slot at all
+    # (``_require_bound`` *raises* on ``.clusterer`` there). Anything that wants
+    # to fit the cut must go through this pair, or it silently no-ops on one
+    # topology and raises on the other.
+    # ------------------------------------------------------------------
+
+    def _threshold_seam(self) -> Literal["clusterer", "threshold_select"] | None:
+        """Name where THIS model keeps its match cut, or ``None`` if it keeps none.
+
+        ``None`` is a real state, not an error: an explicit chain need not contain
+        a ``ThresholdSelect`` (a pure top-k retrieval recipe has no threshold to
+        fit), and an unbound model has no clusterer yet.
+        """
+        if self._ops is not None:
+            return None if self._chain_threshold_select() is None else "threshold_select"
+        return None if self._clusterer is None else "clusterer"
+
+    def _match_threshold(self) -> float | None:
+        """This model's match cut, from whichever seam holds it (``None`` if neither)."""
+        if self._ops is not None:
+            return self._chain_threshold()
+        return None if self._clusterer is None else self._clusterer.threshold
+
+    def _set_match_threshold(self, threshold: float) -> None:
+        """Write the match cut to whichever seam holds it.
+
+        Raises:
+            RuntimeError: If this model has no threshold seam
+                (:meth:`_threshold_seam` is ``None``) -- writing nowhere and
+                returning would be the silent no-op this pair exists to prevent.
+        """
+        if self._ops is not None:
+            select = self._chain_threshold_select()
+            if select is None:
+                raise RuntimeError(
+                    "cannot set a match threshold: this ERModel's explicit Op chain "
+                    "contains no ThresholdSelect, so it has no match cut to write. "
+                    "Add a ThresholdSelect to the topology, or fit a model that has one."
+                )
+            select.threshold = threshold
+            return
+        if self._clusterer is None:
+            raise RuntimeError(
+                "cannot set a match threshold: this ERModel is not bound to a schema "
+                "yet, so it has no clusterer. Pass schema=<YourModel> to the "
+                "constructor, or call dedupe()/compare() once (which binds)."
+            )
+        self._clusterer.threshold = threshold
 
     def _chain_source_schema(self) -> type[BaseModel] | None:
         """The schema the chain's Source blocks against (for front-door normalization),

--- a/src/langres/core/resolver.py
+++ b/src/langres/core/resolver.py
@@ -1221,6 +1221,13 @@ class ERModel(ModelRun, ModelPersistence):
         metrics: PairMetrics | None = None
         if aligned.valid.candidates:
             judgements = list(self._scorer().forward(iter(aligned.valid.candidates)))
+            if derive_threshold:
+                # A derived cut sits on the CUT's scale, which a fitted calibrator
+                # moves (see :meth:`_cut_scale_scores`). Grading raw scores against
+                # it would compare two different scales and report a number that
+                # looks fine and means nothing. Only rescaled when something was
+                # derived, so the non-deriving path stays byte-identical.
+                judgements = self._on_cut_scale(judgements)
             gold_pairs = {
                 frozenset({str(c.left.id), str(c.right.id)})
                 for c, label in zip(aligned.valid.candidates, aligned.valid.labels, strict=True)
@@ -1312,6 +1319,20 @@ class ERModel(ModelRun, ModelPersistence):
         for index, value in zip(scored, mapped, strict=True):
             scores[index] = value
         return scores
+
+    def _on_cut_scale(self, judgements: Sequence[PairwiseJudgement]) -> list[PairwiseJudgement]:
+        """Copies of ``judgements`` with their scores moved onto the match cut's scale.
+
+        The judgement-shaped counterpart of :meth:`_cut_scale_scores`, for the
+        graders (:func:`~langres.core.metrics.classify_pairs`) that want objects
+        rather than a score list. Pure copies -- the caller's judgements are not
+        mutated.
+        """
+        scores = self._cut_scale_scores(list(judgements))
+        return [
+            judgement.model_copy(update={"score": score})
+            for judgement, score in zip(judgements, scores, strict=True)
+        ]
 
     def _apply_derived_threshold(
         self, labeled: Sequence[LabeledPair], *, held_out: bool

--- a/src/langres/core/resolver.py
+++ b/src/langres/core/resolver.py
@@ -1557,6 +1557,36 @@ class ERModel(ModelRun, ModelPersistence):
                 "the clusterer). Nothing was scored: this is checked before the "
                 "chain runs, so a paid Score in the chain has not been billed."
             )
+        # Same rule, same reason. Whether the chain gates twice is decidable from
+        # the topology alone, so it must be decided here rather than after the
+        # scoring pass -- a guard placed below turns "we cannot fit this" into
+        # "we billed you, then could not fit this". (The unscored-rows guard
+        # further down genuinely needs the rows and cannot be hoisted.)
+        #
+        # ``getattr``: ClusterStage is the abstract contract and carries no
+        # clusterer; only the ClustererStage adapter wraps a legacy one. A custom
+        # ClusterStage has no second threshold to conflict with, so absent means
+        # "no independent cut", not "unknown".
+        stage_clusterer = getattr(self._chain_cluster_stage(), "clusterer", None)
+        cluster_cut = None if stage_clusterer is None else stage_clusterer.threshold
+        if cluster_cut:
+            # A chain can gate TWICE: the ThresholdSelect this fit writes, and the
+            # nested clusterer, which "keeps thresholding on the projected
+            # judgements". Fitting only the first would let a winning cut of 0.80
+            # be reported as applied while a clusterer cut of 0.90 still rejects
+            # every pair between them -- a held-out improvement resolve() never
+            # realizes. The shipped research recipes build this stage
+            # threshold-free for exactly that reason; refuse rather than silently
+            # fit one of two gates.
+            raise ValueError(
+                "fit(derive_threshold=True) cannot fit this chain: its ClusterStage "
+                f"clusterer carries its own threshold ({cluster_cut}), so the chain "
+                "gates twice and fitting the ThresholdSelect alone would report an "
+                "improvement that resolve() cannot deliver. Build the stage "
+                "threshold-free -- ClustererStage(Clusterer(threshold=0.0)) -- and "
+                "let the ThresholdSelect own the match cut. Nothing was scored: "
+                "this is checked before the chain runs."
+            )
         scored = self._prethreshold_pairs(data)
         score_by_pair = {_row_key(row): row.score for row in scored.rows}
         judgement_by_pair = {
@@ -1580,29 +1610,6 @@ class ERModel(ModelRun, ModelPersistence):
                 "them regardless of the cut and this fit would be silently inert. "
                 "Add a Score (e.g. MatcherScore) to the chain before the "
                 "ThresholdSelect."
-            )
-        # ``getattr``: ClusterStage is the abstract contract and carries no
-        # clusterer; only the ClustererStage adapter wraps a legacy one. A custom
-        # ClusterStage has no second threshold to conflict with, so absent means
-        # "no independent cut", not "unknown".
-        cluster_cut = getattr(self._chain_cluster_stage(), "clusterer", None)
-        cluster_cut = None if cluster_cut is None else cluster_cut.threshold
-        if cluster_cut:
-            # A chain can gate TWICE: the ThresholdSelect this fit writes, and the
-            # nested clusterer, which "keeps thresholding on the projected
-            # judgements". Fitting only the first would let a winning cut of 0.80
-            # be reported as applied while a clusterer cut of 0.90 still rejects
-            # every pair between them -- a held-out improvement resolve() never
-            # realizes. The shipped research recipes build this stage
-            # threshold-free for exactly that reason; refuse rather than silently
-            # fit one of two gates.
-            raise ValueError(
-                "fit(derive_threshold=True) cannot fit this chain: its ClusterStage "
-                f"clusterer carries its own threshold ({cluster_cut}), so the chain "
-                "gates twice and fitting the ThresholdSelect alone would report an "
-                "improvement that resolve() cannot deliver. Build the stage "
-                "threshold-free -- ClustererStage(Clusterer(threshold=0.0)) -- and "
-                "let the ThresholdSelect own the match cut."
             )
         aligned = align_pairs(scored.to_candidates(), pairs, split=split, seed=seed)
 

--- a/src/langres/core/resolver.py
+++ b/src/langres/core/resolver.py
@@ -64,7 +64,12 @@ from langres.core.fit import (
     SupervisedFitMixin,
     UnsupervisedFitMixin,
 )
-from langres.training.fit_report import CalibrationDelta, FitReport, ThresholdFit
+from langres.training.fit_report import (
+    CalibrationDelta,
+    FitReport,
+    ThresholdCandidate,
+    ThresholdFit,
+)
 from langres.curation.harvest import (
     Correction,
     LabeledPair,
@@ -118,6 +123,21 @@ def _pair_key(candidate: ERCandidate[Any]) -> frozenset[str]:
 def _row_key(row: PairRow[Any]) -> frozenset[str]:
     """The same identity for a carrier row, so row-side and candidate-side maps join."""
     return frozenset({row.left_id, row.right_id})
+
+
+def _pair_f1(labeled: Sequence[LabeledPair], threshold: float) -> float:
+    """Pair-F1 of ``score >= threshold`` against the gold labels -- the selection metric.
+
+    Deliberately score-only, unlike
+    :func:`~langres.core.metrics.classify_pairs`: every pair reaching a threshold
+    fit carries a score (``derive_threshold_from_pairs`` refuses the input
+    otherwise), so the decider/abstention branches cannot arise here. ``0.0`` for
+    a cut that predicts nothing, which is the honest score for "matches nothing".
+    """
+    tp = sum(1 for p in labeled if p.score is not None and p.score >= threshold and p.label)
+    fp = sum(1 for p in labeled if p.score is not None and p.score >= threshold and not p.label)
+    fn = sum(1 for p in labeled if not (p.score is not None and p.score >= threshold) and p.label)
+    return 0.0 if tp == 0 else 2 * tp / (2 * tp + fp + fn)
 
 
 def _build_module_for_judge(
@@ -515,15 +535,26 @@ class ERModel(ModelRun, ModelPersistence):
 
         **``derive_threshold=True``: fit the decision cut from the labels.**
         Off by default. When set, ``fit`` scores the labeled ``train`` pairs
-        through this model's own scoring path and derives the match threshold
-        from that score distribution via
-        :func:`~langres.curation.harvest.derive_threshold_from_pairs`, then writes
-        it to wherever *this* model keeps its cut -- ``clusterer.threshold`` on a
-        classic four-slot model, the terminal
-        :class:`~langres.core.op.ThresholdSelect` on an explicit ``_ops`` chain
-        (which has no clusterer slot at all). ``fit_report_.threshold_fit``
-        records which, from how many pairs, and whether the reported metrics are
-        held-out. Three things worth knowing before you switch it on:
+        through this model's own scoring path, derives a candidate match
+        threshold from that score distribution via
+        :func:`~langres.curation.harvest.derive_threshold_from_pairs`, and
+        **races it against the threshold already in force** -- applying it only
+        if it strictly beats the incumbent's pair-F1 on ``train``. A winner is
+        written to wherever *this* model keeps its cut
+        (``clusterer.threshold`` on a classic four-slot model, the terminal
+        :class:`~langres.core.op.ThresholdSelect` on an explicit ``_ops`` chain,
+        which has no clusterer slot at all); a loser is reported and discarded,
+        leaving the threshold untouched. ``fit_report_.threshold_fit`` records
+        which happened, both candidates, and how each scored.
+
+        The race is not ceremony. A derived cut is not automatically a better
+        one: Youden's J is flat across a wide separating gap, so on cleanly
+        separated data it returns a cut that ties on ``train`` and is *worse* on
+        unseen pairs -- measured during development at held-out pair-F1 1.0000 vs
+        0.8000 (``tests/core/test_resolver_fit_threshold.py``). Selection runs on
+        ``train``, never on ``valid``, so the held-out numbers stay clean
+        estimates rather than becoming selection-set numbers. Four more things
+        worth knowing before you switch it on:
 
         - **It needs ``pairs=``, not ``labels=``.** ``pairs=`` is what carries the
           entity-disjoint ``split``, and a threshold derived from the same rows
@@ -548,6 +579,12 @@ class ERModel(ModelRun, ModelPersistence):
           asymmetric, take the derived cut as a *starting point* and move it up,
           or call :func:`~langres.training.calibration.derive_threshold` yourself
           with ``method="percentile"``.
+        - **On an explicit ``_ops`` chain it costs a full pass over ``data``.** A
+          chain's Source owns retrieval, so it cannot score an arbitrary
+          candidate subset the way a classic model can -- deriving runs the whole
+          chain once over every record, not just the labeled pairs. Cheap for a
+          local scorer; with a paid ``Score`` wired into a large chain, size the
+          ``budget_usd`` for it.
 
         Needs scikit-learn (the ``[trained]`` extra). On a core-only install it
         raises a directed :class:`ImportError` rather than falling back to the
@@ -593,7 +630,12 @@ class ERModel(ModelRun, ModelPersistence):
                 implements ``SupervisedFitMixin`` and neither is given; or if
                 ``labels``/``pairs`` is given to a module that cannot use them.
                 Also if ``derive_threshold=True`` without ``pairs=``, together
-                with ``method=``, or on a model that keeps no match cut.
+                with ``method=``, or on a model that keeps no match cut; and --
+                for an explicit ``_ops`` topology, whose only fittable parameter
+                is its ``ThresholdSelect`` -- for any ``fit()`` call that is not
+                ``pairs=... , derive_threshold=True``. (That last case previously
+                surfaced as a ``RuntimeError`` from the four-slot property
+                accessors, which could not describe what such a model *can* fit.)
             ImportError: If ``derive_threshold=True`` and scikit-learn (the
                 ``[trained]`` extra) is not installed.
             NotImplementedError: If ``method`` is given but its ``kind``'s fit
@@ -1208,17 +1250,8 @@ class ERModel(ModelRun, ModelPersistence):
                 iter(aligned.train.candidates), aligned.train.labels
             )
 
-        # Derive BEFORE grading valid: the whole point is that the reported
-        # metrics measure the cut the fit chose, on rows the cut never saw.
-        threshold_fit = ThresholdFit(source="default")
-        if derive_threshold:
-            _warn_if_silver_only(pairs)
-            threshold_fit = self._apply_derived_threshold(
-                self._labeled_for_derivation(aligned.train.candidates, aligned.train.labels),
-                held_out=bool(aligned.valid.candidates),
-            )
-
-        metrics: PairMetrics | None = None
+        judgements: list[PairwiseJudgement] = []
+        gold_pairs: set[frozenset[str]] = set()
         if aligned.valid.candidates:
             judgements = list(self._scorer().forward(iter(aligned.valid.candidates)))
             if derive_threshold:
@@ -1233,6 +1266,21 @@ class ERModel(ModelRun, ModelPersistence):
                 for c, label in zip(aligned.valid.candidates, aligned.valid.labels, strict=True)
                 if label
             }
+
+        # Select BEFORE grading, so the reported metrics measure the cut actually
+        # in force. Selection reads ``train`` only; the valid judgements are
+        # passed in purely to be *scored* at each candidate, never to choose.
+        threshold_fit = ThresholdFit(source="default")
+        if derive_threshold:
+            _warn_if_silver_only(pairs)
+            threshold_fit = self._select_threshold(
+                self._labeled_for_derivation(aligned.train.candidates, aligned.train.labels),
+                valid_judgements=judgements,
+                valid_gold=gold_pairs,
+            )
+
+        metrics: PairMetrics | None = None
+        if aligned.valid.candidates:
             metrics = classify_pairs(judgements, gold_pairs, self.clusterer.threshold)
 
         return FitReport.build(
@@ -1334,10 +1382,41 @@ class ERModel(ModelRun, ModelPersistence):
             for judgement, score in zip(judgements, scores, strict=True)
         ]
 
-    def _apply_derived_threshold(
-        self, labeled: Sequence[LabeledPair], *, held_out: bool
+    def _select_threshold(
+        self,
+        train: Sequence[LabeledPair],
+        *,
+        valid_judgements: list[PairwiseJudgement],
+        valid_gold: set[frozenset[str]],
     ) -> ThresholdFit:
-        """Derive the cut from ``labeled`` and write it to this model's threshold seam.
+        """Derive a candidate cut, race it against the incumbent, keep the winner.
+
+        **Deriving is not the same as keeping.** Youden's J maximizes
+        ``tpr - fpr`` on ``train``; on a wide, cleanly-separated margin that can
+        return a cut which ties there and loses on unseen pairs (measured on a
+        toy fixture: held-out pair-F1 1.00 -> 0.80). So the derived cut has to
+        earn the seat: it is applied only if it *strictly* beats the incumbent's
+        pair-F1. A tie keeps the incumbent -- do not move a threshold without
+        evidence that moving it helps.
+
+        **The race runs on ``train``, never on ``valid``.** Picking the winner on
+        ``valid`` would make ``valid`` a selection set and silently downgrade
+        :attr:`FitReport.metrics` from a held-out estimate to an optimistic one.
+        ``train`` is already spent (the candidate was derived from it), so
+        selecting there costs no further honesty. ``valid_judgements`` are used
+        only to *score* both cuts for the report -- they never influence the
+        choice -- which is why both ``held_out_f1`` values stay clean estimates.
+
+        Args:
+            train: Scored + labeled train pairs; both the derivation input and
+                the selection set.
+            valid_judgements: Held-out judgements, already on the cut's scale.
+                Empty when no split was given.
+            valid_gold: Held-out gold pair keys, aligned with the above.
+
+        Returns:
+            The :class:`ThresholdFit` provenance, with the threshold already
+            written to this model when the candidate won.
 
         Raises:
             ValueError: If this model keeps no match cut at all (an explicit chain
@@ -1353,16 +1432,37 @@ class ERModel(ModelRun, ModelPersistence):
                 "topology (or use a classic four-slot model, whose cut lives on "
                 "the clusterer)."
             )
-        previous = self._match_threshold()
-        threshold = derive_threshold_from_pairs(labeled)
-        self._set_match_threshold(threshold)
+        incumbent = cast(float, self._match_threshold())
+        candidate = derive_threshold_from_pairs(train)
+
+        def _described(threshold: float) -> ThresholdCandidate:
+            return ThresholdCandidate(
+                threshold=threshold,
+                selection_f1=_pair_f1(train, threshold),
+                held_out_f1=(
+                    classify_pairs(valid_judgements, valid_gold, threshold).f1
+                    if valid_judgements
+                    else None
+                ),
+            )
+
+        previous_described, candidate_described = _described(incumbent), _described(candidate)
+        kept = cast(float, candidate_described.selection_f1) > cast(
+            float, previous_described.selection_f1
+        )
+        if kept:
+            self._set_match_threshold(candidate)
         return ThresholdFit(
-            source="derived",
+            source="derived" if kept else "declined",
             method=_THRESHOLD_METHOD,
-            n_pairs=len(labeled),
-            held_out=held_out,
-            applied_to=seam,
-            previous=previous,
+            n_pairs=len(train),
+            held_out=bool(valid_judgements),
+            # Nothing was written when the candidate lost, so naming a seam would
+            # overclaim -- the threshold is still the one the model came with.
+            applied_to=seam if kept else None,
+            selected_on="train",
+            previous=previous_described,
+            candidate=candidate_described,
         )
 
     def _fit_chain_threshold(
@@ -1403,8 +1503,19 @@ class ERModel(ModelRun, ModelPersistence):
         }
         aligned = align_pairs(scored.to_candidates(), pairs, split=split, seed=seed)
 
+        judgements = [
+            judgement
+            for candidate in aligned.valid.candidates
+            if (judgement := judgement_by_pair.get(_pair_key(candidate))) is not None
+        ]
+        gold_pairs = {
+            _pair_key(c)
+            for c, label in zip(aligned.valid.candidates, aligned.valid.labels, strict=True)
+            if label
+        }
+
         _warn_if_silver_only(pairs)
-        threshold_fit = self._apply_derived_threshold(
+        threshold_fit = self._select_threshold(
             [
                 LabeledPair(
                     left_id=str(candidate.left.id),
@@ -1417,21 +1528,12 @@ class ERModel(ModelRun, ModelPersistence):
                     aligned.train.candidates, aligned.train.labels, strict=True
                 )
             ],
-            held_out=bool(aligned.valid.candidates),
+            valid_judgements=judgements,
+            valid_gold=gold_pairs,
         )
 
         metrics: PairMetrics | None = None
         if aligned.valid.candidates:
-            judgements = [
-                judgement
-                for candidate in aligned.valid.candidates
-                if (judgement := judgement_by_pair.get(_pair_key(candidate))) is not None
-            ]
-            gold_pairs = {
-                _pair_key(c)
-                for c, label in zip(aligned.valid.candidates, aligned.valid.labels, strict=True)
-                if label
-            }
             metrics = classify_pairs(judgements, gold_pairs, cast(float, self._match_threshold()))
 
         matcher = self._chain_scoring_matcher()

--- a/src/langres/core/resolver.py
+++ b/src/langres/core/resolver.py
@@ -64,8 +64,14 @@ from langres.core.fit import (
     SupervisedFitMixin,
     UnsupervisedFitMixin,
 )
-from langres.training.fit_report import CalibrationDelta, FitReport
-from langres.curation.harvest import Correction, LabeledPair, align_pairs
+from langres.training.fit_report import CalibrationDelta, FitReport, ThresholdFit
+from langres.curation.harvest import (
+    Correction,
+    LabeledPair,
+    align_pairs,
+    derive_threshold_from_pairs,
+    warn_if_silver_only as _warn_if_silver_only,
+)
 from langres.core.matcher import Matcher
 from langres.core.methods_api import Method, UnsupportedMethodKind
 from langres.core.metrics import (
@@ -74,7 +80,8 @@ from langres.core.metrics import (
     classify_pairs,
     expected_calibration_error,
 )
-from langres.core.models import ERCandidate
+from langres.core.models import ERCandidate, PairwiseJudgement
+from langres.core.pairs import PairRow
 from langres.core.registry import get_model
 from langres.tracking.runs import current_run
 from langres.core.spend import SpendMonitor
@@ -94,6 +101,23 @@ logger = logging.getLogger(__name__)
 #: (with its ``core.presets`` machinery) rather than moving it -- naming a model
 #: is the user's job, not a heuristic's. This stays a plain, explicit argument.
 _FromSchemaJudge = Literal["string", "embedding", "zero_shot_llm", "prompt_llm", "random_forest"]
+
+#: The threshold-derivation method ``fit(derive_threshold=True)`` uses -- Youden's
+#: J, ``derive_threshold``'s own default. Named here (rather than typed as
+#: ``ThresholdMethod``) because importing that Literal would pull
+#: ``training.calibration`` -- and with it scikit-learn -- into every
+#: ``import langres``; the ``[trained]`` extra must stay lazy on this path.
+_THRESHOLD_METHOD = "youden"
+
+
+def _pair_key(candidate: ERCandidate[Any]) -> frozenset[str]:
+    """The order-independent identity of a candidate pair, as ``align_pairs`` keys it."""
+    return frozenset({str(candidate.left.id), str(candidate.right.id)})
+
+
+def _row_key(row: PairRow[Any]) -> frozenset[str]:
+    """The same identity for a carrier row, so row-side and candidate-side maps join."""
+    return frozenset({row.left_id, row.right_id})
 
 
 def _build_module_for_judge(
@@ -450,6 +474,7 @@ class ERModel(ModelRun, ModelPersistence):
         split: float | None = None,
         seed: int = 0,
         method: Method | None = None,
+        derive_threshold: bool = False,
     ) -> Self:
         """Fit the module when it supports a fit hook; sklearn-style no-op otherwise.
 
@@ -488,6 +513,52 @@ class ERModel(ModelRun, ModelPersistence):
         ``labels``/``pairs`` was passed, in which case it raises rather than
         silently discarding them.
 
+        **``derive_threshold=True``: fit the decision cut from the labels.**
+        Off by default. When set, ``fit`` scores the labeled ``train`` pairs
+        through this model's own scoring path and derives the match threshold
+        from that score distribution via
+        :func:`~langres.curation.harvest.derive_threshold_from_pairs`, then writes
+        it to wherever *this* model keeps its cut -- ``clusterer.threshold`` on a
+        classic four-slot model, the terminal
+        :class:`~langres.core.op.ThresholdSelect` on an explicit ``_ops`` chain
+        (which has no clusterer slot at all). ``fit_report_.threshold_fit``
+        records which, from how many pairs, and whether the reported metrics are
+        held-out. Three things worth knowing before you switch it on:
+
+        - **It needs ``pairs=``, not ``labels=``.** ``pairs=`` is what carries the
+          entity-disjoint ``split``, and a threshold derived from the same rows
+          you then score is *in-sample*: it will look like a large win and will
+          not reproduce. With ``split=``, the cut is derived on ``train`` and the
+          report's P/R/F1 grade it on ``valid``, which the cut never saw. Without
+          ``split=`` the cut is still derived -- honestly, and the report says
+          ``IN-SAMPLE`` -- but no metrics are computed, because an in-sample
+          number here would only flatter the cut.
+        - **It also fits a matcher with no fit hook.** A fixed scorer
+          (``WeightedAverageMatcher``, ``RapidfuzzMatcher``, an LLM judge) has
+          nothing to train, so ``fit(pairs=...)`` refuses it today. Its threshold
+          *is* fittable, so with ``derive_threshold=True`` that call is accepted
+          and fits exactly that one parameter. ``trained`` stays ``False`` (no
+          matcher hook ran); ``threshold_fit.source`` is what says a cut was
+          derived.
+        - **Youden's J treats both errors as equally bad.** The default (and only)
+          method maximizes ``tpr - fpr``, which is symmetric in cost. Entity
+          resolution usually is not: a false merge propagates through transitive
+          closure and can poison a whole cluster, while a false split leaves two
+          records that can still be merged later. If your costs are that
+          asymmetric, take the derived cut as a *starting point* and move it up,
+          or call :func:`~langres.training.calibration.derive_threshold` yourself
+          with ``method="percentile"``.
+
+        Needs scikit-learn (the ``[trained]`` extra). On a core-only install it
+        raises a directed :class:`ImportError` rather than falling back to the
+        constructed default -- identical code must not yield a different
+        threshold depending on which extras happen to be installed.
+
+        The derived threshold **survives** ``save``/``load`` (it lives on the
+        clusterer / ``ThresholdSelect``); its provenance does **not**
+        (``fit_report_`` is never serialized). See
+        :class:`~langres.training.fit_report.ThresholdFit`.
+
         Args:
             data: Raw records (dicts) in a stable list order, same shape as
                 ``resolve()``/``predict()`` accept.
@@ -510,6 +581,9 @@ class ERModel(ModelRun, ModelPersistence):
                 ``DSPyMatcher``'s prompt -- see :meth:`_fit_prompt`); the
                 fine-tune (PR-F) and calibrate (PR-D) handlers are still stubs
                 that raise a clear NotImplementedError naming their PR.
+            derive_threshold: Derive the match threshold from ``pairs`` and apply
+                it (see above). ``False`` (default) leaves the model's constructed
+                threshold untouched -- the correct no-data fallback.
 
         Returns:
             ``self``, so ``resolver.fit(data).resolve(data)`` chains.
@@ -518,6 +592,10 @@ class ERModel(ModelRun, ModelPersistence):
             ValueError: If both ``labels`` and ``pairs`` are given; if the module
                 implements ``SupervisedFitMixin`` and neither is given; or if
                 ``labels``/``pairs`` is given to a module that cannot use them.
+                Also if ``derive_threshold=True`` without ``pairs=``, together
+                with ``method=``, or on a model that keeps no match cut.
+            ImportError: If ``derive_threshold=True`` and scikit-learn (the
+                ``[trained]`` extra) is not installed.
             NotImplementedError: If ``method`` is given but its ``kind``'s fit
                 path is not implemented yet (the seam is wired ahead of the
                 concrete methods; the error names the PR that will land it).
@@ -526,6 +604,17 @@ class ERModel(ModelRun, ModelPersistence):
                 them. The base ``Resolver`` declares none and never raises it.
         """
         if method is not None:
+            if derive_threshold:
+                raise ValueError(
+                    "fit(method=..., derive_threshold=True) is not supported: a "
+                    f"method= fit ({method.describe()}) runs its own handler and "
+                    "owns its own report. Fit the method first, then derive the "
+                    "cut against the resulting pipeline in a second call -- "
+                    "fit(data, method=...) then "
+                    "fit(data, pairs=..., split=..., derive_threshold=True). "
+                    "That ordering also matters for method='calibrate': the "
+                    "threshold must be derived on the CALIBRATED score scale."
+                )
             # Architectures that claim an identity refuse the kinds that would
             # change their topology out from under the class name. The base
             # Resolver declares no kinds and this is a no-op for it.
@@ -559,8 +648,30 @@ class ERModel(ModelRun, ModelPersistence):
                 "candidates) or pairs= (id-keyed labels align_pairs() joins for you), "
                 "not both."
             )
+        if derive_threshold and pairs is None:
+            raise ValueError(
+                "fit(derive_threshold=True) needs pairs=<id-keyed labels>. A "
+                "threshold is derived from a score distribution and its gold "
+                "labels, and pairs= is the argument that carries the "
+                "entity-disjoint split= -- which is what keeps the derived cut "
+                "out of the number you then report. labels= is positional and "
+                "carries no split, so it could only ever produce an in-sample "
+                "cut. Pass pairs=[LabeledPair(...), ...] or a corrections.jsonl "
+                "path (use split=None if you genuinely want the in-sample cut; "
+                "the report will say so)."
+            )
+        if self._ops is not None:
+            # An explicit Op chain has NO module/clusterer slot -- reading either
+            # raises (see ``_require_bound``) -- so it can never reach the
+            # slot-based dispatch below. Its one fittable parameter is the
+            # chain's own ThresholdSelect.
+            return self._fit_chain_threshold(
+                data, pairs=pairs, split=split, seed=seed, derive_threshold=derive_threshold
+            )
         if pairs is not None:
-            self.fit_report_ = self._fit_from_pairs(data, pairs, split=split, seed=seed)
+            self.fit_report_ = self._fit_from_pairs(
+                data, pairs, split=split, seed=seed, derive_threshold=derive_threshold
+            )
             return self
 
         matcher_name = type(self.module).__name__
@@ -1065,6 +1176,7 @@ class ERModel(ModelRun, ModelPersistence):
         *,
         split: float | None,
         seed: int,
+        derive_threshold: bool = False,
     ) -> FitReport:
         """Fit a ``SupervisedFitMixin`` matcher from id-keyed labels via ``align_pairs``.
 
@@ -1072,17 +1184,39 @@ class ERModel(ModelRun, ModelPersistence):
         on the train split, and evaluates held-out pair P/R/F1 on the valid split
         (when a split was given, via :func:`~langres.core.metrics.classify_pairs`
         at the clusterer's threshold). Returns the assembled :class:`FitReport`.
+
+        With ``derive_threshold=True`` the cut is derived from the **train** split
+        and applied *before* the valid split is graded, so the reported metrics
+        measure the derived cut on pairs it never saw. A matcher with no
+        supervised fit hook is accepted in that mode: its threshold is still a
+        fittable parameter even though the matcher itself is fixed.
         """
         matcher_name = type(self.module).__name__
-        if not isinstance(self.module, SupervisedFitMixin):
+        supervised = isinstance(self.module, SupervisedFitMixin)
+        if not supervised and not derive_threshold:
             raise ValueError(
                 f"{matcher_name} does not support fit(pairs=...): pairs= supplies "
                 "labeled pairs for a SupervisedFitMixin matcher, and this matcher "
                 "implements no supervised fit hook. Use fit() with no labels for an "
-                "unsupervised/non-learnable matcher."
+                "unsupervised/non-learnable matcher, or pass derive_threshold=True "
+                "to fit the decision threshold alone (the one parameter a fixed "
+                "scorer does have)."
             )
         aligned = align_pairs(self.candidates(data), pairs, split=split, seed=seed)
-        self.module.fit(iter(aligned.train.candidates), aligned.train.labels)
+        if supervised:
+            cast("SupervisedFitMixin[Any]", self.module).fit(
+                iter(aligned.train.candidates), aligned.train.labels
+            )
+
+        # Derive BEFORE grading valid: the whole point is that the reported
+        # metrics measure the cut the fit chose, on rows the cut never saw.
+        threshold_fit = ThresholdFit(source="default")
+        if derive_threshold:
+            _warn_if_silver_only(pairs)
+            threshold_fit = self._apply_derived_threshold(
+                self._labeled_for_derivation(aligned.train.candidates, aligned.train.labels),
+                held_out=bool(aligned.valid.candidates),
+            )
 
         metrics: PairMetrics | None = None
         if aligned.valid.candidates:
@@ -1095,17 +1229,206 @@ class ERModel(ModelRun, ModelPersistence):
             metrics = classify_pairs(judgements, gold_pairs, self.clusterer.threshold)
 
         return FitReport.build(
-            trainable=f"{matcher_name} (SupervisedFitMixin)",
-            trained=True,
+            trainable=(
+                f"{matcher_name} (SupervisedFitMixin)"
+                if supervised
+                else f"{matcher_name} (no fit hook; threshold only)"
+            ),
+            # ``trained`` means "a matcher fit hook ran" and keeps that meaning: a
+            # derived threshold is reported by ``threshold_fit``, not here.
+            trained=supervised,
             n_train=len(aligned.train.labels),
             n_valid=len(aligned.valid.labels),
             split=split,
             seed=seed,
             coverage=aligned.coverage,
             threshold=self.clusterer.threshold,
+            threshold_fit=threshold_fit,
             metrics=metrics,
             run_ref=current_run.get(),
         )
+
+    # ------------------------------------------------------------------
+    # Threshold fitting -- the ONE derivation seam, shared by both topologies.
+    #
+    # The derivation itself is NOT reimplemented here: it delegates to
+    # ``curation.harvest.derive_threshold_from_pairs`` (which delegates in turn
+    # to ``training.calibration.derive_threshold``), the same function the
+    # harvest loop and the fixed-split pair benchmark already call. What lives
+    # here is only the two things fit() adds: getting scores on the scale the cut
+    # actually sees, and writing the result to whichever seam this model keeps
+    # its cut in.
+    # ------------------------------------------------------------------
+
+    def _labeled_for_derivation(
+        self, candidates: Sequence[ERCandidate[Any]], labels: Sequence[bool]
+    ) -> list[LabeledPair]:
+        """Score ``candidates`` and pair each score with its gold label.
+
+        Scores exactly the labeled candidates -- not every blocked pair -- through
+        :meth:`_scorer`, so a paid matcher bills for the labeled set alone and
+        stays inside this model's ``budget_usd`` ledger.
+        """
+        judgements = list(self._scorer().forward(iter(candidates)))
+        by_pair = {frozenset({j.left_id, j.right_id}): j for j in judgements}
+        scores = self._cut_scale_scores([by_pair.get(_pair_key(c)) for c in candidates])
+        return [
+            LabeledPair(
+                left_id=str(candidate.left.id),
+                right_id=str(candidate.right.id),
+                score=score,
+                label=label,
+                # These labels were asserted by the CALLER, not read back off the
+                # judge's own verdicts, so they are gold rather than silver.
+                # Stamping "verdict" would make derive_threshold_from_pairs warn
+                # about a circularity that is not present; the genuinely-silver
+                # case is caught by ``_warn_if_silver_only`` on the raw input.
+                source="correction",
+            )
+            for candidate, label, score in zip(candidates, labels, scores, strict=True)
+        ]
+
+    def _cut_scale_scores(
+        self, judgements: Sequence[PairwiseJudgement | None]
+    ) -> list[float | None]:
+        """Judgement scores on the scale the match cut actually sees.
+
+        A fitted :attr:`calibrator` remaps every scored ranking row before
+        clustering (:meth:`_scored_pairs` -> ``CalibratorScore``), so a threshold
+        derived from RAW matcher scores would be a cut on a different scale than
+        the one ``resolve()`` thresholds against. Mirror that mapping here.
+        Score-less rows (a decider, or a candidate the matcher returned no
+        judgement for) pass through as ``None``, exactly as
+        :meth:`_apply_calibrator_to_pairs` leaves them --
+        ``derive_threshold_from_pairs`` then refuses the input by name rather
+        than silently calibrating on the scored subset.
+        """
+        scores: list[float | None] = [None if j is None else j.score for j in judgements]
+        calibrator = self.calibrator
+        if calibrator is None:
+            return scores
+        scored = [i for i, score in enumerate(scores) if score is not None]
+        mapped = calibrator.transform([cast(float, scores[i]) for i in scored])
+        for index, value in zip(scored, mapped, strict=True):
+            scores[index] = value
+        return scores
+
+    def _apply_derived_threshold(
+        self, labeled: Sequence[LabeledPair], *, held_out: bool
+    ) -> ThresholdFit:
+        """Derive the cut from ``labeled`` and write it to this model's threshold seam.
+
+        Raises:
+            ValueError: If this model keeps no match cut at all (an explicit chain
+                with no ``ThresholdSelect``) -- deriving a number and writing it
+                nowhere would be the silent no-op this whole seam exists to avoid.
+        """
+        seam = self._threshold_seam()
+        if seam is None:
+            raise ValueError(
+                "fit(derive_threshold=True) found no decision threshold to fit: "
+                "this model's explicit Op chain contains no ThresholdSelect, so "
+                "there is no match cut to write. Add a ThresholdSelect to the "
+                "topology (or use a classic four-slot model, whose cut lives on "
+                "the clusterer)."
+            )
+        previous = self._match_threshold()
+        threshold = derive_threshold_from_pairs(labeled)
+        self._set_match_threshold(threshold)
+        return ThresholdFit(
+            source="derived",
+            method=_THRESHOLD_METHOD,
+            n_pairs=len(labeled),
+            held_out=held_out,
+            applied_to=seam,
+            previous=previous,
+        )
+
+    def _fit_chain_threshold(
+        self,
+        data: list[Any],
+        *,
+        pairs: str | Path | Sequence[LabeledPair] | Sequence[Correction] | None,
+        split: float | None,
+        seed: int,
+        derive_threshold: bool,
+    ) -> Self:
+        """``fit`` for an explicit ``_ops`` chain: the threshold is all there is to fit.
+
+        An explicit chain has no ``module`` slot to train and no ``clusterer``
+        slot to read -- both properties raise -- so the slot-based dispatch in
+        :meth:`fit` cannot run here at all. Its one fittable parameter is the
+        terminal :class:`~langres.core.op.ThresholdSelect`.
+
+        The chain is run ONCE, with that ThresholdSelect omitted
+        (:meth:`_prethreshold_pairs`), so the derivation sees the rows below the
+        current cut too. Both splits are then read off that single pass -- a
+        chain's Source owns retrieval, so unlike a classic model it cannot score
+        an arbitrary candidate subset.
+        """
+        if not derive_threshold or pairs is None:
+            raise ValueError(
+                "fit() on an explicit Op topology can only fit the chain's "
+                "ThresholdSelect: there is no matcher slot to train (the chain's "
+                "Scores are topology, not a fittable slot). Call "
+                "fit(data, pairs=<id-keyed labels>, split=..., "
+                "derive_threshold=True), or build a classic four-slot model if you "
+                "need to train the matcher itself."
+            )
+        scored = self._prethreshold_pairs(data)
+        score_by_pair = {_row_key(row): row.score for row in scored.rows}
+        judgement_by_pair = {
+            _row_key(row): row.to_judgement() for row in scored.rows if row.score_type is not None
+        }
+        aligned = align_pairs(scored.to_candidates(), pairs, split=split, seed=seed)
+
+        _warn_if_silver_only(pairs)
+        threshold_fit = self._apply_derived_threshold(
+            [
+                LabeledPair(
+                    left_id=str(candidate.left.id),
+                    right_id=str(candidate.right.id),
+                    score=score_by_pair.get(_pair_key(candidate)),
+                    label=label,
+                    source="correction",  # caller-asserted gold; see _labeled_for_derivation
+                )
+                for candidate, label in zip(
+                    aligned.train.candidates, aligned.train.labels, strict=True
+                )
+            ],
+            held_out=bool(aligned.valid.candidates),
+        )
+
+        metrics: PairMetrics | None = None
+        if aligned.valid.candidates:
+            judgements = [
+                judgement
+                for candidate in aligned.valid.candidates
+                if (judgement := judgement_by_pair.get(_pair_key(candidate))) is not None
+            ]
+            gold_pairs = {
+                _pair_key(c)
+                for c, label in zip(aligned.valid.candidates, aligned.valid.labels, strict=True)
+                if label
+            }
+            metrics = classify_pairs(judgements, gold_pairs, cast(float, self._match_threshold()))
+
+        matcher = self._chain_scoring_matcher()
+        name = "explicit Op chain" if matcher is None else type(matcher).__name__
+        self.fit_report_ = FitReport.build(
+            trainable=f"{name} (threshold only; an Op chain has no matcher slot to fit)",
+            trained=False,
+            n_train=len(aligned.train.labels),
+            n_valid=len(aligned.valid.labels),
+            split=split,
+            seed=seed,
+            coverage=aligned.coverage,
+            threshold=self._match_threshold(),
+            threshold_fit=threshold_fit,
+            metrics=metrics,
+            run_ref=current_run.get(),
+        )
+        return self
 
     # ------------------------------------------------------------------
     # Linking / streaming (M5)

--- a/src/langres/core/resolver.py
+++ b/src/langres/core/resolver.py
@@ -1581,7 +1581,12 @@ class ERModel(ModelRun, ModelPersistence):
                 "Add a Score (e.g. MatcherScore) to the chain before the "
                 "ThresholdSelect."
             )
-        cluster_cut = self._chain_cluster_stage().clusterer.threshold
+        # ``getattr``: ClusterStage is the abstract contract and carries no
+        # clusterer; only the ClustererStage adapter wraps a legacy one. A custom
+        # ClusterStage has no second threshold to conflict with, so absent means
+        # "no independent cut", not "unknown".
+        cluster_cut = getattr(self._chain_cluster_stage(), "clusterer", None)
+        cluster_cut = None if cluster_cut is None else cluster_cut.threshold
         if cluster_cut:
             # A chain can gate TWICE: the ThresholdSelect this fit writes, and the
             # nested clusterer, which "keeps thresholding on the projected

--- a/src/langres/core/resolver.py
+++ b/src/langres/core/resolver.py
@@ -46,7 +46,7 @@ reconstructs uniformly. See that module for the full convention.
 
 import logging
 import warnings
-from collections.abc import Iterator, Sequence
+from collections.abc import Iterable, Iterator, Sequence
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Literal, Self, cast
 
@@ -138,6 +138,35 @@ def _pair_f1(labeled: Sequence[LabeledPair], threshold: float) -> float:
     fp = sum(1 for p in labeled if p.score is not None and p.score >= threshold and not p.label)
     fn = sum(1 for p in labeled if not (p.score is not None and p.score >= threshold) and p.label)
     return 0.0 if tp == 0 else 2 * tp / (2 * tp + fp + fn)
+
+
+def _refuse_deciders(judgements: Iterable[PairwiseJudgement | None]) -> None:
+    """Refuse to fit a threshold that inference would then ignore.
+
+    :func:`~langres.core.models.predicted_match` -- the ONE place that answers
+    "is this pair a match" -- gives ``decision`` precedence over ``score``: "a
+    judge that both decided and ranked already made its call, so the threshold
+    never overrides it". So for a matcher that emits an explicit ``decision``,
+    moving the cut changes *nothing* at resolve time.
+
+    That is the failure mode this whole feature exists to prevent, one level up:
+    the fit would derive a number, race it, report an improvement, apply it --
+    and resolve identically either way. A silently inert fit reported as a
+    success is worse than a refusal, so this raises.
+
+    (A *pure* decider, ``score=None`` with no ``decision``, is already refused by
+    ``derive_threshold_from_pairs``. This catches the both-emitting case, which
+    has scores and so would otherwise sail through.)
+    """
+    if any(j is not None and j.decision is not None for j in judgements):
+        raise ValueError(
+            "fit(derive_threshold=True) cannot fit a threshold for this matcher: "
+            "it emits an explicit decision, and predicted_match gives decision "
+            "precedence over score -- so resolve() would ignore whatever cut was "
+            "derived and this fit would be silently inert. Use a ranking matcher "
+            "(score only) to fit a cut, or drop derive_threshold=True and let the "
+            "matcher's own decisions stand."
+        )
 
 
 def _build_module_for_judge(
@@ -1270,7 +1299,7 @@ class ERModel(ModelRun, ModelPersistence):
         # Select BEFORE grading, so the reported metrics measure the cut actually
         # in force. Selection reads ``train`` only; the valid judgements are
         # passed in purely to be *scored* at each candidate, never to choose.
-        threshold_fit = ThresholdFit(source="default")
+        threshold_fit = ThresholdFit(source="not_fitted")
         if derive_threshold:
             _warn_if_silver_only(pairs)
             threshold_fit = self._select_threshold(
@@ -1325,6 +1354,7 @@ class ERModel(ModelRun, ModelPersistence):
         stays inside this model's ``budget_usd`` ledger.
         """
         judgements = list(self._scorer().forward(iter(candidates)))
+        _refuse_deciders(judgements)
         by_pair = {frozenset({j.left_id, j.right_id}): j for j in judgements}
         scores = self._cut_scale_scores([by_pair.get(_pair_key(c)) for c in candidates])
         return [
@@ -1518,6 +1548,7 @@ class ERModel(ModelRun, ModelPersistence):
         judgement_by_pair = {
             _row_key(row): row.to_judgement() for row in scored.rows if row.score_type is not None
         }
+        _refuse_deciders(judgement_by_pair.values())
         aligned = align_pairs(scored.to_candidates(), pairs, split=split, seed=seed)
 
         judgements = [

--- a/src/langres/core/resolver.py
+++ b/src/langres/core/resolver.py
@@ -1496,6 +1496,23 @@ class ERModel(ModelRun, ModelPersistence):
                 "derive_threshold=True), or build a classic four-slot model if you "
                 "need to train the matcher itself."
             )
+        # Check for a writable cut BEFORE scoring, not after. _select_threshold
+        # raises the same ValueError, but it is called on the far side of a full
+        # Source+body pass -- so on a chain with a paid MatcherScore and no
+        # ThresholdSelect, deferring to it would bill the entire dataset and then
+        # throw the result away (measured: 435 scoring calls over 30 records
+        # before the refusal). The guard below is the cheap early-out; the one in
+        # _select_threshold stays, because it is the invariant for the classic
+        # path too.
+        if self._threshold_seam() is None:
+            raise ValueError(
+                "fit(derive_threshold=True) found no decision threshold to fit: "
+                "this model's explicit Op chain contains no ThresholdSelect, so "
+                "there is no match cut to write. Add a ThresholdSelect to the "
+                "topology (or use a classic four-slot model, whose cut lives on "
+                "the clusterer). Nothing was scored: this is checked before the "
+                "chain runs, so a paid Score in the chain has not been billed."
+            )
         scored = self._prethreshold_pairs(data)
         score_by_pair = {_row_key(row): row.score for row in scored.rows}
         judgement_by_pair = {
@@ -1532,8 +1549,19 @@ class ERModel(ModelRun, ModelPersistence):
             valid_gold=gold_pairs,
         )
 
+        # Gate on ``judgements``, NOT on ``aligned.valid.candidates``: a chain need
+        # not contain a Score at all (a blocker similarity lands as an *unscored*
+        # row score, ``score_type is None``, so ``[BlockerSource(sim_blocker),
+        # ThresholdSelect, ClustererStage]`` is permitted topology that cuts on
+        # the blocker's own number), and the ``score_type is not None`` filter
+        # above then leaves ``judgements`` legitimately empty.
+        # ``classify_pairs([], gold, t)`` does not return None -- it returns a real
+        # PairMetrics of zeros with ``fn=len(gold)`` -- which would print a
+        # fully-populated "Held-out pair metrics" table of 0.0000 for a fit that
+        # measured nothing. Same convention as ``_described``'s
+        # ``if valid_judgements else None``.
         metrics: PairMetrics | None = None
-        if aligned.valid.candidates:
+        if judgements:
             metrics = classify_pairs(judgements, gold_pairs, cast(float, self._match_threshold()))
 
         matcher = self._chain_scoring_matcher()

--- a/src/langres/core/resolver.py
+++ b/src/langres/core/resolver.py
@@ -1308,8 +1308,22 @@ class ERModel(ModelRun, ModelPersistence):
                 valid_gold=gold_pairs,
             )
 
+        # ``if judgements``, not ``if aligned.valid.candidates`` -- the same
+        # convention as ``_described`` above and ``_fit_chain_threshold`` below,
+        # for the same reason: ``classify_pairs([], gold, t)`` returns a real
+        # PairMetrics of zeros with ``fn=len(gold)``, never None, so an empty
+        # judgement list renders as a fully-populated table of 0.0000 for a fit
+        # that measured nothing.
+        #
+        # No matcher langres ships can trigger it here (every one yields exactly
+        # one judgement per candidate -- an abstention is a judgement with
+        # ``score=None``, not a skipped yield). But ``Matcher`` is a documented
+        # bring-your-own extension point with nothing enforcing that cardinality,
+        # and a custom matcher that skips a candidate reproduces it exactly. All
+        # three sites read the same way so the next reader cannot mistake a
+        # divergence for a deliberate one.
         metrics: PairMetrics | None = None
-        if aligned.valid.candidates:
+        if judgements:
             metrics = classify_pairs(judgements, gold_pairs, self.clusterer.threshold)
 
         return FitReport.build(

--- a/src/langres/core/resolver.py
+++ b/src/langres/core/resolver.py
@@ -1563,6 +1563,42 @@ class ERModel(ModelRun, ModelPersistence):
             _row_key(row): row.to_judgement() for row in scored.rows if row.score_type is not None
         }
         _refuse_deciders(judgement_by_pair.values())
+        if scored.rows and not judgement_by_pair:
+            # Every row is UNSCORED (``score_type is None``) -- a blocker
+            # similarity, which ``PairRow.predicted_match`` deliberately refuses
+            # to threshold ("only a SCORED row's score is a judge score"). It
+            # returns ``self.decision``, i.e. ``None``, so ThresholdSelect drops
+            # every such row *whatever* value is fitted. Deriving here would
+            # report a measured, applied cut for a fit that cannot change one
+            # pair -- the same silently-inert failure as ``_refuse_deciders``,
+            # reached from the other side.
+            raise ValueError(
+                "fit(derive_threshold=True) cannot fit a threshold for this chain: "
+                "its rows carry no judge score (score_type is None -- the score "
+                "column holds a blocker similarity). PairRow.predicted_match will "
+                "not threshold an unscored row, so ThresholdSelect drops all of "
+                "them regardless of the cut and this fit would be silently inert. "
+                "Add a Score (e.g. MatcherScore) to the chain before the "
+                "ThresholdSelect."
+            )
+        cluster_cut = self._chain_cluster_stage().clusterer.threshold
+        if cluster_cut:
+            # A chain can gate TWICE: the ThresholdSelect this fit writes, and the
+            # nested clusterer, which "keeps thresholding on the projected
+            # judgements". Fitting only the first would let a winning cut of 0.80
+            # be reported as applied while a clusterer cut of 0.90 still rejects
+            # every pair between them -- a held-out improvement resolve() never
+            # realizes. The shipped research recipes build this stage
+            # threshold-free for exactly that reason; refuse rather than silently
+            # fit one of two gates.
+            raise ValueError(
+                "fit(derive_threshold=True) cannot fit this chain: its ClusterStage "
+                f"clusterer carries its own threshold ({cluster_cut}), so the chain "
+                "gates twice and fitting the ThresholdSelect alone would report an "
+                "improvement that resolve() cannot deliver. Build the stage "
+                "threshold-free -- ClustererStage(Clusterer(threshold=0.0)) -- and "
+                "let the ThresholdSelect own the match cut."
+            )
         aligned = align_pairs(scored.to_candidates(), pairs, split=split, seed=seed)
 
         judgements = [

--- a/src/langres/curation/harvest.py
+++ b/src/langres/curation/harvest.py
@@ -313,6 +313,9 @@ def derive_threshold_from_pairs(
             biased scored-only subset. Also propagated from
             :func:`~langres.training.calibration.derive_threshold` (empty input,
             single-class labels under ``"youden"``, bad ``percentile``, ...).
+        ImportError: If scikit-learn (the ``[trained]`` extra) is not installed.
+            Raised, never silently defaulted: the same code must not produce a
+            different threshold depending on which extras are present.
 
     Warns:
         UserWarning: If ``pairs`` is non-empty and every label is silver
@@ -344,7 +347,26 @@ def derive_threshold_from_pairs(
             stacklevel=2,
         )
 
-    from langres.training.calibration import derive_threshold
+    # scikit-learn is the ``[trained]`` extra, and ``training.calibration``
+    # imports it at MODULE scope -- so on a core-only install this import fails,
+    # not the ROC computation below it. Translate the bare
+    # ``ModuleNotFoundError: No module named 'sklearn'`` into problem + cause +
+    # fix, and RAISE rather than fall back: a silent default cut would make the
+    # same code produce different artifacts depending on which extras happen to
+    # be installed, which is exactly the "no silent fallback" property langres
+    # advertises (docs/GETTING_STARTED.md).
+    try:
+        from langres.training.calibration import derive_threshold
+    except ImportError as exc:
+        raise ImportError(
+            "cannot derive a threshold: threshold derivation needs scikit-learn "
+            "(it reads the ROC curve), which ships in langres's optional "
+            "'trained' extra and is not installed. "
+            "Fix: pip install 'langres[trained]' (or uv add 'langres[trained]'). "
+            "langres will not substitute an underived default -- a hand-set cut "
+            "is not a derived one, and the same code must not produce different "
+            "artifacts depending on which extras happen to be installed."
+        ) from exc
 
     return derive_threshold(
         scores,

--- a/src/langres/curation/harvest.py
+++ b/src/langres/curation/harvest.py
@@ -61,6 +61,7 @@ __all__ = [
     "align_pairs",
     "derive_threshold_from_pairs",
     "harvest_labeled_pairs",
+    "warn_if_silver_only",
 ]
 
 #: Schema type variable for the entity schema an ``ERCandidate`` carries. Defined
@@ -277,6 +278,43 @@ def harvest_labeled_pairs(
     return pairs
 
 
+def warn_if_silver_only(
+    pairs: str | Path | Sequence[LabeledPair] | Sequence[Correction], *, stacklevel: int = 2
+) -> None:
+    """Warn when every supplied label is the judge's own verdict (circular calibration).
+
+    The shared guard behind :func:`derive_threshold_from_pairs` and
+    ``ERModel.fit(derive_threshold=True)``. Both derive a cut from labels; both
+    must say so when those labels are *silver* -- the judge's logged verdicts,
+    which were produced BY a cut, so a threshold search can only recover the cut
+    that made them. (Training a *different* model on silver labels is
+    legitimate, which is why :func:`harvest_labeled_pairs` stays warning-free.)
+
+    Anything that is not an in-memory sequence of :class:`LabeledPair` is silently
+    accepted: only ``LabeledPair`` carries ``source``, so a ``corrections.jsonl``
+    path or a :class:`Correction` sequence is human-reviewed by construction and
+    has no silver case to warn about.
+
+    Args:
+        pairs: The labels as the caller supplied them.
+        stacklevel: Forwarded to :func:`warnings.warn` (+1 for this frame), so the
+            warning points at the user's call rather than at langres internals.
+    """
+    if isinstance(pairs, (str, Path)) or not pairs:
+        return
+    if not all(isinstance(pair, LabeledPair) and pair.source == "verdict" for pair in pairs):
+        return
+    warnings.warn(
+        "silver-only calibration is circular -- deriving a threshold from "
+        "a judge's own verdicts can only recover the cut that produced "
+        "them; overlay human corrections (source='correction') before "
+        "calibrating. (Training a DIFFERENT model on silver labels is "
+        "fine.)",
+        UserWarning,
+        stacklevel=stacklevel + 1,
+    )
+
+
 def derive_threshold_from_pairs(
     pairs: Sequence[LabeledPair],
     *,
@@ -336,16 +374,7 @@ def derive_threshold_from_pairs(
             )
         scores.append(pair.score)
 
-    if pairs and all(pair.source == "verdict" for pair in pairs):
-        warnings.warn(
-            "silver-only calibration is circular -- deriving a threshold from "
-            "a judge's own verdicts can only recover the cut that produced "
-            "them; overlay human corrections (source='correction') before "
-            "calibrating. (Training a DIFFERENT model on silver labels is "
-            "fine.)",
-            UserWarning,
-            stacklevel=2,
-        )
+    warn_if_silver_only(pairs, stacklevel=3)
 
     # scikit-learn is the ``[trained]`` extra, and ``training.calibration``
     # imports it at MODULE scope -- so on a core-only install this import fails,

--- a/src/langres/training/fit_report.py
+++ b/src/langres/training/fit_report.py
@@ -100,11 +100,21 @@ class ThresholdFit(BaseModel):
         source: What happened to the threshold. ``"derived"`` -- a cut was
             derived and kept. ``"declined"`` -- a cut was derived, lost to the
             incumbent on the selection split, and was **not** applied; the
-            threshold is unchanged. ``"default"`` -- no derivation was attempted,
-            so the threshold is whatever the model was constructed with (an
-            honest no-data fallback, not a measurement).
+            threshold is unchanged. ``"not_fitted"`` -- **this** fit did not fit
+            the threshold (``derive_threshold=False``), so the cut is whatever
+            the model already carried.
+
+            Note what ``"not_fitted"`` deliberately does **not** claim: that the
+            threshold is a constructor default. This report cannot know that. A
+            model whose earlier ``fit(derive_threshold=True)`` derived its cut,
+            re-fitted later without the flag, would be relabelled a "default" by
+            such a claim -- a false provenance record in the one field whose
+            entire job is provenance. ``fit_report_`` is not serialized, so a
+            later fit has no way to recover the earlier one's origin; saying
+            "this fit did not touch it" is the strongest true statement
+            available.
         method: The derivation method (``"youden"``), or ``None`` when
-            ``source="default"``.
+            ``source="not_fitted"``.
         n_pairs: Labeled pairs the cut was derived from (``0`` when defaulted).
             Read this before trusting the threshold.
         held_out: Whether :attr:`FitReport.metrics` grades the threshold in force
@@ -114,7 +124,7 @@ class ThresholdFit(BaseModel):
         applied_to: Which seam the threshold was written to --
             ``"clusterer"`` (a classic four-slot model) or ``"threshold_select"``
             (an explicit ``_ops`` chain's ``ThresholdSelect``). ``None`` when
-            nothing was written, i.e. for ``"default"`` and ``"declined"``.
+            nothing was written, i.e. for ``"not_fitted"`` and ``"declined"``.
         selected_on: The split that chose between the candidates (``"train"``),
             or ``None`` when no derivation ran. Named explicitly so a reader can
             see it was *not* ``valid``.
@@ -124,7 +134,7 @@ class ThresholdFit(BaseModel):
             lets a caller judge the margin instead of trusting the rule.
     """
 
-    source: Literal["derived", "declined", "default"]
+    source: Literal["derived", "declined", "not_fitted"]
     method: str | None = None
     n_pairs: int = 0
     held_out: bool = False
@@ -277,8 +287,8 @@ class FitReport(BaseModel):
         fit = self.threshold_fit
         if fit is None:
             return ""
-        if fit.source == "default":
-            return " (default — not derived from labels)"
+        if fit.source == "not_fitted":
+            return " (not fitted by this fit — pass derive_threshold=True to fit it from labels)"
         if fit.source == "declined":
             candidate = "" if fit.candidate is None else f" {fit.candidate.threshold:.4f}"
             return (
@@ -299,7 +309,7 @@ class FitReport(BaseModel):
         ``train``, so nothing was ever tuned against ``valid``.
         """
         fit = self.threshold_fit
-        if fit is None or fit.source == "default":
+        if fit is None or fit.source == "not_fitted":
             return []
         rows = [("incumbent", fit.previous), ("derived", fit.candidate)]
         lines = [f"## Threshold selection (chosen on {fit.selected_on})", ""]

--- a/src/langres/training/fit_report.py
+++ b/src/langres/training/fit_report.py
@@ -11,6 +11,9 @@ data, and how well does it hold out?" for a single ``fit()``:
 - **did blocking keep the positives** -- the
   :class:`~langres.curation.harvest.GoldCoverage` from
   :func:`~langres.curation.harvest.align_pairs`;
+- **what cut did it settle on** -- the decision threshold, plus whether that
+  number was *derived* from the labels or is the constructor's no-data default
+  (:class:`ThresholdFit`);
 - **how well does it hold out** -- pair P/R/F1 on the entity-disjoint ``valid``
   split (from :func:`~langres.core.metrics.classify_pairs`), when a split was
   given.
@@ -26,10 +29,58 @@ while this model is the human-facing digest.
 
 from __future__ import annotations
 
+from typing import Literal
+
 from pydantic import BaseModel
 
 from langres.curation.harvest import GoldCoverage
 from langres.core.metrics import PairMetrics
+
+
+class ThresholdFit(BaseModel):
+    """How the decision threshold in :attr:`FitReport.threshold` was arrived at.
+
+    The provenance half of the number: a cut derived from 8 labeled pairs and a
+    cut derived from 800 are the same ``float`` and are *not* the same claim, and
+    a cut that was never derived at all is a constructor default masquerading as
+    a measurement. This model makes the difference readable.
+
+    **What survives ``save``/``load``, and what does not.** The threshold *value*
+    does -- it lives on the clusterer (or the chain's
+    :class:`~langres.core.op.ThresholdSelect`), both of which serialize into
+    ``resolver.json``. This provenance does **not**: it hangs off
+    ``ERModel.fit_report_``, which is deliberately never serialized (a fit-time
+    artifact, see ``langres.core._model_state``). So a reloaded model carries a
+    measured threshold with no record that it was measured -- keep the
+    :class:`FitReport` (``model_dump_json()``) beside the artifact if that
+    provenance matters.
+
+    Attributes:
+        source: ``"derived"`` (measured from labels on this fit) or
+            ``"default"`` (whatever the model was constructed with -- an honest
+            no-data fallback, not a measurement).
+        method: The derivation method (``"youden"``), or ``None`` when
+            ``source="default"``.
+        n_pairs: Labeled pairs the cut was derived from (``0`` when defaulted).
+            Read this before trusting the threshold.
+        held_out: Whether :attr:`FitReport.metrics` grades this cut on pairs it
+            was *not* derived from. ``False`` means the cut and the score share
+            rows (in-sample), so any improvement is optimistic. Deriving without
+            an entity-disjoint ``split`` always yields ``False``.
+        applied_to: Which seam the threshold was written to --
+            ``"clusterer"`` (a classic four-slot model) or ``"threshold_select"``
+            (an explicit ``_ops`` chain's ``ThresholdSelect``). ``None`` when
+            nothing was written.
+        previous: The threshold in force before this fit, so the report shows the
+            move rather than only the destination.
+    """
+
+    source: Literal["derived", "default"]
+    method: str | None = None
+    n_pairs: int = 0
+    held_out: bool = False
+    applied_to: Literal["clusterer", "threshold_select"] | None = None
+    previous: float | None = None
 
 
 class CalibrationDelta(BaseModel):
@@ -73,7 +124,10 @@ class FitReport(BaseModel):
         coverage: Blocking coverage of the labeled positives, or ``None`` when
             fit was given pre-aligned labels (no id-join, so no coverage) or
             nothing trained.
-        threshold: The clusterer decision threshold in force, or ``None``.
+        threshold: The decision threshold in force after this fit, or ``None``.
+        threshold_fit: Where that threshold came from -- derived from labels or
+            left at its constructed default (see :class:`ThresholdFit`), or
+            ``None`` for a fit that reports no threshold at all.
         metrics: Held-out pair P/R/F1 on ``valid``, or ``None`` when no split.
         cost: The derived dollar cost of a paid/GPU fit (tokens→$ or
             GPU-seconds→$), else ``None``. For a local fine-tune with no
@@ -100,6 +154,7 @@ class FitReport(BaseModel):
     entity_disjoint: bool
     coverage: GoldCoverage | None
     threshold: float | None = None
+    threshold_fit: ThresholdFit | None = None
     metrics: PairMetrics | None = None
     cost: float | None = None
     gpu_seconds: float | None = None
@@ -119,6 +174,7 @@ class FitReport(BaseModel):
         seed: int = 0,
         coverage: GoldCoverage | None = None,
         threshold: float | None = None,
+        threshold_fit: ThresholdFit | None = None,
         metrics: PairMetrics | None = None,
         cost: float | None = None,
         gpu_seconds: float | None = None,
@@ -142,6 +198,7 @@ class FitReport(BaseModel):
             entity_disjoint=split is not None,
             coverage=coverage,
             threshold=threshold,
+            threshold_fit=threshold_fit,
             metrics=metrics,
             cost=cost,
             gpu_seconds=gpu_seconds,
@@ -158,6 +215,25 @@ class FitReport(BaseModel):
         nothing to train") rather than an anonymous empty report.
         """
         return cls.build(trainable=f"{matcher_name} (no fit hook)", trained=False, n_train=0)
+
+    def _threshold_suffix(self) -> str:
+        """The provenance clause appended to the rendered threshold line.
+
+        Says *how* the number was reached in the same breath as the number, so a
+        reader cannot take a constructor default for a measurement, nor an
+        in-sample cut for a held-out one.
+        """
+        fit = self.threshold_fit
+        if fit is None:
+            return ""
+        if fit.source == "default":
+            return " (default — not derived from labels)"
+        moved = "" if fit.previous is None else f" from {fit.previous:.4f}"
+        sample = "held-out" if fit.held_out else "IN-SAMPLE"
+        return (
+            f" (derived{moved} by {fit.method} on {fit.n_pairs} labeled pairs, "
+            f"{sample}, applied to the {fit.applied_to})"
+        )
 
     def to_markdown(self) -> str:
         """Render a human-readable Markdown digest of the report.
@@ -179,7 +255,7 @@ class FitReport(BaseModel):
             split_line,
         ]
         if self.threshold is not None:
-            lines.append(f"- Threshold: {self.threshold:.4f}")
+            lines.append(f"- Threshold: {self.threshold:.4f}{self._threshold_suffix()}")
         if self.model_ref is not None:
             lines.append(f"- Model ref: {self.model_ref}")
         if self.gpu_seconds is not None:

--- a/src/langres/training/fit_report.py
+++ b/src/langres/training/fit_report.py
@@ -37,6 +37,26 @@ from langres.curation.harvest import GoldCoverage
 from langres.core.metrics import PairMetrics
 
 
+class ThresholdCandidate(BaseModel):
+    """One cut that was considered, with pair-F1 wherever it was measured.
+
+    Attributes:
+        threshold: The cut itself.
+        selection_f1: Pair-F1 on the split that *chose* between the candidates
+            (``train``). This is the number the decision was made on, so it is
+            fitted to that split by construction.
+        held_out_f1: Pair-F1 on the entity-disjoint ``valid`` split, or ``None``
+            when no split was given. **This one is a clean estimate:** selection
+            happens on ``train``, so nothing ever tuned against ``valid``. The
+            honest before/after of a threshold fit is ``previous.held_out_f1``
+            vs ``candidate.held_out_f1``.
+    """
+
+    threshold: float
+    selection_f1: float | None = None
+    held_out_f1: float | None = None
+
+
 class ThresholdFit(BaseModel):
     """How the decision threshold in :attr:`FitReport.threshold` was arrived at.
 
@@ -44,6 +64,27 @@ class ThresholdFit(BaseModel):
     cut derived from 800 are the same ``float`` and are *not* the same claim, and
     a cut that was never derived at all is a constructor default masquerading as
     a measurement. This model makes the difference readable.
+
+    **Deriving is not the same as keeping.** A derived cut is not automatically
+    better: Youden's J maximizes ``tpr - fpr`` on ``train``, and on a wide,
+    cleanly-separated margin that can pick a cut which scores identically there
+    and *worse* on unseen pairs (measured on a toy fixture during development,
+    not hypothesized: held-out pair-F1 1.00 -> 0.80). So a threshold fit derives
+    a candidate, scores it against the incumbent **on the same ``train`` split it
+    was derived from**, and keeps the incumbent unless the candidate is strictly
+    better. :attr:`source` records which happened.
+
+    Selecting on ``train`` rather than ``valid`` is deliberate. Choosing the
+    winner on ``valid`` would make ``valid`` a selection set and quietly turn
+    :attr:`FitReport.metrics` from a held-out estimate into an optimistic one.
+    ``train`` was already spent on the derivation, so selecting there costs no
+    additional honesty and both :attr:`ThresholdCandidate.held_out_f1` values
+    stay clean. Residual gap, stated rather than hidden: a cut chosen on
+    ``train`` can still fail to generalize -- selecting there bounds that risk,
+    it does not remove it. A three-way derive/select/report split would close it,
+    and is deliberately left as follow-on work: at the label counts this feature
+    targets (a handful of corrections out of a review loop) three splits would
+    make every number noise.
 
     **What survives ``save``/``load``, and what does not.** The threshold *value*
     does -- it lives on the clusterer (or the chain's
@@ -56,31 +97,41 @@ class ThresholdFit(BaseModel):
     provenance matters.
 
     Attributes:
-        source: ``"derived"`` (measured from labels on this fit) or
-            ``"default"`` (whatever the model was constructed with -- an honest
-            no-data fallback, not a measurement).
+        source: What happened to the threshold. ``"derived"`` -- a cut was
+            derived and kept. ``"declined"`` -- a cut was derived, lost to the
+            incumbent on the selection split, and was **not** applied; the
+            threshold is unchanged. ``"default"`` -- no derivation was attempted,
+            so the threshold is whatever the model was constructed with (an
+            honest no-data fallback, not a measurement).
         method: The derivation method (``"youden"``), or ``None`` when
             ``source="default"``.
         n_pairs: Labeled pairs the cut was derived from (``0`` when defaulted).
             Read this before trusting the threshold.
-        held_out: Whether :attr:`FitReport.metrics` grades this cut on pairs it
-            was *not* derived from. ``False`` means the cut and the score share
-            rows (in-sample), so any improvement is optimistic. Deriving without
-            an entity-disjoint ``split`` always yields ``False``.
+        held_out: Whether :attr:`FitReport.metrics` grades the threshold in force
+            on pairs it was *not* derived from. ``False`` means the cut and the
+            score share rows (in-sample), so any improvement is optimistic.
+            Deriving without an entity-disjoint ``split`` always yields ``False``.
         applied_to: Which seam the threshold was written to --
             ``"clusterer"`` (a classic four-slot model) or ``"threshold_select"``
             (an explicit ``_ops`` chain's ``ThresholdSelect``). ``None`` when
-            nothing was written.
-        previous: The threshold in force before this fit, so the report shows the
-            move rather than only the destination.
+            nothing was written, i.e. for ``"default"`` and ``"declined"``.
+        selected_on: The split that chose between the candidates (``"train"``),
+            or ``None`` when no derivation ran. Named explicitly so a reader can
+            see it was *not* ``valid``.
+        previous: The incumbent cut -- the one in force before this fit.
+        candidate: The cut the derivation produced. Present for ``"declined"``
+            too: a rejected candidate is evidence, not noise, and reporting it
+            lets a caller judge the margin instead of trusting the rule.
     """
 
-    source: Literal["derived", "default"]
+    source: Literal["derived", "declined", "default"]
     method: str | None = None
     n_pairs: int = 0
     held_out: bool = False
     applied_to: Literal["clusterer", "threshold_select"] | None = None
-    previous: float | None = None
+    selected_on: Literal["train"] | None = None
+    previous: ThresholdCandidate | None = None
+    candidate: ThresholdCandidate | None = None
 
 
 class CalibrationDelta(BaseModel):
@@ -228,12 +279,42 @@ class FitReport(BaseModel):
             return ""
         if fit.source == "default":
             return " (default — not derived from labels)"
-        moved = "" if fit.previous is None else f" from {fit.previous:.4f}"
+        if fit.source == "declined":
+            candidate = "" if fit.candidate is None else f" {fit.candidate.threshold:.4f}"
+            return (
+                f" (kept: the cut derived from {fit.n_pairs} labeled pairs"
+                f"{candidate} did not beat it on {fit.selected_on})"
+            )
+        moved = "" if fit.previous is None else f" from {fit.previous.threshold:.4f}"
         sample = "held-out" if fit.held_out else "IN-SAMPLE"
         return (
             f" (derived{moved} by {fit.method} on {fit.n_pairs} labeled pairs, "
-            f"{sample}, applied to the {fit.applied_to})"
+            f"chosen on {fit.selected_on}, {sample}, applied to the {fit.applied_to})"
         )
+
+    def _threshold_choice_lines(self) -> list[str]:
+        """The before/after block: both candidate cuts and how each scored.
+
+        ``held-out`` here is a genuinely clean estimate -- selection ran on
+        ``train``, so nothing was ever tuned against ``valid``.
+        """
+        fit = self.threshold_fit
+        if fit is None or fit.source == "default":
+            return []
+        rows = [("incumbent", fit.previous), ("derived", fit.candidate)]
+        lines = [f"## Threshold selection (chosen on {fit.selected_on})", ""]
+        for label, candidate in rows:
+            if candidate is None:
+                continue
+            kept = (label == "derived") == (fit.source == "derived")
+            parts = [f"- {label} {candidate.threshold:.4f}{' — KEPT' if kept else ''}"]
+            if candidate.selection_f1 is not None:
+                parts.append(f"selection F1 {candidate.selection_f1:.4f}")
+            if candidate.held_out_f1 is not None:
+                parts.append(f"held-out F1 {candidate.held_out_f1:.4f}")
+            lines.append(": ".join([parts[0], ", ".join(parts[1:])]) if parts[1:] else parts[0])
+        lines.append("")
+        return lines
 
     def to_markdown(self) -> str:
         """Render a human-readable Markdown digest of the report.
@@ -265,6 +346,8 @@ class FitReport(BaseModel):
         if self.run_ref is not None:
             lines.append(f"- Run: {self.run_ref}")
         lines.append("")
+
+        lines += self._threshold_choice_lines()
 
         lines.append("## Gold coverage (labeled positives kept by blocking)")
         if self.coverage is None:

--- a/tests/core/test_resolver_fit_threshold.py
+++ b/tests/core/test_resolver_fit_threshold.py
@@ -39,6 +39,7 @@ from langres.core.op import ThresholdSelect, TopKSelect
 from langres.core.op_adapters import BlockerSource, ClustererStage, MatcherScore
 from langres.core.resolver import ERModel, Resolver
 from langres.curation.harvest import LabeledPair, align_pairs, warn_if_silver_only
+from langres.training.fit_report import FitReport, ThresholdCandidate, ThresholdFit
 from langres.training.methods_calibrate import Platt
 
 # Ten disconnected groups. Each is one entity-disjoint component: a twin pair
@@ -326,6 +327,35 @@ def test_declined_markdown_says_the_candidate_lost() -> None:
     assert "did not beat it on train" in rendered
     assert "Threshold selection (chosen on train)" in rendered
     assert "KEPT" in rendered
+
+
+def test_markdown_renders_a_partial_threshold_fit() -> None:
+    """``FitReport`` is public and loadable, so its renderer must not need every field.
+
+    ``fit()`` always fills both candidates, but a ``ThresholdFit`` is a plain
+    Pydantic model a caller can build or deserialize with an absent incumbent and
+    no selection score. Rendering must degrade to the rows it has rather than
+    raise on the missing ones.
+    """
+    report = FitReport.build(
+        trainable=None,
+        trained=False,
+        n_train=4,
+        threshold=0.9,
+        threshold_fit=ThresholdFit(
+            source="derived",
+            method="youden",
+            n_pairs=4,
+            applied_to="clusterer",
+            selected_on="train",
+            previous=None,
+            candidate=ThresholdCandidate(threshold=0.9, selection_f1=None, held_out_f1=None),
+        ),
+    )
+    rendered = report.to_markdown()
+    assert "- derived 0.9000 — KEPT" in rendered
+    assert "incumbent" not in rendered
+    assert "selection F1" not in rendered
 
 
 def test_selection_never_reads_the_held_out_split() -> None:

--- a/tests/core/test_resolver_fit_threshold.py
+++ b/tests/core/test_resolver_fit_threshold.py
@@ -1,0 +1,558 @@
+"""Tests for ``fit(derive_threshold=True)`` -- measuring the match cut from labels.
+
+``derive_threshold`` was already wired into the harvest loop
+(``curation/harvest.py``) and the fixed-split pair benchmark
+(``data/fixed_split_pair_benchmark.py``). The gap this closes is narrower: **the
+model's own ``fit()`` never called it**, so a user who supplied labels still
+resolved at whatever constant the constructor set.
+
+Two things get tested here that a single code path would get wrong:
+
+- **Where the threshold lives.** A classic four-slot model keeps it on
+  ``clusterer.threshold``. An explicit ``_ops`` chain has *no clusterer slot at
+  all* -- the property raises ``_require_bound`` -- and keeps the cut in a
+  ``ThresholdSelect``. Before this change ``fit()`` could not run on an ``_ops``
+  model at all (it raises on ``self.module`` first). Both are exercised.
+- **Leakage.** Deriving a cut on the rows you then score is in-sample and
+  flatters the cut. ``test_derived_cut_beats_the_default_on_held_out_pairs``
+  is the honest measurement: the cut comes from ``train`` only and is graded on
+  the entity-disjoint ``valid`` split it never saw.
+
+Everything here is ``$0`` and deterministic -- rapidfuzz over company names, no
+LM calls, no network.
+"""
+
+import sys
+import warnings
+from collections.abc import Iterator, Sequence
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from langres.core.blockers.all_pairs import AllPairsBlocker
+from langres.core.clusterer import Clusterer
+from langres.core.matchers import RapidfuzzMatcher
+from langres.core.metrics import classify_pairs
+from langres.core.models import CompanySchema, ERCandidate, PairwiseJudgement
+from langres.core.op import ThresholdSelect, TopKSelect
+from langres.core.op_adapters import BlockerSource, ClustererStage, MatcherScore
+from langres.core.resolver import ERModel, Resolver
+from langres.curation.harvest import LabeledPair, align_pairs
+from langres.training.methods_calibrate import Platt
+
+# Ten disconnected groups. Each is one entity-disjoint component: a twin pair
+# that matches, plus a HARD negative sharing the leading token ("Acme
+# Corporation" vs "Acme Holdings"). rapidfuzz scores those negatives well above
+# 0.5, so the hand-set default cut is genuinely wrong on this data -- which is
+# what makes a derived cut measurable rather than decorative.
+_GROUPS = [
+    ("acme", "Acme Corporation", "Acme Corporation Ltd", "Acme Holdings"),
+    ("globex", "Globex Incorporated", "Globex Incorporated Co", "Globex Ventures"),
+    ("initech", "Initech Systems", "Initech Systems Ltd", "Initech Capital"),
+    ("umbrella", "Umbrella Holdings", "Umbrella Holdings Inc", "Umbrella Pharma"),
+    ("soylent", "Soylent Industries", "Soylent Industries Co", "Soylent Foods"),
+    ("tyrell", "Tyrell Corporation", "Tyrell Corporation Ltd", "Tyrell Genetics"),
+    ("weyland", "Weyland Systems", "Weyland Systems Inc", "Weyland Mining"),
+    ("stark", "Stark Industries", "Stark Industries Ltd", "Stark Aerospace"),
+    ("oscorp", "Oscorp Laboratories", "Oscorp Laboratories Inc", "Oscorp Realty"),
+    ("nakatomi", "Nakatomi Trading", "Nakatomi Trading Co", "Nakatomi Estates"),
+]
+
+_DEFAULT_THRESHOLD = 0.5
+_SPLIT = 0.4
+_SEED = 0
+
+
+def _dataset() -> tuple[list[dict[str, str]], list[LabeledPair]]:
+    records: list[dict[str, str]] = []
+    pairs: list[LabeledPair] = []
+    for key, twin_a, twin_b, other in _GROUPS:
+        a, b, c = f"{key}1", f"{key}2", f"{key}3"
+        records += [
+            {"id": a, "name": twin_a},
+            {"id": b, "name": twin_b},
+            {"id": c, "name": other},
+        ]
+        pairs += [
+            LabeledPair(left_id=a, right_id=b, score=None, label=True, source="correction"),
+            LabeledPair(left_id=a, right_id=c, score=None, label=False, source="correction"),
+            LabeledPair(left_id=b, right_id=c, score=None, label=False, source="correction"),
+        ]
+    return records, pairs
+
+
+def _matcher() -> RapidfuzzMatcher[Any]:
+    return RapidfuzzMatcher({"name": (lambda entity: entity.name, 1.0)})
+
+
+def _classic(threshold: float = _DEFAULT_THRESHOLD) -> Resolver:
+    """A classic four-slot model: the cut lives on ``clusterer.threshold``."""
+    return Resolver(
+        blocker=AllPairsBlocker(schema=CompanySchema),
+        comparator=None,
+        matcher=_matcher(),
+        clusterer=Clusterer(threshold=threshold),
+    )
+
+
+def _explicit(threshold: float = _DEFAULT_THRESHOLD) -> ERModel:
+    """An explicit Op chain: the cut lives in the terminal ``ThresholdSelect``.
+
+    Its ``ClustererStage`` clusterer is threshold-free (0.0), matching how the
+    shipped research recipes build one, so the ``ThresholdSelect`` is the single
+    match cut rather than one of two gates.
+    """
+    return ERModel.from_topology(
+        ops=[
+            BlockerSource(AllPairsBlocker(schema=CompanySchema)),
+            MatcherScore(_matcher(), out_space="heuristic"),
+            ThresholdSelect(threshold),
+            ClustererStage(Clusterer(threshold=0.0)),
+        ]
+    )
+
+
+class _SupervisedMatcher:
+    """A matcher that implements ``SupervisedFitMixin`` and records its training call.
+
+    Structural typing: no subclassing needed for ``isinstance`` against the
+    runtime-checkable Protocol, so this is deliberately minimal.
+    """
+
+    def __init__(self) -> None:
+        self.fit_calls: list[int] = []
+
+    def fit(
+        self, candidates: Iterator[ERCandidate[Any]], labels: Sequence[bool]
+    ) -> None:
+        self.fit_calls.append(len(list(candidates)))
+
+    def forward(self, candidates: Iterator[ERCandidate[Any]]) -> Iterator[PairwiseJudgement]:
+        for candidate in candidates:
+            left = candidate.left.name
+            right = candidate.right.name
+            shared = len(set(left.split()) & set(right.split()))
+            yield PairwiseJudgement(
+                left_id=candidate.left.id,
+                right_id=candidate.right.id,
+                score=min(1.0, shared / 3.0),
+                score_type="heuristic",
+                decision_step="supervised_stub",
+                provenance={},
+            )
+
+
+# --- The classic seam: clusterer.threshold ----------------------------------
+
+
+def test_derive_threshold_moves_the_classic_cut_off_its_default() -> None:
+    """A derived cut replaces the constructor's constant on ``clusterer.threshold``."""
+    records, pairs = _dataset()
+    model = _classic()
+
+    model.fit(records, pairs=pairs, split=_SPLIT, seed=_SEED, derive_threshold=True)
+
+    assert model.clusterer.threshold != _DEFAULT_THRESHOLD
+    assert 0.0 <= model.clusterer.threshold <= 1.0
+
+
+def test_report_records_derived_provenance_for_the_classic_seam() -> None:
+    """``threshold_fit`` says derived, by what, from how many, held-out, and where."""
+    records, pairs = _dataset()
+    model = _classic()
+
+    model.fit(records, pairs=pairs, split=_SPLIT, seed=_SEED, derive_threshold=True)
+    report = model.fit_report_
+    assert report is not None and report.threshold_fit is not None
+    fit = report.threshold_fit
+
+    assert fit.source == "derived"
+    assert fit.method == "youden"
+    assert fit.n_pairs == report.n_train
+    assert fit.held_out is True
+    assert fit.applied_to == "clusterer"
+    assert fit.previous == _DEFAULT_THRESHOLD
+    assert report.threshold == model.clusterer.threshold
+
+
+def test_default_leaves_the_threshold_untouched_and_says_so() -> None:
+    """``derive_threshold=False`` (the default) is a no-op the report still reports.
+
+    The constructed threshold is the correct no-data fallback; what would be
+    wrong is letting a reader mistake it for a measurement.
+    """
+    records, pairs = _dataset()
+    model = _classic()
+
+    # A fixed scorer needs derive_threshold=True to accept pairs= at all, so the
+    # honest "not derived" case is read off a supervised matcher.
+    supervised = Resolver(
+        blocker=AllPairsBlocker(schema=CompanySchema),
+        comparator=None,
+        matcher=_SupervisedMatcher(),  # type: ignore[arg-type]
+        clusterer=Clusterer(threshold=_DEFAULT_THRESHOLD),
+    )
+    supervised.fit(records, pairs=pairs, split=_SPLIT, seed=_SEED)
+
+    assert supervised.clusterer.threshold == _DEFAULT_THRESHOLD
+    assert supervised.fit_report_ is not None
+    assert supervised.fit_report_.threshold_fit is not None
+    assert supervised.fit_report_.threshold_fit.source == "default"
+    assert supervised.fit_report_.threshold_fit.n_pairs == 0
+    assert model.clusterer.threshold == _DEFAULT_THRESHOLD  # untouched, never fitted
+
+
+# --- Leakage: the number that matters is the one the cut never saw ----------
+
+
+def test_derived_cut_beats_the_default_on_held_out_pairs() -> None:
+    """The measured claim, held-out: derived on ``train``, graded on ``valid``.
+
+    The cut is derived from the train split ONLY and applied before valid is
+    graded, so this comparison contains no in-sample leakage. On this fixture the
+    hand-set 0.5 admits the hard negatives; the derived cut excludes them.
+    """
+    records, pairs = _dataset()
+    model = _classic()
+
+    model.fit(records, pairs=pairs, split=_SPLIT, seed=_SEED, derive_threshold=True)
+    derived_cut = model.clusterer.threshold
+
+    # Rebuild the exact same deterministic split and score it at both cuts.
+    reference = _classic()
+    aligned = align_pairs(reference.candidates(records), pairs, split=_SPLIT, seed=_SEED)
+    assert aligned.valid.candidates, "fixture must produce a non-empty held-out split"
+    judgements = list(reference._scorer().forward(iter(aligned.valid.candidates)))
+    gold = {
+        frozenset({str(c.left.id), str(c.right.id)})
+        for c, label in zip(aligned.valid.candidates, aligned.valid.labels, strict=True)
+        if label
+    }
+
+    before = classify_pairs(judgements, gold, _DEFAULT_THRESHOLD)
+    after = classify_pairs(judgements, gold, derived_cut)
+
+    assert after.f1 > before.f1
+    # The report's own held-out metrics ARE the after-cut number, not a
+    # separately computed one.
+    assert model.fit_report_ is not None and model.fit_report_.metrics is not None
+    assert model.fit_report_.metrics.f1 == pytest.approx(after.f1)
+    assert model.fit_report_.metrics.threshold == pytest.approx(derived_cut)
+
+
+def test_without_a_split_the_cut_is_in_sample_and_no_metrics_are_reported() -> None:
+    """No ``split`` -> the cut is derived honestly, flagged IN-SAMPLE, and ungraded.
+
+    Reporting P/R/F1 on the same rows the cut came from would manufacture a large
+    fake improvement; refusing to compute it is the point.
+    """
+    records, pairs = _dataset()
+    model = _classic()
+
+    model.fit(records, pairs=pairs, split=None, derive_threshold=True)
+    report = model.fit_report_
+    assert report is not None and report.threshold_fit is not None
+
+    assert report.threshold_fit.source == "derived"
+    assert report.threshold_fit.held_out is False
+    assert report.metrics is None
+    assert "IN-SAMPLE" in report.to_markdown()
+
+
+def test_markdown_never_shows_a_bare_number_for_a_derived_or_default_cut() -> None:
+    """The rendered threshold carries its provenance in the same line."""
+    records, pairs = _dataset()
+    model = _classic()
+    model.fit(records, pairs=pairs, split=_SPLIT, seed=_SEED, derive_threshold=True)
+    assert model.fit_report_ is not None
+    line = next(
+        row for row in model.fit_report_.to_markdown().splitlines() if row.startswith("- Threshold")
+    )
+    assert "derived" in line and "youden" in line and "held-out" in line
+
+
+# --- The explicit _ops seam: ThresholdSelect --------------------------------
+
+
+def test_derive_threshold_writes_the_chains_threshold_select() -> None:
+    """An explicit chain has no clusterer slot; the cut is its ``ThresholdSelect``."""
+    records, pairs = _dataset()
+    model = _explicit()
+
+    model.fit(records, pairs=pairs, split=_SPLIT, seed=_SEED, derive_threshold=True)
+
+    assert model._chain_threshold() != _DEFAULT_THRESHOLD
+    assert model.fit_report_ is not None and model.fit_report_.threshold_fit is not None
+    assert model.fit_report_.threshold_fit.applied_to == "threshold_select"
+    assert model.fit_report_.threshold_fit.previous == _DEFAULT_THRESHOLD
+    # The seam a classic model uses still raises here -- which is exactly why a
+    # single code path would have been wrong.
+    with pytest.raises(RuntimeError, match="explicit, slot-neutral Op topology"):
+        _ = model.clusterer
+
+
+def test_explicit_chain_derivation_sees_rows_below_the_current_cut() -> None:
+    """Derivation runs the chain with the fitted ``ThresholdSelect`` omitted.
+
+    Deriving from ``_scored_pairs`` instead would only ever see rows that already
+    cleared today's cut, so the "derived" threshold could not move below it. Start
+    from a cut high enough to delete every row and check the fit still recovers a
+    lower one.
+    """
+    records, pairs = _dataset()
+    model = _explicit(threshold=0.99)
+    assert model._prethreshold_pairs(records).rows, "the pre-cut pass must keep rows"
+
+    model.fit(records, pairs=pairs, split=_SPLIT, seed=_SEED, derive_threshold=True)
+
+    assert model._chain_threshold() is not None
+    assert model._chain_threshold() < 0.99
+
+
+def test_explicit_chain_keeps_upstream_selects_when_deriving() -> None:
+    """Only the fitted ThresholdSelect is omitted -- an upstream TopKSelect still runs."""
+    records, _ = _dataset()
+    model = ERModel.from_topology(
+        ops=[
+            BlockerSource(AllPairsBlocker(schema=CompanySchema)),
+            MatcherScore(_matcher(), out_space="heuristic"),
+            TopKSelect(1),
+            ThresholdSelect(_DEFAULT_THRESHOLD),
+            ClustererStage(Clusterer(threshold=0.0)),
+        ]
+    )
+    rows = model._prethreshold_pairs(records).rows
+    by_left: dict[str, int] = {}
+    for row in rows:
+        by_left[row.left_id] = by_left.get(row.left_id, 0) + 1
+    assert by_left and max(by_left.values()) == 1
+
+
+def test_explicit_chain_fit_without_derive_threshold_raises_a_directed_error() -> None:
+    """``fit()`` on an Op chain says what it CAN fit instead of failing obscurely."""
+    records, pairs = _dataset()
+    with pytest.raises(ValueError, match="can only fit the chain's ThresholdSelect"):
+        _explicit().fit(records, pairs=pairs)
+
+
+def test_explicit_chain_without_a_threshold_select_refuses_to_derive() -> None:
+    """No cut to write -> raise, rather than derive a number and drop it."""
+    records, pairs = _dataset()
+    model = ERModel.from_topology(
+        ops=[
+            BlockerSource(AllPairsBlocker(schema=CompanySchema)),
+            MatcherScore(_matcher(), out_space="heuristic"),
+            ClustererStage(Clusterer(threshold=0.0)),
+        ]
+    )
+    with pytest.raises(ValueError, match="contains no ThresholdSelect"):
+        model.fit(records, pairs=pairs, split=_SPLIT, seed=_SEED, derive_threshold=True)
+
+
+def test_threshold_seam_reports_where_each_topology_keeps_its_cut() -> None:
+    """The reader half of the seam, so a caller need not branch on ``_ops`` itself."""
+    assert _classic()._threshold_seam() == "clusterer"
+    assert _classic()._match_threshold() == _DEFAULT_THRESHOLD
+    assert _explicit()._threshold_seam() == "threshold_select"
+    assert _explicit()._match_threshold() == _DEFAULT_THRESHOLD
+
+
+def test_set_match_threshold_refuses_an_unbound_model() -> None:
+    """Writing nowhere and returning would be the silent no-op the seam prevents."""
+    model = ERModel.__new__(ERModel)
+    model._init_state(budget_usd=None)
+    assert model._threshold_seam() is None
+    with pytest.raises(RuntimeError, match="not bound to a schema"):
+        model._set_match_threshold(0.7)
+
+
+# --- Which matchers may fit a threshold -------------------------------------
+
+
+def test_a_matcher_with_no_fit_hook_can_still_fit_its_threshold() -> None:
+    """The case that matters most: a fixed scorer has nothing else to fit.
+
+    ``fit(pairs=...)`` alone still refuses it (unchanged), because without
+    ``derive_threshold`` there genuinely is nothing to do with those labels.
+    """
+    records, pairs = _dataset()
+    with pytest.raises(ValueError, match="does not support fit\\(pairs=\\.\\.\\.\\)"):
+        _classic().fit(records, pairs=pairs)
+
+    model = _classic()
+    model.fit(records, pairs=pairs, split=_SPLIT, seed=_SEED, derive_threshold=True)
+    report = model.fit_report_
+    assert report is not None and report.threshold_fit is not None
+    # ``trained`` keeps its meaning -- "a matcher fit hook ran" -- and no hook
+    # ran here. The derived cut is reported by ``threshold_fit``, not by lying.
+    assert report.trained is False
+    assert report.trainable is not None and "threshold only" in report.trainable
+    assert report.threshold_fit.source == "derived"
+
+
+def test_a_supervised_matcher_trains_and_derives_in_one_fit() -> None:
+    """Deriving does not displace the matcher fit hook; both run, hook first."""
+    records, pairs = _dataset()
+    matcher = _SupervisedMatcher()
+    model = Resolver(
+        blocker=AllPairsBlocker(schema=CompanySchema),
+        comparator=None,
+        matcher=matcher,  # type: ignore[arg-type]
+        clusterer=Clusterer(threshold=_DEFAULT_THRESHOLD),
+    )
+
+    model.fit(records, pairs=pairs, split=_SPLIT, seed=_SEED, derive_threshold=True)
+
+    assert matcher.fit_calls, "the supervised hook must still run"
+    assert model.fit_report_ is not None
+    assert model.fit_report_.trained is True
+    assert model.fit_report_.trainable == "_SupervisedMatcher (SupervisedFitMixin)"
+    assert model.fit_report_.threshold_fit is not None
+    assert model.fit_report_.threshold_fit.source == "derived"
+
+
+def test_resolve_actually_uses_the_derived_cut() -> None:
+    """End to end: the derived threshold changes what ``resolve()`` merges.
+
+    At 0.5 the hard negatives merge into their twins' clusters; at the derived cut
+    they do not.
+    """
+    records, pairs = _dataset()
+    before = _classic().resolve(records)
+
+    model = _classic()
+    model.fit(records, pairs=pairs, split=_SPLIT, seed=_SEED, derive_threshold=True)
+    after = model.resolve(records)
+
+    assert before != after
+    assert all(len(cluster) == 2 for cluster in after)
+
+
+# --- Guards ------------------------------------------------------------------
+
+
+def test_derive_threshold_requires_pairs_not_labels() -> None:
+    """``labels=`` carries no split, so it could only ever give an in-sample cut."""
+    records, _ = _dataset()
+    with pytest.raises(ValueError, match="needs pairs="):
+        _classic().fit(records, derive_threshold=True)
+    with pytest.raises(ValueError, match="needs pairs="):
+        _classic().fit(records, labels=[True], derive_threshold=True)
+
+
+def test_derive_threshold_is_refused_alongside_method() -> None:
+    """A ``method=`` fit owns its own report -- and calibrate changes the scale."""
+    records, pairs = _dataset()
+    with pytest.raises(ValueError, match="not supported"):
+        _classic().fit(records, pairs=pairs, method=Platt(), derive_threshold=True)
+
+
+def test_silver_only_labels_still_warn_on_the_fit_path() -> None:
+    """The circularity guard survives the trip through ``fit``.
+
+    ``fit`` restamps its labeled pairs as gold before handing them to
+    ``derive_threshold_from_pairs`` (they were asserted by the caller, not read
+    off the judge's verdicts), which would otherwise silently suppress the
+    silver-only warning -- so ``fit`` checks the raw input itself.
+    """
+    records, pairs = _dataset()
+    silver = [pair.model_copy(update={"source": "verdict"}) for pair in pairs]
+    with pytest.warns(UserWarning, match="silver-only calibration is circular"):
+        _classic().fit(records, pairs=silver, split=_SPLIT, seed=_SEED, derive_threshold=True)
+
+
+def test_gold_labels_do_not_trigger_the_silver_warning() -> None:
+    """Caller-asserted labels are not the judge's own verdicts."""
+    records, pairs = _dataset()
+    with warnings.catch_warnings():
+        warnings.simplefilter("error", UserWarning)
+        _classic().fit(records, pairs=pairs, split=_SPLIT, seed=_SEED, derive_threshold=True)
+
+
+def test_missing_sklearn_raises_a_directed_error_and_never_falls_back(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A core-only install must fail loudly, not silently keep the default cut.
+
+    ``training.calibration`` imports scikit-learn at MODULE scope, so on a
+    core-only install the failure is an ImportError at that import, not a
+    numerical one later. ``None`` in ``sys.modules`` reproduces exactly that.
+    """
+    records, pairs = _dataset()
+    model = _classic()
+    monkeypatch.setitem(sys.modules, "langres.training.calibration", None)
+
+    with pytest.raises(ImportError) as excinfo:
+        model.fit(records, pairs=pairs, split=_SPLIT, seed=_SEED, derive_threshold=True)
+
+    message = str(excinfo.value)
+    assert "scikit-learn" in message  # problem
+    assert "'trained' extra" in message  # cause
+    assert "pip install 'langres[trained]'" in message  # fix
+    # No silent fallback: the threshold is exactly what it was.
+    assert model.clusterer.threshold == _DEFAULT_THRESHOLD
+
+
+# --- Score scale --------------------------------------------------------------
+
+
+def test_derivation_uses_the_calibrated_scale_when_a_calibrator_is_fitted() -> None:
+    """``resolve()`` thresholds calibrated scores, so the cut must be derived on them.
+
+    Deriving from raw matcher scores would place the cut on a different scale than
+    the one it is later compared against.
+    """
+    pytest.importorskip("sklearn", reason="requires the [trained] extra")
+    records, pairs = _dataset()
+    model = _classic()
+    model.fit(records, pairs=pairs, split=_SPLIT, seed=_SEED, method=Platt())
+    assert model.calibrator is not None
+
+    raw = [j.score for j in model._scorer().forward(iter(model.candidates(records)))]
+    calibrated = model._cut_scale_scores(
+        list(model._scorer().forward(iter(model.candidates(records))))
+    )
+    assert calibrated != raw
+
+    model.fit(records, pairs=pairs, split=_SPLIT, seed=_SEED, derive_threshold=True)
+    derived = model.clusterer.threshold
+    assert min(s for s in calibrated if s is not None) <= derived
+    assert derived <= max(s for s in calibrated if s is not None)
+
+
+def test_cut_scale_scores_passes_through_without_a_calibrator() -> None:
+    """No calibrator -> the raw judgement scores are already the cut's scale."""
+    records, _ = _dataset()
+    model = _classic()
+    judgements = list(model._scorer().forward(iter(model.candidates(records))))
+    assert model._cut_scale_scores(judgements) == [j.score for j in judgements]
+
+
+def test_cut_scale_scores_keeps_missing_judgements_as_none() -> None:
+    """A candidate the matcher returned nothing for stays ``None``, never a fake 0.0."""
+    assert _classic()._cut_scale_scores([None]) == [None]
+
+
+# --- Persistence: what survives, and what does not ---------------------------
+
+
+def test_the_derived_threshold_survives_save_load_but_its_provenance_does_not(
+    tmp_path: Path,
+) -> None:
+    """The value is model state; the provenance is a fit-time artifact.
+
+    ``fit_report_`` is deliberately never serialized, so a reloaded model carries
+    a measured cut with no record that it was measured. Stated here rather than
+    left undefined.
+    """
+    records, pairs = _dataset()
+    model = _classic()
+    model.fit(records, pairs=pairs, split=_SPLIT, seed=_SEED, derive_threshold=True)
+    derived = model.clusterer.threshold
+
+    model.save(tmp_path / "model")
+    reloaded = Resolver.load(tmp_path / "model")
+
+    assert reloaded.clusterer.threshold == derived
+    assert reloaded.fit_report_ is None

--- a/tests/core/test_resolver_fit_threshold.py
+++ b/tests/core/test_resolver_fit_threshold.py
@@ -38,7 +38,7 @@ from langres.core.models import CompanySchema, ERCandidate, PairwiseJudgement
 from langres.core.op import ThresholdSelect, TopKSelect
 from langres.core.op_adapters import BlockerSource, ClustererStage, MatcherScore
 from langres.core.resolver import ERModel, Resolver
-from langres.curation.harvest import LabeledPair, align_pairs
+from langres.curation.harvest import LabeledPair, align_pairs, warn_if_silver_only
 from langres.training.methods_calibrate import Platt
 
 # Ten disconnected groups. Each is one entity-disjoint component: a twin pair
@@ -367,6 +367,42 @@ def test_set_match_threshold_refuses_an_unbound_model() -> None:
         model._set_match_threshold(0.7)
 
 
+def test_set_match_threshold_refuses_a_chain_with_no_threshold_select() -> None:
+    """Same guard on the other seam: an Op chain with no cut has nowhere to write."""
+    model = ERModel.from_topology(
+        ops=[
+            BlockerSource(AllPairsBlocker(schema=CompanySchema)),
+            MatcherScore(_matcher(), out_space="heuristic"),
+            ClustererStage(Clusterer(threshold=0.0)),
+        ]
+    )
+    assert model._threshold_seam() is None
+    assert model._match_threshold() is None
+    with pytest.raises(RuntimeError, match="contains no ThresholdSelect"):
+        model._set_match_threshold(0.7)
+
+
+def test_set_match_threshold_writes_the_last_threshold_select() -> None:
+    """Reader and writer agree on WHICH select owns the cut when a chain has two."""
+    first, last = ThresholdSelect(0.1), ThresholdSelect(0.2)
+    model = ERModel.from_topology(
+        ops=[
+            BlockerSource(AllPairsBlocker(schema=CompanySchema)),
+            MatcherScore(_matcher(), out_space="heuristic"),
+            first,
+            last,
+            ClustererStage(Clusterer(threshold=0.0)),
+        ]
+    )
+    assert model._match_threshold() == 0.2
+
+    model._set_match_threshold(0.75)
+
+    assert last.threshold == 0.75
+    assert first.threshold == 0.1
+    assert model._match_threshold() == 0.75
+
+
 # --- Which matchers may fit a threshold -------------------------------------
 
 
@@ -470,6 +506,21 @@ def test_gold_labels_do_not_trigger_the_silver_warning() -> None:
         _classic().fit(records, pairs=pairs, split=_SPLIT, seed=_SEED, derive_threshold=True)
 
 
+@pytest.mark.parametrize(
+    "supplied",
+    [
+        pytest.param("corrections.jsonl", id="path-str"),
+        pytest.param(Path("corrections.jsonl"), id="path-object"),
+        pytest.param([], id="empty"),
+    ],
+)
+def test_silver_guard_ignores_inputs_that_carry_no_source(supplied: Any) -> None:
+    """Only ``LabeledPair`` carries ``source``; a file or a Correction has no silver case."""
+    with warnings.catch_warnings():
+        warnings.simplefilter("error", UserWarning)
+        warn_if_silver_only(supplied)
+
+
 def test_missing_sklearn_raises_a_directed_error_and_never_falls_back(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -532,6 +583,28 @@ def test_cut_scale_scores_passes_through_without_a_calibrator() -> None:
 def test_cut_scale_scores_keeps_missing_judgements_as_none() -> None:
     """A candidate the matcher returned nothing for stays ``None``, never a fake 0.0."""
     assert _classic()._cut_scale_scores([None]) == [None]
+
+
+def test_held_out_metrics_are_graded_on_the_same_scale_as_the_derived_cut() -> None:
+    """A calibrator moves the scale; the cut and the grader must move together.
+
+    Grading raw scores against a cut derived on calibrated ones compares two
+    different scales and reports a number that looks fine and means nothing.
+    """
+    pytest.importorskip("sklearn", reason="requires the [trained] extra")
+    records, pairs = _dataset()
+    model = _classic()
+    model.fit(records, pairs=pairs, split=_SPLIT, seed=_SEED, method=Platt())
+    model.fit(records, pairs=pairs, split=_SPLIT, seed=_SEED, derive_threshold=True)
+
+    assert model.fit_report_ is not None and model.fit_report_.metrics is not None
+    assert model.fit_report_.metrics.threshold == pytest.approx(model.clusterer.threshold)
+
+    raw = list(model._scorer().forward(iter(model.candidates(records))))
+    rescaled = model._on_cut_scale(raw)
+    # Copies, on the calibrated scale -- the caller's judgements are untouched.
+    assert [j.score for j in rescaled] != [j.score for j in raw]
+    assert [j.left_id for j in rescaled] == [j.left_id for j in raw]
 
 
 # --- Persistence: what survives, and what does not ---------------------------

--- a/tests/core/test_resolver_fit_threshold.py
+++ b/tests/core/test_resolver_fit_threshold.py
@@ -59,15 +59,39 @@ _GROUPS = [
     ("nakatomi", "Nakatomi Trading", "Nakatomi Trading Co", "Nakatomi Estates"),
 ]
 
+# The fixture where deriving a cut makes things WORSE, and the reason the fit
+# races the candidate instead of trusting it. Negatives share nothing, so 0.5
+# already separates perfectly; the twins are abbreviations ("Acme Corporation" /
+# "Acme Corp"), so they score in a wide band well above the negatives. Youden's J
+# maximizes tpr - fpr, which ties across that whole gap, and returns a cut high
+# enough to drop a genuine twin. MEASURED at seeds 0/1/4/5: train F1 ties at
+# 1.0000 while held-out pair-F1 would go 1.0000 -> 0.8000.
+_SEPARATED_GROUPS = [
+    ("acme", "Acme Corporation", "Acme Corp", "Zenith Trading"),
+    ("globex", "Globex Incorporated", "Globex Inc", "Wayland Foods"),
+    ("initech", "Initech LLC", "Initech L.L.C.", "Praxis Mining"),
+    ("umbrella", "Umbrella Holdings", "Umbrella Holding Co", "Delos Media"),
+    ("soylent", "Soylent Industries", "Soylent Ind", "Kwik-E Retail"),
+    ("tyrell", "Tyrell Corporation", "Tyrell Corp", "Nakatomi Realty"),
+    ("weyland", "Weyland Yutani Ltd", "Weyland-Yutani Limited", "Cyberdyne Systems"),
+    ("stark", "Stark Industries Inc", "Stark Industries", "Oscorp Labs"),
+]
+
 _DEFAULT_THRESHOLD = 0.5
 _SPLIT = 0.4
 _SEED = 0
 
 
-def _dataset() -> tuple[list[dict[str, str]], list[LabeledPair]]:
+def _dataset(
+    groups: list[tuple[str, str, str, str]] | None = None,
+) -> tuple[list[dict[str, str]], list[LabeledPair]]:
+    """Records + id-keyed labels. ``_GROUPS`` adds a second negative; the
+    separated fixture deliberately does not (it is reproduced exactly as the
+    regression was measured)."""
+    chosen = groups or _GROUPS
     records: list[dict[str, str]] = []
     pairs: list[LabeledPair] = []
-    for key, twin_a, twin_b, other in _GROUPS:
+    for key, twin_a, twin_b, other in chosen:
         a, b, c = f"{key}1", f"{key}2", f"{key}3"
         records += [
             {"id": a, "name": twin_a},
@@ -77,8 +101,11 @@ def _dataset() -> tuple[list[dict[str, str]], list[LabeledPair]]:
         pairs += [
             LabeledPair(left_id=a, right_id=b, score=None, label=True, source="correction"),
             LabeledPair(left_id=a, right_id=c, score=None, label=False, source="correction"),
-            LabeledPair(left_id=b, right_id=c, score=None, label=False, source="correction"),
         ]
+        if chosen is _GROUPS:
+            pairs.append(
+                LabeledPair(left_id=b, right_id=c, score=None, label=False, source="correction")
+            )
     return records, pairs
 
 
@@ -123,9 +150,7 @@ class _SupervisedMatcher:
     def __init__(self) -> None:
         self.fit_calls: list[int] = []
 
-    def fit(
-        self, candidates: Iterator[ERCandidate[Any]], labels: Sequence[bool]
-    ) -> None:
+    def fit(self, candidates: Iterator[ERCandidate[Any]], labels: Sequence[bool]) -> None:
         self.fit_calls.append(len(list(candidates)))
 
     def forward(self, candidates: Iterator[ERCandidate[Any]]) -> Iterator[PairwiseJudgement]:
@@ -172,7 +197,9 @@ def test_report_records_derived_provenance_for_the_classic_seam() -> None:
     assert fit.n_pairs == report.n_train
     assert fit.held_out is True
     assert fit.applied_to == "clusterer"
-    assert fit.previous == _DEFAULT_THRESHOLD
+    assert fit.selected_on == "train"
+    assert fit.previous is not None and fit.previous.threshold == _DEFAULT_THRESHOLD
+    assert fit.candidate is not None and fit.candidate.threshold == model.clusterer.threshold
     assert report.threshold == model.clusterer.threshold
 
 
@@ -241,6 +268,85 @@ def test_derived_cut_beats_the_default_on_held_out_pairs() -> None:
     assert model.fit_report_.metrics.threshold == pytest.approx(derived_cut)
 
 
+def test_a_derived_cut_that_ties_on_train_is_declined_not_applied() -> None:
+    """Deriving is not keeping, and a tie is not evidence.
+
+    Youden's J maximizes ``tpr - fpr``, which is flat across a wide separating
+    gap, so on this fixture it returns a cut that ties the incumbent on train.
+    Strictly-better wins; a tie keeps the incumbent and writes nothing.
+    """
+    records, pairs = _dataset(_SEPARATED_GROUPS)
+    model = _classic()
+
+    model.fit(records, pairs=pairs, split=_SPLIT, seed=_SEED, derive_threshold=True)
+    fit = model.fit_report_.threshold_fit if model.fit_report_ else None
+    assert fit is not None and fit.previous is not None and fit.candidate is not None
+
+    assert fit.source == "declined"
+    assert model.clusterer.threshold == _DEFAULT_THRESHOLD  # untouched
+    assert fit.applied_to is None  # nothing was written, so claim nothing
+    # The rejected candidate is still reported -- evidence, not noise.
+    assert fit.candidate.threshold != _DEFAULT_THRESHOLD
+    assert fit.candidate.selection_f1 == fit.previous.selection_f1 == 1.0
+
+
+@pytest.mark.parametrize("seed", [0, 1, 4, 5])
+def test_declining_prevents_a_real_held_out_regression(seed: int) -> None:
+    """The measurement that justifies the race, not a hypothetical.
+
+    On these seeds the derived cut ties on train (so nothing on the selection
+    split warns you) and is genuinely **worse** held-out: pair-F1 1.0000 vs
+    0.8000. Applying it unconditionally -- which is what this fit did before the
+    race was added -- would have shipped that regression as an improvement.
+
+    Both numbers are clean estimates: selection ran on ``train``, so ``valid``
+    was never tuned against.
+    """
+    records, pairs = _dataset(_SEPARATED_GROUPS)
+    model = _classic()
+    model.fit(records, pairs=pairs, split=_SPLIT, seed=seed, derive_threshold=True)
+    fit = model.fit_report_.threshold_fit if model.fit_report_ else None
+    assert fit is not None and fit.previous is not None and fit.candidate is not None
+    assert fit.previous.held_out_f1 == 1.0
+    assert fit.candidate.held_out_f1 == 0.8
+
+    assert fit.source == "declined"
+    assert model.clusterer.threshold == _DEFAULT_THRESHOLD
+    assert model.fit_report_ is not None and model.fit_report_.metrics is not None
+    assert model.fit_report_.metrics.f1 == pytest.approx(fit.previous.held_out_f1)
+
+
+def test_declined_markdown_says_the_candidate_lost() -> None:
+    """A reader must not mistake 'declined' for 'never tried'."""
+    records, pairs = _dataset(_SEPARATED_GROUPS)
+    model = _classic()
+    model.fit(records, pairs=pairs, split=_SPLIT, seed=_SEED, derive_threshold=True)
+    assert model.fit_report_ is not None
+    rendered = model.fit_report_.to_markdown()
+    assert "did not beat it on train" in rendered
+    assert "Threshold selection (chosen on train)" in rendered
+    assert "KEPT" in rendered
+
+
+def test_selection_never_reads_the_held_out_split() -> None:
+    """The clean-estimate guarantee: valid changes nothing about which cut wins.
+
+    Re-fitting with a different ``seed`` reshuffles which entity components land
+    in valid. If selection touched valid, the chosen threshold could move with
+    it. It must not: the race runs on train.
+    """
+    records, pairs = _dataset()
+
+    def _cut(seed: int) -> float:
+        model = _classic()
+        model.fit(records, pairs=pairs, split=None, seed=seed, derive_threshold=True)
+        return model.clusterer.threshold
+
+    # With split=None every labeled pair is train, so the seed cannot change the
+    # selection set -- and therefore cannot change the chosen cut.
+    assert _cut(0) == _cut(7) == _cut(99)
+
+
 def test_without_a_split_the_cut_is_in_sample_and_no_metrics_are_reported() -> None:
     """No ``split`` -> the cut is derived honestly, flagged IN-SAMPLE, and ungraded.
 
@@ -285,7 +391,8 @@ def test_derive_threshold_writes_the_chains_threshold_select() -> None:
     assert model._chain_threshold() != _DEFAULT_THRESHOLD
     assert model.fit_report_ is not None and model.fit_report_.threshold_fit is not None
     assert model.fit_report_.threshold_fit.applied_to == "threshold_select"
-    assert model.fit_report_.threshold_fit.previous == _DEFAULT_THRESHOLD
+    previous = model.fit_report_.threshold_fit.previous
+    assert previous is not None and previous.threshold == _DEFAULT_THRESHOLD
     # The seam a classic model uses still raises here -- which is exactly why a
     # single code path would have been wrong.
     with pytest.raises(RuntimeError, match="explicit, slot-neutral Op topology"):
@@ -444,8 +551,12 @@ def test_a_supervised_matcher_trains_and_derives_in_one_fit() -> None:
     assert model.fit_report_ is not None
     assert model.fit_report_.trained is True
     assert model.fit_report_.trainable == "_SupervisedMatcher (SupervisedFitMixin)"
-    assert model.fit_report_.threshold_fit is not None
-    assert model.fit_report_.threshold_fit.source == "derived"
+    fit = model.fit_report_.threshold_fit
+    assert fit is not None
+    # A threshold fit ran; whether it KEPT the candidate is the selection's call,
+    # not this test's business (see the decline tests below).
+    assert fit.source in {"derived", "declined"}
+    assert fit.selected_on == "train" and fit.candidate is not None
 
 
 def test_resolve_actually_uses_the_derived_cut() -> None:

--- a/tests/core/test_resolver_fit_threshold.py
+++ b/tests/core/test_resolver_fit_threshold.py
@@ -799,18 +799,25 @@ def test_a_chain_that_gates_twice_refuses_to_derive() -> None:
     everything between them yields a held-out "improvement" that never reaches
     ``resolve()``. The shipped research recipes build the stage threshold-free for
     this reason; a chain that does not is refused rather than half-fitted.
+
+    Like the no-``ThresholdSelect`` refusal, this is decidable from the topology
+    alone, so it must be decided **before** the scoring pass -- a guard below it
+    would bill a paid chain and only then refuse. The counter is what observes
+    that; asserting the exception alone would pass either way.
     """
     records, pairs = _dataset()
+    counting = _CountingMatcher()
     model = ERModel.from_topology(
         ops=[
             BlockerSource(AllPairsBlocker(schema=CompanySchema)),
-            MatcherScore(_matcher(), out_space="heuristic"),
+            MatcherScore(counting, out_space="heuristic"),
             ThresholdSelect(0.9),
             ClustererStage(Clusterer(threshold=0.9)),
         ]
     )
     with pytest.raises(ValueError, match="gates twice"):
         model.fit(records, pairs=pairs, split=_SPLIT, seed=_SEED, derive_threshold=True)
+    assert counting.calls == 0
 
 
 def test_threshold_seam_reports_where_each_topology_keeps_its_cut() -> None:

--- a/tests/core/test_resolver_fit_threshold.py
+++ b/tests/core/test_resolver_fit_threshold.py
@@ -35,8 +35,9 @@ from langres.core.clusterer import Clusterer
 from langres.core.matchers import RapidfuzzMatcher
 from langres.core.metrics import classify_pairs
 from langres.core.models import CompanySchema, ERCandidate, PairwiseJudgement
-from langres.core.op import ThresholdSelect, TopKSelect
+from langres.core.op import ClusterStage, ThresholdSelect, TopKSelect
 from langres.core.op_adapters import BlockerSource, ClustererStage, MatcherScore
+from langres.core.pairs import Pairs
 from langres.core.resolver import ERModel, Resolver
 from langres.curation.harvest import LabeledPair, align_pairs, warn_if_silver_only
 from langres.training.fit_report import FitReport, ThresholdCandidate, ThresholdFit
@@ -736,6 +737,36 @@ def test_a_score_less_chain_refuses_to_derive() -> None:
     )
     with pytest.raises(ValueError, match="no judge score"):
         model.fit(records, pairs=pairs, split=_SPLIT, seed=_SEED, derive_threshold=True)
+
+
+def test_a_custom_cluster_stage_has_no_second_gate_to_conflict_with() -> None:
+    """The double-gate refusal must not fire on a stage that carries no threshold.
+
+    ``ClusterStage`` is a public topology contract; only the ``ClustererStage``
+    adapter wraps a legacy ``Clusterer`` and its threshold. A custom stage has no
+    independent cut, so absence reads as "no second gate", not "unknown" -- and
+    reading the attribute off the contract rather than the adapter would have
+    been an ``AttributeError`` here.
+    """
+
+    class _PairwiseStage(ClusterStage[Any]):
+        """Minimal custom stage: one cluster per surviving pair, no threshold."""
+
+        def forward(self, pairs: Pairs[Any]) -> list[set[str]]:
+            return [{row.left_id, row.right_id} for row in pairs.rows]
+
+    records, pairs = _dataset()
+    model = ERModel.from_topology(
+        ops=[
+            BlockerSource(AllPairsBlocker(schema=CompanySchema)),
+            MatcherScore(_matcher(), out_space="heuristic"),
+            ThresholdSelect(_DEFAULT_THRESHOLD),
+            _PairwiseStage(),
+        ]
+    )
+    model.fit(records, pairs=pairs, split=_SPLIT, seed=_SEED, derive_threshold=True)
+    assert model.fit_report_ is not None and model.fit_report_.threshold_fit is not None
+    assert model.fit_report_.threshold_fit.source == "derived"
 
 
 def test_a_chain_that_gates_twice_refuses_to_derive() -> None:

--- a/tests/core/test_resolver_fit_threshold.py
+++ b/tests/core/test_resolver_fit_threshold.py
@@ -739,6 +739,27 @@ def test_a_score_less_chain_refuses_to_derive() -> None:
         model.fit(records, pairs=pairs, split=_SPLIT, seed=_SEED, derive_threshold=True)
 
 
+def test_an_explicit_chain_without_a_split_says_in_sample() -> None:
+    """The chain seam owes the same honesty as the classic one when there is no valid.
+
+    With ``split=None`` every labeled pair is train, so the cut and any score
+    would share rows. The fit still runs -- a measured cut beats an unmeasured
+    one -- but it must report no held-out metrics and label itself IN-SAMPLE in
+    capitals rather than let an in-sample number pass for a held-out estimate.
+    """
+    records, pairs = _dataset()
+    model = _explicit()
+    model.fit(records, pairs=pairs, split=None, seed=_SEED, derive_threshold=True)
+    report = model.fit_report_
+    assert report is not None and report.threshold_fit is not None
+    assert report.threshold_fit.source == "derived"
+    assert report.threshold_fit.held_out is False
+    assert report.threshold_fit.candidate is not None
+    assert report.threshold_fit.candidate.held_out_f1 is None
+    assert report.metrics is None
+    assert "IN-SAMPLE" in report.to_markdown()
+
+
 def test_a_custom_cluster_stage_has_no_second_gate_to_conflict_with() -> None:
     """The double-gate refusal must not fire on a stage that carries no threshold.
 

--- a/tests/core/test_resolver_fit_threshold.py
+++ b/tests/core/test_resolver_fit_threshold.py
@@ -711,16 +711,20 @@ def test_the_classic_seam_also_reports_no_metrics_when_nothing_was_judged() -> N
     assert "No held-out pair P/R/F1 computed for this fit." in report.to_markdown()
 
 
-def test_a_score_less_chain_reports_no_held_out_metrics() -> None:
-    """Empty judgements must read as "not computed", never as a table of zeros.
+def test_a_score_less_chain_refuses_to_derive() -> None:
+    """A blocker similarity is not a judge score, and a cut on it governs nothing.
 
-    A chain need not contain a ``Score``: cutting on the blocker's own similarity
-    is permitted topology, and every row then carries ``score_type=None``. The
-    metrics gate used to test ``aligned.valid.candidates`` instead of the
-    judgements themselves, and ``classify_pairs([], gold, t)`` does not return
-    ``None`` -- it returns a real ``PairMetrics`` of zeros with ``fn=len(gold)``.
-    That printed a fully-populated "Held-out pair metrics" table of 0.0000 for a
-    fit that measured nothing.
+    A chain need not contain a ``Score``, and its rows then carry a blocker
+    similarity with ``score_type=None``. ``PairRow.predicted_match`` deliberately
+    refuses to threshold such a row ("only a SCORED row's ``score`` is a judge
+    score") and returns ``self.decision`` -- ``None`` -- so ``ThresholdSelect``
+    drops *every* row whatever value is fitted.
+
+    An earlier version of this test asserted that such a fit merely reported no
+    held-out metrics. That was the wrong bar: the fit still stamped
+    ``source="derived"`` and an applied threshold for something that cannot
+    change one pair at resolve time. A measured-looking number attached to an
+    inert change is exactly what this feature exists to prevent, so it raises.
     """
     records, pairs = _dataset()
     model = ERModel.from_topology(
@@ -730,17 +734,31 @@ def test_a_score_less_chain_reports_no_held_out_metrics() -> None:
             ClustererStage(Clusterer(threshold=0.0)),
         ]
     )
-    model.fit(records, pairs=pairs, split=_SPLIT, seed=_SEED, derive_threshold=True)
-    report = model.fit_report_
-    assert report is not None and report.threshold_fit is not None
-    # The cut really was fitted -- the blocker's similarity is a usable score...
-    assert report.threshold_fit.source in {"derived", "declined"}
-    assert report.n_valid > 0  # ...and a held-out split really did exist...
-    # ...but no judgement was ever produced, so there is nothing to grade.
-    assert report.metrics is None
-    assert report.threshold_fit.previous is not None
-    assert report.threshold_fit.previous.held_out_f1 is None
-    assert "No held-out pair P/R/F1 computed for this fit." in report.to_markdown()
+    with pytest.raises(ValueError, match="no judge score"):
+        model.fit(records, pairs=pairs, split=_SPLIT, seed=_SEED, derive_threshold=True)
+
+
+def test_a_chain_that_gates_twice_refuses_to_derive() -> None:
+    """Fitting one of two gates would report an improvement resolve() cannot deliver.
+
+    An explicit chain can cut twice: at its ``ThresholdSelect`` and again at the
+    nested clusterer, which keeps thresholding the projected judgements. Lowering
+    the select to a winning 0.80 while a clusterer cut of 0.90 still rejects
+    everything between them yields a held-out "improvement" that never reaches
+    ``resolve()``. The shipped research recipes build the stage threshold-free for
+    this reason; a chain that does not is refused rather than half-fitted.
+    """
+    records, pairs = _dataset()
+    model = ERModel.from_topology(
+        ops=[
+            BlockerSource(AllPairsBlocker(schema=CompanySchema)),
+            MatcherScore(_matcher(), out_space="heuristic"),
+            ThresholdSelect(0.9),
+            ClustererStage(Clusterer(threshold=0.9)),
+        ]
+    )
+    with pytest.raises(ValueError, match="gates twice"):
+        model.fit(records, pairs=pairs, split=_SPLIT, seed=_SEED, derive_threshold=True)
 
 
 def test_threshold_seam_reports_where_each_topology_keeps_its_cut() -> None:

--- a/tests/core/test_resolver_fit_threshold.py
+++ b/tests/core/test_resolver_fit_threshold.py
@@ -183,6 +183,35 @@ class _CountingMatcher:
             )
 
 
+class _SkippingMatcher:
+    """A matcher that scores the labeled pairs but yields nothing for held-out ones.
+
+    No matcher langres ships behaves this way -- every one yields exactly one
+    judgement per candidate, and an abstention is a judgement with ``score=None``
+    rather than a skipped yield. But ``Matcher`` is a documented bring-your-own
+    extension point and nothing enforces that cardinality, so this is the shape a
+    custom matcher can legitimately take. It exists to make the classic seam's
+    empty-judgement behaviour observable instead of assumed.
+    """
+
+    def __init__(self, skip_ids: set[str]) -> None:
+        self.skip_ids = skip_ids
+
+    def forward(self, candidates: Iterator[ERCandidate[Any]]) -> Iterator[PairwiseJudgement]:
+        for candidate in candidates:
+            if candidate.left.id in self.skip_ids or candidate.right.id in self.skip_ids:
+                continue
+            same = candidate.left.name.split()[0] == candidate.right.name.split()[0]
+            yield PairwiseJudgement(
+                left_id=candidate.left.id,
+                right_id=candidate.right.id,
+                score=0.9 if same else 0.1,
+                score_type="heuristic",
+                decision_step="skipping_stub",
+                provenance={},
+            )
+
+
 class _DecidingMatcher:
     """A matcher that both decides and ranks -- the case a threshold cannot govern."""
 
@@ -645,6 +674,41 @@ def test_explicit_chain_without_a_threshold_select_refuses_to_derive() -> None:
     with pytest.raises(ValueError, match="contains no ThresholdSelect"):
         model.fit(records, pairs=pairs, split=_SPLIT, seed=_SEED, derive_threshold=True)
     assert counting.calls == 0
+
+
+def test_the_classic_seam_also_reports_no_metrics_when_nothing_was_judged() -> None:
+    """The classic path uses the same gate as the chain path, for the same reason.
+
+    ``classify_pairs([], gold, t)`` returns a real ``PairMetrics`` of zeros with
+    ``fn=len(gold)``, never ``None``. A matcher that yields no judgement for the
+    held-out candidates must therefore produce "not computed", not a
+    fully-populated table of ``0.0000``. Nothing langres ships behaves this way,
+    but ``Matcher`` is a bring-your-own extension point that permits it -- and
+    this keeps all three sites (``_described``, classic, chain) on one convention
+    rather than leaving one to drift.
+    """
+    records, pairs = _dataset()
+    model = _classic()
+    aligned = align_pairs(
+        # Same split the fit will take, so the ids skipped below are exactly the
+        # held-out ones -- the train side stays fully scored and derivable.
+        _classic()._candidates(records).to_candidates(),
+        pairs,
+        split=_SPLIT,
+        seed=_SEED,
+    )
+    held_out_ids = {str(c.left.id) for c in aligned.valid.candidates} | {
+        str(c.right.id) for c in aligned.valid.candidates
+    }
+    assert held_out_ids  # the split really did hold something out
+    model.module = _SkippingMatcher(held_out_ids)  # type: ignore[assignment]
+
+    model.fit(records, pairs=pairs, split=_SPLIT, seed=_SEED, derive_threshold=True)
+    report = model.fit_report_
+    assert report is not None
+    assert report.n_valid > 0  # a held-out split existed...
+    assert report.metrics is None  # ...but nothing was judged on it
+    assert "No held-out pair P/R/F1 computed for this fit." in report.to_markdown()
 
 
 def test_a_score_less_chain_reports_no_held_out_metrics() -> None:

--- a/tests/core/test_resolver_fit_threshold.py
+++ b/tests/core/test_resolver_fit_threshold.py
@@ -141,6 +141,47 @@ def _explicit(threshold: float = _DEFAULT_THRESHOLD) -> ERModel:
     )
 
 
+class _SimilarityBlocker(AllPairsBlocker[Any]):
+    """All pairs, each stamped with a blocker ``similarity_score``.
+
+    The shape a Score-less chain needs: ``BlockerSource`` lands
+    ``similarity_score`` as an **unscored** row score (``score_type is None`` --
+    a blocker similarity is not a judge score), so rows carry a real number to
+    threshold on while producing no ``PairwiseJudgement`` at all.
+    """
+
+    def stream(self, data: list[Any]) -> Iterator[ERCandidate[Any]]:
+        for candidate in super().stream(data):
+            left, right = candidate.left.name.split()[0], candidate.right.name.split()[0]
+            candidate.similarity_score = 0.9 if left == right else 0.1
+            yield candidate
+
+
+class _CountingMatcher:
+    """A ``$0`` stand-in for a paid scorer that records how often it was asked to score.
+
+    Stands in for the thing the cost actually rides on. A real
+    ``LLMMatcher`` here would make the assertion expensive and non-hermetic; what
+    matters is only *whether* the scoring seam was entered, which a counter
+    observes exactly as well and for free.
+    """
+
+    def __init__(self) -> None:
+        self.calls = 0
+
+    def forward(self, candidates: Iterator[ERCandidate[Any]]) -> Iterator[PairwiseJudgement]:
+        for candidate in candidates:
+            self.calls += 1
+            yield PairwiseJudgement(
+                left_id=candidate.left.id,
+                right_id=candidate.right.id,
+                score=1.0,
+                score_type="heuristic",
+                decision_step="counting_stub",
+                provenance={},
+            )
+
+
 class _SupervisedMatcher:
     """A matcher that implements ``SupervisedFitMixin`` and records its training call.
 
@@ -474,17 +515,59 @@ def test_explicit_chain_fit_without_derive_threshold_raises_a_directed_error() -
 
 
 def test_explicit_chain_without_a_threshold_select_refuses_to_derive() -> None:
-    """No cut to write -> raise, rather than derive a number and drop it."""
+    """No cut to write -> raise, rather than derive a number and drop it.
+
+    Asserting only the exception would be a check decoupled from what it guards:
+    it passes whether the refusal happens before or after the chain runs. The
+    ``ValueError`` used to be raised inside ``_select_threshold``, one full
+    Source+body pass downstream, so a chain with a paid ``MatcherScore`` billed
+    the whole dataset and then threw the scores away. The counter is what makes
+    that regression observable: the scorer must be called **zero** times.
+    """
     records, pairs = _dataset()
+    counting = _CountingMatcher()
     model = ERModel.from_topology(
         ops=[
             BlockerSource(AllPairsBlocker(schema=CompanySchema)),
-            MatcherScore(_matcher(), out_space="heuristic"),
+            MatcherScore(counting, out_space="heuristic"),
             ClustererStage(Clusterer(threshold=0.0)),
         ]
     )
     with pytest.raises(ValueError, match="contains no ThresholdSelect"):
         model.fit(records, pairs=pairs, split=_SPLIT, seed=_SEED, derive_threshold=True)
+    assert counting.calls == 0
+
+
+def test_a_score_less_chain_reports_no_held_out_metrics() -> None:
+    """Empty judgements must read as "not computed", never as a table of zeros.
+
+    A chain need not contain a ``Score``: cutting on the blocker's own similarity
+    is permitted topology, and every row then carries ``score_type=None``. The
+    metrics gate used to test ``aligned.valid.candidates`` instead of the
+    judgements themselves, and ``classify_pairs([], gold, t)`` does not return
+    ``None`` -- it returns a real ``PairMetrics`` of zeros with ``fn=len(gold)``.
+    That printed a fully-populated "Held-out pair metrics" table of 0.0000 for a
+    fit that measured nothing.
+    """
+    records, pairs = _dataset()
+    model = ERModel.from_topology(
+        ops=[
+            BlockerSource(_SimilarityBlocker(schema=CompanySchema)),
+            ThresholdSelect(_DEFAULT_THRESHOLD),
+            ClustererStage(Clusterer(threshold=0.0)),
+        ]
+    )
+    model.fit(records, pairs=pairs, split=_SPLIT, seed=_SEED, derive_threshold=True)
+    report = model.fit_report_
+    assert report is not None and report.threshold_fit is not None
+    # The cut really was fitted -- the blocker's similarity is a usable score...
+    assert report.threshold_fit.source in {"derived", "declined"}
+    assert report.n_valid > 0  # ...and a held-out split really did exist...
+    # ...but no judgement was ever produced, so there is nothing to grade.
+    assert report.metrics is None
+    assert report.threshold_fit.previous is not None
+    assert report.threshold_fit.previous.held_out_f1 is None
+    assert "No held-out pair P/R/F1 computed for this fit." in report.to_markdown()
 
 
 def test_threshold_seam_reports_where_each_topology_keeps_its_cut() -> None:

--- a/tests/core/test_resolver_fit_threshold.py
+++ b/tests/core/test_resolver_fit_threshold.py
@@ -166,8 +166,9 @@ class _CountingMatcher:
     observes exactly as well and for free.
     """
 
-    def __init__(self) -> None:
+    def __init__(self, score: float = 1.0) -> None:
         self.calls = 0
+        self.score = score
 
     def forward(self, candidates: Iterator[ERCandidate[Any]]) -> Iterator[PairwiseJudgement]:
         for candidate in candidates:
@@ -175,9 +176,26 @@ class _CountingMatcher:
             yield PairwiseJudgement(
                 left_id=candidate.left.id,
                 right_id=candidate.right.id,
-                score=1.0,
+                score=self.score,
                 score_type="heuristic",
                 decision_step="counting_stub",
+                provenance={},
+            )
+
+
+class _DecidingMatcher:
+    """A matcher that both decides and ranks -- the case a threshold cannot govern."""
+
+    def forward(self, candidates: Iterator[ERCandidate[Any]]) -> Iterator[PairwiseJudgement]:
+        for candidate in candidates:
+            same = candidate.left.name.split()[0] == candidate.right.name.split()[0]
+            yield PairwiseJudgement(
+                left_id=candidate.left.id,
+                right_id=candidate.right.id,
+                score=0.9 if same else 0.1,
+                decision=same,
+                score_type="heuristic",
+                decision_step="deciding_stub",
                 provenance={},
             )
 
@@ -267,7 +285,7 @@ def test_default_leaves_the_threshold_untouched_and_says_so() -> None:
     assert supervised.clusterer.threshold == _DEFAULT_THRESHOLD
     assert supervised.fit_report_ is not None
     assert supervised.fit_report_.threshold_fit is not None
-    assert supervised.fit_report_.threshold_fit.source == "default"
+    assert supervised.fit_report_.threshold_fit.source == "not_fitted"
     assert supervised.fit_report_.threshold_fit.n_pairs == 0
     assert model.clusterer.threshold == _DEFAULT_THRESHOLD  # untouched, never fitted
 
@@ -368,6 +386,97 @@ def test_declined_markdown_says_the_candidate_lost() -> None:
     assert "did not beat it on train" in rendered
     assert "Threshold selection (chosen on train)" in rendered
     assert "KEPT" in rendered
+
+
+def test_a_later_plain_fit_does_not_relabel_a_derived_cut_as_a_default() -> None:
+    """``not_fitted`` must not claim the cut is a constructor default.
+
+    Provenance is the whole job of this field, so a false provenance record is
+    the worst thing it can carry. ``fit_report_`` is not serialized, so a second
+    ``fit()`` cannot recover the first one's origin -- "this fit did not touch
+    it" is the strongest true statement available, and the rendering must say
+    exactly that and no more.
+    """
+    records, pairs = _dataset()
+    model = _classic()
+    model.fit(records, pairs=pairs, split=_SPLIT, seed=_SEED, derive_threshold=True)
+    assert model.fit_report_ is not None and model.fit_report_.threshold_fit is not None
+    assert model.fit_report_.threshold_fit.source == "derived"
+    derived_cut = model.clusterer.threshold
+
+    model.module = _SupervisedMatcher()  # type: ignore[assignment]
+    model.fit(records, pairs=pairs, split=_SPLIT, seed=_SEED)  # no derive_threshold
+
+    assert model.clusterer.threshold == derived_cut  # the derived cut is still in force
+    assert model.fit_report_ is not None and model.fit_report_.threshold_fit is not None
+    assert model.fit_report_.threshold_fit.source == "not_fitted"
+    rendered = model.fit_report_.to_markdown()
+    assert "not fitted by this fit" in rendered
+    assert "default" not in rendered  # never claims an origin it cannot know
+
+
+def test_deriving_refuses_a_matcher_that_emits_decisions() -> None:
+    """A cut resolve() would ignore must raise, not be reported as an improvement.
+
+    ``predicted_match`` gives ``decision`` precedence over ``score``, so for a
+    matcher emitting both, moving the threshold changes nothing at resolve time.
+    Deriving one anyway would report a measured improvement for a fit that is
+    silently inert -- the exact class of failure this feature exists to prevent.
+    """
+    records, pairs = _dataset()
+    model = Resolver(
+        blocker=AllPairsBlocker(schema=CompanySchema),
+        comparator=None,
+        matcher=_DecidingMatcher(),  # type: ignore[arg-type]
+        clusterer=Clusterer(threshold=_DEFAULT_THRESHOLD),
+    )
+    with pytest.raises(ValueError, match="emits an explicit decision"):
+        model.fit(records, pairs=pairs, split=_SPLIT, seed=_SEED, derive_threshold=True)
+    assert model.clusterer.threshold == _DEFAULT_THRESHOLD
+
+
+def test_a_score_after_the_fitted_select_does_not_contaminate_the_derivation() -> None:
+    """The cut must be derived from the scores its own Select actually reads.
+
+    ``Source -> ScoreA -> ThresholdSelect -> ScoreB -> ClusterStage`` is supported
+    topology -- that is what a reranker is. Merely *removing* the Select and
+    running the rest would let ``ScoreB`` overwrite the score column, so the fit
+    would derive a cut from ``ScoreB`` values and write it into a Select that
+    thresholds ``ScoreA`` values. ``ScoreB`` here returns a constant 0.01, far
+    below anything ``ScoreA`` produces: if it ran, the derived cut would collapse
+    toward it and the marker below would be reached.
+    """
+    records, pairs = _dataset()
+    downstream = _CountingMatcher(score=0.01)
+    model = ERModel.from_topology(
+        ops=[
+            BlockerSource(AllPairsBlocker(schema=CompanySchema)),
+            MatcherScore(_matcher(), out_space="heuristic"),
+            ThresholdSelect(_DEFAULT_THRESHOLD),
+            MatcherScore(downstream, out_space="heuristic"),
+            ClustererStage(Clusterer(threshold=0.0)),
+        ]
+    )
+    model.fit(records, pairs=pairs, split=_SPLIT, seed=_SEED, derive_threshold=True)
+
+    assert downstream.calls == 0  # nothing past the fitted cut runs during the fit
+    fit = model.fit_report_.threshold_fit if model.fit_report_ else None
+    assert fit is not None and fit.candidate is not None
+    assert fit.candidate.threshold > 0.5  # a rapidfuzz cut, not a 0.01-contaminated one
+
+
+def test_fit_normalizes_raw_records_for_an_explicit_chain() -> None:
+    """A chain Source is handed typed entities, never the raw dicts fit() received.
+
+    ``_dedupe_explicit`` and ``execute`` both call ``normalize_records`` first;
+    the fit path must not be the one door that skips it.
+    """
+    records, pairs = _dataset()
+    assert isinstance(records[0], dict)  # the fixture really is raw dicts
+    model = _explicit()
+    model.fit(records, pairs=pairs, split=_SPLIT, seed=_SEED, derive_threshold=True)
+    assert model.fit_report_ is not None and model.fit_report_.threshold_fit is not None
+    assert model.fit_report_.threshold_fit.n_pairs > 0
 
 
 def test_markdown_renders_a_partial_threshold_fit() -> None:

--- a/tests/core/test_resolver_fit_threshold.py
+++ b/tests/core/test_resolver_fit_threshold.py
@@ -544,10 +544,12 @@ def test_the_derived_threshold_survives_save_load_but_its_provenance_does_not(
 
     ``fit_report_`` is deliberately never serialized, so a reloaded model carries
     a measured cut with no record that it was measured. Stated here rather than
-    left undefined.
+    left undefined. (Built via ``from_schema`` because the raw ``RapidfuzzMatcher``
+    used elsewhere in this file carries no registry ``type_name`` and so cannot be
+    saved at all.)
     """
     records, pairs = _dataset()
-    model = _classic()
+    model = Resolver.from_schema(CompanySchema, matcher="string", threshold=_DEFAULT_THRESHOLD)
     model.fit(records, pairs=pairs, split=_SPLIT, seed=_SEED, derive_threshold=True)
     derived = model.clusterer.threshold
 


### PR DESCRIPTION
## The gap this closes

`derive_threshold` was **not** "wired to nothing" — it already has two production
callers (`curation/harvest.py`, whose module docstring calls itself "its first
production caller", and `data/fixed_split_pair_benchmark.py:309`). The real gap
is narrower and worse: **`ERModel.fit()` never called it.** A user who supplied
labels still resolved at whatever constant the constructor happened to set.

`fit(data, pairs=..., derive_threshold=True)` now fits the match cut from those
labels, reusing the existing `derive_threshold_from_pairs` seam rather than
re-implementing it.

## It races the derived cut and keeps the winner

Deriving a threshold from labels is **not** unconditionally an improvement, and
this PR has the measurement to prove it. `derive_threshold` maximizes Youden's J
(`tpr - fpr`), which ties flat across a whole separating gap. On a fixture where
the default `0.5` already separates cleanly, J returns a cut high enough to drop
a genuine twin:

| fixture | incumbent | derived | train pair-F1 | held-out pair-F1 | kept |
|---|---|---|---|---|---|
| default 0.5 is wrong (hard negatives share a token) | 0.5000 | 0.8824 | 0.5217 → **1.0000** | 0.5714 → **1.0000** | derived |
| default 0.5 already right (abbreviated twins, dissimilar negatives) | 0.5000 | 0.8824 | 1.0000 → 1.0000 | 1.0000 → **0.8000** | **incumbent** |

The second row reproduces at seeds 0/1/4/5. A derive-and-apply implementation —
which is what this PR was originally scoped as — would have shipped that
regression as an improvement.

So `fit()` **races** the derived cut against the threshold already in force and
keeps whichever wins, recording both in `FitReport.threshold_fit`.

## Which split did the selecting (the leakage question)

**Selection runs on `train`. `valid` is never read to decide anything.**

`train` was already spent deriving the candidate, so selecting there adds no
leakage that deriving had not already incurred — and it leaves *both*
`held_out_f1` numbers in the report as clean estimates of a split nothing ever
tuned against. The honest before/after of a threshold fit is
`previous.held_out_f1` vs `candidate.held_out_f1`, and both held-out columns
above are exactly that, not in-sample numbers.

`test_selection_never_reads_the_held_out_split` is the guarantee: re-fitting at
different seeds reshuffles which entity components land in `valid`, and the
chosen cut must not move with it.

**The residual gap, stated plainly:** there is no clean estimate *of the
selection itself*. Choosing between two cuts on `train` and then reporting
`valid` is honest about `valid`, but the selection decision has no untouched
third split behind it. A proper three-way split (derive / select / report) is
the fix and is named as a follow-up in `docs/EXPERIMENTS.md` — it is more than
this PR should carry.

When `split=None`, every labeled pair is train: `held_out` is `False`,
`held_out_f1` is `None`, and the Markdown digest prints the word **IN-SAMPLE**
in capitals rather than letting the number pass for held-out.

## New capability: `fit()` could not run on an `_ops` model at all before this

This is not a bug fix or a new branch on an existing path. On `main`,
`ERModel.fit()` reads `type(self.module).__name__` unconditionally as the first
statement of the fit body; `from_topology` "leaves the four slots empty" and the
`module` property raises `_require_bound`. So **every** `fit()` call on an
explicit Op topology raised before any fit logic ran, regardless of arguments.

`_fit_chain_threshold` is the new path. An Op chain has no matcher slot to train
(its `Score`s are topology, not a fittable slot) and no clusterer to read — its
one fittable parameter is the terminal `ThresholdSelect`. Calling `fit()` on such
a model without `derive_threshold=True` now raises a message that says exactly
that, instead of the misleading unbound-model error.

## Both threshold seams, and how each is tested

| topology | where the cut lives | test |
|---|---|---|
| classic four-slot | `clusterer.threshold` | `_classic()` fixture — derive, decline, persist, guard tests |
| explicit `_ops` chain | terminal `ThresholdSelect.threshold` | `_explicit()` fixture — `applied_to == "threshold_select"`, the no-`ThresholdSelect` error, `TopKSelect`-only chains |

The branch is not written twice. `_model_state.py` gains a topology-neutral trio
— `_threshold_seam()` / `_match_threshold()` / `_set_match_threshold()` — and the
reader and the writer are derived from one `_chain_threshold_select()` helper so
they cannot disagree about which `Select` is the cut.

One subtlety the `_ops` path had to get right: deriving from the *post-threshold*
rows would only recover the cut that already filtered the sample. So
`_prethreshold_pairs` runs the chain once **truncated at** the fitted
`ThresholdSelect`, and both splits are read off that single pass (a chain's
`Source` owns retrieval, so unlike a classic model it cannot score an arbitrary
candidate subset). That is one extra full pass — documented as a cost. See
finding #3 below for why it truncates rather than merely omitting the select.

## No silent fallback when scikit-learn is missing

`training/calibration.py` imports sklearn at module scope, so on a bare install
the lazy import inside `derive_threshold_from_pairs` used to surface as a raw
`ImportError`. It now raises a directed one naming the problem, the cause, and
the fix (`pip install 'langres[trained]'`), and says explicitly that langres will
**not** substitute an underived default — identical code must not produce
different artifacts depending on which extras happen to be installed.
`docs/GETTING_STARTED.md` already sells "No key, no silent fallback"; this keeps
that promise on the extras axis too.

Note `test-core-only` is *not* a gate for this: scikit-learn is duplicated in
`[dependency-groups] dev`, so `uv sync` installs it. The test simulates absence
via `monkeypatch.setitem(sys.modules, ...)`.

## Provenance, and what survives save/load

`FitReport.threshold_fit` is a new `ThresholdFit` carrying `source`
(`derived`/`declined`/`not_fitted`), `method`, `n_pairs`, `held_out`, `applied_to`
(`clusterer` or `threshold_select`), `selected_on`, and a `ThresholdCandidate`
for each of `previous` and `candidate` with that candidate's selection F1 and
held-out F1.

**`fit_report_` is deliberately never serialized** (`_model_state.py:160`). The
asymmetry is now stated in the code: `save()`/`load()` carry the *threshold
value* — it lives on the clusterer or the `ThresholdSelect`, both of which
persist — but **not** the provenance of how it was chosen. A loaded model
resolves at the derived cut and cannot tell you it was derived. Keep the
`FitReport` (it is JSON-serializable) if you need the audit trail.

## Youden's J is symmetric in cost; ER is not

Called out in the `fit()` docstring and in `docs/EXPERIMENTS.md` at the point of
choice: J weights a false positive and a false negative equally, but in entity
resolution a false merge can poison an entire cluster through transitive closure
while a false split is recoverable by a later merge. A user who cares about that
asymmetry should pass their own threshold, or call `derive_threshold` directly
with a method that prices it.

## The default stays `False`

`derive_threshold: bool = False`. The measured decline above is the reason: a
feature that sometimes helps and sometimes hurts does not belong on by default,
and flipping it would silently move the cut for every existing `fit(pairs=...)`
caller. The race makes the opt-in safe; it does not make it free.

## Scope notes

- `fit(pairs=..., derive_threshold=True)` is now accepted for matchers that are
  **not** `SupervisedFitMixin` (e.g. `WeightedAverageMatcher`) — previously
  `fit(pairs=...)` raised for those, even though a fixed scorer is exactly where
  threshold fitting is the *only* useful thing to fit. `fit(method=...)` and
  `derive_threshold=True` together are refused: two different fits of the same
  parameter.
- The walkthrough went in **`docs/EXPERIMENTS.md`, deliberately, not in
  `GETTING_STARTED.md`** — `tools/doc_snippets.py` executes python blocks from
  `README.md` / `docs/index.md` / `docs/GETTING_STARTED.md` only, against a bare
  wheel in a fresh venv. A `[trained]`-dependent snippet in that set would trip
  the clean-install gate. `EXPERIMENTS.md` is where `derive_threshold` is already
  documented, so the new section sits beside the primitive it wraps. This was a
  placement decision, not an oversight.
- No constructor default was touched: the six `threshold: float = 0.5` values in
  `src/langres/architectures/` are unchanged.

## Two P1s cross-review caught, and how each is now guarded

**1. The refusal ran *after* the spend.** The "no `ThresholdSelect` to write"
`ValueError` was raised inside `_select_threshold`, one full Source+body pass
downstream of `_prethreshold_pairs`. So `from_topology([BlockerSource,
MatcherScore(paid_llm), ClustererStage])` + `fit(derive_threshold=True)` billed
the entire dataset and then threw the scores away. **Measured: 435 scoring calls
over 30 records before the refusal.** The check is hoisted to the top of
`_fit_chain_threshold`; the guard inside `_select_threshold` stays, because it is
the invariant for the classic path too.

The existing test asserted only the exception — which passes whether the refusal
happens before or after the spend, i.e. a check decoupled from what it guards. It
now runs a counting matcher and asserts `calls == 0`.

**2. Fabricated held-out metrics on a Score-less chain.** The metrics gated on
`aligned.valid.candidates` while computing over `judgements`, which is filtered to
`score_type is not None`. A blocker similarity lands as an *unscored* row score
(`PairRow.score_type is None` — "blocked, not yet scored"), so
`[BlockerSource(sim_blocker), ThresholdSelect, ClustererStage]` is permitted
topology whose `judgements` are legitimately empty — and `classify_pairs([], gold,
t)` does not return `None`, it returns a real `PairMetrics` of zeros with
`fn=len(gold)`. That printed a fully-populated "Held-out pair metrics" table of
`0.0000` for a fit that measured nothing. Now gated on `judgements`, matching
`_described`'s own `if valid_judgements else None` convention.

**Both new assertions were confirmed to FAIL against the unfixed code** before
being kept — I reverted each fix, watched the test go red (435 calls; a
`PairMetrics(..., f1=0.0, fn=4)` where `None` was required), then restored it.

## Four more from codex review, all verified and fixed

Each was checked against source before touching anything —
`predicted_match`'s decision precedence, `classify_pairs`' use of it,
`_dedupe_explicit`'s `normalize_records` call, `PairRow`'s unscored-similarity
state. All four were real.

**3. A `Score` after the fitted `Select` contaminated the derivation.**
`_prethreshold_pairs` *removed* the fitted `ThresholdSelect` and ran everything
else. In the supported reranker topology — `Source -> ScoreA -> ThresholdSelect ->
ScoreB -> ClusterStage` — `ScoreB` then overwrote the score column, so the fit
derived a cut from `ScoreB` values and wrote it into a `Select` that thresholds
`ScoreA` values. It now **truncates at** the select instead of removing it. Test
puts a constant-0.01 scorer downstream and asserts both `calls == 0` and that the
derived cut did not collapse toward it.

**4. `fit()` on an explicit chain skipped `normalize_records`.** Every other door
into a chain Source (`_dedupe_explicit`, `execute`) normalizes first; the fit path
was handing it the raw dicts the caller passed to `fit()`.

**5. Every non-deriving pair-fit claimed the cut was a constructor default.**
`ThresholdFit(source="default")` was stamped on all `fit(pairs=...)` calls, so a
model whose *earlier* `fit(derive_threshold=True)` derived its cut had that cut
relabelled a default by the next plain fit — a false record in the one field
whose entire job is provenance. `fit_report_` is not serialized, so a later fit
cannot recover the earlier one's origin. Renamed to **`"not_fitted"`**, which
claims only what is true: *this* fit did not touch the threshold. The test asserts
the rendered digest never contains the word "default".

**6. A decider's threshold fit was silently inert.** `predicted_match` gives
`decision` precedence over `score`, so for a matcher emitting both, moving the cut
changes nothing at resolve time — the fit would derive a number, race it, report an
improvement, and resolve identically either way. That is precisely the failure
class this feature exists to prevent, so it now raises. (A *pure* decider was
already refused by `derive_threshold_from_pairs`; this catches the both-emitting
case, which has scores and would otherwise sail through.)

**7. Unscored blocker-similarity rows made the fit inert.** `PairRow.predicted_match`
deliberately refuses to threshold a row with `score_type is None` ("only a SCORED
row's `score` is a judge score") and returns `self.decision` — `None` — so
`ThresholdSelect.forward` drops **every** such row whatever value is fitted. A
Score-less chain therefore cannot have its cut fitted at all, and now raises. My
own earlier test asserted this case merely reported no held-out metrics; that was
the wrong bar — it was validating an inert fit that still stamped
`source="derived"` and an applied threshold.

**8. Chains that gate twice** — and the guard for it initially repeated the same
"bill, then refuse" mistake as #1. A `ClustererStage`'s clusterer keeps its own
threshold and gates the projected judgements independently of the
`ThresholdSelect`. Lowering the select to a winning 0.80 while the clusterer
still cuts at 0.90 reports a held-out improvement `resolve()` never realizes.
Refused rather than half-fitted — and the refusal is decided **before** the
scoring pass, because it is decidable from the topology alone. That is now the
stated rule in the code, after this PR hit the same shape three times: *every
refusal decidable from topology alone is decided before a paid `Score` runs*.
The one guard that genuinely cannot be hoisted (unscored rows) is annotated as
such. (`ClusterStage` is the abstract contract and carries no clusterer, so a
*custom* stage correctly reads as "no second gate" — tested.)

**9. The classic seam was left on the old convention.** `_fit_from_pairs` still
gated its held-out metrics on `aligned.valid.candidates` — the same pattern
fixed above in `_fit_chain_threshold`. **No shipped matcher can trigger it**
(every one yields exactly one judgement per candidate; an abstention is a
judgement with `score=None`, not a skipped yield), so this is hardening rather
than a live bug — but `Matcher` is a documented bring-your-own extension point
with nothing enforcing that cardinality, and leaving two sibling paths 280 lines
apart on different conventions, one just corrected, is how the next reader
concludes the divergence was deliberate. All three sites (`_described`, classic,
chain) now read the same way, and the test uses a custom matcher that skips the
held-out candidates.

## Known adjacent issue, not fixed here

On the **non-deriving** path, `_fit_from_pairs` grades held-out judgements on the
raw `_scorer()` scale while a fitted `Calibrator` may have rescaled the cut. That
is pre-existing, its docstring records the byte-identical behaviour as
deliberate, and changing it would alter results for every existing
`fit(pairs=...)` caller. Recorded here rather than silently carried. (The
*deriving* path does handle it — `_cut_scale_scores` / `_on_cut_scale` put both
sides on the cut's scale, applied only when `derive_threshold=True` so the old
path stays byte-identical.)

## Verification

- `uv run pytest -m "not integration and not slow and not finetune"` — **4543 passed**, 2 skipped
- `uv run pytest -m "not integration and not finetune"` (full, incl. slow) — **4642 passed**, 2 skipped, 16m31s
- `uv run ruff format --check . && uv run ruff check . && uv run mypy src` — clean
- `docs-clean-install` (the `tools/doc_snippets.py` gate) — **pass** in CI on this PR

Every new assertion in this PR that guards a specific defect was confirmed to
**fail against the unfixed code** before being kept — the counting matcher (435
calls), the Score-less chain (`PairMetrics(f1=0.0, fn=4)` where `None` was
required), and the classic-seam skipping matcher. A test that has never been
seen to fail is a hypothesis, not a safety net.

### Coverage delta on the contract glob

Measured locally, **both sides with the identical command below**, on the fast
subset — because `test-full`, which carries the real gate, is
`if: github.event_name != 'pull_request'` and structurally cannot run on a PR.
Baseline is this PR's merge-base, `82a222f`. The absolute is therefore not CI's
`test-full` number; the **delta** is the comparable quantity.

Reproduce (run once on this branch, once on `82a222f`):

```bash
uv run pytest -m "not integration and not slow and not finetune" -q -p no:randomly --cov-fail-under=0
uv run coverage report --precision=2 --include="src/langres/core/*,src/langres/metrics/*,src/langres/curation/anchor_store.py,src/langres/curation/canonicalizer.py,src/langres/curation/harvest.py,src/langres/curation/review.py,src/langres/tracking/judgement_log.py,src/langres/tracking/runs.py,src/langres/tracking/trackers/*,src/langres/training/*,src/langres/report/*,src/langres/autoresearch/*,src/langres/optimize.py"
```

| | statements | missing | branches | partial | total |
|---|---|---|---|---|---|
| `main` @ 82a222f | 9023 | 206 | 2616 | 130 | 96.94% |
| this branch @ 3b8bd51 | 9194 | **206** | 2678 | **130** | **97.00%** |

**Δ +0.06pp.** Missing statements *and* partial branches are **identical** on both
sides (206 / 130): this adds 171 statements and 62 branches to the contract glob
with **zero** newly uncovered lines and **zero** newly partial branches.

Per touched file: `training/fit_report.py` 85.00% → 90.74%, `core/_model_state.py`
93.93% → 95.32%, `core/resolver.py` 96.64% → 97.09%, `core/_model_run.py` 89.85%
→ 89.95%, `curation/harvest.py` 100% → 100%. Every one up or flat.

The one line this change originally added to the uncovered set was a dead branch
in `_prethreshold_pairs` (a classic-model arm whose only caller runs when
`_ops is not None`). It is deleted rather than covered or `pragma`'d.

**Why a green PR is not evidence here.** `test-full` — the job carrying the 98%
contract gate — is `if: github.event_name != 'pull_request'`, so it did not run
on this PR and could not have caught a regression in that number. That is why
the gate was run locally on both sides and the delta quoted above, rather than
inferred from the green checks.

Separately: `main` is currently **below** the 98 contract floor for reasons
predating this branch, and that is owned elsewhere — this PR moves the number
up, it does not reach the floor.
