### PR TITLE
Make main green honestly: fix the contract coverage gate, and the blindness that hid it for six days

### DIFF
--- a/.claude/rules/testing.md
+++ b/.claude/rules/testing.md
@@ -81,8 +81,8 @@ code. Verify as you go.** Read before writing tests or running the suite.
   the same include list (same denominator), so **full-suite coverage ≥ fast-suite
   coverage, always** — the per-PR gate can never demand what the authoritative one
   does not already meet. The observed gap is small, which is why 97.5 is close
-  rather than slack: measured on one tree, 2026-07-28, full suite **98.05%** vs
-  fast suite **97.87%** — **0.18pp**.
+  rather than slack: measured at `1b24a2a`, 2026-07-28, full suite **98.26%** vs
+  fast suite **97.93%** — **0.33pp**.
 - **Timings, measured 2026-07-28** (the previous "~10min" claim was stale by 4x and
   was the justification for keeping the contract gate off PRs entirely):
   `test-full` **~38–41 min**, the per-PR `test` job **~6 min**, the gate step

--- a/.claude/rules/testing.md
+++ b/.claude/rules/testing.md
@@ -34,12 +34,15 @@ code. Verify as you go.** Read before writing tests or running the suite.
 - Mark slow tests with `@pytest.mark.slow`, integration tests with `@pytest.mark.integration`
   - **Mark any heavy test `@pytest.mark.slow`** (loads embedding/ML models, runs
     torch inference, etc.). CI runs the **fast** subset (`not slow`) on every
-    PR; the **slow** tests + the coverage gates run on **every merge to main
-    (push)** + **on demand** (`workflow_dispatch`) via the `test-full` job. So
-    per-PR CI does not gate coverage or exercise slow ML paths — mislabeling a
-    heavy test as fast slows every PR, and the coverage floors are verified on
-    each merge to main, not per-PR. Run the full suite locally
-    (`uv run pytest`) before merging a change to ML/embedding code.
+    PR; the **slow** tests run on **every merge to main (push)** + **on demand**
+    (`workflow_dispatch`) via the `test-full` job. So per-PR CI does not exercise
+    slow ML paths — mislabeling a heavy test as fast slows every PR. Run the full
+    suite locally (`uv run pytest`) before merging a change to ML/embedding code.
+  - **Coverage is gated in both places, but not on the same numbers** — see the
+    two-gate table below. The *contract* floor runs on **every PR** (early
+    warning, 97.5) and authoritatively on **each merge** (98). The *repo-wide*
+    90% floor is enforced only on `test-full`, because the fast suite omits the
+    slow tests that are the only cover for some ML paths.
 - Run tests: `uv run pytest` (pre-push hook runs non-slow, non-integration tests automatically)
 - Check coverage: `uv run pytest --cov`; keep `core/**` in the 95–100% tier
   (the repo-wide gate is a relaxed 90% floor — see `pyproject.toml`)

--- a/.claude/rules/testing.md
+++ b/.claude/rules/testing.md
@@ -73,10 +73,16 @@ code. Verify as you go.** Read before writing tests or running the suite.
 - **Why two floors is not the "two numbers drift" disease.** The thing that rots
   is the include *list*, and there is only one of it. The floors differ because the
   two gates measure genuinely different data: the per-PR job excludes the slow ML
-  tests, so paths covered only by them read as uncovered there. Measured on one
-  tree, 2026-07-28: full suite **98.05%**, fast suite **97.87%** — the slow tests
-  are worth only **0.18pp** of this include list, so the fast measurement is a close
-  proxy, not a different quantity wearing the same name.
+  tests, so paths covered only by them read as uncovered there.
+  The lower floor is **structural, not tuned**: the per-PR selection
+  (`not integration and not slow and not finetune`) differs from `test-full`'s
+  (`not integration and not finetune`) *only* by `not slow`, so its tests are a
+  strict **subset**. Coverage is monotone in tests executed and both gates score
+  the same include list (same denominator), so **full-suite coverage ≥ fast-suite
+  coverage, always** — the per-PR gate can never demand what the authoritative one
+  does not already meet. The observed gap is small, which is why 97.5 is close
+  rather than slack: measured on one tree, 2026-07-28, full suite **98.05%** vs
+  fast suite **97.87%** — **0.18pp**.
 - **Timings, measured 2026-07-28** (the previous "~10min" claim was stale by 4x and
   was the justification for keeping the contract gate off PRs entirely):
   `test-full` **~38–41 min**, the per-PR `test` job **~6 min**, the gate step

--- a/.claude/rules/testing.md
+++ b/.claude/rules/testing.md
@@ -43,42 +43,45 @@ code. Verify as you go.** Read before writing tests or running the suite.
 - Run tests: `uv run pytest` (pre-push hook runs non-slow, non-integration tests automatically)
 - Check coverage: `uv run pytest --cov`; keep `core/**` in the 95–100% tier
   (the repo-wide gate is a relaxed 90% floor — see `pyproject.toml`)
-- **Two gates run on `test-full`, and they are not the same number as this
-  policy.** The repo-wide floor is 90% (`--cov-fail-under` in `pyproject.toml`).
-  The contract additionally has its own path-scoped gate
-  (`coverage report --include="src/langres/core/*,src/langres/report/*,src/langres/autoresearch/*,src/langres/training/*,src/langres/optimize.py"
-  --precision=2 --fail-under=98` in `.github/workflows/test.yml`). That 98 is a
-  **regression ratchet** pinned just under the measured value (98.84% at
-  `ba4b1b7`), not the policy — the *target* remains 95–100%. It exists because
-  the repo-wide 90% floor sits ~8 points below actual coverage, so the contract
-  could be quietly declassified with CI green throughout. Raise it as the real
-  number climbs; if it blocks legitimate work, lower it deliberately rather than
-  deleting it.
-  **When the contract moves to a new package, extend that `--include` glob** or
-  the gate silently stops covering it. (`report/`, `autoresearch/`, `training/`
-  and the `optimize.py` facade are in the glob for exactly that reason — they
-  carry public surface (`EvalReport`, `optimize()`/`score_blocking`,
-  `derive_threshold`/`Calibrator`/`FitReport`/`QLoRA`), so letting them fall out
-  would un-gate contract code while making the remaining number look *better*.
-  `training/*` was added when the fit family moved there out of `core/` — a
-  coverage-neutral relocation of already-gated code.)
-  **`src/langres/optimize.py` is listed as a file, not folded into a `*` glob**:
-  the facade is a module and the engine beside it is the `autoresearch/` package,
-  and coverage compiles a trailing `/*` to `optimize[/\\].*` — which matches a
-  directory's contents and can never match `optimize.py`. An `optimize/*` entry
-  here matches **nothing** and drops the facade silently. (Trailing `/*` *is*
-  recursive, so `autoresearch/*` covers the whole engine and `core/*` reaches
-  `core/blockers/vector.py`.)
-- **Headroom: the glob TOTAL is 98.39% against the 98 floor** (measured
-  2026-07-17 on `test-full`, at `0a38e46`, before the optimize/autoresearch
-  rename — which moves files without changing a line, so the number carries).
-  Note the floor gates the **whole include list**, not `core/*` alone: `core/*`
-  by itself measures 98.43%, which is close enough to mislead but is not the
-  number the gate compares. The floor was set from a measured 98.84%, so the
-  glob has drifted ~0.45pp down and the ratchet has ~0.39pp of slack left. If
-  this gate fires on you after a small change, you probably did not break it —
-  it has been tightening for a while. Diagnose the drift before lowering the
-  floor.
+- **The contract coverage gate runs in TWO places, at two floors, over ONE
+  include list.** The repo-wide floor is 90% (`--cov-fail-under` in
+  `pyproject.toml`). The contract additionally has its own path-scoped gate:
+
+  | where | suite | floor | role |
+  |---|---|---|---|
+  | `test` job (**every PR**) | fast (`not slow`) | **97.5** | early warning, ~12s |
+  | `test-full` job (**merge to main**) | full incl. slow | **98** | authoritative |
+
+  **Do not copy the `--include` list into this file or anywhere else.** It is
+  defined once, as `env.CONTRACT_COVERAGE_INCLUDE` at the top of
+  `.github/workflows/test.yml`, and both gates read it. A list duplicated in two
+  places drifts, and the copy that drifts silently stops gating what it names —
+  the paragraph that used to live here had already gone stale, omitting
+  `metrics/*`, `tracking/*` and the four `curation/` contract files. Read the
+  `env` block for the maintenance rules (why `optimize.py` is a FILE and not an
+  `optimize/*` glob; why the curation modules are listed individually; why the
+  glob follows the contract, not the average).
+
+  That 98 is a **regression ratchet** pinned just under a measured value, not the
+  policy — the *target* remains 95–100%. It exists because the repo-wide 90% floor
+  sits ~8 points below actual coverage, so the contract could be quietly
+  declassified with CI green throughout. Raise it as the real number climbs; if it
+  blocks legitimate work, lower it deliberately rather than deleting it.
+- **Why two floors is not the "two numbers drift" disease.** The thing that rots
+  is the include *list*, and there is only one of it. The floors differ because the
+  two gates measure genuinely different data: the per-PR job excludes the slow ML
+  tests, so paths covered only by them read as uncovered there. Measured on one
+  tree, 2026-07-28: full suite **98.05%**, fast suite **97.87%** — the slow tests
+  are worth only **0.18pp** of this include list, so the fast measurement is a close
+  proxy, not a different quantity wearing the same name.
+- **Timings, measured 2026-07-28** (the previous "~10min" claim was stale by 4x and
+  was the justification for keeping the contract gate off PRs entirely):
+  `test-full` **~38–41 min**, the per-PR `test` job **~6 min**, the gate step
+  itself **~12 s**. The cost is the suite, never the gate.
+- **If the contract gate fires on you, diagnose the drift before touching the
+  floor.** It has real precedent: `main` was red for six days across seven merges
+  because #229 took the TOTAL 98.28% → 97.27% in a single commit and `test-full`
+  does not run on PRs, so nothing observed it until after the merge.
 - Type-check as you go: `uv run mypy src/`
 
 ## Development Workflow (Human-Like Iteration)

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -142,14 +142,27 @@ jobs:
       # gates measure different data: this job deliberately excludes the slow ML
       # tests, so paths covered only by them read as uncovered here.
       #
-      # MEASURED on the same tree, 2026-07-28:
+      # The lower floor is STRUCTURAL, not tuned to an observation. This job's
+      # selection is `not integration and not slow and not finetune`;
+      # `test-full`'s is `not integration and not finetune`. They are identical
+      # except for `not slow`, so the tests run here are a strict SUBSET of the
+      # tests run there. Coverage is monotone in tests executed -- running more
+      # tests can only cover more lines -- and both gates score the same include
+      # list, hence the same denominator. Therefore, on the same tree:
+      #
+      #     full-suite coverage  >=  fast-suite coverage,   ALWAYS.
+      #
+      # So this gate can never demand something the authoritative gate does not
+      # already meet, and a number that clears 98 on `test-full` cannot be failed
+      # here for having been measured on less data.
+      #
+      # The observed gap is small, which is why 97.5 is close rather than
+      # slack. MEASURED on the same tree, 2026-07-28:
       #   full suite (test-full)   98.05%
       #   fast suite (this job)    97.87%
       #   difference                0.18pp
-      # The slow tests are worth only 0.18pp of THIS include list -- so the fast
-      # measurement is a close proxy for the real one, not a different quantity
-      # wearing the same name. 97.5 is that 97.87 with the same conservative
-      # rounding-down the 98 floor gets, leaving ~0.37pp of working room.
+      # 97.5 is that 97.87 with the same conservative rounding-down the 98 floor
+      # gets, leaving ~0.37pp of working room.
       #
       # This floor is a per-PR EARLY WARNING; `test-full`'s 98 remains the
       # authoritative contract floor. If this one fires, the contract slipped --

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -85,7 +85,7 @@ jobs:
   #     for some ML paths, so a repo-wide number measured here would be wrong.
   #   - the `langres.core` CONTRACT floor IS enforced, at a lower early-warning
   #     97.5 -- see the long comment on that step below for why the fast-suite
-  #     number is a close proxy (measured: 0.18pp under the full suite).
+  #     number is a close proxy (measured: 0.33pp under the full suite).
   # The authoritative contract floor (98) still runs on `test-full`.
   test:
     if: github.event_name == 'pull_request'
@@ -157,12 +157,12 @@ jobs:
       # here for having been measured on less data.
       #
       # The observed gap is small, which is why 97.5 is close rather than
-      # slack. MEASURED on the same tree, 2026-07-28:
-      #   full suite (test-full)   98.05%
-      #   fast suite (this job)    97.87%
-      #   difference                0.18pp
-      # 97.5 is that 97.87 with the same conservative rounding-down the 98 floor
-      # gets, leaving ~0.37pp of working room.
+      # slack. MEASURED at 1b24a2a, 2026-07-28 -- both numbers on THIS tree:
+      #   full suite (test-full)   98.26%   local run, 9011 stmts / 98 miss
+      #   fast suite (this job)    97.93%   CI run 30317465537, same commit
+      #   difference                0.33pp
+      # 97.5 is that 97.93 with the same conservative rounding-down the 98 floor
+      # gets, leaving ~0.43pp of working room.
       #
       # This floor is a per-PR EARLY WARNING; `test-full`'s 98 remains the
       # authoritative contract floor. If this one fires, the contract slipped --
@@ -385,9 +385,11 @@ jobs:
       # declassify the number they no longer own. A re-export owns no contract,
       # and the module each one redirects to is itself inside this list.
       #
-      # HEADROOM, measured 2026-07-28 on the full suite: the include-list TOTAL is
-      # **98.05%** before this PR's headroom tests and higher after (see the PR that
-      # restored it). The floor gates this WHOLE include list, not `core/*` alone.
+      # HEADROOM, measured 2026-07-28 at 1b24a2a on the full suite: the include-list
+      # TOTAL is **98.26%** (9011 stmts / 98 miss) against the 98 floor. Neutralising
+      # the six W2 shim pragmas costs 0.10pp (98.16%, 9023 stmts) -- still clear of
+      # the floor, so the exclusions are NOT what carries this number. The floor
+      # gates this WHOLE include list, not `core/*` alone.
       #
       # HOW THIS GATE CAME TO BE RED FOR SIX DAYS, so the next reader does not
       # repeat the diagnosis: #229 merged ~2,000 lines into gated `core/` paths at

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -77,10 +77,16 @@ concurrency:
 
 jobs:
   # Fast per-PR tests: everything EXCEPT the ~76 slow embedding/ML tests (they
-  # load heavy torch models and dominate wall-time). Coverage is collected but
-  # NOT gated here (`--cov-fail-under=0` overrides the pyproject default),
-  # because the excluded slow tests are the only cover for some ML paths -- the
-  # coverage floors are enforced on `test-full` below.
+  # load heavy torch models and dominate wall-time).
+  #
+  # Coverage here is gated on ONE number and not the other:
+  #   - the REPO-WIDE floor is NOT enforced (`--cov-fail-under=0` overrides the
+  #     pyproject default), because the excluded slow tests are the only cover
+  #     for some ML paths, so a repo-wide number measured here would be wrong.
+  #   - the `langres.core` CONTRACT floor IS enforced, at a lower early-warning
+  #     97.5 -- see the long comment on that step below for why the fast-suite
+  #     number is a close proxy (measured: 0.18pp under the full suite).
+  # The authoritative contract floor (98) still runs on `test-full`.
   test:
     if: github.event_name == 'pull_request'
     runs-on: ubuntu-latest

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,16 +1,60 @@
 name: Test
 
-# Per-PR: run the FAST suite only (slow ML tests excluded -- see the `test`
-# job). The full suite incl. slow tests + the coverage gates runs on every
-# merge to main (push) + on demand (workflow_dispatch) via the `test-full` job,
-# so slow embedding/ML tests don't cost ~10min on every PR. This repo is public,
-# so Actions minutes are free/unlimited -- per-merge coverage is worth it, while
-# the fast suite still runs per-PR. Jobs are gated by event with `if:` below.
+# Per-PR: run the FAST suite (slow ML tests excluded -- see the `test` job) AND
+# the contract coverage gate against that fast suite's data. The full suite incl.
+# slow tests + the AUTHORITATIVE coverage gates run on every merge to main (push)
+# + on demand (workflow_dispatch) via the `test-full` job, so the slow
+# embedding/ML tests don't cost ~40min on every PR. This repo is public, so
+# Actions minutes are free/unlimited -- per-merge coverage is worth it, while the
+# fast suite still runs per-PR. Jobs are gated by event with `if:` below.
+#
+# MEASURED 2026-07-28, because the previous version of this comment said "~10min"
+# and that number was what justified keeping the contract gate off PRs entirely:
+#   test-full        ~38-41 min   (green run 3dbd13d 37m39s; run 30307689766 41m)
+#   test (fast)      ~6 min       (PR #229's run: 5m53s)
+#   the gate step itself  ~12 s
+# The cost is the SUITE, never the gate. That is why the gate now runs in both
+# places and only the suite under it differs.
 on:
   pull_request:
   push:
     branches: [main, feat/core-packages, epic/193-core-algebra]
   workflow_dispatch:
+
+env:
+  # ONE definition of the langres.core contract include list, used by BOTH
+  # coverage gates below (per-PR on the fast suite, per-merge on the full suite).
+  #
+  # It is here, not written out twice, for the reason this repo keeps
+  # rediscovering: a value duplicated in two places drifts, and the copy that
+  # drifts silently stops gating what it names. Referenced as a plain shell
+  # variable ("$CONTRACT_COVERAGE_INCLUDE"), not `${{ }}`, so nothing is
+  # template-interpolated into a `run:` script.
+  #
+  # !! KEEP THIS IN SYNC WITH THE CONTRACT !! As refactor waves relocate the
+  # contract out of `core/` (components/, architectures/, ... -- see the tier
+  # definition in .claude/rules/testing.md), ADD the new paths here. If the glob
+  # ever matches NOTHING, `coverage report` exits 1 ("No data to report.") and the
+  # gates go red rather than passing vacuously -- but a PARTIAL move still passes
+  # while silently covering less of the contract, so this is a real maintenance
+  # obligation, not a self-healing gate.
+  #
+  # `src/langres/optimize.py` IS LISTED SEPARATELY ON PURPOSE -- DO NOT FOLD IT
+  # INTO AN `optimize/*` GLOB. The facade is a MODULE (a file), not a package; the
+  # engine beside it is the `autoresearch/` package. Coverage compiles a trailing
+  # `/*` to `optimize[/\\].*` (verified against coverage.files.globs_to_regex,
+  # 7.15.0), which matches a directory's contents and can NEVER match the file
+  # `optimize.py`. Writing only `autoresearch/*` here would drop the facade.
+  # (Trailing `/*` is recursive, so `autoresearch/*` does cover the whole engine,
+  # and `core/*` covers `core/blockers/vector.py`.)
+  #
+  # The four `src/langres/curation/{anchor_store,canonicalizer,harvest,review}.py`
+  # files are the CONTRACT half of the curation package. They are listed as FILES,
+  # not a `curation/*` glob, on purpose: the rest of curation is behavior/smoke-tier
+  # harness code, so a `curation/*` glob would drag it under these floors.
+  # `tracking/factories.py` is deliberately NOT listed: it was `clients/tracking.py`,
+  # never under `core/*`, so it was never in this contract tier.
+  CONTRACT_COVERAGE_INCLUDE: "src/langres/core/*,src/langres/metrics/*,src/langres/curation/anchor_store.py,src/langres/curation/canonicalizer.py,src/langres/curation/harvest.py,src/langres/curation/review.py,src/langres/tracking/judgement_log.py,src/langres/tracking/runs.py,src/langres/tracking/trackers/*,src/langres/training/*,src/langres/report/*,src/langres/autoresearch/*,src/langres/optimize.py"
 
 concurrency:
   # `pull_request`: one group per PR ref, so a new push supersedes the previous
@@ -69,6 +113,46 @@ jobs:
 
       - name: Run fast unit tests (excludes slow ML tests)
         run: uv run pytest -m "not integration and not slow and not finetune" --cov-fail-under=0
+
+      # THE PER-PR HALF OF THE CONTRACT GATE. This exists because the
+      # authoritative gate on `test-full` is gated `if: github.event_name !=
+      # 'pull_request'` and therefore CANNOT run on a PR. That is not a
+      # hypothetical: PR #229 merged with its check list reading
+      #     lint pass · test pass · test-core-only pass · test-finetune pass
+      #     test-full SKIPPING        <- the only job running the contract gate
+      # It dropped the contract from 98.28% to 97.27% and `main` stayed red for
+      # SIX DAYS across seven merges, because the only place that could see the
+      # failure was a job nobody opens after a merge is already done.
+      #
+      # A gate positioned where no one reads it is not a gate. So the same
+      # include list is checked here too, on data this job already produces:
+      # pyproject's addopts carry `--cov=langres`, so `.coverage` is on disk by
+      # the time this step runs and the check costs ~12 SECONDS.
+      #
+      # WHY A SEPARATE, LOWER FLOOR -- and why that is not the "two numbers
+      # drift" disease this repo has been bitten by. The include LIST (the thing
+      # that actually rots) is defined ONCE, in `env` at the top of this file, and
+      # both gates read it. Only the floor differs, and it must, because the two
+      # gates measure different data: this job deliberately excludes the slow ML
+      # tests, so paths covered only by them read as uncovered here.
+      #
+      # MEASURED on the same tree, 2026-07-28:
+      #   full suite (test-full)   98.05%
+      #   fast suite (this job)    97.87%
+      #   difference                0.18pp
+      # The slow tests are worth only 0.18pp of THIS include list -- so the fast
+      # measurement is a close proxy for the real one, not a different quantity
+      # wearing the same name. 97.5 is that 97.87 with the same conservative
+      # rounding-down the 98 floor gets, leaving ~0.37pp of working room.
+      #
+      # This floor is a per-PR EARLY WARNING; `test-full`'s 98 remains the
+      # authoritative contract floor. If this one fires, the contract slipped --
+      # diagnose it here, where it is cheap, instead of after the merge.
+      - name: Coverage gate -- langres.core contract (fast suite, early warning)
+        run: |
+          uv run coverage report \
+            --include="$CONTRACT_COVERAGE_INCLUDE" \
+            --precision=2 --fail-under=97.5
 
   test-core-only:
     if: github.event_name == 'pull_request'
@@ -177,14 +261,20 @@ jobs:
       - name: Run the user-facing docs against a clean wheel install
         run: uv run python tools/doc_snippets.py
 
-  # Full suite INCLUDING the slow embedding/ML tests, plus the coverage gates:
-  # the repo-wide floor (inherited from pyproject addopts) and the core-contract
-  # floor (a separate step). Runs on every merge to main (push) + on
-  # demand (workflow_dispatch) -- NOT per PR -- so ML regressions and the
-  # coverage floors are enforced on every merge without paying ~10min on every
-  # PR. Trigger an ad-hoc run before a release or a risky ML change with the
-  # "Run workflow" button (workflow_dispatch). Do NOT mark this a required
-  # status check (it is skipped on PR events).
+  # Full suite INCLUDING the slow embedding/ML tests, plus the AUTHORITATIVE
+  # coverage gates: the repo-wide floor (inherited from pyproject addopts) and the
+  # core-contract floor (a separate step). Runs on every merge to main (push) + on
+  # demand (workflow_dispatch) -- NOT per PR -- so ML regressions and the honest
+  # coverage floors are enforced on every merge without paying ~40min on every PR
+  # (measured; see the timings at the top of this file). Trigger an ad-hoc run
+  # before a release or a risky ML change with the "Run workflow" button
+  # (workflow_dispatch). Do NOT mark this a required status check (it is skipped
+  # on PR events).
+  #
+  # This job being PR-invisible is what let the contract gate stay red on `main`
+  # for six days across seven merges (#229 -> #237). The per-PR early-warning
+  # gate on the `test` job above exists so that failure mode has a cheaper,
+  # visible tripwire; this job remains the number of record.
   test-full:
     if: github.event_name != 'pull_request'
     # 4-vCPU: the slow ML tests' torch inference uses all 4 cores via torch's
@@ -258,54 +348,35 @@ jobs:
       # vanish before firing. Raise it as the real number climbs; if it ever
       # blocks legitimate work, lower it deliberately rather than deleting it.
       #
-      # !! KEEP THE GLOB IN SYNC !! As refactor waves relocate the contract out
-      # of `core/` (components/, architectures/, ... -- see the tier definition
-      # in .claude/rules/testing.md), ADD the new paths here. If the glob ever
-      # matches NOTHING, `coverage report` exits 1 ("No data to report.") and
-      # this step goes red rather than passing vacuously -- but a PARTIAL move
-      # still passes while silently covering less of the contract, so this is a
-      # real maintenance obligation, not a self-healing gate.
+      # !! THE INCLUDE LIST LIVES IN `env.CONTRACT_COVERAGE_INCLUDE` AT THE TOP OF
+      # THIS FILE, not here. !! It is shared with the per-PR early-warning gate on
+      # the `test` job so the two can never name different things. Its maintenance
+      # rules -- keep it in sync as the contract relocates, why `optimize.py` is a
+      # FILE and not an `optimize/*` glob, why the four curation modules are listed
+      # individually -- are documented there. Read that block before editing it.
       #
-      # `src/langres/report/*`, `src/langres/autoresearch/*` and
-      # `src/langres/optimize.py` were added when the render seam and the
-      # autoresearch engine moved out of core. All measure ~93-100% (report
-      # ~1,400 lines; the engine files all 100%), so they were LIFTING core's
-      # average, not dragging it. Dropping them would have quietly un-gated
-      # 99%-covered public surface (`EvalReport` is root-exported;
-      # `optimize()`/`score_blocking` are the public facade) while making the
-      # remaining number look BETTER. That is the failure this comment exists to
-      # prevent: the glob follows the contract, not the average.
+      # `report/*`, `autoresearch/*`, `optimize.py`, `training/*`, `metrics/*` and
+      # the `tracking/*` contract modules are all in the list because they carry
+      # public surface that USED to live under `core/*` and moved out. Dropping any
+      # of them would un-gate contract code while making the remaining number look
+      # BETTER -- the glob follows the contract, not the average.
       #
-      # The four `src/langres/curation/{anchor_store,canonicalizer,harvest,review}.py`
-      # files are the CONTRACT half of the curation package -- they moved out of
-      # `core/` when bootstrap dissolved in (W2). They are listed as FILES, not a
-      # `curation/*` glob, on purpose: the rest of curation (bootstrapper, labelers,
-      # miners, models, report, base, _pairs -- the former `langres.bootstrap`) is
-      # behavior/smoke-tier harness code, so a `curation/*` glob would drag it under
-      # this 98 floor. The temporary `core/{...}.py` re-export shims left behind carry
-      # `# pragma: no cover` (throwaway back-compat, deleted by the W2 sweep), so they
-      # do not declassify the number they no longer own.
+      # The temporary `core/{...}.py` re-export shims carry `# pragma: no cover`
+      # (throwaway back-compat, deleted by the W2 sweep), so they do not
+      # declassify the number they no longer own. A re-export owns no contract,
+      # and the module each one redirects to is itself inside this list.
       #
-      # !! `src/langres/optimize.py` IS LISTED SEPARATELY ON PURPOSE -- DO NOT
-      # !! FOLD IT INTO AN `optimize/*` GLOB. The facade is a MODULE (a file), not
-      # a package; the engine beside it is the `autoresearch/` package. Coverage
-      # compiles a trailing `/*` to `optimize[/\\].*` (verified against
-      # coverage.files.globs_to_regex, 7.15.0), which matches a directory's
-      # contents and can NEVER match the file `optimize.py`. Writing only
-      # `autoresearch/*` here would drop the facade -- 66 statements, 92.86%, the
-      # WORST-covered file in the glob -- and the TOTAL would go UP while
-      # measuring less. (Trailing `/*` is recursive, so `autoresearch/*` does
-      # cover the whole engine, and `core/*` covers `core/blockers/vector.py`.)
+      # HEADROOM, measured 2026-07-28 on the full suite: the include-list TOTAL is
+      # **98.05%** before this PR's headroom tests and higher after (see the PR that
+      # restored it). The floor gates this WHOLE include list, not `core/*` alone.
       #
-      # HEADROOM WARNING, measured 2026-07-17: the glob TOTAL is **98.39%**
-      # against this 98 floor -- and the 98 was set from a measured **98.84%**
-      # (see above). Note the floor gates this WHOLE include list, not `core/*`
-      # alone (which measures 98.43% by itself -- close, but not the number the
-      # gate compares). It has drifted ~0.45pp DOWN since, so the ratchet now has
-      # ~0.39pp of slack, not the ~0.84pp it was designed with. The next person to
-      # add a handful of uncovered lines here will trip this gate and reasonably
-      # conclude they broke it. They did not: it has been tightening around them
-      # for a while. Diagnose the drift before lowering the floor.
+      # HOW THIS GATE CAME TO BE RED FOR SIX DAYS, so the next reader does not
+      # repeat the diagnosis: #229 merged ~2,000 lines into gated `core/` paths at
+      # ~90% coverage and took the TOTAL 98.28% -> 97.27% in one commit. Nothing
+      # caught it because this job does not run on PRs (see the job comment above),
+      # and `main` then absorbed six more merges. The include list was NOT the
+      # cause -- it is byte-identical to the last green run. If this gate fires on
+      # you, diagnose which commit moved the number before touching the floor.
       #
       # Deliberately AFTER the Codecov upload: that upload is advisory, and when
       # this gate fails you still want the data published to diagnose the drop.
@@ -315,40 +386,17 @@ jobs:
       # passes a --fail-under=98 gate -- the floor would silently mean 97.5.
       # With it the comparison is exact and 98 means 98.
       #
-      # `src/langres/training/*` was ADDED when the fit family (finetune /
-      # calibration / fit_report / methods_prompt / methods_calibrate) moved out
-      # of `core/` into the `langres.training` package (W2). Those five modules
-      # were ALREADY in this gate via `core/*`; dropping them would silently
-      # un-gate ~1000 lines of public-surface contract (`derive_threshold`,
-      # `Calibrator`, `FitReport`, `QLoRA`/`run_finetune`, `Bootstrap`/`MIPRO`/
-      # `GEPA`, `Platt`/`Isotonic` are all root/core-exported). Re-including them
-      # is coverage-NEUTRAL by construction -- the same files, relocated -- so
-      # the TOTAL is unchanged. The glob follows the contract, not the average.
-      #
-      # `src/langres/metrics/*` was ADDED when the ER-metrics/diagnostics family
-      # (metrics / analysis / debugging / diagnostics) moved out of `core/` into
-      # the `langres.metrics` package (W2). Those modules were ALREADY in this
-      # gate via `core/*` (they measure ~99%); re-including them at the new path
-      # is coverage-NEUTRAL by construction and keeps the public metrics surface
-      # (root / `langres.eval`-exported) gated. The metrics branch did not touch
-      # this workflow; the term is added here, at integration, on purpose.
-      #
-      # `src/langres/tracking/{judgement_log.py,runs.py,trackers/*}` are the
-      # CONTRACT half of the tracking package -- observability that left `core/`
-      # (W2). They were in this gate via `core/*`, and `test-full` runs
-      # `--all-extras` so mlflow/wandb/trackio actually exercise the adapters, so
-      # they are re-listed at the new path to stay gated (coverage-NEUTRAL, same
-      # files relocated). `tracking/factories.py` is deliberately NOT listed: it
-      # was `clients/tracking.py`, never under `core/*`, so it was never in this
-      # contract tier. The tracking branch did not touch this workflow either;
-      # these terms are added here, at integration, on purpose.
-      #
-      # STALE-NUMBER NOTE: the HEADROOM WARNING's 98.39% figure above was measured
-      # before the `metrics/*` and `tracking/*` terms were added at integration.
-      # The `--fail-under=98` floor is deliberately left unchanged here; the
-      # test-full TOTAL (and any floor re-derivation) is recomputed once this lands.
+      # RESOLVED (2026-07-28): the old STALE-NUMBER NOTE here promised that the
+      # test-full TOTAL "is recomputed once this lands" after the `metrics/*` and
+      # `tracking/*` terms were added at integration. It never was. It has now
+      # been: the include list is byte-identical to the last green run (3dbd13d,
+      # 98.28%), so the widening was NOT the cause of this gate going red -- #229
+      # was. The floor stays 98.
       - name: Coverage gate -- langres.core contract
-        run: uv run coverage report --include="src/langres/core/*,src/langres/metrics/*,src/langres/curation/anchor_store.py,src/langres/curation/canonicalizer.py,src/langres/curation/harvest.py,src/langres/curation/review.py,src/langres/tracking/judgement_log.py,src/langres/tracking/runs.py,src/langres/tracking/trackers/*,src/langres/training/*,src/langres/report/*,src/langres/autoresearch/*,src/langres/optimize.py" --precision=2 --fail-under=98
+        run: |
+          uv run coverage report \
+            --include="$CONTRACT_COVERAGE_INCLUDE" \
+            --precision=2 --fail-under=98
 
   # The [finetune] extra's OWN job: install the QLoRA training stack (peft/trl/
   # bitsandbytes) that every other job deliberately excludes (`--no-extra

--- a/src/langres/core/debugging.py
+++ b/src/langres/core/debugging.py
@@ -7,7 +7,12 @@ lives in the ``langres.metrics`` package. This shim keeps the old
 repoints callers.
 """
 
-from langres.metrics.debugging import (
+# `# pragma: no cover`, as on every other W2 shim (see core/harvest.py): a
+# re-export owns no contract. `langres.metrics.debugging` is itself inside the
+# `langres.core` contract coverage gate, so measuring this redirect would book a
+# miss against code already covered at its real home. Goes away with this file
+# in the W2 sweep.
+from langres.metrics.debugging import (  # pragma: no cover
     CandidateStats,
     ClusterStats,
     ErrorExample,
@@ -15,7 +20,7 @@ from langres.metrics.debugging import (
     ScoreStats,
 )
 
-__all__ = [
+__all__ = [  # pragma: no cover
     "CandidateStats",
     "ClusterStats",
     "ErrorExample",

--- a/src/langres/core/diagnostics.py
+++ b/src/langres/core/diagnostics.py
@@ -7,13 +7,18 @@ are not part of the modelling contract, so they now live in the
 import path working while the refactor's final sweep repoints callers.
 """
 
-from langres.metrics.diagnostics import (
+# `# pragma: no cover`, as on every other W2 shim (see core/harvest.py): a
+# re-export owns no contract. `langres.metrics.diagnostics` is itself inside the
+# `langres.core` contract coverage gate, so measuring this redirect would book a
+# miss against code already covered at its real home. Goes away with this file
+# in the W2 sweep.
+from langres.metrics.diagnostics import (  # pragma: no cover
     DiagnosticExamples,
     FalsePositiveExample,
     MissedMatchExample,
 )
 
-__all__ = [
+__all__ = [  # pragma: no cover
     "DiagnosticExamples",
     "FalsePositiveExample",
     "MissedMatchExample",

--- a/src/langres/core/runs.py
+++ b/src/langres/core/runs.py
@@ -8,7 +8,12 @@ Run identity/persistence is observability, not ER modelling, so it now lives in
 re-exports these names).
 """
 
-from langres.tracking.runs import (
+# `# pragma: no cover`, as on every other W2 shim (see core/harvest.py): a
+# re-export owns no contract. `langres.tracking.runs` is itself inside the
+# `langres.core` contract coverage gate, so measuring this redirect would book a
+# miss against code already covered at its real home. Goes away with this file
+# in the W2 sweep.
+from langres.tracking.runs import (  # pragma: no cover
     RunContext,
     RunRecord,
     RunStore,
@@ -21,7 +26,7 @@ from langres.tracking.runs import (
     resolve_store,
 )
 
-__all__ = [
+__all__ = [  # pragma: no cover
     "RunContext",
     "RunRecord",
     "RunStore",

--- a/src/langres/core/trackers/__init__.py
+++ b/src/langres/core/trackers/__init__.py
@@ -13,14 +13,18 @@ module's top level. A bare ``import langres`` must not pull mlflow/wandb/trackio
 the adapters eagerly from this shim would defeat it.
 """
 
-# `# pragma: no cover`, as on every other W2 shim (see core/harvest.py): a
-# re-export owns no contract. `langres.tracking.trackers` is itself inside the
-# `langres.core` contract coverage gate (at 100%), so measuring this redirect
-# would book a miss against code already covered at its real home. Goes away
-# with this file in the W2 sweep.
-from typing import TYPE_CHECKING, Any  # pragma: no cover
+# NOT `# pragma: no cover`, unlike the sibling W2 shims (see core/harvest.py).
+# Those are pure `from X import Y` redirects that own no contract and cannot
+# fail in isolation. This one is different in kind: `__getattr__` below carries
+# real conditional resolution -- a lazy-adapter branch and an unknown-name
+# `AttributeError` branch -- and behavior excluded from the gate is behavior a
+# regression can break silently. It is covered by
+# tests/core/test_trackers_backcompat_shim.py instead, which also pins
+# `_LAZY_ADAPTERS` against the real module's adapter table so the two cannot
+# drift apart. Goes away with this file in the W2 sweep.
+from typing import TYPE_CHECKING, Any
 
-from langres.tracking.trackers import (  # pragma: no cover
+from langres.tracking.trackers import (
     ExperimentTracker,
     MultiTracker,
     NoOpTracker,
@@ -31,7 +35,7 @@ from langres.tracking.trackers import (  # pragma: no cover
 if TYPE_CHECKING:
     from langres.tracking.trackers import MlflowTracker, TrackioTracker, WandbTracker
 
-__all__ = [  # pragma: no cover
+__all__ = [
     "ExperimentTracker",
     "MultiTracker",
     "NoOpTracker",
@@ -40,12 +44,10 @@ __all__ = [  # pragma: no cover
 ]
 
 #: The lazily-resolved adapter names, mirroring the real module's ``__getattr__``.
-_LAZY_ADAPTERS = frozenset(  # pragma: no cover
-    {"MlflowTracker", "WandbTracker", "TrackioTracker"}
-)
+_LAZY_ADAPTERS = frozenset({"MlflowTracker", "WandbTracker", "TrackioTracker"})
 
 
-def __getattr__(name: str) -> Any:  # pragma: no cover
+def __getattr__(name: str) -> Any:
     """Resolve the backend adapters through the new module, keeping them lazy."""
     if name in _LAZY_ADAPTERS:
         import langres.tracking.trackers as _trackers

--- a/src/langres/core/trackers/__init__.py
+++ b/src/langres/core/trackers/__init__.py
@@ -13,9 +13,14 @@ module's top level. A bare ``import langres`` must not pull mlflow/wandb/trackio
 the adapters eagerly from this shim would defeat it.
 """
 
-from typing import TYPE_CHECKING, Any
+# `# pragma: no cover`, as on every other W2 shim (see core/harvest.py): a
+# re-export owns no contract. `langres.tracking.trackers` is itself inside the
+# `langres.core` contract coverage gate (at 100%), so measuring this redirect
+# would book a miss against code already covered at its real home. Goes away
+# with this file in the W2 sweep.
+from typing import TYPE_CHECKING, Any  # pragma: no cover
 
-from langres.tracking.trackers import (
+from langres.tracking.trackers import (  # pragma: no cover
     ExperimentTracker,
     MultiTracker,
     NoOpTracker,
@@ -26,7 +31,7 @@ from langres.tracking.trackers import (
 if TYPE_CHECKING:
     from langres.tracking.trackers import MlflowTracker, TrackioTracker, WandbTracker
 
-__all__ = [
+__all__ = [  # pragma: no cover
     "ExperimentTracker",
     "MultiTracker",
     "NoOpTracker",
@@ -35,10 +40,12 @@ __all__ = [
 ]
 
 #: The lazily-resolved adapter names, mirroring the real module's ``__getattr__``.
-_LAZY_ADAPTERS = frozenset({"MlflowTracker", "WandbTracker", "TrackioTracker"})
+_LAZY_ADAPTERS = frozenset(  # pragma: no cover
+    {"MlflowTracker", "WandbTracker", "TrackioTracker"}
+)
 
 
-def __getattr__(name: str) -> Any:
+def __getattr__(name: str) -> Any:  # pragma: no cover
     """Resolve the backend adapters through the new module, keeping them lazy."""
     if name in _LAZY_ADAPTERS:
         import langres.tracking.trackers as _trackers

--- a/src/langres/core/trackers/mlflow_tracker.py
+++ b/src/langres/core/trackers/mlflow_tracker.py
@@ -7,6 +7,11 @@ Experiment tracking is observability, not ER modelling, so it now lives in
 imported lazily by the real adapter, never by this shim.
 """
 
-from langres.tracking.trackers.mlflow_tracker import MlflowTracker
+# `# pragma: no cover`, as on every other W2 shim (see core/harvest.py): a
+# re-export owns no contract. The real adapter is itself inside the
+# `langres.core` contract coverage gate, so measuring this redirect would book a
+# miss against code already covered at its real home. Goes away with this file
+# in the W2 sweep.
+from langres.tracking.trackers.mlflow_tracker import MlflowTracker  # pragma: no cover
 
-__all__ = ["MlflowTracker"]
+__all__ = ["MlflowTracker"]  # pragma: no cover

--- a/src/langres/core/trackers/trackio_tracker.py
+++ b/src/langres/core/trackers/trackio_tracker.py
@@ -7,6 +7,11 @@ Experiment tracking is observability, not ER modelling, so it now lives in
 imported lazily by the real adapter, never by this shim.
 """
 
-from langres.tracking.trackers.trackio_tracker import TrackioTracker
+# `# pragma: no cover`, as on every other W2 shim (see core/harvest.py): a
+# re-export owns no contract. The real adapter is itself inside the
+# `langres.core` contract coverage gate, so measuring this redirect would book a
+# miss against code already covered at its real home. Goes away with this file
+# in the W2 sweep.
+from langres.tracking.trackers.trackio_tracker import TrackioTracker  # pragma: no cover
 
-__all__ = ["TrackioTracker"]
+__all__ = ["TrackioTracker"]  # pragma: no cover

--- a/src/langres/core/trackers/wandb_tracker.py
+++ b/src/langres/core/trackers/wandb_tracker.py
@@ -7,6 +7,11 @@ Experiment tracking is observability, not ER modelling, so it now lives in
 imported lazily by the real adapter, never by this shim.
 """
 
-from langres.tracking.trackers.wandb_tracker import WandbTracker
+# `# pragma: no cover`, as on every other W2 shim (see core/harvest.py): a
+# re-export owns no contract. The real adapter is itself inside the
+# `langres.core` contract coverage gate, so measuring this redirect would book a
+# miss against code already covered at its real home. Goes away with this file
+# in the W2 sweep.
+from langres.tracking.trackers.wandb_tracker import WandbTracker  # pragma: no cover
 
-__all__ = ["WandbTracker"]
+__all__ = ["WandbTracker"]  # pragma: no cover

--- a/tests/core/test_blocker.py
+++ b/tests/core/test_blocker.py
@@ -273,3 +273,26 @@ def test_blocker_stream_groups_default_pairs_equivalence_property() -> None:
 
     assert group_pairs == stream_pairs
     assert len(group_pairs) == 15  # C(6, 2)
+
+
+class TestBlockerSchemaProperty:
+    """`Blocker.schema` resolves a registry NAME, so it must survive the name
+    not resolving -- that is the normal state in a fresh process, not an error."""
+
+    def test_no_schema_name_means_no_schema(self) -> None:
+        blocker = DummyBlocker()
+        assert not hasattr(blocker, "_schema_type_name")
+        assert blocker.schema is None
+
+    def test_a_registered_name_resolves_to_its_class(self) -> None:
+        blocker = DummyBlocker()
+        blocker._schema_type_name = "CompanySchema"  # type: ignore[attr-defined]
+        assert blocker.schema is CompanySchema
+
+    def test_an_unregistered_name_answers_none_instead_of_raising(self) -> None:
+        """A model saved with an inferred, ephemeral schema reloads in a process
+        where that name was never registered. `schema` is a property callers treat
+        as cheap, so "I don't know" beats raising SchemaNotRegistered at them."""
+        blocker = DummyBlocker()
+        blocker._schema_type_name = "NeverRegisteredSchema_123"  # type: ignore[attr-defined]
+        assert blocker.schema is None

--- a/tests/core/test_method_registry.py
+++ b/tests/core/test_method_registry.py
@@ -15,6 +15,7 @@ registry now has two name-dispatch callers, not three. The named architectures
 name->builder indirection to keep in sync, because the class IS the identity.
 """
 
+import sys
 from typing import Any
 from unittest.mock import Mock
 
@@ -183,6 +184,45 @@ class TestBuiltinSpecs:
         assert "[trained] extra" in message
         assert "scikit-learn is not installed" in message
         assert "langres[trained]" in message
+
+    @pytest.mark.parametrize(
+        ("method", "judge_module", "extra"),
+        [
+            ("zero_shot_llm", "langres.core.matchers.dspy_judge", "[llm] extra"),
+            ("prompt_llm", "langres.core.matchers.llm_judge", "[llm] extra"),
+            ("select_judge", "langres.core.matchers.select_judge", "[llm] extra"),
+            ("cascade", "langres.core.matchers.cascade", "[llm] extra"),
+            (
+                "random_forest",
+                "langres.core.matchers.random_forest_judge",
+                "[trained] extra",
+            ),
+        ],
+    )
+    def test_every_optional_builder_names_its_extra_when_the_import_fails(
+        self,
+        method: str,
+        judge_module: str,
+        extra: str,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Each builder's lazy import is wrapped, so a missing extra is actionable.
+
+        CI installs ``--all-extras``, so these branches are unreachable there --
+        every one of them was untested. They are the whole point of the extras
+        split: a user on a bare ``pip install langres`` who names a paid judge must
+        be told which extra to install, not handed a raw ModuleNotFoundError from
+        somewhere inside the judge module.
+
+        ``None`` in ``sys.modules`` is the documented way to make an import of that
+        exact module raise ``ImportError`` without disturbing the real install.
+        """
+        monkeypatch.setitem(sys.modules, judge_module, None)
+        with pytest.raises(ImportError) as exc:
+            get_method(method).build(RegistryCompany)
+        message = str(exc.value)
+        assert extra in message
+        assert "pip install" in message or "langres[" in message
 
     def test_embedding_reports_the_pinned_embedder_as_its_model(self) -> None:
         spec = get_method("embedding")

--- a/tests/core/test_op_adapters.py
+++ b/tests/core/test_op_adapters.py
@@ -25,6 +25,7 @@ from langres.core.models import CompanySchema, ERCandidate, PairwiseJudgement
 from langres.core.op import ClusterStage, Finalize, Score, Source
 from langres.core.op_adapters import (
     BlockerSource,
+    CalibratorScore,
     CanonicalizeFinalize,
     ClustererStage,
     ComparatorScore,
@@ -567,3 +568,45 @@ def test_adapter_chain_with_rapidfuzz_and_pivot_clusterer() -> None:
     adapter_clusters = ClustererStage(clusterer).forward(pairs)
 
     assert _sorted_clusters(adapter_clusters) == _sorted_clusters(legacy)
+
+
+def test_matcher_score_reports_no_spend_monitor_before_binding() -> None:
+    """An unbound MatcherScore has no ledger to report -- not an empty one.
+
+    ``bind_spend_monitor`` is what wraps the matcher in a SpendCappedMatcher; until
+    then there is genuinely nothing metering this score, and saying so with ``None``
+    is what lets callers tell "uncapped" from "capped at zero spend so far".
+    """
+    matcher: RapidfuzzMatcher[CompanySchema] = RapidfuzzMatcher(
+        field_extractors={"name": (lambda e: e.name, 1.0)}
+    )
+    assert MatcherScore(matcher, out_space="heuristic").spend_monitor is None
+
+
+class _SpyCalibrator:
+    """Minimal CalibratorFitMixin surface: records whether it was asked to work."""
+
+    def __init__(self) -> None:
+        self.calls = 0
+
+    def transform(self, scores: list[float]) -> list[float]:
+        self.calls += 1
+        return [min(1.0, score * 2) for score in scores]
+
+
+def test_calibrator_score_passes_unscored_rows_through_untouched() -> None:
+    """Calibrating a row that carries no score would have to invent one.
+
+    Rows arrive unscored (straight off the blocker) or carry a decider's verdict
+    with ``score=None``. Both must pass through, and the calibrator must not be
+    called at all -- feeding it ``None`` would either crash or fabricate a
+    probability the pipeline never measured.
+    """
+    calibrator = _SpyCalibrator()
+    pairs = BlockerSource(AllPairsBlocker(schema=CompanySchema)).forward(_RECORDS)
+    assert pairs.rows, "fixture must produce candidate rows"
+
+    out = CalibratorScore(calibrator).forward(pairs)  # type: ignore[arg-type]
+
+    assert calibrator.calls == 0
+    assert [row.score for row in out.rows] == [None] * len(pairs.rows)

--- a/tests/core/test_persist_v2_explicit_chain.py
+++ b/tests/core/test_persist_v2_explicit_chain.py
@@ -677,6 +677,31 @@ def test_builtin_loader_refuses_to_build_around_a_missing_component(
         serializer.load({}, None, tmp_path)
 
 
+def test_calibrator_score_serializer_round_trips_its_nested_calibrator(tmp_path: Path) -> None:
+    """`calibrator_score` carries the fitted calibrator as its nested component.
+
+    The dump must hand back the calibrator itself (the artifact layer serializes it
+    through the component registry and its sidecar), and the load must rebuild a
+    CalibratorScore around whatever it is given back.
+    """
+    from langres.core.op_adapters import CalibratorScore
+
+    class _FittedCalibrator:
+        def transform(self, scores: list[float]) -> list[float]:
+            return scores
+
+    calibrator = _FittedCalibrator()
+    serializer = get_op_serializer("calibrator_score")
+
+    params, component = serializer.dump(CalibratorScore(calibrator))  # type: ignore[arg-type]
+    assert params == {}
+    assert component is calibrator
+
+    restored = serializer.load(params, calibrator, tmp_path)
+    assert isinstance(restored, CalibratorScore)
+    assert restored.calibrator is calibrator
+
+
 def test_rebuild_op_fails_closed_when_a_role_has_no_param_schema(tmp_path: Path) -> None:
     """No registered `validate_params` means no way to prove the params are safe."""
 

--- a/tests/core/test_persist_v2_explicit_chain.py
+++ b/tests/core/test_persist_v2_explicit_chain.py
@@ -14,7 +14,7 @@ from __future__ import annotations
 import json
 from collections.abc import Iterator
 from pathlib import Path
-from typing import Any, ClassVar
+from typing import Any, ClassVar, cast
 
 import pytest
 from pydantic import BaseModel, ConfigDict
@@ -32,7 +32,13 @@ from langres.core.op_adapters import (
     GroupwiseMatcherScore,
     MatcherScore,
 )
-from langres.core.registry import register, register_op
+from langres.core.registry import (
+    OpSerializer,
+    get_op_serializer,
+    register,
+    register_op,
+    register_op_serializer,
+)
 from langres.core.resolver import ERModel
 from langres.core.results import DedupeResult
 from langres.core.serialization import ArtifactManifest, ComponentSpec, OpSpec
@@ -626,3 +632,118 @@ def test_registered_custom_op_rejects_unknown_params_before_from_config(tmp_path
             ),
             state_dir=tmp_path,
         )
+
+
+# --------------------------------------------------------------------------
+# The fail-closed guards on the OpSpec seam.
+#
+# `rebuild_op` validates the role/component envelope before it constructs
+# anything, and re-checks the Stage contract after. Each guard below is the
+# thing that turns a malformed or hostile manifest into a loud error instead of
+# a half-built pipeline, so each is asserted on its own.
+# --------------------------------------------------------------------------
+
+
+def _dump_nothing(op: object) -> tuple[dict[str, object], object | None]:
+    return {}, None
+
+
+def _passthrough_params(params: dict[str, object]) -> dict[str, object]:
+    return dict(params)
+
+
+@pytest.mark.parametrize(
+    "role",
+    [
+        "blocker_source",
+        "comparator_score",
+        "matcher_score",
+        "calibrator_score",
+        "clusterer_stage",
+    ],
+)
+def test_builtin_loader_refuses_to_build_around_a_missing_component(
+    role: str, tmp_path: Path
+) -> None:
+    """Every component-bearing built-in role rejects a `None` component.
+
+    This is the layer beneath `rebuild_op`'s envelope check: `load` is reachable
+    directly through `get_op_serializer(role)`, which is exactly what a custom-Op
+    author holds. Without the guard a built-in stage would be constructed around
+    `None` and fail much later, far from the malformed manifest that caused it.
+    """
+    serializer = get_op_serializer(role)
+    with pytest.raises(ValueError, match="requires a nested component"):
+        serializer.load({}, None, tmp_path)
+
+
+def test_rebuild_op_fails_closed_when_a_role_has_no_param_schema(tmp_path: Path) -> None:
+    """No registered `validate_params` means no way to prove the params are safe."""
+
+    class _SchemalessStage:
+        pass
+
+    def _load(params: dict[str, object], component: object | None, state_dir: Path) -> object:
+        return _SchemalessStage()
+
+    register_op_serializer(
+        OpSerializer(
+            role="persist_v2_schemaless",
+            op_type=_SchemalessStage,
+            dump=_dump_nothing,
+            load=_load,
+        )
+    )
+    with pytest.raises(ValueError, match="no registered parameter schema"):
+        rebuild_op(OpSpec(role="persist_v2_schemaless", params={}), state_dir=tmp_path)
+
+
+def test_op_spec_rejects_a_component_the_role_never_declared() -> None:
+    """A serializer that hands back a component must have declared a slot for it.
+
+    Otherwise `op_spec` would silently drop the component on save and the stage
+    would reload without it.
+    """
+
+    class _LeakyStage:
+        pass
+
+    def _dump_leaky(op: object) -> tuple[dict[str, object], object | None]:
+        return {}, object()
+
+    def _load(params: dict[str, object], component: object | None, state_dir: Path) -> object:
+        return _LeakyStage()
+
+    register_op_serializer(
+        OpSerializer(
+            role="persist_v2_leaky",
+            op_type=_LeakyStage,
+            dump=_dump_leaky,
+            load=_load,
+            validate_params=_passthrough_params,
+        )
+    )
+    with pytest.raises(TypeError, match="declares no component_slot"):
+        op_spec(cast(Stage, _LeakyStage()))
+
+
+def test_rebuild_op_rejects_a_rebuilt_object_that_is_not_a_stage(tmp_path: Path) -> None:
+    """A registered serializer cannot smuggle a non-Stage into the chain."""
+
+    class _NotAStage:
+        pass
+
+    def _load(params: dict[str, object], component: object | None, state_dir: Path) -> object:
+        return _NotAStage()
+
+    register_op_serializer(
+        OpSerializer(
+            role="persist_v2_not_a_stage",
+            op_type=_NotAStage,
+            dump=_dump_nothing,
+            load=_load,
+            validate_params=_passthrough_params,
+        )
+    )
+    with pytest.raises(TypeError, match="not a Source/Op/ClusterStage/Finalize"):
+        rebuild_op(OpSpec(role="persist_v2_not_a_stage", params={}), state_dir=tmp_path)

--- a/tests/core/test_registry.py
+++ b/tests/core/test_registry.py
@@ -1,18 +1,26 @@
 """Unit tests for the component/schema registry (M0 Wave 1)."""
 
-import pytest
-from pydantic import BaseModel
+from pathlib import Path
 
+import pytest
+from pydantic import BaseModel, ConfigDict
+
+from langres.core import registry as registry_module
 from langres.core.registry import (
+    OpSerializer,
     SchemaNotRegistered,
     UnknownComponentType,
     UnknownModelType,
+    UnknownOpType,
     get_component,
     get_model,
+    get_op_serializer,
     get_schema,
     model_type_name,
     register,
     register_model,
+    register_op,
+    register_op_serializer,
     register_schema,
 )
 
@@ -162,3 +170,255 @@ class TestRegisterModel:
 
         with pytest.raises(UnknownComponentType):
             get_component("test_namespace_isolation")
+
+
+class _StrictOpConfig(BaseModel):
+    """The parameter envelope ``@register_op`` demands: closed and strictly typed."""
+
+    model_config = ConfigDict(extra="forbid", strict=True)
+
+    factor: float = 1.0
+
+
+class TestRegisterOpValidation:
+    """``@register_op`` is a fail-closed contract; each rule rejects at decoration time.
+
+    These guardrails are what stop a saved chain from naming a class whose
+    parameter envelope is open or loosely typed — without them an artifact could
+    smuggle unvalidated keys straight into ``from_config``.
+    """
+
+    def test_requires_from_config(self) -> None:
+        with pytest.raises(TypeError, match="from_config"):
+
+            @register_op("test_op_no_from_config")
+            class _NoFromConfig:
+                config_model = _StrictOpConfig
+                config: dict[str, object] = {"factor": 1.0}
+
+    def test_requires_config(self) -> None:
+        with pytest.raises(TypeError, match=r"requires _NoConfig\.config"):
+
+            @register_op("test_op_no_config")
+            class _NoConfig:
+                config_model = _StrictOpConfig
+
+                @classmethod
+                def from_config(cls, config: dict[str, object]) -> "_NoConfig":
+                    return cls()
+
+    def test_requires_a_pydantic_config_model(self) -> None:
+        with pytest.raises(TypeError, match="config_model to be a "):
+
+            @register_op("test_op_no_config_model")
+            class _NoConfigModel:
+                config: dict[str, object] = {"factor": 1.0}
+                config_model = dict  # not a BaseModel subclass
+
+                @classmethod
+                def from_config(cls, config: dict[str, object]) -> "_NoConfigModel":
+                    return cls()
+
+    def test_requires_extra_forbid(self) -> None:
+        class _OpenConfig(BaseModel):
+            model_config = ConfigDict(strict=True)
+
+        with pytest.raises(TypeError, match="extra='forbid'"):
+
+            @register_op("test_op_extra_allowed")
+            class _OpenOp:
+                config: dict[str, object] = {}
+                config_model = _OpenConfig
+
+                @classmethod
+                def from_config(cls, config: dict[str, object]) -> "_OpenOp":
+                    return cls()
+
+    def test_requires_strict(self) -> None:
+        class _LooseConfig(BaseModel):
+            model_config = ConfigDict(extra="forbid")
+
+        with pytest.raises(TypeError, match="strict=True"):
+
+            @register_op("test_op_not_strict")
+            class _LooseOp:
+                config: dict[str, object] = {}
+                config_model = _LooseConfig
+
+                @classmethod
+                def from_config(cls, config: dict[str, object]) -> "_LooseOp":
+                    return cls()
+
+
+class TestRegisteredOpSerializer:
+    """What the serializer built by ``@register_op`` actually does."""
+
+    def test_dump_reads_a_mapping_config_property(self) -> None:
+        @register_op("test_op_mapping_config")
+        class _MappingOp:
+            config_model = _StrictOpConfig
+
+            def __init__(self, factor: float = 2.0) -> None:
+                self.factor = factor
+
+            @property
+            def config(self) -> dict[str, object]:
+                return {"factor": self.factor}
+
+            @classmethod
+            def from_config(cls, config: dict[str, object]) -> "_MappingOp":
+                return cls(float(config["factor"]))  # type: ignore[arg-type]
+
+        serializer = get_op_serializer("test_op_mapping_config")
+        params, component = serializer.dump(_MappingOp(3.0))
+        assert params == {"factor": 3.0}
+        assert component is None
+
+    def test_dump_reads_a_callable_config_returning_a_model(self) -> None:
+        """``config`` may be a method returning a BaseModel; both dump as plain data."""
+
+        @register_op("test_op_model_config")
+        class _ModelConfigOp:
+            config_model = _StrictOpConfig
+
+            def __init__(self, factor: float = 1.0) -> None:
+                self.factor = factor
+
+            def config(self) -> _StrictOpConfig:
+                return _StrictOpConfig(factor=self.factor)
+
+            @classmethod
+            def from_config(cls, config: dict[str, object]) -> "_ModelConfigOp":
+                return cls(float(config["factor"]))  # type: ignore[arg-type]
+
+        serializer = get_op_serializer("test_op_model_config")
+        params, _ = serializer.dump(_ModelConfigOp(4.0))
+        assert params == {"factor": 4.0}
+
+    def test_validate_params_rejects_unknown_keys(self) -> None:
+        @register_op("test_op_validate")
+        class _ValidatedOp:
+            config_model = _StrictOpConfig
+
+            def __init__(self, factor: float = 1.0) -> None:
+                self.factor = factor
+
+            @property
+            def config(self) -> dict[str, object]:
+                return {"factor": self.factor}
+
+            @classmethod
+            def from_config(cls, config: dict[str, object]) -> "_ValidatedOp":
+                return cls(float(config["factor"]))  # type: ignore[arg-type]
+
+        serializer = get_op_serializer("test_op_validate")
+        assert serializer.validate_params is not None
+        assert serializer.validate_params({"factor": 2.0}) == {"factor": 2.0}
+        with pytest.raises(ValueError, match="smuggled"):
+            serializer.validate_params({"factor": 2.0, "smuggled": True})
+
+    def test_load_rebuilds_from_validated_params(self) -> None:
+        @register_op("test_op_load")
+        class _LoadableOp:
+            config_model = _StrictOpConfig
+
+            def __init__(self, factor: float = 1.0) -> None:
+                self.factor = factor
+
+            @property
+            def config(self) -> dict[str, object]:
+                return {"factor": self.factor}
+
+            @classmethod
+            def from_config(cls, config: dict[str, object]) -> "_LoadableOp":
+                return cls(float(config["factor"]))  # type: ignore[arg-type]
+
+        serializer = get_op_serializer("test_op_load")
+        restored = serializer.load({"factor": 5.0}, None, Path("."))
+        assert isinstance(restored, _LoadableOp)
+        assert restored.factor == 5.0
+
+    def test_load_rejects_a_component_it_cannot_own(self) -> None:
+        """A ``@register_op`` Op is component-free; a spec carrying one is corrupt."""
+
+        @register_op("test_op_rejects_component")
+        class _ComponentFreeOp:
+            config_model = _StrictOpConfig
+
+            @property
+            def config(self) -> dict[str, object]:
+                return {}
+
+            @classmethod
+            def from_config(cls, config: dict[str, object]) -> "_ComponentFreeOp":
+                return cls()
+
+        serializer = get_op_serializer("test_op_rejects_component")
+        with pytest.raises(ValueError, match="component-free"):
+            serializer.load({}, object(), Path("."))
+
+
+class TestOpSerializerRegistration:
+    @staticmethod
+    def _dump(op: object) -> tuple[dict[str, object], object | None]:
+        return {}, None
+
+    @staticmethod
+    def _load(params: dict[str, object], component: object | None, state_dir: Path) -> object:
+        return object()
+
+    def test_duplicate_role_is_rejected(self) -> None:
+        class _RoleA:
+            pass
+
+        class _RoleB:
+            pass
+
+        register_op_serializer(
+            OpSerializer(role="test_dup_role", op_type=_RoleA, dump=self._dump, load=self._load)
+        )
+        with pytest.raises(ValueError, match="already registered"):
+            register_op_serializer(
+                OpSerializer(role="test_dup_role", op_type=_RoleB, dump=self._dump, load=self._load)
+            )
+
+    def test_duplicate_op_type_is_rejected(self) -> None:
+        """One class, one serializer — a second would silently shadow the first."""
+
+        class _SharedOp:
+            pass
+
+        register_op_serializer(
+            OpSerializer(
+                role="test_dup_type_a", op_type=_SharedOp, dump=self._dump, load=self._load
+            )
+        )
+        with pytest.raises(ValueError, match="already has a registered serializer"):
+            register_op_serializer(
+                OpSerializer(
+                    role="test_dup_type_b", op_type=_SharedOp, dump=self._dump, load=self._load
+                )
+            )
+
+
+class TestTrustedLazyOpRoles:
+    """The closed trusted-role map may import one module; it never trusts the result."""
+
+    def test_a_trusted_module_that_does_not_register_fails_closed(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # Point a role at a real, importable module that registers no serializer.
+        # Importing it must not leave the role resolvable: the lookup fails closed
+        # rather than handing back something the module never claimed.
+        monkeypatch.setitem(
+            registry_module._LAZY_OP_SERIALIZER_MODULES,
+            "test_trusted_but_silent",
+            "langres.core.score_type",
+        )
+        with pytest.raises(UnknownOpType, match="did not register role"):
+            get_op_serializer("test_trusted_but_silent")
+
+    def test_an_unknown_role_imports_nothing_and_fails_closed(self) -> None:
+        with pytest.raises(UnknownOpType) as exc:
+            get_op_serializer("no_such_op_role_123")
+        assert "no_such_op_role_123" in str(exc.value)

--- a/tests/core/test_results.py
+++ b/tests/core/test_results.py
@@ -1,0 +1,65 @@
+"""Tests for the self-describing result models (`langres.core.results`).
+
+`LinkVerdict` is what `ERModel.compare` hands a user, so its two affordances --
+`if verdict:` and a readable `repr` -- are public API, not conveniences. Both are
+documented in the class docstring and neither had a test.
+"""
+
+from langres.core.models import PairwiseJudgement
+from langres.core.results import LinkVerdict
+
+
+def _judgement(score: float | None = 0.91) -> PairwiseJudgement:
+    return PairwiseJudgement(
+        left_id="a",
+        right_id="b",
+        score=score,
+        score_type="heuristic",
+        decision_step="test",
+        provenance={},
+    )
+
+
+def _verdict(*, match: bool, score: float | None = 0.91) -> LinkVerdict:
+    return LinkVerdict(
+        match=match,
+        score=score,
+        architecture="FuzzyString",
+        score_type="heuristic",
+        threshold=0.5,
+        judgement=_judgement(score),
+    )
+
+
+class TestLinkVerdictTruthiness:
+    """`if model.compare(a, b):` must read the verdict, not the object's existence.
+
+    Without `__bool__`, every LinkVerdict is truthy -- so the documented one-liner
+    would silently report "match" for a non-match. That is a wrong answer, not a
+    missing feature.
+    """
+
+    def test_a_match_is_truthy(self) -> None:
+        assert _verdict(match=True)
+
+    def test_a_non_match_is_falsy(self) -> None:
+        assert not _verdict(match=False)
+
+    def test_truthiness_follows_match_not_score(self) -> None:
+        # A high score that did not clear the cut is still a non-match.
+        assert not _verdict(match=False, score=0.99)
+        # And a match with no score at all (a decider judge) is still truthy.
+        assert _verdict(match=True, score=None)
+
+
+class TestLinkVerdictRepr:
+    def test_repr_names_the_verdict_score_and_architecture(self) -> None:
+        text = repr(_verdict(match=True))
+        assert "MATCH" in text
+        assert "0.910" in text
+        assert "FuzzyString" in text
+
+    def test_repr_says_no_match_and_handles_a_scoreless_decider(self) -> None:
+        text = repr(_verdict(match=False, score=None))
+        assert "NO MATCH" in text
+        assert "n/a" in text  # never a fabricated 0.000

--- a/tests/core/test_serialization.py
+++ b/tests/core/test_serialization.py
@@ -8,10 +8,13 @@ Covers:
 
 from pathlib import Path
 
+import pytest
+
 from langres.core.serialization import (
     ARTIFACT_VERSION,
     CLASSIC_ARTIFACT_VERSION,
     ArtifactManifest,
+    ArtifactSource,
     ComponentSpec,
     OpSpec,
     SerializableState,
@@ -134,3 +137,40 @@ class TestSerializableStateProtocol:
             pass
 
         assert not isinstance(_Light(), SerializableState)
+
+
+class TestArtifactSourceProvenance:
+    """Where an artifact came from, typed -- and pinned when it came from the Hub.
+
+    `ArtifactSource` is core's transport-neutral provenance record, so it carries
+    the pin rule itself rather than delegating it to `langres.hub`. A Hub source
+    identified by a branch or tag would silently mean different weights later; only
+    an immutable 40-character commit SHA is accepted.
+    """
+
+    def test_a_local_source_needs_no_revision(self) -> None:
+        source = ArtifactSource(kind="local", location="/models/resolver")
+        assert source.resolved_revision is None
+
+    def test_location_must_be_non_empty(self) -> None:
+        with pytest.raises(ValueError, match="location must be non-empty"):
+            ArtifactSource(kind="local", location="   ")
+
+    def test_a_hub_source_pinned_to_a_commit_sha_is_accepted(self) -> None:
+        sha = "a" * 40
+        source = ArtifactSource(kind="hub", location="org/model", resolved_revision=sha)
+        assert source.resolved_revision == sha
+
+    @pytest.mark.parametrize(
+        "revision",
+        [
+            None,  # unpinned entirely
+            "main",  # a moving branch
+            "v1.0.0",  # a tag, which can be re-pointed
+            "a" * 39,  # a truncated SHA
+            "g" * 40,  # right length, not hex
+        ],
+    )
+    def test_a_hub_source_without_an_immutable_sha_is_refused(self, revision: str | None) -> None:
+        with pytest.raises(ValueError, match="immutable 40-character commit SHA"):
+            ArtifactSource(kind="hub", location="org/model", resolved_revision=revision)

--- a/tests/core/test_spend_cap.py
+++ b/tests/core/test_spend_cap.py
@@ -205,3 +205,73 @@ class TestSpendCapBudgetEdges:
 
         capped = SpendCappedMatcher(_NoneCostMatcher(), budget_usd=0.0)
         assert len(list(capped.forward(_candidates()))) == 1
+
+
+class _GroupwiseCostlyMatcher(Matcher[object]):
+    """Mimics SelectMatcher's group accounting: full cost on the group's first
+    judgement, $0 on its K-1 siblings, ``group_end`` on the last.
+
+    Lazy on purpose -- ``pulled`` records how far the consumer actually advanced
+    the generator, which is what proves the drain stops at the group boundary
+    instead of resuming the matcher and firing the next group's paid call.
+    """
+
+    def __init__(self, group_size: int, cost_per_group: float, groups: int = 2) -> None:
+        self._group_size = group_size
+        self._cost_per_group = cost_per_group
+        self._groups = groups
+        self.pulled = 0
+
+    def forward(self, candidates: Iterator[ERCandidate[object]]) -> Iterator[PairwiseJudgement]:
+        list(candidates)
+        for group in range(self._groups):
+            for member in range(self._group_size):
+                self.pulled += 1
+                yield PairwiseJudgement(
+                    left_id=f"g{group}",
+                    right_id=f"m{member}",
+                    score=0.9,
+                    score_type="prob_llm",
+                    decision_step="fake_groupwise",
+                    provenance={
+                        "cost_usd": self._cost_per_group if member == 0 else 0.0,
+                        "group_id": f"g{group}",
+                        "group_end": member == self._group_size - 1,
+                    },
+                )
+
+    def inspect_scores(self, judgements: list[PairwiseJudgement], sample_size: int = 10) -> object:
+        raise NotImplementedError
+
+
+class TestGroupsAreNeverSplitAcrossTheCap:
+    """A group is one paid call, so the cap must not keep half of what was paid for.
+
+    The whole group's cost is stamped on its first judgement. If the cap trips
+    there and simply raises, the K-1 already-paid-for siblings are lost: the
+    caller is billed for the call but only sees a fraction of its output.
+    """
+
+    def test_partial_judgements_carry_the_whole_paid_group(self) -> None:
+        matcher = _GroupwiseCostlyMatcher(group_size=3, cost_per_group=5.0)
+        capped = SpendCappedMatcher(matcher, budget_usd=1.0)
+
+        with pytest.raises(BudgetExceeded) as exc:
+            list(capped.forward(_candidates()))
+
+        partial = exc.value.partial_judgements
+        assert [j.right_id for j in partial] == ["m0", "m1", "m2"]
+        assert all(j.provenance["group_id"] == "g0" for j in partial)
+
+    def test_the_drain_stops_at_the_boundary_and_bills_no_second_group(self) -> None:
+        """Draining must not pull past ``group_end`` -- that would resume the
+        matcher and fire the NEXT group's paid call for output nobody keeps."""
+        matcher = _GroupwiseCostlyMatcher(group_size=3, cost_per_group=5.0)
+        capped = SpendCappedMatcher(matcher, budget_usd=1.0)
+
+        with pytest.raises(BudgetExceeded):
+            list(capped.forward(_candidates()))
+
+        # Exactly the first group was produced; the second group's first
+        # judgement (the next paid call) was never requested.
+        assert matcher.pulled == 3

--- a/tests/core/test_trackers_backcompat_shim.py
+++ b/tests/core/test_trackers_backcompat_shim.py
@@ -8,10 +8,20 @@ is why this shim is covered by tests instead of carrying the ``# pragma: no
 cover`` its plain-re-export siblings use (see ``test_training_backcompat_shims``
 for the sibling pattern).
 
-The lazy-path tests deliberately resolve against a monkeypatched attribute on the
-real module: asserting against the genuine ``MlflowTracker`` would import
+The lazy-path tests resolve against a stand-in injected into the real module's
+``__dict__``: asserting against the genuine ``MlflowTracker`` would import
 ``mlflow`` (it sits at that adapter module's top level), which is exactly the
 heavyweight import the laziness exists to avoid.
+
+``monkeypatch.setitem(real.__dict__, ...)`` -- NOT ``monkeypatch.setattr(real,
+..., raising=False)``. That distinction is load-bearing and was found the hard
+way: ``setattr`` records the previous value with ``getattr``, which on a PEP 562
+module *invokes* ``__getattr__`` (importing the backend), and its teardown then
+writes that class back into the module ``__dict__``. The name would be cached
+there permanently, ``__getattr__`` would never run for it again, and every later
+test asserting the missing-extra ``ImportError`` path would fail. ``setitem``
+reads with ``dict.get``, which does not trigger ``__getattr__``, and deletes the
+key on teardown -- leaving the module exactly as it was found.
 """
 
 from __future__ import annotations
@@ -51,9 +61,11 @@ def test_lazy_adapter_resolves_through_the_new_module(
 ) -> None:
     """Accessing an adapter name delegates to ``langres.tracking.trackers``."""
     sentinel = object()
-    # Set it on the real module so the shim's `getattr` finds it directly --
-    # this exercises the shim's lazy branch without importing the backend.
-    monkeypatch.setattr(real, name, sentinel, raising=False)
+    # Inject into the real module's __dict__ so the shim's `getattr` finds it
+    # directly -- exercising the shim's lazy branch without importing the
+    # backend, and without perturbing the real module's __getattr__ for any
+    # later test (see this module's docstring: setitem, never setattr).
+    monkeypatch.setitem(real.__dict__, name, sentinel)
     assert getattr(shim, name) is sentinel
 
 

--- a/tests/core/test_trackers_backcompat_shim.py
+++ b/tests/core/test_trackers_backcompat_shim.py
@@ -1,0 +1,66 @@
+"""Back-compat: the W2-sweep shim at the old ``langres.core.trackers`` path.
+
+The tracker layer moved to ``langres.tracking.trackers`` (observability, not ER
+modelling). The shim left behind is *not* a plain re-export: the three backend
+adapters must stay lazy, so it mirrors the real module's PEP 562 ``__getattr__``
+rather than importing them. That conditional resolution is real behavior, which
+is why this shim is covered by tests instead of carrying the ``# pragma: no
+cover`` its plain-re-export siblings use (see ``test_training_backcompat_shims``
+for the sibling pattern).
+
+The lazy-path tests deliberately resolve against a monkeypatched attribute on the
+real module: asserting against the genuine ``MlflowTracker`` would import
+``mlflow`` (it sits at that adapter module's top level), which is exactly the
+heavyweight import the laziness exists to avoid.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+import langres.core.trackers as shim
+import langres.tracking.trackers as real
+
+#: The names the shim re-exports eagerly (no backend import involved).
+_EAGER = ["ExperimentTracker", "MultiTracker", "NoOpTracker", "TrackerSpec", "resolve_tracker"]
+
+
+def test_eager_reexports_are_the_new_objects() -> None:
+    """Every eagerly re-exported name is identity-equal to its new home."""
+    for name in _EAGER:
+        assert getattr(shim, name) is getattr(real, name), name
+    assert sorted(shim.__all__) == sorted(_EAGER)
+
+
+def test_lazy_adapter_names_match_the_real_adapter_table() -> None:
+    """The shim's lazy-name set cannot drift from the real module's table.
+
+    The shim hardcodes the adapter names; the real module derives them from
+    ``_ADAPTERS``. If a fourth backend is added there and not here, the shim
+    would silently raise ``AttributeError`` for a name that does resolve at its
+    real home -- so pin the two together.
+    """
+    assert shim._LAZY_ADAPTERS == {cls_name for _mod, cls_name in real._ADAPTERS.values()}
+
+
+@pytest.mark.parametrize("name", sorted({"MlflowTracker", "WandbTracker", "TrackioTracker"}))
+def test_lazy_adapter_resolves_through_the_new_module(
+    name: str, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Accessing an adapter name delegates to ``langres.tracking.trackers``."""
+    sentinel = object()
+    # Set it on the real module so the shim's `getattr` finds it directly --
+    # this exercises the shim's lazy branch without importing the backend.
+    monkeypatch.setattr(real, name, sentinel, raising=False)
+    assert getattr(shim, name) is sentinel
+
+
+def test_unknown_attribute_raises_attribute_error() -> None:
+    """A name that is neither re-exported nor a lazy adapter still fails cleanly."""
+    with pytest.raises(AttributeError) as excinfo:
+        _: Any = shim.NoSuchTracker  # type: ignore[attr-defined]
+    message = str(excinfo.value)
+    assert "langres.core.trackers" in message
+    assert "NoSuchTracker" in message

--- a/tests/tracking/test_runs.py
+++ b/tests/tracking/test_runs.py
@@ -753,64 +753,43 @@ class TestCaptureRun:
 
 
 # ---------------------------------------------------------------------------
-# A persisted run snapshot is immutable and JSON-safe.
+# A run snapshot is immutable and JSON-safe.
 #
-# A RunRecord is the durable record of what ran. If a caller could mutate its
-# snapshot after the fact, the persisted line and the in-memory object would
-# disagree; if a snapshot could hold a set or a NaN, the record would not
-# round-trip through JSON at all. Both are enforced at validation time.
+# A RunContext is the recipe half of the durable record of what ran, and
+# `compute_recipe_id` content-addresses it. If a caller could mutate a snapshot
+# after the id was computed, the id would no longer describe the object; if a
+# snapshot could hold a set or a NaN, the record would not round-trip through
+# JSON at all. Both are enforced at validation time.
 # ---------------------------------------------------------------------------
-
-
-def _minimal_record_payload(**overrides: Any) -> dict[str, Any]:
-    payload: dict[str, Any] = {
-        "attempt_id": "recipe-time",
-        "recipe_id": "recipe",
-        "context": {"experiment": "snapshot", "dataset_name": "dataset"},
-        "started_at": "2026-07-18T12:00:00+00:00",
-        "status": "completed",
-    }
-    payload.update(overrides)
-    return payload
 
 
 class TestRunSnapshotsAreImmutable:
     def test_popitem_is_refused(self) -> None:
-        record = pydantic.TypeAdapter(RunRecord).validate_python(
-            _minimal_record_payload(tags={"stage": "eval"})
-        )
+        context = _context(tags={"stage": "eval"})
         with pytest.raises(TypeError, match="run snapshots are immutable"):
-            record.tags.popitem()
+            context.tags.popitem()
 
     def test_in_place_union_is_refused(self) -> None:
-        record = pydantic.TypeAdapter(RunRecord).validate_python(
-            _minimal_record_payload(tags={"stage": "eval"})
-        )
+        context = _context(tags={"stage": "eval"})
         with pytest.raises(TypeError, match="run snapshots are immutable"):
-            record.tags |= {"stage": "smuggled"}
+            context.tags |= {"stage": "smuggled"}
 
     def test_nested_mappings_are_frozen_too(self) -> None:
         """Freezing only the top level would leave the interesting part mutable."""
-        record = pydantic.TypeAdapter(RunRecord).validate_python(
-            _minimal_record_payload(resolver_config={"matcher": {"threshold": 0.5}})
-        )
-        assert record.resolver_config is not None
+        context = _context(resolver_config={"matcher": {"threshold": 0.5}})
+        assert context.resolver_config is not None
         with pytest.raises(TypeError, match="run snapshots are immutable"):
-            record.resolver_config["matcher"]["threshold"] = 0.9
+            context.resolver_config["matcher"]["threshold"] = 0.9
 
 
 class TestRunSnapshotsMustBeJsonValues:
     def test_a_set_is_refused(self) -> None:
         with pytest.raises(pydantic.ValidationError, match="sets are not supported"):
-            pydantic.TypeAdapter(RunRecord).validate_python(
-                _minimal_record_payload(resolver_config={"kinds": {"a", "b"}})
-            )
+            _context(resolver_config={"kinds": {"a", "b"}})
 
     def test_a_non_finite_decimal_is_refused(self) -> None:
         with pytest.raises(pydantic.ValidationError, match="finite numeric values"):
-            pydantic.TypeAdapter(RunRecord).validate_python(
-                _minimal_record_payload(resolver_config={"cost": decimal.Decimal("NaN")})
-            )
+            _context(resolver_config={"cost": decimal.Decimal("NaN")})
 
 
 class TestDatasetFingerprintCanonicalization:

--- a/tests/tracking/test_runs.py
+++ b/tests/tracking/test_runs.py
@@ -11,6 +11,7 @@ fan-out, failure path).
 
 from __future__ import annotations
 
+import decimal
 import json
 import logging
 import os
@@ -749,3 +750,91 @@ class TestCaptureRun:
             pass
         record = RunStore(path).read()[0]
         assert "http://mlflow/run/1" in record.artifacts.values()
+
+
+# ---------------------------------------------------------------------------
+# A persisted run snapshot is immutable and JSON-safe.
+#
+# A RunRecord is the durable record of what ran. If a caller could mutate its
+# snapshot after the fact, the persisted line and the in-memory object would
+# disagree; if a snapshot could hold a set or a NaN, the record would not
+# round-trip through JSON at all. Both are enforced at validation time.
+# ---------------------------------------------------------------------------
+
+
+def _minimal_record_payload(**overrides: Any) -> dict[str, Any]:
+    payload: dict[str, Any] = {
+        "attempt_id": "recipe-time",
+        "recipe_id": "recipe",
+        "context": {"experiment": "snapshot", "dataset_name": "dataset"},
+        "started_at": "2026-07-18T12:00:00+00:00",
+        "status": "completed",
+    }
+    payload.update(overrides)
+    return payload
+
+
+class TestRunSnapshotsAreImmutable:
+    def test_popitem_is_refused(self) -> None:
+        record = pydantic.TypeAdapter(RunRecord).validate_python(
+            _minimal_record_payload(tags={"stage": "eval"})
+        )
+        with pytest.raises(TypeError, match="run snapshots are immutable"):
+            record.tags.popitem()
+
+    def test_in_place_union_is_refused(self) -> None:
+        record = pydantic.TypeAdapter(RunRecord).validate_python(
+            _minimal_record_payload(tags={"stage": "eval"})
+        )
+        with pytest.raises(TypeError, match="run snapshots are immutable"):
+            record.tags |= {"stage": "smuggled"}
+
+    def test_nested_mappings_are_frozen_too(self) -> None:
+        """Freezing only the top level would leave the interesting part mutable."""
+        record = pydantic.TypeAdapter(RunRecord).validate_python(
+            _minimal_record_payload(resolver_config={"matcher": {"threshold": 0.5}})
+        )
+        assert record.resolver_config is not None
+        with pytest.raises(TypeError, match="run snapshots are immutable"):
+            record.resolver_config["matcher"]["threshold"] = 0.9
+
+
+class TestRunSnapshotsMustBeJsonValues:
+    def test_a_set_is_refused(self) -> None:
+        with pytest.raises(pydantic.ValidationError, match="sets are not supported"):
+            pydantic.TypeAdapter(RunRecord).validate_python(
+                _minimal_record_payload(resolver_config={"kinds": {"a", "b"}})
+            )
+
+    def test_a_non_finite_decimal_is_refused(self) -> None:
+        with pytest.raises(pydantic.ValidationError, match="finite numeric values"):
+            pydantic.TypeAdapter(RunRecord).validate_python(
+                _minimal_record_payload(resolver_config={"cost": decimal.Decimal("NaN")})
+            )
+
+
+class TestDatasetFingerprintCanonicalization:
+    """The fingerprint normalizes what is unordered and preserves what is not."""
+
+    def test_a_finite_decimal_is_canonicalized_not_rejected(self) -> None:
+        fingerprint = dataset_fingerprint([{"price": decimal.Decimal("1.50")}], [])
+        assert fingerprint == dataset_fingerprint([{"price": decimal.Decimal("1.50")}], [])
+
+    def test_a_non_finite_decimal_cannot_be_fingerprinted(self) -> None:
+        with pytest.raises(ValueError, match="must be finite"):
+            dataset_fingerprint([{"price": decimal.Decimal("Infinity")}], [])
+
+    def test_ordinary_list_order_is_content_not_noise(self) -> None:
+        """A token sequence is ordered data; reordering it is a different dataset.
+
+        Contrast the set-of-clusters case, where list order is a graph-traversal
+        artifact and *is* normalized away.
+        """
+        assert dataset_fingerprint([{"tokens": ["a", "b"]}], []) != dataset_fingerprint(
+            [{"tokens": ["b", "a"]}], []
+        )
+
+    def test_cluster_order_is_noise_and_is_normalized_away(self) -> None:
+        assert dataset_fingerprint([[{"a"}, {"b"}]], []) == dataset_fingerprint(
+            [[{"b"}, {"a"}]], []
+        )


### PR DESCRIPTION
`main` has been red for six days. This makes it green without moving the floor, and fixes the reason nobody saw it.

## Headline numbers

| measurement | value | floor | |
|---|---|---|---|
| **before** (CI, `82a222f`) | **97.28%** | 98 | ✗ |
| **after — tests only, this PR's pragmas reverted** | **98.16%** | 98 | ✓ |
| **after — as shipped** | **98.26%** | 98 | ✓ |
| after — fast suite (new per-PR gate) | 97.93% | 97.5 | ✓ |

**The `# pragma: no cover` change is not load-bearing: the gate clears 98 on the new tests alone.** Split of the +0.98pp, measured (see "Earned vs. arithmetic" below): **+0.88pp from new tests, +0.10pp from removing 12 shim statements from the denominator.**

`--fail-under=98` is untouched.

## Root cause: a code regression in #229 — not the include set widening

Two candidates had to be separated: (a) #229 added code that genuinely dropped coverage, or (b) the include set was widened without the floor being re-derived, so the floor had been nominally-98/actually-unmet for a while. The workflow's own `STALE-NUMBER NOTE` explicitly raised (b).

**It is (a), entirely.** `git diff 3dbd13d HEAD -- .github/workflows/test.yml` shows the `--include` list is **byte-identical** between the last green run and `HEAD`. The widening had already happened *and been measured green at 98.28%*. Nothing about the list changed when the gate went red.

The per-merge series, read out of the `Coverage gate` step of each merge commit's own CI run:

| commit | PR | gate TOTAL | stmts | miss |
|---|---|---|---|---|
| `3dbd13d` | #217 | **98.28%** | 8024 | 105 |
| `c270522` | **#229** | **97.27%** | 8883 | 178 |
| `94df55e` | #230 | 97.16% | 8968 | 187 |
| `82a222f` | tonight's 5 | 97.28% | 9023 | 178 |

**#229 alone accounts for the whole drop** (−1.01pp of a −1.00pp total). It merged ~2,000 net new lines into gated `core/` paths at roughly 90% coverage:

```
core/_model_run.py    +241 stmts  100%    -> 89.85%
core/_artifacts.py     +86 stmts  100%    -> 89.10%
core/registry.py       +76 stmts  97.44%  -> 84.09%
tracking/runs.py      +141 stmts  100%    -> 95.99%
core/op_adapters.py    +84 stmts  100%    -> 97.47%
```

#230 added `core/indexes/qdrant_dense_index.py` (−0.11pp). Tonight's five merges moved it **up** 0.12pp — they inherited the red, they did not cause it.

The `STALE-NUMBER NOTE` at the gate step promised the TOTAL "is recomputed once this lands". It never was. It has now been, and is replaced with the resolved finding.

## Why six days passed

`test-full` — the only job that runs this gate — is gated `if: github.event_name != 'pull_request'`. On PR #229 the check list read:

```
lint pass · test pass · test-core-only pass · test-finetune pass
test-full  SKIPPING        <- the only job running the contract gate
```

It merged fully green with the gate never having executed once, and `main` then absorbed six more merges. Step 7 of `test-full` is the *sole* failure on `main`; steps 1–6 and every other workflow (Lint, CodeQL, Docs, Scorecard) are green.

## What changed

### 1. Real tests for contract code #229 shipped untested (the bulk)

- **`core/registry.py` — the `@register_op` fail-closed contract.** Every validation branch was untested: missing `from_config`/`config`, a non-Pydantic `config_model`, a `config_model` without `extra="forbid"` or `strict=True`, duplicate role, duplicate `op_type`, a trusted lazy role whose module registers nothing, a component handed to a component-free Op. These are what stop a saved artifact smuggling unvalidated keys into `from_config`. **84.09% → 97.73%**
- **`core/_artifacts.py` — the OpSpec guards.** Five built-in loaders' missing-component refusals, the missing-param-schema refusal, the undeclared-component refusal on save, the not-a-Stage refusal on load, and the `calibrator_score` round-trip. **89.10% → ~99%**
- **`tracking/runs.py` — the run-snapshot contract.** Immutability (`popitem`, `|=`, nested freezing) and JSON-safety (sets and non-finite numbers refused), plus the fingerprint's deliberate asymmetry: cluster order is traversal noise and normalises away, token order is content and does not. **95.99% → 99.20%**
- **`core/method_registry.py` — every optional builder's missing-extra `ImportError`.** CI installs `--all-extras`, so all five "you need the `[llm]`/`[trained]` extra" branches are unreachable there and all five were untested. They are the point of the extras split. **92.76% → 100%**
- **`ArtifactSource`** had **no test anywhere**: a Hub artifact source must be pinned to an immutable 40-character commit SHA, never a branch or tag that re-points later.
- **`SpendCappedMatcher`'s group drain** — a group is one paid call, so the cap must return the whole group in `partial_judgements`, and must not pull past `group_end` (which would fire the *next* group's paid call for output nobody keeps).
- **`LinkVerdict.__bool__`** — without it every verdict is truthy, so the documented `if model.compare(a, b):` reports a match for a **non-match**. A wrong answer, not a missing feature.
- **`Blocker.schema`** returns `None` when the registry no longer knows the name (the normal state for an inferred schema in a fresh process) instead of raising from a property callers treat as cheap.

### 2. Six of the last seven W2 shims get the pragma their five siblings already carry

`core/{debugging,diagnostics,runs}.py` and the three `core/trackers/*` adapters are `# TEMPORARY: deleted by the W2 sweep` re-export shims. A re-export owns no contract, and the module each redirects to is *itself* inside this gate at 100%. Five sibling shims (`harvest`, `anchor_store`, `benchmark`, `canonicalizer`, `review`) already carry `# pragma: no cover`, and the gate's own comment already documents this as the intended treatment. Each is commented with why and when it goes away.

#### Earned vs. arithmetic — the numbers, because pragma raises a percentage without testing anything

Re-measured on the shipped tree from **one** full-suite `.coverage` (4657 passed, 2 skipped, 18m43s), reporting three times against that same data file with the pragma tokens mangled and restored, so nothing but the pragma differs. `coverage.py` applies exclusions at *report* time, so this needs no re-running:

- **A — as shipped: 98.26%** (9011 stmts, 98 miss).
- **B — this PR's six shim pragmas neutralised: 98.16%** (9023 stmts, 110 miss) — **still passes 98**. Cost of the exclusion: **0.10pp, 12 statements.**
- **12 of 12** of those statements were uncovered beforehand (all six shims sat at 0.00%), so this is pure denominator reduction — no already-covered line was pragma'd.
- **Attribution of the +0.98pp: tests +0.88pp (~90%), pragma +0.10pp (~10%).** The test figure is approximate — it compares two different trees (`82a222f` vs here), not a controlled A/B.

So the pragma is hygiene, not the fix. Revert it and this PR still turns `main` green.

**The honest count-everything figure, for completeness: 97.20%** (9141 stmts, 204 miss) — every `# pragma: no cover` in `src/` neutralised, which is 130 statements across 34 files, and it sits **below the 98 floor**. That is not this PR's doing and is not proposed as the gate: **118 of those 130 pre-date this PR**, and most are the ordinary kind — `Protocol` method bodies (`core/op.py` 7, `core/embeddings.py` 7, `core/indexes/vector_index.py` 6, `core/fit.py` 5), the real QLoRA `train` that only runs in `test-finetune`/on GPU (`training/finetune.py` 38), and platform- or extra-specific `ImportError` branches. It is recorded so the floor is read for what it is — a ratchet over a denominator that excludes those — rather than as a claim that ~98% of every line in the contract is executed.

### 3. The positioning fix — the gate now runs per-PR

Fixing the number without fixing the blindness leaves the next regression equally invisible.

**Measured first, because the existing justification was stale by 4×.** The workflow said slow tests "cost ~10min on every PR"; that number is what justified keeping the gate off PRs:

| | measured |
|---|---|
| `test-full` | **~38–41 min** (green run `3dbd13d` 37m39s; run `30307689766` 41m) |
| per-PR `test` job | **~6 min** (PR #229's own run: 5m53s) |
| the gate step itself | **~12 s** |

The cost is the *suite*, never the gate. So running `test-full` on every PR is genuinely too slow (6× PR wall-clock), but the gate itself is nearly free — and the per-PR `test` job already writes `.coverage` (pyproject addopts carry `--cov=langres`).

**So the gate now runs in both places, over one include list, at two floors:**

| where | suite | floor | role |
|---|---|---|---|
| `test` (**every PR**) | fast | **97.5** | early warning, ~12s |
| `test-full` (merge to main) | full | **98** | authoritative |

**Why two floors is not the "two numbers drift" disease.** The thing that rots is the include *list*, and there is now only **one** of it — hoisted to `env.CONTRACT_COVERAGE_INCLUDE`, read by both gates, verified byte-identical to the previous inline list. The floors differ because the two gates measure genuinely different data, and that difference is small and measured: full **98.26%** vs fast **97.93%** on the same tree — the slow tests are worth **0.33pp** of this include list, so the fast number is a close proxy, not a different quantity wearing the same name. 97.5 is that value rounded down the same way the 98 floor was.

`.claude/rules/testing.md` is updated to match — its copy of the include list had *already* gone stale (it omitted `metrics/*`, `tracking/*` and the four `curation/` files), which is the duplication this PR removes.

## What I deliberately did not do

- **Did not lower `--fail-under`.** That is the exact disease this repo has already shipped once (a step named "95% coverage gate" enforcing 90).
- **Did not touch `core/_model_run.py` (29 uncovered), `core/_model_state.py` (8), `training/fit_report.py` (9)** — another agent holds those files. They are now the largest uncovered blocks in the gate and the natural next PR.
- **Did not touch `core/indexes/*`** (T2's files) or `core/op.py` (T1's).
- **Did not add tests that assert nothing** to reach the number.

## Verification

```
uv run pytest -m "not integration and not finetune" --cov-report=xml   # 4657 passed, 2 skipped, 18m43s
uv run coverage report --include="$CONTRACT_COVERAGE_INCLUDE" --precision=2 --fail-under=98
                                                                       # TOTAL 98.26%
uv run ruff format --check . && uv run ruff check . && uv run mypy src # clean, 215 files
```

*Isolation, since it is the whole basis of these numbers: the full-suite run above had **no** concurrent pytest in the same worktree, verified by sampling every 30s for its full 18m43s — 38 samples, zero foreign pids, zero unobservable probes. An earlier attempt overlapped ~9 minutes with an orphaned run left by a previous agent in this worktree and was discarded unread: two `uv run` in one worktree contend on `.venv`/`.coverage` and yield a plausible but falsely LOW number. Two cross-checks that the tree matches CI: this run's include-list denominator is **9011 statements**, identical to the 9011 CI reports for the fast suite on the same commit; and the full suite's **98** misses are strictly fewer than the fast suite's **126**, the direction coverage monotonicity requires.*

## Summary by Sourcery

Add regression tests around core contract behaviors and make the coverage gate visible and reliable both per-PR and on merge while keeping the existing 98% floor.

New Features:
- Cover the core op registration and serialization contracts, including @register_op validation, OpSpec guards, and serializer registration invariants.
- Add tests for tracking run snapshot immutability, JSON-safety, and dataset fingerprint normalization.
- Add tests for artifact provenance pinning, blocker schema resolution behavior, matcher spend capping semantics, and LinkVerdict truthiness and repr.
- Verify method registry optional builders surface actionable extras installation errors.

Enhancements:
- Mark temporary core re-export shims with no-cover pragmas to exclude throwaway compatibility layers from the contract coverage denominator.
- Document the dual contract coverage gates and their maintenance rules in the testing guidelines, including measured timings and rationale for separate floors.

CI:
- Run the contract coverage gate against a shared include list from both the fast per-PR test job (at a 97.5% early-warning floor) and the full test-full job (at the authoritative 98% floor), and centralize the include configuration in workflow env to prevent drift.

Tests:
- Extend core and tracking test suites to exercise previously untested validation, error handling, and contract paths across registry, serialization, method registry, spend caps, blockers, run snapshots, and result models.
