### PR TITLE
chore: consolidate the Dependabot backlog, un-red CodeQL, and close the fixable security alerts

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -23,10 +23,10 @@ jobs:
       contents: read
     steps:
       - name: Checkout
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@99df26d4f13ea111d4ec1a7dddef6063f76b97e9 # v4
+        uses: github/codeql-action/init@e4fba868fa4b1b91e1fdab776edc8cfbe6e9fb81 # v4.37.3
         with:
           languages: python
           # security-extended adds lower-severity/precision queries on top of
@@ -34,6 +34,6 @@ jobs:
           queries: security-extended
 
       - name: Perform CodeQL analysis
-        uses: github/codeql-action/analyze@99df26d4f13ea111d4ec1a7dddef6063f76b97e9 # v4
+        uses: github/codeql-action/analyze@e4fba868fa4b1b91e1fdab776edc8cfbe6e9fb81 # v4.37.3
         with:
           category: "/language:python"

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -41,12 +41,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Install uv and set the python version
-        uses: astral-sh/setup-uv@11f9893b081a58869d3b5fccaea48c9e9e46f990 # v8.3.2
+        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
         with:
-          version: "0.11.28"
+          version: "0.11.32"
           python-version: "3.13"
 
       - name: Build site (strict)
@@ -57,7 +57,7 @@ jobs:
 
       - name: Upload Pages artifact
         if: github.event_name != 'pull_request'
-        uses: actions/upload-pages-artifact@fc324d3547104276b827a68afc52ff2a11cc49c9 # v5
+        uses: actions/upload-pages-artifact@fc324d3547104276b827a68afc52ff2a11cc49c9 # v5.0.0
         with:
           path: site
 
@@ -74,4 +74,4 @@ jobs:
     steps:
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@cd2ce8fcbc39b97be8ca5fce6e763baed58fa128 # v5
+        uses: actions/deploy-pages@cd2ce8fcbc39b97be8ca5fce6e763baed58fa128 # v5.0.0

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -11,6 +11,12 @@ on:
   pull_request:
     branches: [main, feat/core-packages, epic/193-core-algebra]
 
+# Least-privilege GITHUB_TOKEN. The repo default is `write`, so without this
+# block every job here gets a read-write token it never uses (checkout + ruff + mypy read the tree and nothing else).
+# Flagged by OpenSSF Scorecard (TokenPermissions, high).
+permissions:
+  contents: read
+
 concurrency:
   # Mirrors `test.yml`: grouping on the ref alone means merging one PR CANCELS
   # another's in-flight run, and a cancelled run is not a green one. Grouping on
@@ -24,13 +30,22 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Set up uv
-        uses: astral-sh/setup-uv@11f9893b081a58869d3b5fccaea48c9e9e46f990 # v8.3.2
+        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
         with:
-          version: "0.11.28"
+          version: "0.11.32"
           enable-cache: true
+          # setup-uv v9's one breaking change: `prune-cache` now defaults to
+          # false (upstream is easing load on PyPI). Held at the pre-v9 `true`
+          # here so this bump changes no CI behaviour: `uv sync --all-extras`
+          # pulls the torch/faiss/litellm stack, and keeping those wheels across
+          # the repo's 7 job caches would dwarf today's 503 MB total against
+          # GitHub's 10 GB per-repo cap -- LRU eviction would then cost more
+          # than the re-downloads pruning saves. Revisit by measuring one
+          # unpruned run, not by assuming.
+          prune-cache: true
 
       - name: Install dependencies
         # --all-extras: mypy must resolve the [semantic]/[llm]/[trained]

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -5,6 +5,13 @@ on:
     types: [published]
   workflow_dispatch:  # Allows manual triggering
 
+# Least-privilege GITHUB_TOKEN. The repo default is `write`, so without this
+# block every job here gets a read-write token it never uses (the publish job re-declares its own (id-token: write for
+# trusted publishing), and a job-level block replaces this one wholesale).
+# Flagged by OpenSSF Scorecard (TokenPermissions, high).
+permissions:
+  contents: read
+
 jobs:
   publish:
     runs-on: ubuntu-latest
@@ -14,10 +21,10 @@ jobs:
       contents: read
 
     steps:
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Set up Python
-        uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
           python-version: '3.12'
 
@@ -25,9 +32,9 @@ jobs:
         # Pinned action instead of `curl … | sh`: a hash-pinned install avoids
         # running an unpinned remote script in the release pipeline (Scorecard
         # PinnedDependencies). Same pin/version used across the CI workflows.
-        uses: astral-sh/setup-uv@11f9893b081a58869d3b5fccaea48c9e9e46f990 # v8.3.2
+        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
         with:
-          version: "0.11.28"
+          version: "0.11.32"
 
       - name: Build package
         run: uv build

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -24,12 +24,12 @@ jobs:
       id-token: write # to publish results (publish_results: true)
     steps:
       - name: Checkout
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
 
       - name: Run analysis
-        uses: ossf/scorecard-action@4eaacf0543bb3f2c246792bd56e8cdeffafb205a # v2.4.3
+        uses: ossf/scorecard-action@2d1146689b8cda280b9bc96326124645441f03bc # v2.4.4
         with:
           results_file: results.sarif
           results_format: sarif
@@ -38,13 +38,13 @@ jobs:
           publish_results: true
 
       - name: Upload artifact
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: SARIF file
           path: results.sarif
           retention-days: 5
 
       - name: Upload to code-scanning
-        uses: github/codeql-action/upload-sarif@99df26d4f13ea111d4ec1a7dddef6063f76b97e9 # v4
+        uses: github/codeql-action/upload-sarif@e4fba868fa4b1b91e1fdab776edc8cfbe6e9fb81 # v4.37.3
         with:
           sarif_file: results.sarif

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -12,6 +12,12 @@ on:
     - cron: "0 8 * * 1"
   workflow_dispatch:
 
+# Least-privilege GITHUB_TOKEN. The repo default is `write`, so without this
+# block every job here gets a read-write token it never uses (pip-audit + guarddog only read the synced env).
+# Flagged by OpenSSF Scorecard (TokenPermissions, high).
+permissions:
+  contents: read
+
 jobs:
   security:
     # Standard GitHub runner: free with unlimited minutes on public repos.
@@ -20,13 +26,22 @@ jobs:
       contents: read
     steps:
       - name: Checkout
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Set up uv
-        uses: astral-sh/setup-uv@11f9893b081a58869d3b5fccaea48c9e9e46f990 # v8.3.2
+        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
         with:
-          version: "0.11.28"
+          version: "0.11.32"
           enable-cache: true
+          # setup-uv v9's one breaking change: `prune-cache` now defaults to
+          # false (upstream is easing load on PyPI). Held at the pre-v9 `true`
+          # here so this bump changes no CI behaviour: `uv sync --all-extras`
+          # pulls the torch/faiss/litellm stack, and keeping those wheels across
+          # the repo's 7 job caches would dwarf today's 503 MB total against
+          # GitHub's 10 GB per-repo cap -- LRU eviction would then cost more
+          # than the re-downloads pruning saves. Revisit by measuring one
+          # unpruned run, not by assuming.
+          prune-cache: true
 
       - name: Install dependencies
         # --all-extras: scan the [semantic]/[llm] extras' dependencies (torch,

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -56,6 +56,13 @@ env:
   # never under `core/*`, so it was never in this contract tier.
   CONTRACT_COVERAGE_INCLUDE: "src/langres/core/*,src/langres/metrics/*,src/langres/curation/anchor_store.py,src/langres/curation/canonicalizer.py,src/langres/curation/harvest.py,src/langres/curation/review.py,src/langres/tracking/judgement_log.py,src/langres/tracking/runs.py,src/langres/tracking/trackers/*,src/langres/training/*,src/langres/report/*,src/langres/autoresearch/*,src/langres/optimize.py"
 
+# Least-privilege GITHUB_TOKEN. The repo default is `write`, so without this
+# block every job here gets a read-write token it never uses (checkout + pytest only read; the Codecov upload authenticates
+# with CODECOV_TOKEN, not the workflow token).
+# Flagged by OpenSSF Scorecard (TokenPermissions, high).
+permissions:
+  contents: read
+
 concurrency:
   # `pull_request`: one group per PR ref, so a new push supersedes the previous
   # run (`cancel-in-progress` below) -- the usual minute-saving behaviour.
@@ -95,16 +102,25 @@ jobs:
         python-version: ["3.13"]
     steps:
       - name: Checkout
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 0
 
       - name: Install uv and set the python version
-        uses: astral-sh/setup-uv@11f9893b081a58869d3b5fccaea48c9e9e46f990 # v8.3.2
+        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
         with:
-          version: "0.11.28"
+          version: "0.11.32"
           python-version: ${{ matrix.python-version }}
           enable-cache: true
+          # setup-uv v9's one breaking change: `prune-cache` now defaults to
+          # false (upstream is easing load on PyPI). Held at the pre-v9 `true`
+          # here so this bump changes no CI behaviour: `uv sync --all-extras`
+          # pulls the torch/faiss/litellm stack, and keeping those wheels across
+          # the repo's 7 job caches would dwarf today's 503 MB total against
+          # GitHub's 10 GB per-repo cap -- LRU eviction would then cost more
+          # than the re-downloads pruning saves. Revisit by measuring one
+          # unpruned run, not by assuming.
+          prune-cache: true
 
       - name: Install dependencies
         # --all-extras: the non-slow suite still exercises VectorBlocker/
@@ -190,14 +206,15 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Set up uv
-        uses: astral-sh/setup-uv@11f9893b081a58869d3b5fccaea48c9e9e46f990 # v8.3.2
+        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
         with:
-          version: "0.11.28"
+          version: "0.11.32"
           python-version: "3.13"
           enable-cache: true
+          prune-cache: true
 
       - name: Install dependencies (core only -- no [semantic]/[llm] extras)
         run: uv sync
@@ -259,14 +276,15 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Install uv and set the python version
-        uses: astral-sh/setup-uv@11f9893b081a58869d3b5fccaea48c9e9e46f990 # v8.3.2
+        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
         with:
-          version: "0.11.28"
+          version: "0.11.32"
           python-version: "3.13"
           enable-cache: true
+          prune-cache: true
 
       # Bare `uv sync` (no extras): tools/doc_snippets.py is stdlib-only and
       # builds its own clean venv for the snippets. Installing extras here would
@@ -305,16 +323,17 @@ jobs:
         python-version: ["3.13"]
     steps:
       - name: Checkout
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 0
 
       - name: Install uv and set the python version
-        uses: astral-sh/setup-uv@11f9893b081a58869d3b5fccaea48c9e9e46f990 # v8.3.2
+        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
         with:
-          version: "0.11.28"
+          version: "0.11.32"
           python-version: ${{ matrix.python-version }}
           enable-cache: true
+          prune-cache: true
 
       - name: Install dependencies
         # --no-extra finetune: same rationale as the `test` job -- the QLoRA
@@ -433,16 +452,17 @@ jobs:
     continue-on-error: true
     steps:
       - name: Checkout
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 0
 
       - name: Install uv and set the python version
-        uses: astral-sh/setup-uv@v7
+        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
         with:
-          version: "0.11.24"
+          version: "0.11.32"
           python-version: "3.13"
           enable-cache: true
+          prune-cache: true
 
       - name: Install dependencies (incl. the [finetune] training stack)
         run: uv sync --all-extras

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -540,6 +540,39 @@ changing the default model hard."* Design note:
   `author/method` namespacing (model ids keep their slashes in the separate
   `model=` kwarg).
 
+### CI & supply-chain maintenance
+
+- **Every GitHub Action is now hash-pinned to an exact commit, and every pin
+  names its exact version.** `test.yml`'s `test-finetune` job still used
+  floating `actions/checkout@v7` / `astral-sh/setup-uv@v7` (OpenSSF Scorecard
+  `PinnedDependencies`). The `# v7`-style comments on the hash-pinned steps were
+  their own hazard: they read as current while `actions/checkout` had moved
+  v7.0.0 -> v7.0.1 underneath them, so the comments now carry exact versions.
+- **Workflows run with a least-privilege `GITHUB_TOKEN`.** `lint`, `publish`,
+  `security` and `test` declared no top-level `permissions:`, and the
+  repository default is `write` — every job in them held a read-write token it
+  never used. All four are now `contents: read` (Scorecard `TokenPermissions`,
+  4x high). `publish.yml`'s job-level block (`id-token: write` for trusted
+  publishing) replaces the top-level one wholesale and is unaffected.
+- **Action versions rolled forward**, superseding Dependabot #231-#234:
+  `github/codeql-action` v4.37.0 -> v4.37.3, `actions/setup-python` v6 ->
+  v7.0.0, `actions/checkout` v7.0.0 -> v7.0.1, `astral-sh/setup-uv` v8.3.2 ->
+  v9.0.0, `ossf/scorecard-action` v2.4.3 -> v2.4.4, and `uv` itself 0.11.28 ->
+  0.11.32 (`test.yml` had drifted to 0.11.24 in one job).
+  `setup-uv` v9's one breaking change — `prune-cache` defaulting to false — is
+  explicitly held at the pre-v9 `true` at all seven cache sites, so the bump
+  changes no CI behaviour.
+- **The CodeQL jobs are green again.** `github/codeql-action` refuses to run
+  when its steps disagree on version (`Loaded a configuration file for version
+  '4.37.3', but running version '4.37.0'`). Dependabot raises one PR per action
+  path, so bumping `init` (#231) or `analyze` (#233) alone could only ever be
+  red; the three steps are moved together here.
+- **Dependency quarantine rolled 2026-07-08 -> 2026-07-21.** Since `uv.lock` is
+  gitignored, `exclude-newer` *is* the reproducibility pin and CI re-resolves on
+  every run, so this is the whole of the Python-side update: 47 packages, no
+  major bumps, nothing added or removed. Verified against the new resolve —
+  ruff, `ruff format --check`, `mypy src` (2.3.0) and 4557 tests all pass.
+
 ### Fixed
 
 - **`langres.__version__` no longer drifts from the released version.** It was a

--- a/docs/DOCS.md
+++ b/docs/DOCS.md
@@ -370,44 +370,33 @@ nav:
 
 ### `.github/workflows/docs.yml`
 
-```yaml
-name: Deploy Documentation
+**The shipped workflow is the source of truth — read
+[`.github/workflows/docs.yml`](https://github.com/fxd24/langres/blob/main/.github/workflows/docs.yml).**
 
-on:
-  push:
-    branches:
-      - main
-      - poc/core-foundation  # Add any other branches you want docs for
-  pull_request:
+This section used to carry a copy of it. The copy drifted: it still showed
+floating `actions/checkout@v4` / `setup-python@v5` / `setup-uv@v8` tags, a
+repo-wide `permissions: contents: write`, a `poc/core-foundation` trigger
+branch that no longer exists, and `mkdocs gh-deploy --force` — which the real
+workflow replaced with the Pages-native `upload-pages-artifact` +
+`deploy-pages` flow. A second copy of a live file is a doc that lies as soon as
+the file moves, so it is a pointer now.
 
-permissions:
-  contents: write
+Two conventions the workflow follows that any new workflow here must too:
 
-jobs:
-  deploy:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
+- **Every `uses:` is pinned to a 40-character commit SHA**, with the exact
+  version in a trailing comment (`# v7.0.1`, not `# v7` — a floating major
+  comment cannot express that the pin has gone stale). Floating tags are
+  flagged by OpenSSF Scorecard (`PinnedDependencies`) and are a supply-chain
+  risk: a tag can be repointed at new code.
+- **Every workflow declares top-level `permissions:`.** The repository default
+  is `write`, so a workflow without the block hands every job a read-write
+  `GITHUB_TOKEN` it almost never needs (Scorecard `TokenPermissions`). `docs.yml`
+  is `contents: read` at the top; only the `deploy` job widens it, to
+  `pages: write` + `id-token: write`.
 
-      - name: Setup Python
-        uses: actions/setup-python@v5
-        with:
-          python-version: '3.12'
-
-      - name: Install uv
-        uses: astral-sh/setup-uv@v8
-
-      - name: Install dependencies
-        run: |
-          uv pip install --system mkdocs-material "mkdocstrings[python]"
-
-      - name: Build documentation
-        run: mkdocs build
-
-      - name: Deploy to GitHub Pages
-        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
-        run: mkdocs gh-deploy --force
-```
+One-time setup this workflow needs: **Settings → Pages → Build and deployment →
+Source = "GitHub Actions"**. Until that is set, the deploy job fails with a
+Pages configuration error.
 
 ### `docs/index.md` Template
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -236,7 +236,7 @@ docs = [
 # 7-day supply-chain quarantine: resolution only picks packages published at
 # least 7 days ago, giving time for malicious uploads to be caught and
 # yanked. Roll this forward with `make upgrade-deps`.
-exclude-newer = "2026-07-08"
+exclude-newer = "2026-07-21"
 # To block a known-bad version, uncomment and set:
 # constraint-dependencies = ["somepkg!=1.2.3"]
 


### PR DESCRIPTION
One PR for the whole chore backlog: the four Dependabot PRs (two of them red),
the drift Dependabot had not raised yet, and every GitHub security alert that a
PR can actually close.

## Why the two Dependabot PRs are red

`github/codeql-action` is used from **three** steps across two workflows —
`init` + `analyze` in `codeql.yml`, `upload-sarif` in `scorecard.yml` — and the
action refuses to run when they disagree:

```
Loaded a configuration file for version '4.37.3', but running version '4.37.0'
```

Dependabot raises one PR per action path, so #231 (`init`) and #233 (`analyze`)
each created exactly that mismatch and failed `Analyze (python)`. #234
(`upload-sarif`) is green only because `scorecard.yml` has no second codeql step
to disagree with. **No individual Dependabot PR here can be green** — the three
steps have to move together. That is the core reason this is one PR.

## Supersedes

| PR | Bump | Was |
|----|------|-----|
| #231 | `codeql-action/init` 4.37.0 → 4.37.3 | ❌ red |
| #232 | `actions/setup-python` 6.3.0 → 7.0.0 | ✅ green |
| #233 | `codeql-action/analyze` 4.37.0 → 4.37.3 | ❌ red |
| #234 | `codeql-action/upload-sarif` 4.37.0 → 4.37.3 | ✅ green |

Close all four once this lands.

## Also bumped — drift Dependabot had not raised yet

Its `github-actions` schedule is weekly and last ran 2026-07-22:

- `actions/checkout` v7.0.0 → **v7.0.1** (released 07-20)
- `astral-sh/setup-uv` v8.3.2 → **v9.0.0** (released 07-21)
- `ossf/scorecard-action` v2.4.3 → **v2.4.4** (released 07-23)
- `uv` itself 0.11.28 → **0.11.32** (`test.yml` had also drifted to 0.11.24 in one job)

All SHAs were dereferenced from the annotated tag object to the **commit** SHA
(`/git/ref/tags/X` returns the tag object for these repos, not the commit — a
tag-object SHA would be an invalid pin). The `codeql-action` SHA matches
Dependabot's own.

### Two majors, both checked rather than assumed

- **`setup-python` v7.0.0** drops the `pip-install` input. `publish.yml` is the
  only caller and passes `python-version` only → no-op.
- **`setup-uv` v9.0.0**'s only breaking change is `prune-cache` defaulting to
  `false`. Held explicitly at the pre-v9 `true` at all 7 cache sites, so this
  bump changes no CI behaviour. Reasoning is in the workflow comment: `uv sync
  --all-extras` pulls the torch/faiss/litellm stack, and keeping those wheels
  across 7 job caches would dwarf today's measured 503 MB total against
  GitHub's 10 GB per-repo cap — LRU eviction would cost more than the
  re-downloads pruning saves. Revisit by *measuring* one unpruned run.

## Security alerts closed

From Security → Code scanning (OpenSSF Scorecard):

- **`TokenPermissions` ×4 (high)** — `lint`, `publish`, `security` and `test`
  declared no top-level `permissions:`. The repo default is
  `default_workflow_permissions: "write"`, so every job in them ran with a
  read-write `GITHUB_TOKEN` none of them uses. Now `contents: read`.
  `publish.yml`'s job-level block (`id-token: write` for trusted publishing)
  replaces the top-level one wholesale, so PyPI publishing is unaffected.
- **`PinnedDependencies` ×2 (medium)** — `test-finetune` used floating
  `actions/checkout@v7` and `astral-sh/setup-uv@v7`. Both hash-pinned. **Every
  `uses:` in `.github/workflows` is now a 40-char commit SHA.**

### The `# v7` comments were themselves the bug

`actions/checkout` sat at v7.0.0 while v7.0.1 shipped on 07-20, and a pin
commented `# v7` still read as current — the comment could not express the
drift. Every pin now carries its exact version, including the three
already-latest ones (`upload-artifact`, `upload-pages-artifact`,
`deploy-pages`) that were relabelled **without** changing SHA.

## Python dependencies: quarantine rolled 2026-07-08 → 2026-07-21

`uv.lock` is gitignored, so `exclude-newer` *is* the reproducibility pin — CI
re-resolves from scratch every run and this one line is the entire Python-side
update.

Measured by diffing a fresh resolve at each date. This matters: diffing against
the **local** `uv.lock` instead makes it look like a 177-package upheaval with
23 major bumps, because that lock is months stale and is not what CI installs.
The honest delta is:

```
286 -> 286 packages    47 changed    0 added    0 removed    0 major bumps
```

Notable minors are the ones that gate CI: `mypy` 2.2.0 → 2.3.0, `ruff` 0.15.20
→ 0.15.22, `litellm` 1.91.0 → 1.93.0, `openai` 2.44.0 → 2.46.0, `trl` 1.7.1 →
1.9.0 (finetune extra only, non-blocking job).

Verified locally on the new resolve before pushing:

| gate | result |
|---|---|
| `ruff check .` | All checks passed |
| `ruff format --check .` | 568 files already formatted |
| `mypy src` (2.3.0) | no issues in 215 source files |
| `pytest` fast suite | **4557 passed, 3 skipped, 0 failed** |

## Deliberately NOT in this PR

Four Scorecard alerts cannot be closed by a PR, and one I judged out of scope:

- **`BranchProtection` (high)** and **`CodeReview` (high, 0/13 approved
  changesets)** — repository *settings*, not files. `main` currently has **no
  branch protection and no rulesets**, so every check in this repo is advisory.
  Needs a decision (see below), and as sole maintainer a "require approvals"
  rule would block your own merges.
- **`SAST` (medium, score 7)** — "9 of 30 commits checked". CodeQL already runs
  on every PR and every push to `main`; the score reflects commit-level
  attribution, not a missing scan. No config change fixes this cleanly.
- **`Fuzzing` (medium)** and **`CIIBestPractices` (low)** — new infrastructure
  (OSS-Fuzz/atheris) and an external registration on bestpractices.dev.

There are **0 open Dependabot vulnerability alerts** and no CodeQL findings —
every open code-scanning alert is Scorecard posture, not a vulnerability.

## Summary by Sourcery

Consolidate CI and supply-chain maintenance by updating pinned GitHub Actions, tightening workflow token permissions, aligning CodeQL action versions, and rolling forward the Python dependency quarantine window.

Enhancements:
- Align CodeQL init/analyze/upload steps on a single version to restore green CodeQL runs.
- Roll the Python dependency quarantine window forward to 2026-07-21 via the `exclude-newer` pin.

Build:
- Pin all GitHub Actions in workflows to exact commit SHAs and annotate each with its precise released version.
- Update core CI actions and tools, including `github/codeql-action`, `actions/setup-python`, `actions/checkout`, `astral-sh/setup-uv`, `ossf/scorecard-action`, and `uv` itself to current versions while preserving caching behavior.

CI:
- Introduce least-privilege `GITHUB_TOKEN` settings (`contents: read`) for lint, test, security, and publish workflows in line with OpenSSF Scorecard recommendations.
- Ensure all CI jobs using `setup-uv` v9 explicitly retain `prune-cache: true` to avoid changing caching behavior across workflows.

Documentation:
- Document CI and supply-chain maintenance changes in the changelog, including action pinning, permission tightening, dependency updates, and CodeQL status.

Chores:
- Supersede and consolidate multiple Dependabot PRs and GitHub security alerts into a single maintenance change set.