### PR TITLE
feat(embeddings): default embedder -> intfloat/e5-base-v2 (measured, OSI-licensed)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,17 +48,47 @@ above was measured bare** — the ladder's `prompt_arm="none"`, with no
 ship a configuration nobody measured under the measured numbers' banner, so it is
 left off and pinned by test. Measure it in the ladder first if you want it.
 
-**Migration — if you have a saved vector index, it will not load.** The
-dimension changes 384 → 768, so an index built with the old default is
-incompatible with a freshly-constructed default embedder, and even at equal
-dimension the vectors would be from a different model. Either re-embed your
-corpus, or pin the old model explicitly and change nothing:
+**Migration.** A **normally saved artifact keeps working** — `Resolver.save` /
+`FAISSIndex.config()` serialize the embedder you built with, so `load` rebuilds
+*that* embedder (still `all-MiniLM-L6-v2`) and `load_state` restores the stored
+vectors verbatim without re-embedding. Do **not** discard those.
+
+What does change:
+
+- **Anything that rebuilds an index against the new default** now produces
+  768-dim vectors from a different model. Recall changes as measured above, and
+  such an index cannot be compared against, or mixed with, 384-dim vectors from
+  the old default.
+- **A `DiskCachedEmbedder` cache is re-encoded once** — see the entry below;
+  before that fix the same cache would have silently served the old model's
+  vectors.
+
+To keep the previous behaviour exactly, name the old model:
 
 ```python
 from langres.core.embeddings import SentenceTransformerEmbedder
 
 embedder = SentenceTransformerEmbedder("all-MiniLM-L6-v2")   # previous default
 ```
+
+### Fixed: `DiskCachedEmbedder` could serve a different model's vectors
+
+`_embedder_discriminator()` covered `prompt_name` / `truncate_dim` / `prompts`
+but **not the model**, and `namespace` defaults to `"default"` — so the ordinary
+`DiskCachedEmbedder(embedder=SentenceTransformerEmbedder(), cache_dir=...)` wrote
+every model's vectors into one `default.db` keyed on the bare text. Swapping the
+wrapped model then hit those entries and returned the **previous** model's
+vectors, at the previous model's dimensionality: silently on a fully warm cache,
+and as a ragged 384/768 stack on a partially warm one.
+
+The model now forms part of the key — the `ModelRef` where there is one, so a
+`revision` pin counts too. **Existing caches written by a named model are
+re-encoded once**; caches from an embedder with no model identity (e.g.
+`FakeEmbedder`) still hit, as before.
+
+Changing `DEFAULT_EMBEDDING_MODEL` in the same release is what turned this latent
+hazard into a live one — every user of the default would have kept reading
+MiniLM vectors without touching a line of their own code.
 
 Affected defaults: `SentenceTransformerEmbedder()`,
 `Resolver.from_schema(..., matcher="embedding")`, `VectorLLMCascade(embedder=...)`,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,72 @@
 
 ## [Unreleased]
 
+### The default embedding model is now `intfloat/e5-base-v2`
+
+**This changes results, and it invalidates saved vector indexes.** Read the
+migration note below before upgrading if you have one on disk.
+
+`DEFAULT_EMBEDDING_MODEL` moves from `all-MiniLM-L6-v2` to `intfloat/e5-base-v2`
+(MIT). The embedder ladder (`docs/research/20260727_embedder_ladder.md`) measured
+it ahead of the incumbent on **3 of the 5** benchmarks and behind on **none** —
+mean per-record candidate recall at k=20, bootstrapped by gold cluster:
+
+| benchmark | Δ per-record recall | 95% CI | clusters |
+|---|---:|---|---:|
+| `wdc_computers` | **+0.1528** | [+0.1254, +0.1797] | 877 |
+| `abt_buy` | **+0.0324** | [+0.0216, +0.0451] | 1,012 |
+| `walmart_amazon` | **+0.0159** | [+0.0078, +0.0246] | 846 |
+| `amazon_google` | +0.0056 | [-0.0002, +0.0116] (spans 0) | 995 |
+| `fodors_zagat` | +0.0000 | [+0.0000, +0.0000] (exactly 0) | 112 |
+
+It is also a *cheaper* ceiling at that operating point, not just a higher one:
+candidates per unit recall fall on all five (`wdc_computers` 56,103 → 43,834;
+`abt_buy` 11,985 → 9,095).
+
+**What this is not.** It is a **blocking** result — candidate recall, not
+end-to-end F1 — and the field is the **7 of 14** ladder models with rows at
+`metric_revision` 1, so this is the best *measured* model, not a survey.
+`fodors_zagat` is saturated and settles nothing. The ladder's `index build (s)`
+column cannot be used to price the switch either: every `all-MiniLM-L6-v2` row
+read from the embedding cache (`enc 0`) while the e5 rows encoded for real, so
+those two columns measure different things. What is certain is that e5-base-v2
+is **109.5M parameters against 22.7M** and **768-dim against 384** — a bigger
+download, more memory, and slower encoding.
+
+**`google/embeddinggemma-300m` measured better overall and is deliberately not
+the default.** It ships under the Gemma Terms of Use, which is *not* OSI-approved
+and carries a prohibited-use policy that survives redistribution. langres is
+Apache-2.0; a default may not push terms onto users who never chose them. It
+stays a documented opt-in: `SentenceTransformerEmbedder("google/embeddinggemma-300m")`.
+
+**The new default ships with no prompt, on purpose.** E5's model card documents
+an asymmetric `"query: "` / `"passage: "` recipe, but the checkpoint registers no
+prompts (it ships no `config_sentence_transformers.json`) and **every number
+above was measured bare** — the ladder's `prompt_arm="none"`, with no
+`documented` arm for this model at all. Wiring the model-card prefixes in would
+ship a configuration nobody measured under the measured numbers' banner, so it is
+left off and pinned by test. Measure it in the ladder first if you want it.
+
+**Migration — if you have a saved vector index, it will not load.** The
+dimension changes 384 → 768, so an index built with the old default is
+incompatible with a freshly-constructed default embedder, and even at equal
+dimension the vectors would be from a different model. Either re-embed your
+corpus, or pin the old model explicitly and change nothing:
+
+```python
+from langres.core.embeddings import SentenceTransformerEmbedder
+
+embedder = SentenceTransformerEmbedder("all-MiniLM-L6-v2")   # previous default
+```
+
+Affected defaults: `SentenceTransformerEmbedder()`,
+`Resolver.from_schema(..., matcher="embedding")`, `VectorLLMCascade(embedder=...)`,
+the `embedding` method's `default_model`, and `CascadeChainMatcher` — whose
+`embedding_model_name` was a fourth hard-coded copy of the old literal and now
+reads the shared constant. **Not** changed: the pinned `all-MiniLM-L6-v2` in the
+benchmark loaders under `langres.data` (they back published baselines) and in
+`SearchSpace` / `BlockerOptimizer` (explicitly enumerated search axes).
+
 ### The better clusterer is now reachable (`clusterer=` opt-in)
 
 `CorrelationClusterer` measured better than the default transitive-closure

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,8 +4,9 @@
 
 ### The default embedding model is now `intfloat/e5-base-v2`
 
-**This changes results, and it invalidates saved vector indexes.** Read the
-migration note below before upgrading if you have one on disk.
+**This changes results for any index built against the default.** Saved
+artifacts are *not* invalidated — they reload on the model they were saved with —
+so read the migration note below before re-embedding anything.
 
 `DEFAULT_EMBEDDING_MODEL` moves from `all-MiniLM-L6-v2` to `intfloat/e5-base-v2`
 (MIT). The embedder ladder (`docs/research/20260727_embedder_ladder.md`) measured

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,13 +40,24 @@ and carries a prohibited-use policy that survives redistribution. langres is
 Apache-2.0; a default may not push terms onto users who never chose them. It
 stays a documented opt-in: `SentenceTransformerEmbedder("google/embeddinggemma-300m")`.
 
-**The new default ships with no prompt, on purpose.** E5's model card documents
-an asymmetric `"query: "` / `"passage: "` recipe, but the checkpoint registers no
-prompts (it ships no `config_sentence_transformers.json`) and **every number
-above was measured bare** — the ladder's `prompt_arm="none"`, with no
-`documented` arm for this model at all. Wiring the model-card prefixes in would
-ship a configuration nobody measured under the measured numbers' banner, so it is
-left off and pinned by test. Measure it in the ladder first if you want it.
+**The new default ships with no prompt, on purpose — and this is an open
+question, not a settled one.** E5's model card asks for a prefix and warns that
+omitting one degrades the model. For a *symmetric* task like ER the card's recipe
+is `"query: "` on **both** sides (semantic-similarity guidance), not the
+`"query: "`/`"passage: "` retrieval pair — a shape `VectorBlocker` already
+documents and accepts without warning.
+
+It still ships bare, because **every number above was measured bare**: the
+ladder's `prompt_arm="none"`, `registered_prompts: []` (the checkpoint ships no
+`config_sentence_transformers.json`, so nothing was applied implicitly either),
+and no `documented` arm for this model at all. Switching the recipe on would put
+a configuration nobody measured behind those numbers.
+
+The two facts set a floor rather than conflicting: **e5-base-v2 beat the previous
+default by the margins above while running in the configuration its own card
+calls degraded.** The prefix is uncollected upside, and collecting it is a
+measurement job — add a symmetric arm to the ladder and re-run, then move the
+constant's configuration and its numbers together. Pinned by test meanwhile.
 
 **Migration.** A **normally saved artifact keeps working** — `Resolver.save` /
 `FAISSIndex.config()` serialize the embedder you built with, so `load` rebuilds

--- a/docs/research/20260727_embedder_ladder.md
+++ b/docs/research/20260727_embedder_ladder.md
@@ -22,7 +22,7 @@ Requires `OMP_NUM_THREADS=1` and `KMP_DUPLICATE_LIB_OK=1` on macOS (`run_ladder.
 
 ## Headline: there is no single winner — the answer is per benchmark
 
-The widest disagreement measured here is `google/embeddinggemma-300m` against `all-MiniLM-L6-v2` (langres's current default) at k=20: **+0.2079** per-record recall on `wdc_computers` [+0.1787, +0.2365] and **-0.0294** on `amazon_google` [-0.0425, -0.0163] — the same model, better on one benchmark and **worse** on the other, with both intervals clear of zero.
+The widest disagreement measured here is `google/embeddinggemma-300m` against `all-MiniLM-L6-v2` (this ladder's reference model, and langres's default when these rows were measured) at k=20: **+0.2079** per-record recall on `wdc_computers` [+0.1787, +0.2365] and **-0.0294** on `amazon_google` [-0.0425, -0.0163] — the same model, better on one benchmark and **worse** on the other, with both intervals clear of zero.
 
 Averaging those into one number would report a middling win or loss and hide both. **This document deliberately publishes no cross-benchmark mean.** Pick the model against the data you actually have; the per-benchmark tables below are the unit of decision.
 
@@ -241,7 +241,7 @@ This harness still prefixes the corpus text itself, because it must reproduce ro
 
 ## Is it better than what ships today? (k=20, no instruction)
 
-Every model against `all-MiniLM-L6-v2` — langres's current `DEFAULT_EMBEDDING_MODEL` — on the same records, paired per record and resampled by gold cluster. **Δ is the mean per-record recall difference**, not the difference of the two aggregate recalls above: the bootstrap resamples per-record units, so the point estimate has to be the same statistic the interval is built from. `clusters` is the number of independent units resampled — the honest denominator, and much smaller than the record count.
+Every model against `all-MiniLM-L6-v2` — this ladder's reference model, which was `DEFAULT_EMBEDDING_MODEL` when these rows were measured — on the same records, paired per record and resampled by gold cluster. **Δ is the mean per-record recall difference**, not the difference of the two aggregate recalls above: the bootstrap resamples per-record units, so the point estimate has to be the same statistic the interval is built from. `clusters` is the number of independent units resampled — the honest denominator, and much smaller than the record count.
 
 **This sweep does not change the default.** A CI spanning 0 is not evidence of a better default; it is evidence the measurement cannot tell them apart on that benchmark.
 
@@ -288,7 +288,7 @@ A model with no interval is shown with `—` rather than dropped: a measured mod
 
 ### The OSI-licensed field — the only candidates for a default
 
-langres ships under Apache-2.0. A default that carries a use-restricted licence pushes that restriction onto every user who never chose it, so the candidates for `DEFAULT_EMBEDDING_MODEL` are exactly the OSI-licensed models — including the incumbent, `all-MiniLM-L6-v2` (apache-2.0).
+langres ships under Apache-2.0. A default that carries a use-restricted licence pushes that restriction onto every user who never chose it, so the candidates for `DEFAULT_EMBEDDING_MODEL` are exactly the OSI-licensed models — including the reference model, `all-MiniLM-L6-v2` (apache-2.0).
 
 | model | licence | benchmarks beaten (CI clear of 0) | best Δ | on |
 |---|---|---:|---:|---|

--- a/examples/research/embedder_ladder.py
+++ b/examples/research/embedder_ladder.py
@@ -1565,7 +1565,7 @@ def _render_recommendation(
         f"\nlangres ships under Apache-2.0. A default that carries a use-restricted "
         f"licence pushes that restriction onto every user who never chose it, so the "
         f"candidates for `DEFAULT_EMBEDDING_MODEL` are exactly the OSI-licensed "
-        f"models — including the incumbent, `{REFERENCE_MODEL}` "
+        f"models — including the reference model, `{REFERENCE_MODEL}` "
         f"({(MODELS_BY_NAME.get(REFERENCE_MODEL) or ModelSpec(REFERENCE_MODEL)).license}).\n"
     )
     if not osi:
@@ -2022,7 +2022,8 @@ def render_report(rows: Sequence[LadderRow], headline_k: int = 20) -> str:
         out.append("\n## Headline: there is no single winner — the answer is per benchmark\n")
         out.append(
             f"\nThe widest disagreement measured here is `{model}` against "
-            f"`{REFERENCE_MODEL}` (langres's current default) at k={headline_k}: "
+            f"`{REFERENCE_MODEL}` (this ladder's reference model, and langres's "
+            f"default when these rows were measured) at k={headline_k}: "
             f"**{high:+.4f}** per-record recall on `{high_row.benchmark}` "
             f"{_ci(high_row.vs_reference_ci_low, high_row.vs_reference_ci_high)} and "
             f"**{low:+.4f}** on `{low_row.benchmark}` "
@@ -2432,8 +2433,9 @@ def render_report(rows: Sequence[LadderRow], headline_k: int = 20) -> str:
 
     out.append(f"\n## Is it better than what ships today? (k={headline_k}, no instruction)\n")
     out.append(
-        f"\nEvery model against `{REFERENCE_MODEL}` — langres's current "
-        "`DEFAULT_EMBEDDING_MODEL` — on the same records, paired per record and "
+        f"\nEvery model against `{REFERENCE_MODEL}` — this ladder's reference model, "
+        "which was `DEFAULT_EMBEDDING_MODEL` when these rows were measured — on the "
+        "same records, paired per record and "
         "resampled by gold cluster. **Δ is the mean per-record recall difference**, "
         "not the difference of the two aggregate recalls above: the bootstrap "
         "resamples per-record units, so the point estimate has to be the same "

--- a/src/langres/core/embeddings.py
+++ b/src/langres/core/embeddings.py
@@ -1407,13 +1407,35 @@ class DiskCachedEmbedder:
         it is actually a mapping, and serialized sorted — dict order is not part
         of its meaning, so it must not be part of the key.
 
-        Returns ``""`` when none of them is set, so every cache written before
-        these knobs existed still hits. That is deliberate: closing the hazard
-        must not cost a full re-encode for the overwhelmingly common unset case.
+        **The model itself is the setting that changes the vectors most, and it
+        used to be missing here.** ``namespace`` defaults to ``"default"``, so
+        the ordinary
+        ``DiskCachedEmbedder(embedder=SentenceTransformerEmbedder(), cache_dir=...)``
+        wrote every model's vectors into one ``default.db`` keyed on the bare
+        text. Swapping the wrapped model — including by upgrading langres, since
+        that moved :data:`~langres.core.model_ref.DEFAULT_EMBEDDING_MODEL` — then
+        hit those entries and served the *previous* model's vectors under the new
+        one, at the previous model's dimensionality. A fully warm cache did this
+        silently; a partially warm one produced a ragged 384/768 stack. The model
+        ref is preferred over the bare name because it also pins ``revision``: the
+        same name at a different Hub revision is a different checkpoint and must
+        not share entries.
+
+        Returns ``""`` only for an embedder with **no** model identity and none of
+        the knobs set — a ``FakeEmbedder`` and the like — so caches written by
+        those still hit. A cache written by a *named* model does not: it is
+        re-encoded once, which is the price of no longer being silently wrong.
         """
         prompt_name = getattr(self.embedder, "prompt_name", None)
         truncate_dim = getattr(self.embedder, "truncate_dim", None)
         prompts = getattr(self.embedder, "prompts", None)
+        # `model_ref` first (it carries `revision`), then the bare name. Both are
+        # read defensively: the wrapped embedder is structurally typed and need
+        # not carry either.
+        model = getattr(self.embedder, "model_ref", None) or getattr(
+            self.embedder, "model_name", None
+        )
+        identity = "" if model is None else str(model)
         # A mapping only — the wrapped embedder is structurally typed, so an
         # unrelated `prompts` attribute of some other shape must not become the
         # cache key (nor raise from a key-derivation function). `Mapping`, not
@@ -1421,9 +1443,12 @@ class DiskCachedEmbedder:
         # mapping, and narrowing to the concrete type would silently drop it
         # from the key — the fail-open this check exists to prevent.
         registered = sorted(prompts.items()) if isinstance(prompts, Mapping) else []
-        if prompt_name is None and truncate_dim is None and not registered:
+        if prompt_name is None and truncate_dim is None and not registered and not identity:
             return ""
-        return f"|||NAME|||{prompt_name}|||DIM|||{truncate_dim}|||PROMPTS|||{registered!r}"
+        return (
+            f"|||MODEL|||{identity}|||NAME|||{prompt_name}"
+            f"|||DIM|||{truncate_dim}|||PROMPTS|||{registered!r}"
+        )
 
     def _hash_text(self, text: str, prompt: str | None = None) -> str:
         """Generate cache key from text, prompt, and the embedder's own settings.

--- a/src/langres/core/embeddings.py
+++ b/src/langres/core/embeddings.py
@@ -776,7 +776,9 @@ class FakeEmbedder:
 
         Args:
             embedding_dim: Dimensionality of fake embeddings to produce.
-                Default: 384 (matches all-MiniLM-L6-v2).
+                Default: 384. An arbitrary, stable size — it deliberately does
+                **not** track :data:`~langres.core.model_ref.DEFAULT_EMBEDDING_MODEL`
+                (now 768-dim), since nothing about a fake embedder needs to.
             normalize_embeddings: L2-normalize embeddings to unit vectors.
                 Default: True (matches SentenceTransformerEmbedder behavior).
         """

--- a/src/langres/core/embeddings.py
+++ b/src/langres/core/embeddings.py
@@ -450,7 +450,8 @@ class SentenceTransformerEmbedder:
 
     Note:
         Common models and their dimensions:
-        - "all-MiniLM-L6-v2": 384 dim (fast, good quality)
+        - "intfloat/e5-base-v2": 768 dim (the default; best measured OSI model)
+        - "all-MiniLM-L6-v2": 384 dim (fast, the previous default)
         - "all-mpnet-base-v2": 768 dim (slower, better quality)
         - "all-MiniLM-L12-v2": 384 dim (medium speed/quality)
 
@@ -484,7 +485,11 @@ class SentenceTransformerEmbedder:
 
         Args:
             model_name: Name of the sentence-transformers model to use.
-                Default: "all-MiniLM-L6-v2" (fast, good quality baseline).
+                Default: :data:`~langres.core.model_ref.DEFAULT_EMBEDDING_MODEL`
+                ("intfloat/e5-base-v2", 768-dim, MIT) — the best OSI-licensed
+                model measured in ``docs/research/20260727_embedder_ladder.md``.
+                It is measured and shipped **without** a prompt; see that
+                constant before adding one.
             batch_size: Number of texts to encode per batch.
                 Default: 32. Use 128+ for GPU with sufficient memory.
             show_progress_bar: Display encoding progress for large datasets.

--- a/src/langres/core/matchers/cascade.py
+++ b/src/langres/core/matchers/cascade.py
@@ -24,6 +24,7 @@ from sentence_transformers import SentenceTransformer
 
 from langres.core.models import ERCandidate, PairwiseJudgement
 from langres.core.matcher import Matcher, SchemaT
+from langres.core.model_ref import DEFAULT_EMBEDDING_MODEL
 from langres.core.matchers.llm_judge import (
     DEFAULT_PROMPT,
     render_default_prompt,
@@ -104,7 +105,10 @@ class CascadeChainMatcher(Matcher[SchemaT]):
 
     def __init__(
         self,
-        embedding_model_name: str = "all-MiniLM-L6-v2",
+        # Reads the shared constant rather than repeating the literal: this was
+        # a fourth copy the `model_ref` consolidation missed, and a copy is
+        # exactly how "the default embedding model" comes to mean two things.
+        embedding_model_name: str = DEFAULT_EMBEDDING_MODEL,
         llm_model: str = "gpt-4o-mini",
         llm_api_key: str = "",
         low_threshold: float = 0.3,

--- a/src/langres/core/model_ref.py
+++ b/src/langres/core/model_ref.py
@@ -77,7 +77,46 @@ from typing import Literal, get_args
 #: method's identity) without either importing the other. It previously existed
 #: as three copies of the same literal (``method_registry`` + two in
 #: ``embeddings``), which is exactly how a default drifts.
-DEFAULT_EMBEDDING_MODEL = "all-MiniLM-L6-v2"
+#:
+#: **Chosen from measurement, over the OSI-licensed field only.** langres ships
+#: under Apache-2.0, so a default may not carry a use-restricted licence: it
+#: would push terms onto every user who never chose them. That rules out the
+#: ladder's strongest overall model, ``google/embeddinggemma-300m`` (Gemma Terms
+#: of Use — a prohibited-use policy that survives redistribution, and *not* OSI),
+#: which stays a documented opt-in. Among the OSI field, ``intfloat/e5-base-v2``
+#: (MIT) is ahead of the previous default ``all-MiniLM-L6-v2`` on **3 of the 5**
+#: benchmarks, and behind on **none** — mean per-record candidate recall at
+#: k=20, bootstrapped by gold cluster (``docs/research/20260727_embedder_ladder.md``):
+#:
+#: =============== ========= ====================== =========
+#: benchmark         Δ recall   95% CI                clusters
+#: =============== ========= ====================== =========
+#: wdc_computers     +0.1528   [+0.1254, +0.1797]         877
+#: abt_buy           +0.0324   [+0.0216, +0.0451]       1,012
+#: walmart_amazon    +0.0159   [+0.0078, +0.0246]         846
+#: amazon_google     +0.0056   [-0.0002, +0.0116]         995  (spans 0)
+#: fodors_zagat      +0.0000   [+0.0000, +0.0000]         112  (saturated)
+#: =============== ========= ====================== =========
+#:
+#: **It is measured BARE, and must ship bare — do not add a prompt here.**
+#: E5's model card documents an asymmetric ``"query: "`` / ``"passage: "``
+#: recipe, so the reflex on reading this constant is to wire one up. Don't: the
+#: checkpoint ships **no** ``config_sentence_transformers.json`` (it is a
+#: ``.no_exist`` entry in the Hub cache), so it registers no prompts, and every
+#: row above was produced by the ladder's ``prompt_arm="none"`` — neither side
+#: prefixed. e5-base-v2 has no ``documented`` arm in the ladder at all. Adding
+#: the model-card prefixes would therefore ship a configuration **nobody
+#: measured**, whose sign is unknown, while claiming the numbers above. If the
+#: recipe is worth having, measure it first: add a ``documented_arm`` to this
+#: model's ``ModelSpec`` in ``examples/research/embedder_ladder.py`` and re-run.
+#: (Driving only one half is worse than neither, which is why
+#: ``VectorBlocker`` warns on it — see ``core/blockers/vector.py``.)
+#:
+#: Two consequences worth knowing before changing this again: the ladder ranks
+#: models on **blocking** candidate recall, not end-to-end F1; and the field is
+#: **7 of the 14** models in the ladder — the 7 with rows at ``metric_revision``
+#: 1. This is the best measured model, not a survey of every model that exists.
+DEFAULT_EMBEDDING_MODEL = "intfloat/e5-base-v2"
 
 #: The form of a backbone reference, and the sole input to routing.
 BackboneKind = Literal["api", "endpoint", "hf", "local"]

--- a/src/langres/core/model_ref.py
+++ b/src/langres/core/model_ref.py
@@ -98,19 +98,44 @@ from typing import Literal, get_args
 #: fodors_zagat      +0.0000   [+0.0000, +0.0000]         112  (saturated)
 #: =============== ========= ====================== =========
 #:
-#: **It is measured BARE, and must ship bare — do not add a prompt here.**
-#: E5's model card documents an asymmetric ``"query: "`` / ``"passage: "``
-#: recipe, so the reflex on reading this constant is to wire one up. Don't: the
-#: checkpoint ships **no** ``config_sentence_transformers.json`` (it is a
-#: ``.no_exist`` entry in the Hub cache), so it registers no prompts, and every
-#: row above was produced by the ladder's ``prompt_arm="none"`` — neither side
-#: prefixed. e5-base-v2 has no ``documented`` arm in the ladder at all. Adding
-#: the model-card prefixes would therefore ship a configuration **nobody
-#: measured**, whose sign is unknown, while claiming the numbers above. If the
-#: recipe is worth having, measure it first: add a ``documented_arm`` to this
-#: model's ``ModelSpec`` in ``examples/research/embedder_ladder.py`` and re-run.
-#: (Driving only one half is worse than neither, which is why
-#: ``VectorBlocker`` warns on it — see ``core/blockers/vector.py``.)
+#: **It is measured BARE, and ships bare — deliberately, and this is a known
+#: open question rather than a settled one.** E5's model card asks for a prefix
+#: and says so bluntly: *"Do I need to add the prefix 'query: ' and 'passage: '
+#: to input texts? Yes, this is how the model is trained, otherwise you will see
+#: a performance degradation."* (README FAQ 1, L2685-2687, read from the
+#: checkpoint's own card). Note **which** prefix, though — the card's next lines
+#: split by task shape: ``"query: "``/``"passage: "`` for *asymmetric* retrieval
+#: (L2690), but ``"query: "`` **on both sides** for *symmetric* tasks such as
+#: semantic similarity and paraphrase retrieval (L2692). Entity resolution is
+#: symmetric — records against records, with no "passage" side — so the recipe
+#: this model would want here is the **symmetric** one, not the retrieval one.
+#: ``core/blockers/vector.py`` already documents that shape and accepts it
+#: without warning (``prompt_name="query"``, ``query_prompt`` unset).
+#:
+#: So why bare? Because **the ladder measured bare**, and the numbers above are
+#: only claimable for the configuration that produced them. Every e5 row carries
+#: ``registered_prompts: []`` and ``prompt_arm="none"``; the checkpoint ships no
+#: ``config_sentence_transformers.json`` at all (a ``.no_exist`` entry in the Hub
+#: cache), so nothing was applied implicitly either, and e5-base-v2 has no
+#: ``documented`` arm in the ladder. The symmetric recipe is therefore
+#: **unmeasured here**, and shipping it would put a configuration nobody measured
+#: behind the numbers above.
+#:
+#: The two facts together are not a conflict — they set a floor: e5-base-v2 beat
+#: the previous default by the margins above **while running in the configuration
+#: its own card calls degraded**. The measured win is a lower bound, and the
+#: prefix is upside that has not been collected.
+#:
+#: **To collect it, measure it — don't just switch it on.** Add a symmetric arm
+#: (``"query: "`` bound on both sides) for this model in
+#: ``examples/research/embedder_ladder.py`` and re-run; if it wins, change this
+#: constant's configuration and these numbers together. The ladder's own boxed
+#: warning is the reason for the caution: a query-side prefix *hurt* several
+#: models there, and e5's measured ``instruct`` arm — a generic instruction on
+#: the query side only, which is neither recipe — moved nothing measurable on any
+#: of the five (four intervals span 0; ``fodors_zagat`` is exactly 0).
+#: (Driving a *document* prefix without the matching query side is worse than
+#: neither; ``VectorBlocker`` warns on exactly that.)
 #:
 #: Two consequences worth knowing before changing this again: the ladder ranks
 #: models on **blocking** candidate recall, not end-to-end F1; and the field is

--- a/tests/core/test_cached_embedder.py
+++ b/tests/core/test_cached_embedder.py
@@ -790,3 +790,55 @@ class TestCacheKeyCoversEmbedderSettings:
         """
         cached = self._cached(tmp_path, prompts="not a mapping")
         assert cached._embedder_discriminator() == ""
+
+
+class TestCacheKeyCoversTheModelItself:
+    """The wrapped MODEL is part of the key — the setting that changes vectors most.
+
+    ``namespace`` defaults to ``"default"``, so the ordinary
+    ``DiskCachedEmbedder(embedder=SentenceTransformerEmbedder(), cache_dir=...)``
+    writes into one shared DB. Before the model reached the key, swapping the
+    wrapped model — including by upgrading langres, which moved
+    ``DEFAULT_EMBEDDING_MODEL`` from a 384-dim checkpoint to a 768-dim one — hit
+    the old entries and served the *previous* model's vectors under the new one.
+    """
+
+    def _cached(self, tmp_path, embedder):
+        return DiskCachedEmbedder(
+            embedder=embedder, cache_dir=tmp_path / "cache", namespace="shared"
+        )
+
+    def _named(self, name, ref=None):
+        embedder = FakeEmbedder(embedding_dim=8)
+        embedder.model_name = name
+        if ref is not None:
+            embedder.model_ref = ref
+        return embedder
+
+    def test_two_models_in_one_namespace_do_not_share_entries(self, tmp_path):
+        old = self._cached(tmp_path, self._named("all-MiniLM-L6-v2"))
+        new = self._cached(tmp_path, self._named("intfloat/e5-base-v2"))
+        assert old._hash_text("acme") != new._hash_text("acme")
+
+    def test_the_same_model_still_shares_entries(self, tmp_path):
+        one = self._cached(tmp_path, self._named("intfloat/e5-base-v2"))
+        other = self._cached(tmp_path, self._named("intfloat/e5-base-v2"))
+        assert one._hash_text("acme") == other._hash_text("acme")
+
+    def test_a_revision_pin_changes_the_key(self, tmp_path):
+        """Same name, different Hub revision, different checkpoint — different vectors."""
+        from langres.core.model_ref import ModelRef
+
+        base = "intfloat/e5-base-v2"
+        one = self._cached(
+            tmp_path, self._named(base, ModelRef(base=base, kind="hf", revision="aaa"))
+        )
+        other = self._cached(
+            tmp_path, self._named(base, ModelRef(base=base, kind="hf", revision="bbb"))
+        )
+        assert one._hash_text("acme") != other._hash_text("acme")
+
+    def test_an_embedder_with_no_model_identity_keeps_its_entries(self, tmp_path):
+        """A FakeEmbedder carries no model name, so its caches keep hitting."""
+        cached = self._cached(tmp_path, FakeEmbedder(embedding_dim=8))
+        assert cached._embedder_discriminator() == ""

--- a/tests/core/test_embedding_model_ref.py
+++ b/tests/core/test_embedding_model_ref.py
@@ -107,19 +107,22 @@ def test_parameter_count_sums_the_loaded_weights(monkeypatch) -> None:
 def test_the_default_embedder_ships_with_no_prompt_recipe() -> None:
     """The default must stay in the configuration the ladder measured: BARE.
 
-    ``intfloat/e5-base-v2``'s model card documents an asymmetric
-    ``"query: "`` / ``"passage: "`` recipe, so the standing temptation is to
-    wire one into the default. Every number backing this default
-    (``docs/research/20260727_embedder_ladder.md``) was measured in the
-    ladder's ``prompt_arm="none"`` — neither side prefixed — and the checkpoint
-    ships no ``config_sentence_transformers.json``, so it registers no prompts
-    of its own. e5-base-v2 has no ``documented`` arm in the ladder at all.
+    ``intfloat/e5-base-v2``'s model card asks for a prefix and warns that
+    omitting one degrades the model (README FAQ 1). For a *symmetric* task like
+    ER the card's recipe is ``"query: "`` on **both** sides (L2692) — not the
+    ``"query: "``/``"passage: "`` retrieval pair (L2690) — and
+    ``VectorBlocker`` already accepts that shape without warning. So the
+    standing temptation is to wire it into the default.
 
-    So a prompt appearing here would ship an **unmeasured** configuration under
-    the measured numbers' banner, and half of one (``prompt_name`` without the
-    blocker's ``query_prompt``) is actively worse than neither — the case
-    ``VectorBlocker`` warns about. Measure it in the ladder first, then change
-    this test with the rows to back it.
+    Don't do it here first. Every number backing this default
+    (``docs/research/20260727_embedder_ladder.md``) was measured at
+    ``prompt_arm="none"`` — neither side prefixed, ``registered_prompts: []``,
+    and no ``documented`` arm for this model at all. The symmetric recipe is
+    **unmeasured**, so switching it on would put a configuration nobody measured
+    behind those numbers. That the model still won while degraded makes the
+    measured margin a floor, not a reason to leave the upside uncollected —
+    measure a symmetric arm in the ladder, then change this test together with
+    the rows that justify it.
     """
     embedder = SentenceTransformerEmbedder()
 

--- a/tests/core/test_embedding_model_ref.py
+++ b/tests/core/test_embedding_model_ref.py
@@ -8,7 +8,7 @@ from types import ModuleType
 from typing import Any
 
 from langres.core.embeddings import SentenceTransformerEmbedder
-from langres.core.model_ref import ModelRef
+from langres.core.model_ref import DEFAULT_EMBEDDING_MODEL, ModelRef
 
 
 def test_sentence_transformer_config_round_trips_full_model_ref_and_runtime() -> None:
@@ -102,3 +102,32 @@ def test_parameter_count_sums_the_loaded_weights(monkeypatch) -> None:
     embedder = SentenceTransformerEmbedder(model_name="org/model")
 
     assert embedder.parameter_count == 1_234_567
+
+
+def test_the_default_embedder_ships_with_no_prompt_recipe() -> None:
+    """The default must stay in the configuration the ladder measured: BARE.
+
+    ``intfloat/e5-base-v2``'s model card documents an asymmetric
+    ``"query: "`` / ``"passage: "`` recipe, so the standing temptation is to
+    wire one into the default. Every number backing this default
+    (``docs/research/20260727_embedder_ladder.md``) was measured in the
+    ladder's ``prompt_arm="none"`` — neither side prefixed — and the checkpoint
+    ships no ``config_sentence_transformers.json``, so it registers no prompts
+    of its own. e5-base-v2 has no ``documented`` arm in the ladder at all.
+
+    So a prompt appearing here would ship an **unmeasured** configuration under
+    the measured numbers' banner, and half of one (``prompt_name`` without the
+    blocker's ``query_prompt``) is actively worse than neither — the case
+    ``VectorBlocker`` warns about. Measure it in the ladder first, then change
+    this test with the rows to back it.
+    """
+    embedder = SentenceTransformerEmbedder()
+
+    assert embedder.model_name == DEFAULT_EMBEDDING_MODEL == "intfloat/e5-base-v2"
+    assert embedder.prompt_name is None
+    assert not embedder.prompts
+
+    # The serialized config must not smuggle one back in either.
+    config = embedder.config()
+    assert config.prompt_name is None
+    assert not config.prompts

--- a/tests/core/test_method_registry.py
+++ b/tests/core/test_method_registry.py
@@ -226,7 +226,7 @@ class TestBuiltinSpecs:
 
     def test_embedding_reports_the_pinned_embedder_as_its_model(self) -> None:
         spec = get_method("embedding")
-        assert spec.default_model == DEFAULT_EMBEDDING_MODEL == "all-MiniLM-L6-v2"
+        assert spec.default_model == DEFAULT_EMBEDDING_MODEL == "intfloat/e5-base-v2"
         # Its model slot is the blocker's embedder: in-process kinds, no API.
         assert spec.accepted_kinds == {"hf", "local"}
 


### PR DESCRIPTION
## What

`DEFAULT_EMBEDDING_MODEL` moves from `all-MiniLM-L6-v2` to **`intfloat/e5-base-v2`** (MIT, 109.5M params, 768-dim), chosen from the committed embedder ladder over the OSI-licensed field only.

## The measured numbers

From `docs/research/20260727_embedder_ladder.md` — mean **per-record candidate recall** at k=20, `prompt_arm="none"`, paired per record and bootstrapped by gold cluster. Ahead of the incumbent on **3 of 5**, behind on **none**:

| benchmark | Δ per-record recall vs `all-MiniLM-L6-v2` | 95% CI | clusters |
|---|---:|---|---:|
| `wdc_computers` | **+0.1528** | [+0.1254, +0.1797] | 877 |
| `abt_buy` | **+0.0324** | [+0.0216, +0.0451] | 1,012 |
| `walmart_amazon` | **+0.0159** | [+0.0078, +0.0246] | 846 |
| `amazon_google` | +0.0056 | [-0.0002, +0.0116] (spans 0) | 995 |
| `fodors_zagat` | +0.0000 | [+0.0000, +0.0000] (exactly 0) | 112 |

Absolute recall at k=20, and the cost of that ceiling (`cands/recall`, lower is cheaper) — e5 is cheaper on **all five**:

| benchmark | MiniLM recall | e5 recall | MiniLM cands/recall | e5 cands/recall |
|---|---:|---:|---:|---:|
| `abt_buy` | 0.9349 | 0.9674 | 11,985 | **9,095** |
| `amazon_google` | 0.8266 | 0.8324 | 27,853 | **25,749** |
| `fodors_zagat` | 1.0000 | 1.0000 | 4,880 | **4,431** |
| `walmart_amazon` | 0.8654 | 0.8810 | 53,658 | **52,776** |
| `wdc_computers` | 0.5770 | 0.7264 | 56,103 | **43,834** |

### How partial the field is

**7 of the 14 models in the ladder have rows at `metric_revision` 1.** The other 7 (`Alibaba-NLP/gte-base-en-v1.5`, `nomic-ai/nomic-embed-text-v1.5`, `BAAI/bge-large-en-v1.5`, `mixedbread-ai/mxbai-embed-large-v1`, and the three `Qwen/Qwen3-Embedding-*`) are recorded "not run". **This is the best *measured* model, not a survey** — absence from the table is not evidence against a model.

Two more scope limits, from the ladder's own caveats: the metric is **blocking candidate recall, not end-to-end F1**; and `fodors_zagat` is saturated (every model scores 1.0000), so it settles nothing. Separability AUC is higher for e5 on all five, but the ladder explicitly calls AUC a floor check near its ceiling, not a fine-grained ranking — so it is not offered as evidence here.

### Why not `google/embeddinggemma-300m`

It measured better overall (`wdc_computers` +0.2079, `abt_buy` +0.0392) but ships under the **Gemma Terms of Use — not OSI-approved**, carrying a prohibited-use policy that survives redistribution. langres is Apache-2.0; a default must not push terms onto users who never chose them. It remains a documented opt-in. (It is also **worse** than the incumbent on `amazon_google`, -0.0294 [-0.0425, -0.0163] — there is no single winner.)

## The prompt recipe: unmeasured, so not wired — and it's `query: ` on both sides

Two corrections here, both to premises I was handed. I read the checkpoint's own model card and the committed rows rather than relying on either.

**1. The ER-relevant recipe is the *symmetric* one.** The card (FAQ 1, L2685-2694) splits by task shape: `"query: "`/`"passage: "` for **asymmetric** retrieval (L2690), but `"query: "` on **both sides** for **symmetric** tasks — semantic similarity, paraphrase retrieval (L2692). Entity resolution is symmetric — records against records, no "passage" side — so the retrieval pair is the wrong recipe to reach for. `core/blockers/vector.py:36-48` (from #242) already documents this shape, names e5-base-v2, and accepts it *without* warning.

**2. It is still unmeasured, so it does not ship.** Verified three independent ways:

1. **The winning rows are `prompt_arm: "none"`** — neither side prefixed. The `+0.1528` on `wdc_computers` is `vs_reference_delta` on the `none` row.
2. **e5-base-v2 has no `documented` arm at all.** Row counts by arm: `{none: 20, instruct: 20}`. Only `google/embeddinggemma-300m` has one. The harness's `ModelSpec("intfloat/e5-base-v2", license="mit")` passes no `documented_arm`, and `arms_for()` only adds that arm when one is declared.
3. **The checkpoint registers no prompts.** Every e5 row records `registered_prompts: []`, and `config_sentence_transformers.json` is a `.no_exist` entry in the Hub cache — the checkpoint ships none, so nothing was applied implicitly either.

### The card and the ladder don't conflict — together they set a floor

The card warns that running e5 with **no** prefix degrades it. The ladder ran it with no prefix. So:

> **e5-base-v2 beat the previous default by +0.1528 / +0.0324 / +0.0159 while running in the configuration its own card calls degraded.**

That makes the measured margin a **lower bound**, and the prefix *uncollected upside* — not a correctness problem. Shipping the symmetric recipe now would instead put a configuration nobody measured behind the numbers above, which is the specific way this task fails silently.

The caution isn't theoretical: the ladder's boxed warning records that a query-side prefix **hurt** several models, and e5's measured `instruct` arm (a generic query-side instruction — neither recipe) moved nothing measurable on any of the five benchmarks (four intervals span 0; `fodors_zagat` exactly 0).

**Follow-up, not a blocker:** add a symmetric `"query: "` arm for this model to `examples/research/embedder_ladder.py`, re-run, and move the constant's configuration and its numbers together. Pinned meanwhile by `test_the_default_embedder_ships_with_no_prompt_recipe`, which asserts the default binds no `prompt_name` and no `prompts`, in the object and in its serialized config.

Worth stating explicitly: shipping the symmetric recipe **would** be expressible today without new API (`VectorBlocker` + `SentenceTransformerEmbedder(prompts=..., prompt_name="query")`). The blocker is the missing measurement, not a missing seam.

## Migration, and a latent cache bug this change would have activated

**A normally saved artifact keeps working — do not discard it.** `FAISSIndex.config()` serializes the embedder's own `ComponentSpec`, `from_config()` reconstructs *that* embedder, and `load_state()` restores stored vectors verbatim without invoking it (`vector_index.py:342-392`). (My first draft claimed such indexes "will not load". That was wrong — caught in review, corrected.)

What actually changes:

- **Rebuilding an index against the new default** gives 768-dim vectors from a different model; it can't be mixed with or compared against old 384-dim ones.
- **`DiskCachedEmbedder` caches re-encode once** — because of the fix below.

**Fixed: `DiskCachedEmbedder` could silently serve a different model's vectors.** `_embedder_discriminator()` covered `prompt_name` / `truncate_dim` / `prompts` but **not the model**, and `namespace` defaults to `"default"` — so the ordinary `DiskCachedEmbedder(embedder=SentenceTransformerEmbedder(), cache_dir=...)` wrote every model into one `default.db` keyed on the bare text. Swapping the wrapped model returned the *previous* model's vectors at the previous dimensionality: silently on a warm cache, as a ragged 384/768 stack on a partial one.

This PR is what would have made that latent bug live — every user of the default keeps reading MiniLM vectors without touching a line of their own code. The model is now part of the key (`ModelRef` where present, so a `revision` pin counts). Caches from an identity-less embedder (`FakeEmbedder`) still hit; caches from a named model re-encode once.

To keep the old behaviour exactly, name the old model:

```python
SentenceTransformerEmbedder("all-MiniLM-L6-v2")   # previous default
```

Cost: 109.5M params vs 22.7M — bigger download, more memory, slower encoding. The ladder's `index build (s)` column **cannot** price this and I have not quoted it: every `all-MiniLM-L6-v2` row read from the embedding cache (`enc 0`) while the e5 rows encoded for real, so the two columns measure different things.

## Changed

- `core/model_ref.py` — the constant, the evidence table, and the prompt-recipe reasoning with its reproduction path.
- `core/embeddings.py` — the cache-key fix above; docstrings that stated the default; plus `FakeEmbedder`'s "(matches all-MiniLM-L6-v2)" parenthetical, which was literally true but implied the fake tracks the default (value left at 384).
- `core/matchers/cascade.py` — `embedding_model_name` was a **fourth hard-coded copy** of the old literal that the `model_ref` consolidation missed; now reads the shared constant.
- `docs/research/20260727_embedder_ladder.md` + `examples/research/embedder_ladder.py` — the ladder called MiniLM "langres's current default" in two places, with the wording hard-coded in the renderer so re-rendering regenerated the stale claim. Now described as "this ladder's reference model, and langres's default when these rows were measured" — true permanently, since it's a fact about the measurement rather than the current config. Fixed in the renderer, then regenerated with `--render-only`: that re-render changed exactly those 3 lines and reproduced every other line byte-identically, which also confirms the committed doc still matches the committed rows.
- `tests/` — the assertion pinning the literal, the no-prompt guard, and `TestCacheKeyCoversTheModelItself` for the cache fix.
- `CHANGELOG.md`.

**Deliberately not changed** (flagged rather than silently swept):

- `langres/data/*` benchmark loaders (`_EMBED_MODEL`, `_DEFAULT_EMBED_MODEL`, per-dataset factories) — these pin the model behind **published baselines**; retargeting them would silently invalidate committed results.
- `SearchSpace.embedding_model` / `BlockerOptimizer` — explicitly enumerated **search axes**, not the library default. Changing them would alter every default `optimize()` run and the documented `$0/offline` example in `docs/EXPERIMENTS.md`.

Both are defensible either way; say the word and I'll move them.

No non-research doc claimed the default by name — every `all-MiniLM-L6-v2` hit under `docs/` is an explicit argument in an example, or the `SearchSpace` field default, both still accurate.

## Verification

`ruff format --check` (572 files) pass · `ruff check` pass · `mypy src` (215 files) pass · fast suite **4711 passed, 2 skipped**

I did **not** touch `src/langres/resources/sentence_transformers.py` (owned by another stream this round), and did not need to.

**Note on the check list: Sourcery did not review this PR.** It posted "you have reached your weekly rate limit of 500000 diff characters" and its check reads `skipping`; its "Reviewer's Guide" comment is not a review. Codex did review, and its three findings are addressed above.
