### PR TITLE
fix: restore ruff's default rules, retract the ~12.5x async claim, fix the CodeQL bump

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -21,3 +21,16 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+    groups:
+      # `github/codeql-action/init` and `.../analyze` are separate "dependencies"
+      # to Dependabot but ONE product: init writes a config file stamped with its
+      # own version and analyze refuses to read a config from a different one.
+      # Bumping half the pair therefore always fails the job outright:
+      #   ##[error]Loaded a configuration file for version '4.37.3',
+      #            but running version '4.37.0'
+      # That is exactly what killed PR #231 (init 4.37.0->4.37.3) and #233
+      # (analyze 4.37.0->4.37.3) -- two red PRs for one un-splittable bump.
+      # Grouping them means one PR moves every codeql-action step together.
+      codeql-action:
+        patterns:
+          - "github/codeql-action*"

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -2,11 +2,15 @@ name: CodeQL
 
 # Static security analysis (free for public repos). Python-only; findings land
 # in the repo's Security tab -> Code scanning.
+# NOTE: `pull_request.branches` filters by TARGET branch, so this list has to
+# track the one in `lint.yml`/`test.yml` -- a PR into a branch missing here gets
+# NO security scan at all, silently. Both integration branches below still exist
+# on the remote, so the drift was a live gap, not a stale entry.
 on:
   push:
-    branches: [main]
+    branches: [main, epic/193-core-algebra]
   pull_request:
-    branches: [main]
+    branches: [main, feat/core-packages, epic/193-core-algebra]
   schedule:
     # Weekly on Monday at 07:00 UTC (between the test-full and security crons)
     - cron: "0 7 * * 1"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -683,6 +683,36 @@ changing the default model hard."* Design note:
 
 ### Fixed
 
+- **Retracted a fabricated `~12.5x` speedup claim on `LLMMatcher.forward_async`.**
+  The docstring advertised `~4 requests/second` sequential vs `~50
+  requests/second` async. Neither figure survives contact with the code: the
+  `_RateLimiter` is constructed *only* inside `forward_async`, so the sequential
+  `forward` has no RPM cap at all (its rate is per-call latency), while
+  `forward_async`'s own default `rpm_limit=250` caps it at 250 RPM = **4.17
+  req/s** — it cannot reach 50 req/s, and 4.17 was the number being quoted as
+  the *baseline*. `12.5` was simply `50/4`. The docstring now states what is
+  true — async overlaps request latency, and the rate limiter is the binding
+  ceiling — with **no** replacement ratio, because none has been measured.
+  Anyone who sized a job on the old number should re-derive it from
+  `rpm_limit`. The same claim is retracted in
+  `examples/research/phase2_full_pipeline.py`, whose ETA also divided by
+  requests-per-*second* while reporting minutes (60x under).
+- **Ruff was enforcing almost nothing.** `[tool.ruff.lint] select` *replaces*
+  ruff's default rule set rather than extending it, so listing only the two
+  print bans silently disabled `E4`/`E7`/`E9`/`F` — all of pyflakes included —
+  and `ruff check .` passed on 167 real violations. Now `extend-select`. The
+  latent bug this surfaced in shipped code: `core/_exports/_flywheel.py` and
+  `core/_exports/_training.py` each imported the same names **twice** — once
+  from the canonical module and once from a `# TEMPORARY` W2 back-compat shim
+  (`langres.core.review` / `.judgement_log` / `.harvest` / `.fit_report`).
+  **Nothing resolved differently at runtime** — the shims re-export, so every
+  duplicated binding is `is`-identical, and the two pairs happened to shadow in
+  *opposite* directions (the shim won for `JudgementLog`/`LoggingMatcher`/
+  `align_pairs`, the canonical module won for `ReviewItem`/`ReviewQueue`/
+  `select_for_review`/`FitReport`). The hazard was the pending shim deletion,
+  not current behaviour: importing those shim modules at all means deleting
+  them raises `ImportError` and breaks `langres.core` at import time. Only the
+  canonical imports remain.
 - **`langres.__version__` no longer drifts from the released version.** It was a
   hardcoded string (still `"0.2.0"` in the published 0.3.0 wheel, while pip
   metadata correctly said 0.3.0); it now resolves from the installed package

--- a/examples/flywheel_closed_loop.py
+++ b/examples/flywheel_closed_loop.py
@@ -69,7 +69,6 @@ from langres.core.comparators import StringComparator
 from langres.curation.harvest import (
     Correction,
     CorrectionLog,
-    LabeledPair,
     derive_threshold_from_pairs,
     harvest_labeled_pairs,
 )

--- a/examples/research/blocker_evaluation_comprehensive.py
+++ b/examples/research/blocker_evaluation_comprehensive.py
@@ -140,11 +140,11 @@ def main():
 
     # Score distribution analysis
     logger.info("\n📈 Score Distribution:")
-    logger.info(f"  True match scores:")
+    logger.info("  True match scores:")
     logger.info(f"    Mean:    {report.scores.true_mean:.3f}")
     logger.info(f"    Median:  {report.scores.true_median:.3f}")
     logger.info(f"    Std:     {report.scores.true_std:.3f}")
-    logger.info(f"  False candidate scores:")
+    logger.info("  False candidate scores:")
     logger.info(f"    Mean:    {report.scores.false_mean:.3f}")
     logger.info(f"    Median:  {report.scores.false_median:.3f}")
     logger.info(f"    Std:     {report.scores.false_std:.3f}")

--- a/examples/research/blocking_evaluation_comprehensive_comparison.py
+++ b/examples/research/blocking_evaluation_comprehensive_comparison.py
@@ -41,7 +41,6 @@ import time
 from pathlib import Path
 from typing import Any
 
-import numpy as np
 from pydantic import BaseModel, Field
 from qdrant_client import QdrantClient
 
@@ -545,16 +544,16 @@ def main() -> None:
     print("=" * 140)
     print("COMPREHENSIVE BLOCKING EVALUATION: Model, Instruction & Architecture Comparison")
     print("=" * 140)
-    print(f"\nDataset: Funder organization names (1,741 entities)")
-    print(f"\nModels:")
+    print("\nDataset: Funder organization names (1,741 entities)")
+    print("\nModels:")
     print(f"  Simple:   {MINILM_MODEL} (384 dims, 22M params, no instruction support)")
     print(f"  Advanced: {QWEN3_MODEL} (1024 dims, 600M params, WITH instruction support)")
     print(f"  Sparse:   {SPARSE_MODEL} (BM25 keyword matching)")
     print(f"  Reranking: {RERANKING_MODEL} (ColBERT late-interaction)")
-    print(f"\nParameters:")
+    print("\nParameters:")
     print(f"  k-neighbors: {K_NEIGHBORS}")
     print(f"  Prefetch limit: {PREFETCH_LIMIT}")
-    print(f"\nCache (Qwen3 only):")
+    print("\nCache (Qwen3 only):")
     print(f"  Directory: {CACHE_DIR}")
     print(f"  Namespace: {CACHE_NAMESPACE}")
     print(f"  Memory size: {MEMORY_CACHE_SIZE:,}")
@@ -762,7 +761,7 @@ def main() -> None:
 
     # A. Sparse Vectors Impact
     print("\n📊 A. IMPACT OF SPARSE VECTORS (Adding BM25)")
-    print(f"   Comparison: FAISS-MiniLM vs Hybrid-MiniLM")
+    print("   Comparison: FAISS-MiniLM vs Hybrid-MiniLM")
     recall_diff = (hybrid_minilm_results["recall"] - faiss_results["recall"]) * 100
     precision_diff = (hybrid_minilm_results["precision"] - faiss_results["precision"]) * 100
     f1_diff = (hybrid_minilm_results["f1"] - faiss_results["f1"]) * 100
@@ -788,7 +787,7 @@ def main() -> None:
 
     # B. Reranking Impact
     print("\n🎯 B. IMPACT OF RERANKING (Adding ColBERT)")
-    print(f"   Comparison: Hybrid-MiniLM vs HybridRerank-MiniLM")
+    print("   Comparison: Hybrid-MiniLM vs HybridRerank-MiniLM")
     recall_diff = (rerank_minilm_results["recall"] - hybrid_minilm_results["recall"]) * 100
     precision_diff = (rerank_minilm_results["precision"] - hybrid_minilm_results["precision"]) * 100
     f1_diff = (rerank_minilm_results["f1"] - hybrid_minilm_results["f1"]) * 100
@@ -817,7 +816,7 @@ def main() -> None:
 
     # C. Model Quality Impact
     print("\n🚀 C. IMPACT OF ADVANCED MODEL (MiniLM vs Qwen3)")
-    print(f"   Comparison: Hybrid-MiniLM vs Hybrid-Qwen3-NoInst")
+    print("   Comparison: Hybrid-MiniLM vs Hybrid-Qwen3-NoInst")
     recall_diff = (hybrid_qwen3_noinst_results["recall"] - hybrid_minilm_results["recall"]) * 100
     precision_diff = (
         hybrid_qwen3_noinst_results["precision"] - hybrid_minilm_results["precision"]
@@ -837,7 +836,7 @@ def main() -> None:
         f"   F1:         {f1_diff:+.2f}pp (from {hybrid_minilm_results['f1'] * 100:.2f}% to {hybrid_qwen3_noinst_results['f1'] * 100:.2f}%)"
     )
     print(f"   Time ratio: {time_ratio:.2f}x slower")
-    print(f"   Model size: 22M params (MiniLM) → 600M params (Qwen3) = 27x larger")
+    print("   Model size: 22M params (MiniLM) → 600M params (Qwen3) = 27x larger")
     if f1_diff > 3:
         print(f"   ✅ Qwen3 significantly outperforms MiniLM (+{f1_diff:.1f}pp F1)")
     else:
@@ -847,8 +846,8 @@ def main() -> None:
 
     # D. Instructions + Reranking on Qwen3
     print("\n💡 D. IMPACT OF INSTRUCTIONS + RERANKING (Qwen3 only)")
-    print(f"   Comparison: Hybrid-Qwen3-NoInst vs HybridRerank-Qwen3-WithInst")
-    print(f"   Note: This shows COMBINED effect of instructions + reranking on Qwen3")
+    print("   Comparison: Hybrid-Qwen3-NoInst vs HybridRerank-Qwen3-WithInst")
+    print("   Note: This shows COMBINED effect of instructions + reranking on Qwen3")
     recall_diff = (
         hybrid_qwen3_inst_results["recall"] - hybrid_qwen3_noinst_results["recall"]
     ) * 100
@@ -885,9 +884,9 @@ def main() -> None:
         f"   Total lookups: {cache_info['hits_hot'] + cache_info['hits_cold'] + cache_info['misses']:,}"
     )
     if cache_info["hit_rate"] > 0.5:
-        print(f"   ✅ Caching is highly effective! Second run will be ~100x faster for embeddings")
+        print("   ✅ Caching is highly effective! Second run will be ~100x faster for embeddings")
     else:
-        print(f"   💡 First run - caching will accelerate subsequent runs")
+        print("   💡 First run - caching will accelerate subsequent runs")
 
     # F. Model Specifications
     print("\n" + "=" * 140)

--- a/examples/research/blocking_evaluation_faiss_vs_qdrant.py
+++ b/examples/research/blocking_evaluation_faiss_vs_qdrant.py
@@ -350,7 +350,7 @@ def main() -> None:
     print("=" * 90)
     print("BLOCKING EVALUATION: FAISS vs Qdrant Hybrid Search")
     print("=" * 90)
-    print(f"\nDataset: Funder organization names")
+    print("\nDataset: Funder organization names")
     print(f"Embedding model: {MODEL_NAME}")
     print(f"k-neighbors: {K_NEIGHBORS}")
     print()

--- a/examples/research/blocking_evaluation_with_instructions.py
+++ b/examples/research/blocking_evaluation_with_instructions.py
@@ -64,7 +64,6 @@ import time
 from pathlib import Path
 from typing import Any
 
-import numpy as np
 from pydantic import BaseModel, Field
 from qdrant_client import QdrantClient
 from sentence_transformers import CrossEncoder
@@ -854,7 +853,7 @@ def main() -> None:
     print("              cached at create_index() time, so a prompt cannot reach")
     print("              the encoder. Deltas against it mix index + prompt regime.")
     print("=" * 120)
-    print(f"\nDataset: Funder organization names")
+    print("\nDataset: Funder organization names")
     print(f"Dense model: {DENSE_MODEL}")
     print(f"Sparse model: {SPARSE_MODEL}")
     print(f"CrossEncoder model: {CROSSENCODER_MODEL}")

--- a/examples/research/blocking_evaluation_with_reranking.py
+++ b/examples/research/blocking_evaluation_with_reranking.py
@@ -39,7 +39,6 @@ import time
 from pathlib import Path
 from typing import Any
 
-import numpy as np
 from pydantic import BaseModel, Field
 from qdrant_client import QdrantClient
 from sentence_transformers import CrossEncoder
@@ -880,7 +879,7 @@ def main() -> None:
     print("=" * 120)
     print("BLOCKING EVALUATION: FAISS vs Qdrant Hybrid vs ColBERT Reranking vs Qwen3 CrossEncoder")
     print("=" * 120)
-    print(f"\nDataset: Funder organization names")
+    print("\nDataset: Funder organization names")
     print(f"Dense model: {DENSE_MODEL}")
     print(f"Sparse model: {SPARSE_MODEL}")
     print(f"ColBERT reranking model: {RERANKING_MODEL}")

--- a/examples/research/cached_embedder_demo.py
+++ b/examples/research/cached_embedder_demo.py
@@ -82,7 +82,7 @@ def main() -> None:
 
     # Check cache stats
     info_1 = cached_embedder.cache_info()
-    print(f"\n    Cache stats after first run:")
+    print("\n    Cache stats after first run:")
     print(f"      Hot hits:  {info_1['hits_hot']}")
     print(f"      Cold hits: {info_1['hits_cold']}")
     print(f"      Misses:    {info_1['misses']}")
@@ -101,7 +101,7 @@ def main() -> None:
 
     # Check cache stats again
     info_2 = cached_embedder.cache_info()
-    print(f"\n    Cache stats after second run:")
+    print("\n    Cache stats after second run:")
     print(f"      Hot hits:  {info_2['hits_hot']}")
     print(f"      Cold hits: {info_2['hits_cold']}")
     print(f"      Misses:    {info_2['misses']}")
@@ -155,8 +155,8 @@ def main() -> None:
     )
     print(f"✓ Memory bounded: only {info_2['hot_size']} embeddings in RAM")
     print(f"✓ Disk storage: {info_2['cold_size']} embeddings cached")
-    print(f"✓ Persistent: cache survives restarts (SQLite)")
-    print(f"✓ Order independent: works with any text order")
+    print("✓ Persistent: cache survives restarts (SQLite)")
+    print("✓ Order independent: works with any text order")
     print("\nRun this script again - subsequent runs will be instant!")
     print("=" * 80)
 

--- a/examples/research/compare_embedders_for_funders.py
+++ b/examples/research/compare_embedders_for_funders.py
@@ -138,7 +138,7 @@ def main():
         )
 
         logger.info(f"  🔹 Qdrant collection: {collection_name}")
-        logger.info(f"  🔹 Building index (may be slow on first run)...")
+        logger.info("  🔹 Building index (may be slow on first run)...")
 
         # Build index (creates/caches embeddings)
         index.create_index(texts)
@@ -255,7 +255,7 @@ Recommendation:
         winner = df.loc[winner_idx, "Model"]
         logger.info(f"\n  ✨ RECOMMENDED MODEL: {winner}")
         logger.info(
-            f"     Rationale: Achieves ≥95% recall with best separation among high-recall models"
+            "     Rationale: Achieves ≥95% recall with best separation among high-recall models"
         )
     else:
         winner_idx = best_recall_idx

--- a/examples/research/debug_pipeline.py
+++ b/examples/research/debug_pipeline.py
@@ -104,7 +104,7 @@ def main() -> None:
     print(f"True match mean: {score_stats.true_match_mean:.3f}")
     print(f"Non-match mean: {score_stats.non_match_mean:.3f}")
     print(f"Separation: {score_stats.separation:.3f}")
-    print(f"  ⚠️  Negative separation indicates poor calibration!")
+    print("  ⚠️  Negative separation indicates poor calibration!")
     print()
 
     # Step 3: Analyze clustering

--- a/examples/research/deduplication_with_blocker_optimization.py
+++ b/examples/research/deduplication_with_blocker_optimization.py
@@ -49,7 +49,7 @@ from typing import Any
 import optuna
 from pydantic import BaseModel, Field
 
-from langres.clients import create_llm_client, create_wandb_tracker
+from langres.clients import create_llm_client
 from langres.clients.settings import Settings
 from langres.core.blockers.vector import VectorBlocker
 from langres.core.clusterer import Clusterer

--- a/examples/research/instruction_embeddings_demo.py
+++ b/examples/research/instruction_embeddings_demo.py
@@ -25,7 +25,6 @@ Usage:
 
 import logging
 from pathlib import Path
-from typing import Any
 
 import numpy as np
 

--- a/examples/research/phase1_blocker_optimization.py
+++ b/examples/research/phase1_blocker_optimization.py
@@ -170,7 +170,7 @@ def main() -> None:
         )
 
         logger.info(f"  🔹 Qdrant collection: {collection_name}")
-        logger.info(f"  🔹 Building index (may be slow on first run)...")
+        logger.info("  🔹 Building index (may be slow on first run)...")
 
         # Build index (creates/caches embeddings)
         index.create_index(texts)
@@ -216,7 +216,7 @@ def main() -> None:
                 "MRR": report.ranking.mrr,
                 "NDCG@10": report.ranking.ndcg_at_10,
                 "Median_Rank": report.rank_distribution.median,
-                f"Optimal_K_95%": optimal_k,
+                "Optimal_K_95%": optimal_k,
                 "Candidates": report.candidates.total,
                 "Missed": report.candidates.missed_matches,
                 "False_Pos": report.candidates.false_positives,

--- a/examples/research/phase1_rf_floor.py
+++ b/examples/research/phase1_rf_floor.py
@@ -61,7 +61,6 @@ from langres.data.amazon_google import (  # noqa: E402
     load_amazon_google,
     load_amazon_google_pair_splits,
 )
-from langres.core.comparators import StringComparator  # noqa: E402
 from langres.data.fixed_split_pair_benchmark import (  # noqa: E402
     FixedSplitPairBenchmark,
     HonestPairEval,

--- a/examples/research/phase2_full_pipeline.py
+++ b/examples/research/phase2_full_pipeline.py
@@ -20,9 +20,15 @@ Environment variables required:
     LANGFUSE_SECRET_KEY: Langfuse secret API key (optional)
 
 Performance:
-    - First run: ~2-3 minutes (async LLM scoring with rate limiting)
-    - Subsequent runs: ~30 seconds (cached embeddings and judgments)
-    - Speedup: 12.5x faster than sequential LLM calls
+    - First run: bounded by the 250 RPM rate limit -- about 12 minutes at the
+      default MAX_CANDIDATES=3000 (3000 / 250 RPM), plus embedding time.
+    - Subsequent runs: much faster (cached embeddings and judgments).
+
+    The async path overlaps request latency instead of waiting for each
+    response in turn. It does not raise the ceiling: throughput is capped by
+    rpm_limit either way, so raise that (to your provider's real quota) before
+    expecting concurrency to buy anything. No speedup ratio is quoted because
+    none has been measured here.
 """
 
 import asyncio
@@ -301,11 +307,15 @@ def main() -> None:
         start_time = time.time()
 
         if has_async:
-            # Use async batch processing (12.5x speedup)
+            # Async overlaps request latency; the 250 RPM limiter is still the
+            # ceiling, so that -- not max_concurrent -- sets the ETA below.
             logger.info(
                 "Scoring pairs with async LLM (max_concurrent=50, rate limits: 250 RPM, 250K TPM)..."
             )
-            estimated_time_min = len(candidates) / (250 / 60)  # 250 RPM = 4.17 req/sec
+            # candidates / 250 requests-per-MINUTE is already in minutes. The
+            # previous form divided by (250/60), i.e. by requests-per-SECOND,
+            # which yields seconds while being reported as minutes (60x under).
+            estimated_time_min = len(candidates) / 250
             logger.info(
                 f"Scoring {len(candidates)} filtered candidates (estimated: {estimated_time_min:.1f} minutes)..."
             )
@@ -352,7 +362,9 @@ def main() -> None:
         else:
             # Fallback to sequential processing
             logger.info("Scoring pairs with LLM sequentially (this will take ~15-20 minutes)...")
-            logger.info("Consider implementing forward_async() for 12.5x speedup")
+            logger.info(
+                "Consider forward_async() to overlap request latency (still capped by rpm_limit)"
+            )
 
             judgements = []
             with tqdm(total=len(candidates), desc="LLM scoring") as pbar:

--- a/examples/research/phase2_full_pipeline.py
+++ b/examples/research/phase2_full_pipeline.py
@@ -152,7 +152,7 @@ def main() -> None:
     SIMILARITY_THRESHOLD = 0.24  # TODO: Update from Phase 1 recommendations (balanced threshold)
     MAX_CANDIDATES = 3000  # Limit candidates (~12 min at 250 RPM, ~3 min at 1000 RPM)
 
-    logger.info(f"Configuration:")
+    logger.info("Configuration:")
     logger.info(f"  Embedding model: {WINNER_MODEL}")
     logger.info(f"  k_neighbors: {K_NEIGHBORS}")
     logger.info(f"  LLM model: {LLM_MODEL}")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -293,8 +293,15 @@ line-length = 100
 extend-include = ["*.ipynb"]
 
 [tool.ruff.lint]
-# Enable flake8-print rules to ban print statements (except in examples/)
-select = ["T201", "T203"]
+# `extend-select`, NOT `select`. `select` REPLACES ruff's default rule set
+# (E4/E7/E9/F -- pycodestyle errors + the whole of pyflakes), so the previous
+# `select = ["T201", "T203"]` silently disabled every default rule and left
+# `ruff check .` enforcing nothing but the print bans: undefined names (F821),
+# unused imports (F401) and f-strings missing placeholders (F541) all passed.
+# `extend-select` keeps the defaults and ADDS the flake8-print rules on top.
+# Verify with `ruff check --show-settings . | grep -A20 rules.enabled` -- the
+# enabled list must contain more than T201/T203.
+extend-select = ["T201", "T203"]
 
 [tool.ruff.lint.per-file-ignores]
 # Allow print statements in examples and notebooks

--- a/src/langres/_exports/_core.py
+++ b/src/langres/_exports/_core.py
@@ -10,7 +10,10 @@ from langres.core import CompanySchema, ERCandidate, PairwiseJudgement, Resolver
 if TYPE_CHECKING:
     # Never executed at runtime -- keeps the lazy name visible to `mypy --strict`
     # without pulling litellm into a bare `import langres`.
-    from langres.core.matchers.llm_judge import LLMMatcher
+    # The F401 below is deliberate: "unused" is the point. The name is
+    # re-exported lazily via LAZY_SYMBOLS, not by this import; deleting it
+    # would blind `mypy --strict` to the lazy symbol.
+    from langres.core.matchers.llm_judge import LLMMatcher  # noqa: F401
 
 __all__ = [
     "CompanySchema",

--- a/src/langres/_exports/_data.py
+++ b/src/langres/_exports/_data.py
@@ -14,7 +14,8 @@ from typing import TYPE_CHECKING
 if TYPE_CHECKING:
     # Never executed at runtime -- keeps the lazy name visible to `mypy --strict`
     # without pulling the data-profile module into a bare `import langres`.
-    from langres.data.data_profile import DataProfileReport
+    # The F401 below is deliberate: re-exported lazily via LAZY_SYMBOLS.
+    from langres.data.data_profile import DataProfileReport  # noqa: F401
 
 #: Nothing is eager here by design -- see the module docstring.
 __all__: list[str] = []

--- a/src/langres/_exports/_flywheel.py
+++ b/src/langres/_exports/_flywheel.py
@@ -34,8 +34,9 @@ if TYPE_CHECKING:
     # Never executed at runtime -- keeps the lazy names visible to `mypy --strict`
     # without pulling the eval-report/benchmark modules into a bare
     # `import langres`.
-    from langres.data.benchmark import gold_pairs_from_clusters
-    from langres.report.eval_report import EvalReport
+    # The F401s below are deliberate: re-exported lazily via LAZY_SYMBOLS.
+    from langres.data.benchmark import gold_pairs_from_clusters  # noqa: F401
+    from langres.report.eval_report import EvalReport  # noqa: F401
 
 __all__ = [
     "Correction",

--- a/src/langres/_exports/_training.py
+++ b/src/langres/_exports/_training.py
@@ -25,7 +25,8 @@ from langres.core import (
 if TYPE_CHECKING:
     # Never executed at runtime -- keeps the lazy names visible to `mypy --strict`
     # without pulling scikit-learn into a bare `import langres`.
-    from langres.training.calibration import derive_threshold
+    # The F401 below is deliberate: re-exported lazily via LAZY_SYMBOLS.
+    from langres.training.calibration import derive_threshold  # noqa: F401
 
 __all__ = [
     "align_pairs",

--- a/src/langres/_pretrained_artifact.py
+++ b/src/langres/_pretrained_artifact.py
@@ -27,7 +27,7 @@ from pydantic import (
 
 from langres._version import __version__ as LANGRES_VERSION
 from langres.core.model_ref import IN_PROCESS_KINDS, ModelRef, normalize_model_ref, to_config
-from langres.core.serialization import ArtifactManifest, ArtifactSource, ComponentSpec
+from langres.core.serialization import ArtifactManifest, ComponentSpec
 
 BUNDLE_VERSION = "1"
 BUNDLE_MANIFEST = "langres-artifact.json"

--- a/src/langres/clients/settings.py
+++ b/src/langres/clients/settings.py
@@ -1,6 +1,5 @@
 """Central configuration for external services."""
 
-from pydantic import Field
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
 

--- a/src/langres/core/_exports/_flywheel.py
+++ b/src/langres/core/_exports/_flywheel.py
@@ -11,8 +11,6 @@ from langres.curation.harvest import (
     harvest_labeled_pairs,
 )
 from langres.tracking.judgement_log import JudgementLog, LoggingMatcher
-from langres.core.review import ReviewItem, ReviewQueue, select_for_review
-from langres.core.judgement_log import JudgementLog, LoggingMatcher
 from langres.curation.review import ReviewItem, ReviewQueue, select_for_review
 
 __all__ = [

--- a/src/langres/core/_exports/_tracking.py
+++ b/src/langres/core/_exports/_tracking.py
@@ -23,7 +23,8 @@ from langres.tracking.trackers import (
 if TYPE_CHECKING:
     # Never executed at runtime -- keeps the lazy names visible to `mypy --strict`
     # without pulling mlflow/wandb into a bare `import langres`.
-    from langres.tracking.trackers import MlflowTracker, WandbTracker
+    # The F401 below is deliberate: re-exported lazily via LAZY_SYMBOLS.
+    from langres.tracking.trackers import MlflowTracker, WandbTracker  # noqa: F401
 
 __all__ = [
     "capture_run",

--- a/src/langres/core/_exports/_training.py
+++ b/src/langres/core/_exports/_training.py
@@ -10,10 +10,8 @@ See ``langres.core._exports`` for the fragment contract.
 from typing import TYPE_CHECKING
 
 from langres.core.fit import SupervisedFitMixin, UnsupervisedFitMixin
-from langres.core.fit_report import FitReport
 from langres.curation.harvest import align_pairs
 from langres.training.fit_report import FitReport
-from langres.core.harvest import align_pairs
 from langres.core.methods_api import Method, UnsupportedMethodKind
 from langres.training.methods_calibrate import Isotonic, Platt
 from langres.training.methods_prompt import Bootstrap, GEPA, MIPRO
@@ -21,7 +19,8 @@ from langres.training.methods_prompt import Bootstrap, GEPA, MIPRO
 if TYPE_CHECKING:
     # Never executed at runtime -- keeps the lazy name visible to `mypy --strict`
     # without pulling scikit-learn into a bare `import langres`.
-    from langres.training.calibration import Calibrator
+    # The F401 below is deliberate: re-exported lazily via LAZY_SYMBOLS.
+    from langres.training.calibration import Calibrator  # noqa: F401
 
 __all__ = [
     "align_pairs",

--- a/src/langres/core/clusterer.py
+++ b/src/langres/core/clusterer.py
@@ -6,7 +6,7 @@ judgements into entity clusters using graph algorithms (connected components).
 """
 
 from collections.abc import Iterator
-from typing import Any, ClassVar, Generic, TypeVar
+from typing import Any, ClassVar, TypeVar
 
 import networkx as nx
 

--- a/src/langres/core/indexes/__init__.py
+++ b/src/langres/core/indexes/__init__.py
@@ -65,7 +65,10 @@ if TYPE_CHECKING:
         conforms = hybrid  # type: ignore[assignment]
         conforms = hybrid_fake  # type: ignore[assignment]
         conforms = reranking  # type: ignore[assignment]
-        conforms = reranking_fake  # type: ignore[assignment]
+        # F841 ("assigned but never used") is exactly what this block is: the
+        # assignments exist so mypy checks assignability to VectorIndex. Never
+        # reading `conforms` is the design, not an oversight.
+        conforms = reranking_fake  # type: ignore[assignment]  # noqa: F841
 
 
 __all__ = [

--- a/src/langres/core/indexes/hybrid_vector_index.py
+++ b/src/langres/core/indexes/hybrid_vector_index.py
@@ -15,7 +15,7 @@ Key features:
 """
 
 import logging
-from typing import Any, Literal
+from typing import Literal
 
 import numpy as np
 from qdrant_client import QdrantClient
@@ -25,7 +25,6 @@ from qdrant_client.models import (
     FusionQuery,
     PointStruct,
     Prefetch,
-    ScoredPoint,
     SparseVector,
     SparseVectorParams,
     VectorParams,

--- a/src/langres/core/matchers/llm_judge.py
+++ b/src/langres/core/matchers/llm_judge.py
@@ -948,9 +948,19 @@ class LLMMatcher(Matcher[SchemaT]):
             - Results are returned in the same order as input candidates
 
         Performance:
-            - Sequential forward(): ~4 requests/second (250 RPM / 60s)
-            - Async forward_async(): ~50 requests/second with max_concurrent=50
-            - Speedup: ~12.5x for typical workloads
+            The benefit is overlapping request *latency*: ``forward`` waits for
+            each response before sending the next, so its rate is bounded by
+            per-call round-trip time, while this method keeps up to
+            ``max_concurrent`` requests in flight.
+
+            No speedup ratio is quoted here because none has been measured. The
+            achievable factor depends on ``rpm_limit``/``max_concurrent``, the
+            provider's own limits, and per-call latency. Note that the rate
+            limiter is the binding ceiling: at the defaults
+            (``max_concurrent=50``, ``rpm_limit=250``) throughput cannot exceed
+            250 requests/minute regardless of concurrency. Raise ``rpm_limit``
+            (and ``tpm_limit``) to your provider's actual quota before expecting
+            concurrency to buy anything.
 
         Warning:
             This method materializes all results in memory. For very large

--- a/src/langres/core/matchers/llm_judge.py
+++ b/src/langres/core/matchers/llm_judge.py
@@ -25,7 +25,7 @@ except ImportError:
     RateLimitError = Exception
 
 from langres.clients.openrouter import parse_openrouter_billing
-from langres.core.model_ref import ModelRef, backend_for, normalize_model_ref, to_config
+from langres.core.model_ref import backend_for, normalize_model_ref, to_config
 from langres.core.models import ERCandidate, PairwiseJudgement
 from langres.core.matcher import Matcher, SchemaT
 from langres.core.named_callable import resolve_named

--- a/src/langres/core/trackers/__init__.py
+++ b/src/langres/core/trackers/__init__.py
@@ -33,7 +33,12 @@ from langres.tracking.trackers import (
 )
 
 if TYPE_CHECKING:
-    from langres.tracking.trackers import MlflowTracker, TrackioTracker, WandbTracker
+    # The F401 below is deliberate: these are resolved lazily by __getattr__.
+    from langres.tracking.trackers import (  # noqa: F401
+        MlflowTracker,
+        TrackioTracker,
+        WandbTracker,
+    )
 
 __all__ = [
     "ExperimentTracker",

--- a/src/langres/data/abt_buy.py
+++ b/src/langres/data/abt_buy.py
@@ -29,7 +29,6 @@ as Fodors-Zagat and Amazon-Google.
 from __future__ import annotations
 
 import logging
-from collections.abc import Iterable
 from typing import TYPE_CHECKING, Literal
 
 from pydantic import BaseModel, computed_field

--- a/src/langres/experiments/runner.py
+++ b/src/langres/experiments/runner.py
@@ -15,7 +15,7 @@ from typing import Any, Literal, cast
 
 from langres._version import __version__
 from langres.benchmarks.runner import evaluate_execution_result
-from langres.core.op import ExecutionEvent, ExecutionResult
+from langres.core.op import ExecutionResult
 from langres.core.model_ref import normalize_model_ref
 from langres.core.pairs import PairRow
 from langres.core.resolver import ERModel

--- a/src/langres/experiments/statistics.py
+++ b/src/langres/experiments/statistics.py
@@ -7,7 +7,7 @@ import random
 import statistics
 from typing import Literal
 
-from pydantic import BaseModel, ConfigDict, Field, field_validator
+from pydantic import BaseModel, ConfigDict, field_validator
 
 from langres.experiments.protocol import FrozenDict, freeze_mapping
 

--- a/src/langres/methods.py
+++ b/src/langres/methods.py
@@ -77,7 +77,11 @@ from langres.core.resolver import Resolver
 # leaf (no heavy deps) so name-listing (``data.registry.list_methods``) and
 # dispatch (this module) share one source of truth. Re-exported here so the
 # public ``langres.methods.ALL_METHODS`` etc. stay stable.
-from langres._method_names import ALL_METHODS, LLM_METHODS, ZERO_SPEND_METHODS
+from langres._method_names import (  # noqa: F401 -- deliberate public re-export
+    ALL_METHODS,
+    LLM_METHODS,
+    ZERO_SPEND_METHODS,
+)
 
 #: Default LLM model id for the LLM/cascade methods -- an alias of the one
 #: shared constant (``clients.openrouter.DEFAULT_OPENROUTER_MODEL``) so the

--- a/tests/architectures/test_research_recipes.py
+++ b/tests/architectures/test_research_recipes.py
@@ -34,7 +34,6 @@ from langres.resources import (
     GenerationRequest,
     Generate,
     EmbeddingBatch,
-    Parse,
     Rerank,
     Retrieve as RetrieveOp,
 )

--- a/tests/architectures/test_w4_proofs.py
+++ b/tests/architectures/test_w4_proofs.py
@@ -44,7 +44,7 @@ from pydantic import BaseModel
 
 from langres.architectures import FuzzyString, VectorLLMCascade
 from langres.core.matcher import Matcher
-from langres.core.models import ERCandidate, PairwiseJudgement
+from langres.core.models import PairwiseJudgement
 from langres.core.registry import model_type_name
 from langres.core.resolver import ERModel
 from langres.core.spend import BudgetExceeded

--- a/tests/autoresearch/test_blocker_optimizer.py
+++ b/tests/autoresearch/test_blocker_optimizer.py
@@ -12,7 +12,10 @@ class TestBlockerOptimizer:
 
     def test_blocker_optimizer_initialization(self):
         """Test BlockerOptimizer initializes with correct parameters."""
-        objective = lambda trial, params: {"value": params["k_neighbors"] * 0.1}
+
+        def objective(trial, params):
+            return {"value": params["k_neighbors"] * 0.1}
+
         search_space = {
             "embedding_model": ["model-a", "model-b"],
             "k_neighbors": (5, 50),
@@ -68,10 +71,12 @@ class TestBlockerOptimizer:
     def test_blocker_optimizer_categorical_parameter(self):
         """Test optimizer suggests categorical parameters correctly."""
 
-        objective = lambda trial, params: {"value": 1.0}
+        def objective(trial, params):
+            return {"value": 1.0}
+
         search_space = {"embedding_model": ["model-a", "model-b", "model-c"]}
 
-        with patch("langres.autoresearch.blocker_optimizer.optuna") as mock_optuna:
+        with patch("langres.autoresearch.blocker_optimizer.optuna"):
             optimizer = BlockerOptimizer(
                 objective_fn=objective, search_space=search_space, n_trials=1
             )
@@ -81,7 +86,7 @@ class TestBlockerOptimizer:
             mock_trial.suggest_categorical.return_value = "model-a"
 
             # Call objective wrapper
-            result = optimizer._objective_wrapper(mock_trial)
+            optimizer._objective_wrapper(mock_trial)
 
             # Verify categorical suggestion called
             mock_trial.suggest_categorical.assert_called_once_with(
@@ -90,7 +95,10 @@ class TestBlockerOptimizer:
 
     def test_blocker_optimizer_integer_parameter(self):
         """Test optimizer suggests integer parameters correctly."""
-        objective = lambda trial, params: {"value": 1.0}
+
+        def objective(trial, params):
+            return {"value": 1.0}
+
         search_space = {"k_neighbors": (5, 50)}
 
         with patch("langres.autoresearch.blocker_optimizer.optuna"):
@@ -103,14 +111,17 @@ class TestBlockerOptimizer:
             mock_trial.suggest_int.return_value = 20
 
             # Call objective wrapper
-            result = optimizer._objective_wrapper(mock_trial)
+            optimizer._objective_wrapper(mock_trial)
 
             # Verify integer suggestion called
             mock_trial.suggest_int.assert_called_once_with("k_neighbors", 5, 50)
 
     def test_blocker_optimizer_mixed_parameters(self):
         """Test optimizer with both categorical and integer parameters."""
-        objective = lambda trial, params: {"value": params["k_neighbors"] * 0.1}
+
+        def objective(trial, params):
+            return {"value": params["k_neighbors"] * 0.1}
+
         search_space = {
             "embedding_model": ["model-a", "model-b"],
             "k_neighbors": (5, 50),
@@ -137,7 +148,10 @@ class TestBlockerOptimizer:
 
     def test_blocker_optimizer_direction_maximize(self):
         """Test optimizer with direction='maximize'."""
-        objective = lambda trial, params: {"value": 0.85}
+
+        def objective(trial, params):
+            return {"value": 0.85}
+
         search_space = {"k_neighbors": (5, 50)}
 
         with patch("langres.autoresearch.blocker_optimizer.optuna") as mock_optuna:
@@ -158,7 +172,10 @@ class TestBlockerOptimizer:
 
     def test_blocker_optimizer_direction_minimize(self):
         """Test optimizer with direction='minimize'."""
-        objective = lambda trial, params: {"value": 0.15}
+
+        def objective(trial, params):
+            return {"value": 0.15}
+
         search_space = {"k_neighbors": (5, 50)}
 
         with patch("langres.autoresearch.blocker_optimizer.optuna") as mock_optuna:
@@ -179,7 +196,10 @@ class TestBlockerOptimizer:
 
     def test_blocker_optimizer_wandb_integration(self):
         """Test optimizer integrates with wandb callback."""
-        objective = lambda trial, params: {"value": 0.85}
+
+        def objective(trial, params):
+            return {"value": 0.85}
+
         search_space = {"k_neighbors": (5, 50)}
 
         wandb_kwargs = {"project": "test-project", "entity": "test-team"}
@@ -212,7 +232,10 @@ class TestBlockerOptimizer:
 
     def test_blocker_optimizer_without_wandb_kwargs(self):
         """Test optimizer without wandb integration."""
-        objective = lambda trial, params: {"value": 0.85}
+
+        def objective(trial, params):
+            return {"value": 0.85}
+
         search_space = {"k_neighbors": (5, 50)}
 
         with patch("langres.autoresearch.blocker_optimizer.optuna") as mock_optuna:
@@ -263,7 +286,10 @@ class TestBlockerOptimizer:
 
     def test_blocker_optimizer_raises_error_for_invalid_direction(self):
         """Test that BlockerOptimizer raises ValueError for invalid direction."""
-        objective = lambda trial, params: {"value": 0.85}
+
+        def objective(trial, params):
+            return {"value": 0.85}
+
         search_space = {"k_neighbors": (5, 50)}
 
         with pytest.raises(ValueError, match="direction must be 'maximize' or 'minimize'"):
@@ -276,7 +302,9 @@ class TestBlockerOptimizer:
 
     def test_blocker_optimizer_raises_error_for_empty_search_space(self):
         """Test that BlockerOptimizer raises ValueError for empty search_space."""
-        objective = lambda trial, params: {"value": 0.85}
+
+        def objective(trial, params):
+            return {"value": 0.85}
 
         with pytest.raises(ValueError, match="search_space cannot be empty"):
             BlockerOptimizer(
@@ -288,7 +316,10 @@ class TestBlockerOptimizer:
 
     def test_blocker_optimizer_raises_error_for_invalid_parameter_spec(self):
         """Test that BlockerOptimizer raises ValueError for invalid parameter specification."""
-        objective = lambda trial, params: {"value": 0.85}
+
+        def objective(trial, params):
+            return {"value": 0.85}
+
         # Invalid parameter spec: neither list nor tuple
         search_space = {"k_neighbors": "invalid"}
 

--- a/tests/clients/test_llm.py
+++ b/tests/clients/test_llm.py
@@ -80,7 +80,7 @@ class TestCreateLLMClient:
                 mock_langfuse_instance.auth_check.return_value = True
                 mock_langfuse_class.return_value = mock_langfuse_instance
 
-                client = create_llm_client(enable_langfuse=True)
+                create_llm_client(enable_langfuse=True)
 
                 # Verify Langfuse initialized with env vars
                 mock_langfuse_class.assert_called_once()

--- a/tests/core/blockers/test_all_pairs_inspect.py
+++ b/tests/core/blockers/test_all_pairs_inspect.py
@@ -4,12 +4,10 @@ Tests the inspection capabilities of AllPairsBlocker, which generates
 all possible entity pairs (n*(n-1)/2 candidates).
 """
 
-import pytest
 from pydantic import BaseModel
 
 from langres.core.blockers.all_pairs import AllPairsBlocker
-from langres.core.models import CompanySchema, ERCandidate
-from langres.core.reports import CandidateInspectionReport
+from langres.core.models import CompanySchema
 
 
 class SimpleEntity(BaseModel):

--- a/tests/core/blockers/test_vector_inspect.py
+++ b/tests/core/blockers/test_vector_inspect.py
@@ -6,10 +6,8 @@ analysis without ground truth labels.
 
 import logging
 
-import pytest
 
 from langres.core.blockers.vector import VectorBlocker
-from langres.core.embeddings import FakeEmbedder
 from langres.core.indexes import FakeVectorIndex
 from langres.core.models import CompanySchema
 from langres.core.reports import CandidateInspectionReport
@@ -114,7 +112,6 @@ class TestVectorBlockerInspection:
         report = blocker.inspect_candidates(candidates=candidates, entities=entities, sample_size=5)
 
         # Check for low candidate recommendation
-        recommendations = " ".join(report.recommendations)
         assert report.avg_candidates_per_entity < 3  # Verify assumption
         assert any(
             "increase" in rec.lower() or "k_neighbors" in rec.lower()
@@ -140,7 +137,6 @@ class TestVectorBlockerInspection:
         # With k=9 and 10 entities, avg should be high
         if report.avg_candidates_per_entity > 8:
             # Check for high candidate warning
-            recommendations = " ".join(report.recommendations)
             assert any(
                 "decrease" in rec.lower() or "reduce" in rec.lower()
                 for rec in report.recommendations

--- a/tests/core/indexes/test_hybrid_vector_index.py
+++ b/tests/core/indexes/test_hybrid_vector_index.py
@@ -546,7 +546,6 @@ class TestQdrantHybridIndexInstructionPrompts:
 
     def test_qdrant_hybrid_documents_no_prompts(self):
         """Test that create_index encodes documents without prompts."""
-        from unittest.mock import Mock
 
         # Create tracking embedders
         dense_call_log = []
@@ -589,7 +588,6 @@ class TestQdrantHybridIndexInstructionPrompts:
 
     def test_qdrant_hybrid_queries_dense_with_prompt_sparse_without(self):
         """Test that search encodes queries with prompt for dense, without for sparse."""
-        from unittest.mock import Mock
 
         # Create tracking embedders
         dense_call_log = []
@@ -649,7 +647,6 @@ class TestQdrantHybridIndexInstructionPrompts:
         Performance optimization: search_all should reuse dense embeddings,
         not re-encode with prompt. Sparse embeddings still need to be encoded.
         """
-        from unittest.mock import Mock
 
         # Create tracking embedders
         dense_call_log = []

--- a/tests/core/indexes/test_reranking_vector_index.py
+++ b/tests/core/indexes/test_reranking_vector_index.py
@@ -15,7 +15,6 @@ from qdrant_client.models import (
     Prefetch,
     ScoredPoint,
     SparseVector,
-    VectorParams,
 )
 
 from langres.core.embeddings import (

--- a/tests/core/indexes/test_vector_index.py
+++ b/tests/core/indexes/test_vector_index.py
@@ -733,7 +733,6 @@ class TestFAISSIndexWithCachedEmbedder:
 
     def test_faiss_index_with_cached_embedder_and_query_prompts(self, tmp_path):
         """Test FAISSIndex with DiskCachedEmbedder using query prompts."""
-        from pathlib import Path
 
         from langres.core.embeddings import DiskCachedEmbedder
 
@@ -780,7 +779,6 @@ class TestFAISSIndexWithCachedEmbedder:
 
     def test_faiss_index_with_cached_embedder_and_precomputed(self, tmp_path):
         """Test FAISSIndex with DiskCachedEmbedder using pre-computed query embeddings."""
-        from pathlib import Path
 
         from langres.core.embeddings import DiskCachedEmbedder
 

--- a/tests/core/matchers/test_transformers_backend.py
+++ b/tests/core/matchers/test_transformers_backend.py
@@ -17,8 +17,11 @@ import pytest
 
 torch = pytest.importorskip("torch", reason="requires the [semantic] extra (torch)")
 
-from langres.core.matchers.model_ref import ModelRef
-from langres.core.matchers.transformers_backend import TransformersBackend
+# E402 is deliberate: these modules pull torch, so they must be imported AFTER
+# the importorskip above -- hoisting them to the top would turn a clean skip
+# into a collection error when the [semantic] extra is absent.
+from langres.core.matchers.model_ref import ModelRef  # noqa: E402
+from langres.core.matchers.transformers_backend import TransformersBackend  # noqa: E402
 
 
 class _FakeTokenizer:

--- a/tests/core/modules/test_cascade.py
+++ b/tests/core/modules/test_cascade.py
@@ -519,7 +519,7 @@ def test_cascade_module_uses_custom_prompt_template(mocker):
         blocker_name="test",
     )
 
-    judgements = list(module.forward([candidate]))
+    list(module.forward([candidate]))
 
     # Should use custom prompt
     call_args = mock_client.chat.completions.create.call_args

--- a/tests/core/modules/test_llm_judge.py
+++ b/tests/core/modules/test_llm_judge.py
@@ -8,12 +8,10 @@ import logging
 from unittest.mock import Mock
 
 import pytest
-from openai.types.chat import ChatCompletion, ChatCompletionMessage
-from openai.types.chat.chat_completion import Choice
 
 from langres.clients.openrouter import SpendMonitor
-from langres.core.models import CompanySchema, ERCandidate, PairwiseJudgement
-from langres.core.matchers.llm_judge import LLMMatcher, LLMMatcher
+from langres.core.models import CompanySchema, ERCandidate
+from langres.core.matchers.llm_judge import LLMMatcher
 from langres.core.registry import get_component
 
 logger = logging.getLogger(__name__)

--- a/tests/core/modules/test_llm_judge_async.py
+++ b/tests/core/modules/test_llm_judge_async.py
@@ -7,7 +7,7 @@ concurrent LLM API calls with token-aware rate limiting and retry logic.
 import asyncio
 import logging
 import time
-from unittest.mock import AsyncMock, Mock, patch
+from unittest.mock import AsyncMock, Mock
 
 import pytest
 
@@ -639,7 +639,7 @@ async def test_forward_async_with_custom_prompt_template(mock_llm_client, mock_l
         blocker_name="test",
     )
 
-    judgements = await module.forward_async([candidate])
+    await module.forward_async([candidate])
 
     # Verify custom template was used
     call_args = mock_llm_client.acompletion.call_args
@@ -764,7 +764,7 @@ async def test_forward_async_with_zero_temperature(mock_llm_client, mock_llm_res
         blocker_name="test",
     )
 
-    judgements = await module.forward_async([candidate])
+    await module.forward_async([candidate])
 
     # Verify temperature was passed correctly
     call_args = mock_llm_client.acompletion.call_args

--- a/tests/core/modules/test_llm_judge_inspect.py
+++ b/tests/core/modules/test_llm_judge_inspect.py
@@ -224,7 +224,7 @@ class TestLLMJudgeModuleInspection:
         report = module.inspect_scores(high_scores_judgements, sample_size=5)
 
         # With high median (> 0.7), should NOT recommend threshold=0.6
-        recommendations_text = " ".join(report.recommendations)
+        " ".join(report.recommendations)
         # High scores mean median > 0.7, so should not see balanced precision/recall
         assert report.score_distribution["median"] > 0.7
 

--- a/tests/core/modules/test_llm_judge_serialization.py
+++ b/tests/core/modules/test_llm_judge_serialization.py
@@ -17,7 +17,6 @@ import pytest
 from langres.core.matchers.llm_judge import (
     DEFAULT_PROMPT,
     LLMMatcher,
-    LLMMatcher,
     render_default_prompt,
 )
 from langres.core.registry import get_component

--- a/tests/core/modules/test_select_judge.py
+++ b/tests/core/modules/test_select_judge.py
@@ -28,7 +28,6 @@ import json
 import logging
 import subprocess
 import sys
-from collections.abc import Iterator
 from pathlib import Path
 
 import pytest

--- a/tests/core/test_blocker.py
+++ b/tests/core/test_blocker.py
@@ -2,7 +2,6 @@
 
 from collections.abc import Iterator
 
-import numpy as np
 import pytest
 
 from langres.core.blocker import Blocker

--- a/tests/core/test_cached_embedder.py
+++ b/tests/core/test_cached_embedder.py
@@ -10,10 +10,8 @@ Tests cover:
 
 import logging
 import sqlite3
-from pathlib import Path
 
 import numpy as np
-import pytest
 
 from langres.core.embeddings import DiskCachedEmbedder, FakeEmbedder
 

--- a/tests/core/test_clusterer_inspect.py
+++ b/tests/core/test_clusterer_inspect.py
@@ -6,7 +6,6 @@ analysis without ground truth labels.
 
 import logging
 
-import pytest
 
 from langres.core.clusterer import Clusterer
 from langres.core.models import CompanySchema

--- a/tests/core/test_embeddings.py
+++ b/tests/core/test_embeddings.py
@@ -838,7 +838,6 @@ class TestEmbeddingProviderProtocolWithPrompts:
 
         This verifies the protocol method signature includes prompt parameter.
         """
-        from langres.core.embeddings import EmbeddingProvider
 
         # Verify protocol has encode method accepting prompt
         assert hasattr(EmbeddingProvider, "encode")

--- a/tests/core/test_evaluation_reports.py
+++ b/tests/core/test_evaluation_reports.py
@@ -1396,20 +1396,6 @@ class TestBlockerEvaluationReportPlotting:
         assert report.summary["candidate_recall"] == original_recall
 
 
-"""Tests for BlockerEvaluationReport.to_markdown() recommendations feature."""
-
-import pytest
-
-from langres.core.reports import (
-    BlockerEvaluationReport,
-    CandidateMetrics,
-    RankingMetrics,
-    RankMetrics,
-    RecallCurveStats,
-    ScoreMetrics,
-)
-
-
 class TestBlockerEvaluationReportRecommendations:
     """Test BlockerEvaluationReport.to_markdown() recommendations feature."""
 

--- a/tests/core/test_method_registry.py
+++ b/tests/core/test_method_registry.py
@@ -23,7 +23,6 @@ import pytest
 from pydantic import BaseModel
 
 from langres.clients.openrouter import DEFAULT_OPENROUTER_MODEL
-from langres.core.comparator import Comparator
 from langres.core.comparators import StringComparator
 from langres.core.method_registry import (
     DEFAULT_EMBEDDING_MODEL,

--- a/tests/core/test_op_adapters.py
+++ b/tests/core/test_op_adapters.py
@@ -12,7 +12,6 @@ behavior-equivalent to the legacy ``Resolver.resolve`` path.
 from collections.abc import Iterator
 
 import pytest
-from pydantic import BaseModel
 
 from langres.core.blockers.all_pairs import AllPairsBlocker
 from langres.core.clusterer import Clusterer

--- a/tests/core/test_reports.py
+++ b/tests/core/test_reports.py
@@ -577,8 +577,8 @@ class TestBlockerEvaluationReportImportErrors:
 
     def test_plot_score_distribution_import_error_message(
         self,
-        mock_report: "BlockerEvaluationReport",
-        monkeypatch: pytest.MonkeyPatch,  # noqa: F821
+        mock_report: "BlockerEvaluationReport",  # noqa: F821
+        monkeypatch: pytest.MonkeyPatch,
     ) -> None:
         """Test that plot_score_distribution ImportError has multi-package-manager instructions."""
         import builtins
@@ -605,8 +605,8 @@ class TestBlockerEvaluationReportImportErrors:
 
     def test_plot_rank_distribution_import_error_message(
         self,
-        mock_report: "BlockerEvaluationReport",
-        monkeypatch: pytest.MonkeyPatch,  # noqa: F821
+        mock_report: "BlockerEvaluationReport",  # noqa: F821
+        monkeypatch: pytest.MonkeyPatch,
     ) -> None:
         """Test that plot_rank_distribution ImportError has multi-package-manager instructions."""
         import builtins
@@ -633,8 +633,8 @@ class TestBlockerEvaluationReportImportErrors:
 
     def test_plot_recall_curve_import_error_message(
         self,
-        mock_report: "BlockerEvaluationReport",
-        monkeypatch: pytest.MonkeyPatch,  # noqa: F821
+        mock_report: "BlockerEvaluationReport",  # noqa: F821
+        monkeypatch: pytest.MonkeyPatch,
     ) -> None:
         """Test that plot_recall_curve ImportError has multi-package-manager instructions."""
         import builtins
@@ -661,8 +661,8 @@ class TestBlockerEvaluationReportImportErrors:
 
     def test_plot_all_import_error_message(
         self,
-        mock_report: "BlockerEvaluationReport",
-        monkeypatch: pytest.MonkeyPatch,  # noqa: F821
+        mock_report: "BlockerEvaluationReport",  # noqa: F821
+        monkeypatch: pytest.MonkeyPatch,
     ) -> None:
         """Test that plot_all ImportError has multi-package-manager instructions."""
         import builtins
@@ -969,8 +969,8 @@ class TestBlockerEvaluationReportDiagnose:
             id: str
             name: str
 
-        e1 = Entity(id="e1", name="Acme Corp")
-        e2 = Entity(id="e2", name="Acme Corporation")
+        Entity(id="e1", name="Acme Corp")
+        Entity(id="e2", name="Acme Corporation")
         e3 = Entity(id="e3", name="TechCo")
         e4 = Entity(id="e4", name="TechCo Inc")
 
@@ -1001,7 +1001,6 @@ class TestBlockerEvaluationReportDiagnose:
     def test_blocker_evaluation_report_diagnose_respects_limits(self) -> None:
         """Test that diagnose respects n_missed and n_false_positives."""
         from langres.core.analysis import evaluate_blocker_detailed
-        from langres.core.models import ERCandidate
         from pydantic import BaseModel
 
         class Entity(BaseModel):

--- a/tests/core/test_sparse_embeddings.py
+++ b/tests/core/test_sparse_embeddings.py
@@ -7,7 +7,6 @@ import pytest
 from langres.core.embeddings import (
     FakeSparseEmbedder,
     FastEmbedSparseEmbedder,
-    SparseEmbeddingProvider,
 )
 
 logger = logging.getLogger(__name__)

--- a/tests/core/test_string_comparator.py
+++ b/tests/core/test_string_comparator.py
@@ -10,7 +10,7 @@ import datetime
 import pytest
 from pydantic import BaseModel
 
-from langres.core.comparator import Comparator, NoComparableFeatures
+from langres.core.comparator import NoComparableFeatures
 from langres.core.comparators import StringComparator
 from langres.core.feature import ComparisonLevel, FeatureSpec
 from langres.core.models import CompanySchema

--- a/tests/curation/test_anchor_store.py
+++ b/tests/curation/test_anchor_store.py
@@ -23,7 +23,6 @@ import pytest
 from langres.core import (
     Clusterer,
     CompanySchema,
-    Comparator,
     ERCandidate,
     Matcher,
     PairwiseJudgement,

--- a/tests/curation/test_anchor_store_committed.py
+++ b/tests/curation/test_anchor_store_committed.py
@@ -16,7 +16,6 @@ import sys
 from pathlib import Path
 
 from langres.core import Resolver
-from langres.curation.anchor_store import AnchorStore
 from langres.data.er_benchmarks import RestaurantSchema, load_fodors_zagat
 
 # A Fodors-Zagat gold match pair: Fodor's f534 <-> Zagat z219.

--- a/tests/curation/test_canonicalizer.py
+++ b/tests/curation/test_canonicalizer.py
@@ -14,7 +14,6 @@ import pytest
 
 from langres.curation.canonicalizer import Canonicalizer
 from langres.curation.canonicalizer import (
-    CANONICALIZER_VERSION,
     DEFAULT_STRATEGY,
     FieldContext,
     _is_missing,

--- a/tests/data/data_profile/test_separability.py
+++ b/tests/data/data_profile/test_separability.py
@@ -12,7 +12,6 @@ escaping).
 from __future__ import annotations
 
 import logging
-import math
 import re
 from collections.abc import Hashable
 

--- a/tests/data/test_peeters.py
+++ b/tests/data/test_peeters.py
@@ -18,7 +18,6 @@ from langres.core.metrics import classify_pairs
 from langres.data import peeters as P
 from langres.data.peeters import (
     DOMAIN_COMPLEX_FORCE_PRODUCT_PREFIX,
-    PeetersReplicationSpec,
     get_peeters_replication,
     gold_match_pairs,
     judgements_from_answers,

--- a/tests/data/test_splitting.py
+++ b/tests/data/test_splitting.py
@@ -1,7 +1,5 @@
 """Tests for updated stratified_dedup_split with dataset object parameter."""
 
-import pytest
-
 from langres.data.schemas import LabeledDeduplicationDataset, LabeledGroup
 from langres.data.splitting import stratified_dedup_split
 

--- a/tests/integration/test_research_execution_matrix.py
+++ b/tests/integration/test_research_execution_matrix.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from collections.abc import Sequence
 from pathlib import Path
-from typing import Any, ClassVar
+from typing import ClassVar
 
 import pytest
 from pydantic import BaseModel

--- a/tests/metrics/test_analysis.py
+++ b/tests/metrics/test_analysis.py
@@ -1,7 +1,6 @@
 """Tests for blocker analysis functions."""
 
 import pytest
-import numpy as np
 
 from langres.core.models import ERCandidate, CompanySchema
 from langres.metrics.analysis import (
@@ -14,7 +13,6 @@ from langres.core.reports import (
     ScoreMetrics,
     RankMetrics,
     RecallCurveStats,
-    BlockerEvaluationReport,
 )
 
 
@@ -812,8 +810,8 @@ def test_extract_missed_matches():
         name: str
 
     # Create test data
-    e1 = Entity(id="e1", name="Acme Corp")
-    e2 = Entity(id="e2", name="Acme Corporation")
+    Entity(id="e1", name="Acme Corp")
+    Entity(id="e2", name="Acme Corporation")
     e3 = Entity(id="e3", name="TechCo")
     e4 = Entity(id="e4", name="TechCo Inc")
 
@@ -847,7 +845,6 @@ def test_extract_missed_matches():
 def test_extract_missed_matches_respects_limit():
     """Test that extract_missed_matches respects n parameter."""
     from langres.metrics.analysis import extract_missed_matches
-    from langres.core.models import ERCandidate
     from pydantic import BaseModel
 
     class Entity(BaseModel):

--- a/tests/metrics/test_debugging.py
+++ b/tests/metrics/test_debugging.py
@@ -7,10 +7,8 @@ and report generation.
 """
 
 import json
-import logging
 from pathlib import Path
 
-import numpy as np
 import pytest
 from pydantic import BaseModel
 
@@ -278,7 +276,7 @@ def test_analyze_candidates_generates_error_examples(
 ) -> None:
     """Test that analyze_candidates generates ErrorExample objects for issues."""
     debugger = PipelineDebugger(ground_truth_clusters=ground_truth_clusters, sample_size=10)
-    stats = debugger.analyze_candidates(imperfect_candidates, test_entities)
+    debugger.analyze_candidates(imperfect_candidates, test_entities)
 
     # Should have stored error examples
     assert len(debugger.error_examples) > 0
@@ -389,7 +387,7 @@ def test_analyze_scores_generates_error_examples(
 ) -> None:
     """Test that score analysis generates error examples for misaligned scores."""
     debugger = PipelineDebugger(ground_truth_clusters=ground_truth_clusters, sample_size=10)
-    stats = debugger.analyze_scores(imperfect_judgements)
+    debugger.analyze_scores(imperfect_judgements)
 
     # Should flag low-scoring match (e1-e3 with score 0.25)
     low_match_errors = [e for e in debugger.error_examples if e.error_type == "low_scoring_match"]
@@ -437,7 +435,7 @@ def test_analyze_scores_metadata_includes_reasoning(
 ) -> None:
     """Test that error examples include LLM reasoning in metadata."""
     debugger = PipelineDebugger(ground_truth_clusters=ground_truth_clusters, sample_size=10)
-    stats = debugger.analyze_scores(imperfect_judgements)
+    debugger.analyze_scores(imperfect_judgements)
 
     # Find the low-scoring match error
     low_match_errors = [e for e in debugger.error_examples if e.error_type == "low_scoring_match"]
@@ -506,7 +504,7 @@ def test_analyze_clusters_generates_error_examples(
     debugger = PipelineDebugger(ground_truth_clusters=ground_truth_clusters, sample_size=10)
     # Create a false merge
     predicted = [{"e1", "e2", "e3", "e4"}, {"e5"}, {"e6"}]
-    stats = debugger.analyze_clusters(predicted)
+    debugger.analyze_clusters(predicted)
 
     # Should have false merge error
     merge_errors = [e for e in debugger.error_examples if e.error_type == "false_merge"]

--- a/tests/metrics/test_diagnostics.py
+++ b/tests/metrics/test_diagnostics.py
@@ -1,7 +1,5 @@
 """Tests for diagnostic models."""
 
-import pytest
-
 from langres.metrics.diagnostics import (
     DiagnosticExamples,
     FalsePositiveExample,

--- a/tests/plotting/test_blockers.py
+++ b/tests/plotting/test_blockers.py
@@ -1,6 +1,6 @@
 """Tests for blocker visualization functions."""
 
-from unittest.mock import MagicMock, call, patch
+from unittest.mock import MagicMock, patch
 
 import pytest
 
@@ -325,7 +325,7 @@ def test_plot_evaluation_summary_saves_figure(mock_plt, sample_report, tmp_path)
     mock_ax_10.twinx.return_value = mock_ax_10_secondary
 
     save_path = str(tmp_path / "test_plot.png")
-    result = plot_evaluation_summary(sample_report, save_path=save_path)
+    plot_evaluation_summary(sample_report, save_path=save_path)
 
     # Verify savefig called
     mock_fig.savefig.assert_called_once_with(save_path, dpi=300, bbox_inches="tight")

--- a/tests/resources/test_op_adapters.py
+++ b/tests/resources/test_op_adapters.py
@@ -19,6 +19,7 @@ from langres.resources import (
     Generate,
     GenerationBatch,
     GenerationEnvelope,
+    GenerationRequest,
     LLMMatcherAdapter,
     LiteLLM,
     Parse,

--- a/tests/test_ercandidate_model.py
+++ b/tests/test_ercandidate_model.py
@@ -53,7 +53,7 @@ def test_ercandidate_similarity_score_is_optional() -> None:
     )
 
     assert candidate.similarity_score is None
-    logger.info(f"Created candidate without similarity_score (defaults to None)")
+    logger.info("Created candidate without similarity_score (defaults to None)")
 
 
 def test_ercandidate_similarity_score_range_valid() -> None:

--- a/tests/test_import_budget.py
+++ b/tests/test_import_budget.py
@@ -28,7 +28,6 @@ import importlib.util
 import os
 import subprocess
 import sys
-import time
 from pathlib import Path
 
 import pytest

--- a/tests/test_integration_approach3.py
+++ b/tests/test_integration_approach3.py
@@ -8,7 +8,6 @@ This test validates the complete pipeline:
 """
 
 import logging
-import os
 from unittest.mock import Mock
 
 import pytest

--- a/tests/test_resolver_roundtrip.py
+++ b/tests/test_resolver_roundtrip.py
@@ -87,7 +87,7 @@ def _wrongly_merged_pairs(
 
 def test_resolver_roundtrip_in_process(tmp_path: Path) -> None:
     """A-D: in-process save/load round-trip, accuracy, over-merge, provenance."""
-    from langres.core import Clusterer, Comparator, Resolver
+    from langres.core import Clusterer, Resolver
     from langres.core.blockers import AllPairsBlocker
     from langres.core.matchers import WeightedAverageMatcher
     from langres.core.models import CompanySchema
@@ -140,7 +140,7 @@ def test_resolver_roundtrip_in_process(tmp_path: Path) -> None:
 
 def test_resolver_roundtrip_fresh_process(tmp_path: Path) -> None:
     """E: reload in a fresh subprocess to catch registry/import side-effects."""
-    from langres.core import Clusterer, Comparator, Resolver
+    from langres.core import Clusterer, Resolver
     from langres.core.blockers import AllPairsBlocker
     from langres.core.matchers import WeightedAverageMatcher
     from langres.core.models import CompanySchema
@@ -440,7 +440,7 @@ def test_resolver_load_warns_on_langres_version_skew(
 
 def _vector_resolver() -> "object":
     """Build a Resolver over a VectorBlocker + FAISSIndex (FakeEmbedder, fast)."""
-    from langres.core import Clusterer, Comparator, Resolver
+    from langres.core import Clusterer, Resolver
     from langres.core.blockers import VectorBlocker
     from langres.core.embeddings import FakeEmbedder
     from langres.core.indexes import FAISSIndex
@@ -519,7 +519,7 @@ def _composite_vector_resolver(op: str = "union") -> "object":
     "recall-first key + vector union" pattern documented in the blocking-algebra
     example and TECHNICAL_OVERVIEW.
     """
-    from langres.core import Clusterer, Comparator, Resolver
+    from langres.core import Clusterer, Resolver
     from langres.core.blockers import CompositeBlocker, KeyBlocker, VectorBlocker
     from langres.core.embeddings import FakeEmbedder
     from langres.core.indexes import FAISSIndex
@@ -575,7 +575,7 @@ def test_resolver_builds_vector_index_nested_two_levels_deep_in_composite_blocke
     just one level -- a CompositeBlocker may itself wrap another CompositeBlocker
     (e.g. union of two intersections).
     """
-    from langres.core import Clusterer, Comparator, Resolver
+    from langres.core import Clusterer, Resolver
     from langres.core.blockers import CompositeBlocker, KeyBlocker, VectorBlocker
     from langres.core.embeddings import FakeEmbedder
     from langres.core.indexes import FAISSIndex
@@ -957,7 +957,6 @@ def test_resolver_round_trips_glinker_adapter_slot(tmp_path: Path) -> None:
     ``stream``/``forward``.
     """
     from langres.core import Clusterer, Resolver
-    from langres.core.blockers import AllPairsBlocker
     from langres.core.matchers import WeightedAverageMatcher
     from langres.core.adapters.glinker import GLinkerAdapter, GLinkerConfig
     from langres.core.feature import FeatureSpec

--- a/tests/tracking/test_factories.py
+++ b/tests/tracking/test_factories.py
@@ -66,7 +66,7 @@ class TestCreateWandbTracker:
                 mock_run = MagicMock()
                 mock_wandb.init.return_value = mock_run
 
-                run = create_wandb_tracker()
+                create_wandb_tracker()
 
                 # Verify wandb.init called with env settings
                 mock_wandb.init.assert_called_once_with(


### PR DESCRIPTION
Three independent fixes, one commit each (Fix 1 is split into three for reviewability — see below).

## Fix 1 — ruff was enforcing almost nothing

`[tool.ruff.lint] select = ["T201", "T203"]` **replaces** ruff's default rule set rather than extending it. Verified before touching anything:

```
$ ruff check --show-settings . | grep -A4 rules.enabled
linter.rules.enabled = [ print (T201), p-print (T203) ]
$ ruff check .
All checks passed!
```

So E4/E7/E9/F — pycodestyle errors plus the whole of pyflakes — were silently off. Switched to `extend-select`, which surfaced **167 violations (116 auto-fixable)**: 102 in `tests/`, 34 in `examples/`, and **31 in `src/`** (the brief expected none in shipped code).

**Two were real bugs, not lint nits:**

1. **The public export modules imported deprecated shims that are marked for deletion.** `core/_exports/_flywheel.py` and `core/_exports/_training.py` each imported the same names **twice** — once from the canonical module, once from a `# TEMPORARY: deleted by the W2 sweep` back-compat shim. On `origin/main`:

   ```
   _flywheel.py
    13 from langres.tracking.judgement_log import JudgementLog, LoggingMatcher  canonical
    14 from langres.core.review           import ReviewItem, ReviewQueue, ...   SHIM
    15 from langres.core.judgement_log    import JudgementLog, LoggingMatcher   SHIM      (shadows 13)
    16 from langres.curation.review       import ReviewItem, ReviewQueue, ...   canonical (shadows 14)

   _training.py
    13 from langres.core.fit_report     import FitReport    SHIM
    14 from langres.curation.harvest    import align_pairs  canonical
    15 from langres.training.fit_report import FitReport    canonical (shadows 13)
    16 from langres.core.harvest        import align_pairs  SHIM      (shadows 14)
   ```

   The pairs shadow in **opposite** directions. The surviving binding comes from the **shim** for `JudgementLog`, `LoggingMatcher` and `align_pairs`; it comes from the **canonical** module for `ReviewItem`, `ReviewQueue`, `select_for_review` and `FitReport`.

   **Nothing resolved differently at runtime.** The shims re-export, so all six duplicated bindings are `is`-identical across both paths — verified before removing anything. There is no user-visible difference today either way, and this change introduces none.

   **The hazard is the pending shim deletion, not current behaviour.** These modules import `langres.core.review` / `.judgement_log` / `.harvest` / `.fit_report` *at all*, so deleting those shims raises `ImportError` and breaks `langres.core` at import time — for every one of the four, regardless of which side won the shadowing. Additionally, for the three names where the shim is the survivor, the binding that disappears is the live one. Keeping only the canonical import removes both exposures.

   *(Correction: an earlier version of this description said the shim shadowed the canonical import in both files and named the review triple as shim-resolving. That was wrong in one direction — see the table above. The fix itself is unaffected: both shim imports were removed either way.)*

2. **`tests/resources/test_op_adapters.py` used `GenerationRequest` without importing it** (F821). The test passes only because `.config` raises `TypeError` before the builder is ever invoked — calling it would have raised `NameError`.

**Plus a suppression that suppressed nothing:** four `# noqa: F821` in `tests/core/test_reports.py` sat one line *below* the name they targeted (on `monkeypatch: pytest.MonkeyPatch`, which has no violation) while the undefined annotation was on the line above. Five other sites in the same file get it right. Same decoupled-gate shape the repo keeps rediscovering.

**Nothing was suppressed to make it quiet.** Where a rule fired on a deliberate pattern, the import/statement was **kept** with a documented `# noqa`, never deleted:
- `TYPE_CHECKING` imports backing `LAZY_SYMBOLS` — deleting them blinds `mypy --strict` (confirmed: `mypy src` passes only because they were kept)
- the `TYPE_CHECKING`-only `conforms` `VectorIndex` conformance assertion, whose entire design is to assign and never read
- `methods.py`'s already-documented public re-export
- two `E402`s that must follow `pytest.importorskip("torch")` — hoisting them turns a clean skip into a collection error

Where ruff's `F841` fix left a side-effect-free `" ".join(...)` expression statement dangling, the statement was deleted instead. Also removed a file-concatenation artifact in `test_evaluation_reports.py` (a stray mid-file module docstring plus an import block byte-identical to the header's).

**No `--fail-under` was lowered. No rule was excluded.**

## Fix 2 — retracted a fabricated performance claim

`llm_judge.py` claimed `Speedup: ~12.5x for typical workloads`. The code contradicts every line of it:

- `_RateLimiter` is instantiated in exactly **one** place — inside `forward_async` (`llm_judge.py:966`). Sequential `forward` has no rate limiter at all, so the docstring's "~4 requests/second (250 RPM / 60s)" describes a cap that path does not have.
- `forward_async` defaults to `rpm_limit=250`, so its own ceiling is 250 RPM = **4.17 req/s** — it cannot reach the claimed ~50 req/s. 4.17 is the very number the docstring assigned to the *baseline*.
- 12.5 is just 50/4: one figure from the wrong path over another the code makes unreachable.

Replaced with what is true — the benefit is overlapping request latency, the rate limiter is the binding ceiling, and the factor depends on `rpm_limit`/`max_concurrent` and the provider's limits. **No replacement ratio was invented.**

Also fixes a units bug at the echo site: the ETA computed `len(candidates) / (250 / 60)` — dividing by requests-per-*second* yields seconds, reported as minutes (60x under). Correct form is `len(candidates) / 250`, which agrees with the file's own `MAX_CANDIDATES` comment (3000 → ~12 min at 250 RPM).

Swept `12.5`, `speedup`, `req/s` and `RPM` across `src/`, `examples/`, `docs/`, README and CHANGELOG — no occurrence remains.

**Deliberately not changed:** `phase1_llm_placement.py`'s "~an order of magnitude faster than the ~4s/call sequential path". Unlike the 12.5x, that one is arithmetically consistent with the cap (4s/call ≈ 0.25 req/s vs the 4.17 req/s ceiling ≈ 17x), and it is hedged rather than stated as a precise measured ratio.

## Fix 3 — the CodeQL failure was **not** the branch list

Diagnosed before editing. Both #231 and #233 target `main`, so the workflow triggered fine and the job ran on its merits:

```
##[error]Loaded a configuration file for version '4.37.3', but running version '4.37.0'
CodeQL job status was configuration error.
```

`github/codeql-action/init` and `.../analyze` are one product that must run the same version — init stamps its config with its version, analyze refuses a foreign one. Dependabot sees two independent dependencies and opened two PRs each bumping half the pair (#231 init, #233 analyze), so **each was guaranteed to fail**. Fixed by grouping them in `dependabot.yml`.

**Relation to #245** (merged onto `main` while this branch was open — this PR is now rebased onto it). #245 already fixed the *instance*: it hand-bumped both steps to the same pin (`e4fba868…` v4.37.3), which is why CodeQL is green on `main` today. **That bump is deliberate and is preserved here untouched** — I re-read `codeql.yml` on current `main` and this PR neither re-applies nor reverts it; my only edit to that file is the `on:` block. What #245 did *not* do is fix the **cause**: `main` still has no `codeql-action` group, so the next bump splits into two half-pair PRs and reproduces the identical configuration error. The two changes are complementary.

The branch drift is **real but a different bug**: `codeql.yml` listed only `main` while lint/test also cover `feat/core-packages` and `epic/193-core-algebra`. Since `pull_request.branches` filters by *target* branch, a PR into either got **no security scan at all**, silently. Both branches still exist on the remote, so this was a live coverage gap. Re-checked against `lint.yml` **as it stands after #245** (which reworked several workflows but left its branch lists alone): now aligned exactly on both `push` and `pull_request`.

**Deliberately not changed:** `codeql.yml` still has no `concurrency` block. lint/test carry a warning that a cancelled run is not a green run — adding `cancel-in-progress` to a security scan would introduce that failure mode, not remove one. Repo settings and branch protection untouched.

## Verification

Re-run after rebasing onto #245 — which moved `pyproject.toml`'s `exclude-newer` pin from `2026-07-08` to `2026-07-21` and so re-resolved the toolchain (**ruff 0.15.20**):

`ruff check .` ✅ · `ruff format --check .` ✅ · `mypy src` ✅ (with `--all-extras --no-extra finetune`, as CI runs it) · fast suite **4706 passed, 2 skipped**.

The newer ruff surfaced **no additional violations**. And because a clean run is not by itself evidence the gate is live, I confirmed it can still observe a failure under 0.15.20 — a probe with an unused import, a placeholder-less f-string, an undefined name and a `print` is caught as 4 errors (F401/F541/F821/T201).

## Note on commit count

Six commits, not three: Fix 1 is split into *restore the gate* / *fix `src/`* / *fix `tests/`* so the real export bug is reviewable on its own instead of buried under ~130 mechanical test edits. Fixes 2 and 3 are one commit each, plus a CHANGELOG commit. Confirmed with the coordinator: keep the granularity, since this squash-merges anyway.

## Summary by Sourcery

Restore Ruff’s default lint rules, fix issues surfaced by stricter linting, correct LLM judging performance documentation, and repair CodeQL configuration so security scans run reliably.

Bug Fixes:
- Stop the public export modules from importing the deprecated `# TEMPORARY` core shims, wiring every export through its canonical curation/tracking/training module instead. (Sourcery's wording; see the corrected detail above — no name resolved *differently* at runtime, since the shims re-export identical objects. The exposure was that deleting the shims would break `langres.core` at import time.)
- Fix undefined and unused symbols across tests and core modules, including missing imports, redundant variables, and incorrect annotations or TYPE_CHECKING-only imports.
- Correct the async LLM judge documentation and examples to remove an incorrect ~12.5x speedup claim and fix ETA calculations based on the 250 RPM rate limit.
- Resolve CodeQL configuration errors by grouping github/codeql-action steps into a single Dependabot bump and aligning workflow branch filters with other CI jobs.

Enhancements:
- Re-enable Ruff’s default E/F rules by switching to extend-select and documenting intentional noqa usages for lazy exports, TYPE_CHECKING imports, and deliberate E402/F401/F841 patterns.
- Tighten tests and examples by replacing inline lambdas with named functions, dropping unused imports and variables, and simplifying log and print formatting for clearer outputs.

Build:
- Group github/codeql-action init and analyze dependencies in Dependabot configuration so version bumps stay consistent and avoid configuration-version mismatches.

CI:
- Update CodeQL workflow triggers to cover long-lived integration branches in both push and pull_request events, keeping security scans in sync with lint/test coverage.

Tests:
- Adjust tests to avoid relying on unused return values, clean up unused fixtures and imports, and ensure deliberate noqa patterns and async paths are exercised without spurious lint issues.
