### PR TITLE
ci: main is protected — say so where CodeQL is configured

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -30,7 +30,12 @@ jobs:
         with:
           languages: python
           # security-extended adds lower-severity/precision queries on top of
-          # the default suite; still advisory (not a required check).
+          # the default suite. `Analyze (python)` IS a required check on PRs
+          # into main (branch protection) -- it runs on every such PR, so it
+          # can be required without deadlocking. Findings themselves land in
+          # Security -> Code scanning and do not fail the job; what this gate
+          # catches is the job failing outright, e.g. the codeql-action version
+          # mismatch that this pin exists to prevent.
           queries: security-extended
 
       - name: Perform CodeQL analysis

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -675,6 +675,18 @@ changing the default model hard."* Design note:
   '4.37.3', but running version '4.37.0'`). Dependabot raises one PR per action
   path, so bumping `init` (#231) or `analyze` (#233) alone could only ever be
   red; the three steps are moved together here.
+- **`main` is now a protected branch.** It previously had no branch protection
+  and no rulesets at all, so every check in this repo was advisory -- including
+  the coverage gates. Merging now requires a pull request and five green
+  checks: `lint`, `test (3.13)`, `test-core-only`, `docs-clean-install` and
+  `Analyze (python)`. Force-pushes and branch deletion are blocked.
+  Deliberately excluded from the required set, because they do not report on
+  every PR and a required check that never reports blocks the merge forever:
+  `test-full` (`if: github.event_name != 'pull_request'`), `build`/`deploy`
+  (path-filtered to docs changes), `Sourcery review` (skips when its weekly
+  diff quota is exhausted) and `test-finetune` (`continue-on-error` by design).
+  No approval count is required -- GitHub does not permit self-approval, so on
+  a single-maintainer repo that would block every merge rather than review it.
 - **Dependency quarantine rolled 2026-07-08 -> 2026-07-21.** Since `uv.lock` is
   gitignored, `exclude-newer` *is* the reproducibility pin and CI re-resolves on
   every run, so this is the whole of the Python-side update: 47 packages, no


### PR DESCRIPTION
Follow-up to #245. This commit was pushed to that branch moments after it
merged, so it did not land.

`main` now has branch protection (it previously had **none** — no rules, no
rulesets, so every check in this repo was advisory). Merging requires a PR and
five green checks: `lint`, `test (3.13)`, `test-core-only`,
`docs-clean-install`, `Analyze (python)`. Force-push and deletion are blocked.
Admins can still bypass, so a stuck gate can't lock the repo out.

That makes the comment sitting in `codeql.yml` on `main` false right now:

```yaml
# security-extended adds lower-severity/precision queries on top of
# the default suite; still advisory (not a required check).
```

`Analyze (python)` **is** a required check. A comment that contradicts the
config is how gate/expectation drift has started every previous time in this
repo, so it is corrected here rather than left to rot. The replacement also
records *why* this check is safe to require (it runs on every PR into `main`,
so it cannot deadlock) and what it actually gates: CodeQL findings land in
Security → Code scanning and never fail the job, so the gate catches the job
failing **outright** — exactly the `codeql-action` version mismatch that #245's
pins exist to prevent.

### Why these four are deliberately NOT required

A required check that never reports blocks the merge forever, so the set was
picked from what actually runs on every PR into `main`:

| check | why excluded |
|---|---|
| `test-full` | `if: github.event_name != 'pull_request'` — never runs on a PR |
| `build` / `deploy` | path-filtered to docs changes |
| `Sourcery review` | skips when its weekly diff-char quota is exhausted (it is right now) |
| `test-finetune` | `continue-on-error: true` by design |

No approval count is required: GitHub does not permit self-approval, so on a
single-maintainer repo that setting blocks every merge rather than reviewing
it. Scorecard's `CodeReview` alert therefore stays open until there is a second
maintainer — it is not fixable by configuration.

CHANGELOG records all of the above.

## Summary by Sourcery

Document main branch protection requirements and clarify the status of the CodeQL Analyze (python) check as a required protected-branch gate.

CI:
- Clarify in the CodeQL workflow that the Analyze (python) job is a required check on PRs to main and explain what conditions it gates.

Documentation:
- Record that main is now a protected branch with specific required checks and rationale for excluded checks and approval rules in the changelog.